### PR TITLE
Fix P1/P2 Codex review findings

### DIFF
--- a/src/app/api/filaments/[id]/spools/[spoolId]/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/route.ts
@@ -67,14 +67,20 @@ export async function DELETE(
     await dbConnect();
     const { id, spoolId } = await params;
 
+    // Require the spool to exist on the filament. Without this guard, a
+    // $pull with a missing spoolId is a silent no-op — the client gets a
+    // 200 and can't tell whether the delete actually happened.
     const filament = await Filament.findOneAndUpdate(
-      { _id: id, _deletedAt: null },
+      { _id: id, _deletedAt: null, "spools._id": spoolId },
       { $pull: { spools: { _id: spoolId } } },
       { new: true }
     ).lean();
 
     if (!filament) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Filament or spool not found" },
+        { status: 404 },
+      );
     }
     return NextResponse.json(filament);
   } catch (err) {

--- a/src/app/api/filaments/import-atlas/route.ts
+++ b/src/app/api/filaments/import-atlas/route.ts
@@ -67,8 +67,17 @@ export async function POST(request: NextRequest) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { _id: _remoteId, __v: _remoteV, createdAt: _createdAt, updatedAt: _updatedAt, _deletedAt: _remoteDeleted, ...filamentData } = remote;
 
-        // Strip parent references (they won't exist in the local DB)
+        // Strip every foreign-ObjectId reference — they point at documents
+        // in the *source* Atlas database and won't resolve locally. Leaving
+        // them would surface as dangling refs in calibration/nozzle UIs.
         delete filamentData.parentId;
+        delete filamentData.compatibleNozzles;
+        filamentData.calibrations = [];
+        if (Array.isArray(filamentData.spools)) {
+          for (const s of filamentData.spools) {
+            if (s && typeof s === "object") delete s.locationId;
+          }
+        }
 
         const existing = await Filament.findOne({ name: filamentData.name, _deletedAt: null });
         if (existing) {

--- a/src/app/api/filaments/import-atlas/route.ts
+++ b/src/app/api/filaments/import-atlas/route.ts
@@ -70,12 +70,18 @@ export async function POST(request: NextRequest) {
         // Strip every foreign-ObjectId reference — they point at documents
         // in the *source* Atlas database and won't resolve locally. Leaving
         // them would surface as dangling refs in calibration/nozzle UIs.
-        delete filamentData.parentId;
-        delete filamentData.compatibleNozzles;
+        //
+        // Set these to explicit empty values rather than `delete`ing them so
+        // that when `Filament.updateOne(..., filamentData)` runs on an
+        // existing row, Mongoose actually *clears* the previously-stored
+        // Atlas values. Keys absent from the update doc would otherwise
+        // leave stale Atlas IDs in place on re-import/update.
+        filamentData.parentId = null;
+        filamentData.compatibleNozzles = [];
         filamentData.calibrations = [];
         if (Array.isArray(filamentData.spools)) {
           for (const s of filamentData.spools) {
-            if (s && typeof s === "object") delete s.locationId;
+            if (s && typeof s === "object") s.locationId = null;
           }
         }
 

--- a/src/app/api/print-history/route.ts
+++ b/src/app/api/print-history/route.ts
@@ -136,8 +136,24 @@ export async function POST(request: NextRequest) {
     });
     const byId = new Map(filaments.map((f) => [String(f._id), f]));
     for (const u of usage) {
-      if (!byId.has(u.filamentId)) {
+      const filament = byId.get(u.filamentId);
+      if (!filament) {
         return errorResponse(`Filament not found: ${u.filamentId}`, 404);
+      }
+      // If the caller named a specific spool, confirm it exists on this
+      // filament before we mutate anything. Otherwise an invalid or stale
+      // spoolId silently falls through to "first spool" in pass 2 and
+      // debits the wrong inventory.
+      if (u.spoolId) {
+        const hasSpool = filament.spools.some(
+          (s) => String(s._id) === u.spoolId,
+        );
+        if (!hasSpool) {
+          return errorResponse(
+            `Spool not found on filament ${u.filamentId}: ${u.spoolId}`,
+            400,
+          );
+        }
       }
     }
 

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -66,12 +66,12 @@ export async function POST(request: NextRequest) {
   try {
     await dbConnect();
 
-    const filaments = await Filament.find({
+    const rawFilaments = await Filament.find({
       _id: { $in: body.filamentIds },
       _deletedAt: null,
     }).lean();
 
-    if (filaments.length === 0) {
+    if (rawFilaments.length === 0) {
       return errorResponse("No matching filaments found", 404);
     }
 
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
     const nozzleIds = new Set<string>();
     const printerIds = new Set<string>();
     const bedTypeIds = new Set<string>();
-    for (const f of filaments) {
+    for (const f of rawFilaments) {
       for (const nid of f.compatibleNozzles || []) nozzleIds.add(String(nid));
       for (const cal of f.calibrations || []) {
         if (cal.nozzle) nozzleIds.add(String(cal.nozzle));
@@ -94,6 +94,26 @@ export async function POST(request: NextRequest) {
       Printer.find({ _id: { $in: Array.from(printerIds) }, _deletedAt: null }).lean(),
       BedType.find({ _id: { $in: Array.from(bedTypeIds) }, _deletedAt: null }).lean(),
     ]);
+
+    // Strip per-instance inventory + PII fields that aren't part of the
+    // sharable profile: spools (lot numbers, purchase/open dates, photos,
+    // location refs, dry/usage history), lowStockThreshold, instanceId,
+    // and legacy totalWeight. Recipients can still import the profile and
+    // populate their own spools.
+    const filaments = rawFilaments.map((f) => {
+      const {
+        spools: _spools,
+        lowStockThreshold: _lowStockThreshold,
+        instanceId: _instanceId,
+        totalWeight: _totalWeight,
+        ...publicFields
+      } = f;
+      void _spools;
+      void _lowStockThreshold;
+      void _instanceId;
+      void _totalWeight;
+      return publicFields;
+    });
 
     const payload = {
       version: 1,

--- a/src/app/api/snapshot/delete/route.ts
+++ b/src/app/api/snapshot/delete/route.ts
@@ -3,18 +3,38 @@ import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
+import BedType from "@/models/BedType";
+import Location from "@/models/Location";
+import PrintHistory from "@/models/PrintHistory";
+import SharedCatalog from "@/models/SharedCatalog";
 
 /**
  * DELETE /api/snapshot/delete — Permanently delete all data from all collections.
+ *
+ * Every user-facing collection must be listed here. A missed collection means
+ * a "reset" still surfaces stale data in the dashboard / analytics and can
+ * leave published share links active after what the user asked to be a wipe.
  */
 export async function DELETE() {
   try {
     await dbConnect();
 
-    const [filaments, nozzles, printers] = await Promise.all([
+    const [
+      filaments,
+      nozzles,
+      printers,
+      bedTypes,
+      locations,
+      printHistory,
+      sharedCatalogs,
+    ] = await Promise.all([
       Filament.deleteMany({}),
       Nozzle.deleteMany({}),
       Printer.deleteMany({}),
+      BedType.deleteMany({}),
+      Location.deleteMany({}),
+      PrintHistory.deleteMany({}),
+      SharedCatalog.deleteMany({}),
     ]);
 
     return NextResponse.json({
@@ -23,6 +43,10 @@ export async function DELETE() {
         filaments: filaments.deletedCount,
         nozzles: nozzles.deletedCount,
         printers: printers.deletedCount,
+        bedTypes: bedTypes.deletedCount,
+        locations: locations.deletedCount,
+        printHistory: printHistory.deletedCount,
+        sharedCatalogs: sharedCatalogs.deletedCount,
       },
     });
   } catch (err) {

--- a/tests/print-history.test.ts
+++ b/tests/print-history.test.ts
@@ -110,6 +110,49 @@ describe("print-history POST", () => {
     expect(historyCount).toBe(0);
   });
 
+  it("rejects an invalid spoolId before mutating anything", async () => {
+    // Regression: previously a caller could supply a spoolId that didn't
+    // exist on the referenced filament and the handler would silently fall
+    // through to "first spool" — debiting the wrong inventory and
+    // persisting the caller's invalid id to PrintHistory.
+    const f = await Filament.create({
+      name: "Spool Guard",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [
+        { label: "A", totalWeight: 1000 },
+        { label: "B", totalWeight: 800 },
+      ],
+    });
+
+    const bogusSpool = new mongoose.Types.ObjectId().toString();
+    const res = await postPrintHistory(
+      makeReq({
+        jobLabel: "test-spool-guard",
+        source: "manual",
+        usage: [
+          { filamentId: String(f._id), spoolId: bogusSpool, grams: 50 },
+        ],
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/[Ss]pool/);
+
+    // Filament is untouched — neither spool got charged.
+    const after = await Filament.findById(f._id);
+    expect(after.spools[0].totalWeight).toBe(1000);
+    expect(after.spools[1].totalWeight).toBe(800);
+    expect(after.spools[0].usageHistory).toHaveLength(0);
+    expect(after.spools[1].usageHistory).toHaveLength(0);
+
+    // No PrintHistory row created.
+    const historyCount = await PrintHistory.countDocuments({});
+    expect(historyCount).toBe(0);
+  });
+
   it("applies updates across multiple filaments when all are valid", async () => {
     const a = await Filament.create({
       name: "Multi A",

--- a/tests/share-route.test.ts
+++ b/tests/share-route.test.ts
@@ -129,6 +129,57 @@ describe("/api/share", () => {
       );
       expect(res.status).toBe(404);
     });
+
+    it("strips spool inventory + PII fields from the published payload", async () => {
+      // Regression: previously the full Filament.find().lean() result was
+      // stored in payload, exposing lot numbers, purchase/open dates,
+      // photos, location ids, dry cycle + usage history, and
+      // lowStockThreshold to anyone with the share link.
+      const nozzle = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "brass" });
+      const filament = await Filament.create({
+        name: "Privacy PLA",
+        vendor: "TestCo",
+        type: "PLA",
+        compatibleNozzles: [nozzle._id],
+        lowStockThreshold: 250,
+        totalWeight: 1000,
+        instanceId: "abc-123",
+        spools: [
+          {
+            label: "private",
+            totalWeight: 800,
+            lotNumber: "SECRET-LOT-42",
+            purchaseDate: new Date("2025-01-01"),
+            openedDate: new Date("2025-02-01"),
+          },
+        ],
+      });
+
+      const res = await createShare(
+        postReq({
+          title: "Shareable",
+          filamentIds: [String(filament._id)],
+        }),
+      );
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      const saved = await SharedCatalog.findOne({ slug: body.slug });
+      const shared = saved.payload.filaments[0];
+
+      // Profile data still present.
+      expect(shared.name).toBe("Privacy PLA");
+      expect(shared.vendor).toBe("TestCo");
+
+      // Inventory + PII stripped.
+      expect(shared.spools).toBeUndefined();
+      expect(shared.lowStockThreshold).toBeUndefined();
+      expect(shared.instanceId).toBeUndefined();
+      expect(shared.totalWeight).toBeUndefined();
+
+      // Serialised payload as a string must not contain the secret lot number
+      // (guards against re-adding a leaky field by another name).
+      expect(JSON.stringify(saved.payload)).not.toContain("SECRET-LOT-42");
+    });
   });
 
   describe("GET /api/share/[slug]", () => {

--- a/tests/spool-subroute.test.ts
+++ b/tests/spool-subroute.test.ts
@@ -3,6 +3,7 @@ import mongoose from "mongoose";
 import { NextRequest } from "next/server";
 import { POST as postUsage } from "@/app/api/filaments/[id]/spools/[spoolId]/usage/route";
 import { POST as postDryCycle } from "@/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route";
+import { DELETE as deleteSpool } from "@/app/api/filaments/[id]/spools/[spoolId]/route";
 
 /**
  * Tests for the two v1.11 spool-ledger sub-endpoints:
@@ -174,6 +175,54 @@ describe("spool sub-routes", () => {
           { tempC: 50 },
         ),
         { params: Promise.resolve({ id: String(f._id), spoolId: fakeSpool }) },
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE .../spools/{spoolId}", () => {
+    function delReq(url: string) {
+      return new NextRequest(url, { method: "DELETE" });
+    }
+
+    it("removes the spool and returns the updated filament", async () => {
+      const f = await seedFilament();
+      const sid = String(f.spools[0]._id);
+      const res = await deleteSpool(
+        delReq(`http://localhost/api/filaments/${f._id}/spools/${sid}`),
+        { params: Promise.resolve({ id: String(f._id), spoolId: sid }) },
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools).toHaveLength(0);
+    });
+
+    it("returns 404 for a missing spoolId rather than silently succeeding", async () => {
+      // Regression: a $pull with a non-matching _id used to be a silent
+      // no-op on the filament doc — the client got a 200 and couldn't tell
+      // whether the deletion actually happened.
+      const f = await seedFilament();
+      const originalSpoolId = String(f.spools[0]._id);
+      const fakeSpool = new mongoose.Types.ObjectId().toString();
+      const res = await deleteSpool(
+        delReq(`http://localhost/api/filaments/${f._id}/spools/${fakeSpool}`),
+        { params: Promise.resolve({ id: String(f._id), spoolId: fakeSpool }) },
+      );
+      expect(res.status).toBe(404);
+
+      // Real spool must still be there.
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools).toHaveLength(1);
+      expect(String(fresh.spools[0]._id)).toBe(originalSpoolId);
+    });
+
+    it("returns 404 when the filament itself doesn't exist", async () => {
+      const fakeFilament = new mongoose.Types.ObjectId().toString();
+      const fakeSpool = new mongoose.Types.ObjectId().toString();
+      const res = await deleteSpool(
+        delReq(`http://localhost/api/filaments/${fakeFilament}/spools/${fakeSpool}`),
+        { params: Promise.resolve({ id: fakeFilament, spoolId: fakeSpool }) },
       );
       expect(res.status).toBe(404);
     });


### PR DESCRIPTION
## Summary

Five production bugs the Codex review pass flagged on v1.11. Three P1 (privacy + data-integrity) and two P2 (stale refs + silent no-op).

- **P1** — `/api/share` published full filament docs including spool lot numbers, purchase/open dates, photos, location ids, dry + usage history. Stripped to the profile surface.
- **P1** — `/api/print-history` silently debited the wrong spool when the caller supplied a stale or non-matching spoolId. Now validated in pass 1, returns 400 before any mutations.
- **P1** — `/api/snapshot/delete` only wiped filaments/nozzles/printers. Now clears BedType, Location, PrintHistory, SharedCatalog too — so published share links don't survive a "delete all data" action and the dashboard stops showing deleted data.
- **P2** — `/api/filaments/import-atlas` preserved `compatibleNozzles` / `calibrations.*` / `spools[].locationId` — all pointing at Atlas-only ObjectIds. Now stripped so imported filaments don't carry dangling refs.
- **P2** — `DELETE /api/filaments/{id}/spools/{spoolId}` returned 200 for a missing spoolId. Now the `$pull` filter requires the spool to exist; 404 otherwise.

+5 tests (635 → 640) locking in each fix.

## Test plan

- [x] `npm test` — 640/640 pass
- [x] `npm run lint` — clean
- [x] `tsc --noEmit` — clean
- [ ] Manual: publish a share, verify the payload JSON has no `spools` / `lotNumber` / `instanceId`
- [ ] Manual: POST to `/api/print-history` with a bogus spoolId → expect 400, no DB writes
- [ ] Manual: "Delete database" from Settings, then verify bed types / locations / print history / share links are all gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)