### PR TITLE
Fix #106: variant edit silently severs parent inheritance

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -7,13 +7,31 @@ import "@/models/BedType";
 import { resolveFilament, hasVariants } from "@/lib/resolveFilament";
 import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
 
+/**
+ * GET /api/filaments/{id}
+ *
+ * Returns a single filament with populated references. By default, if the
+ * filament is a variant (has parentId) its inheritable fields are resolved
+ * from its parent so the response is a complete view suitable for display.
+ *
+ * Pass `?raw=true` to skip inheritance resolution and receive the variant's
+ * own values. Fields the variant does not override come back as `null`
+ * (or empty). This is what the edit page needs — prefilling the form with
+ * resolved values and then saving would copy the parent's fields onto the
+ * variant and silently sever the inheritance link (GH #106).
+ *
+ * When `?raw=true` is passed on a parent, the response shape is unchanged
+ * (parents don't inherit from anything).
+ */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     await dbConnect();
     const { id } = await params;
+    const raw = request.nextUrl.searchParams.get("raw") === "true";
+
     const filament = await Filament.findOne({ _id: id, _deletedAt: null })
       .populate("compatibleNozzles")
       .populate("calibrations.nozzle")
@@ -24,16 +42,20 @@ export async function GET(
       return errorResponse("Not found", 404);
     }
 
-    // If this is a variant, resolve inherited values from parent
+    // Resolve inheritance when displaying; skip when editing so the form
+    // only sees the variant's own overrides.
     let resolved: IFilament | ReturnType<typeof resolveFilament> = filament;
+    let parentDoc: IFilament | null = null;
     if (filament.parentId) {
-      const parent = await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
+      parentDoc = (await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
         .populate("compatibleNozzles")
         .populate("calibrations.nozzle")
         .populate("calibrations.printer")
         .populate("calibrations.bedType")
-        .lean();
-      resolved = resolveFilament(filament, parent);
+        .lean()) as IFilament | null;
+      if (!raw && parentDoc) {
+        resolved = resolveFilament(filament, parentDoc);
+      }
     }
 
     // If this is a parent, include its variants
@@ -41,6 +63,17 @@ export async function GET(
       .select("name color cost")
       .sort({ name: 1 })
       .lean();
+
+    // In raw mode, attach the parent doc alongside so the edit UI can show
+    // "inherited from parent" placeholders for any field the variant left
+    // blank, without a second round-trip.
+    if (raw && parentDoc) {
+      return NextResponse.json({
+        ...resolved,
+        _variants: variants,
+        _parent: parentDoc,
+      });
+    }
 
     return NextResponse.json({ ...resolved, _variants: variants });
   } catch (err) {
@@ -70,6 +103,12 @@ export async function PUT(
     delete body.__v;
     delete body.instanceId;
     delete body.syncId;
+    // Server-side response-only fields that clients may echo back (e.g. the
+    // edit page fetches with ?raw=true and receives _parent / _variants /
+    // _inherited). Strip so they don't become persisted document fields.
+    delete body._parent;
+    delete body._variants;
+    delete body._inherited;
 
     // Validate parentId if provided
     if (body.parentId) {

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -72,6 +72,13 @@ export async function POST(request: NextRequest) {
       if (parent.parentId) {
         return errorResponse("Cannot set a variant as parent (no nested inheritance)", 400);
       }
+      // Variants should inherit diameter from the parent unless the client
+      // explicitly provides one. Without this, Mongoose's schema default of
+      // 1.75 materialises on the new variant and silently overrides a
+      // parent's non-1.75 diameter (e.g. 2.85mm). GH #106.
+      if (body.diameter === undefined || body.diameter === null || body.diameter === "") {
+        body.diameter = null;
+      }
     }
 
     const filament = await Filament.create(body);

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -633,7 +633,9 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
         colorName: form.colorName || null,
         cost: parseNum(form.cost),
         density: parseNum(form.density),
-        diameter: parseNum(form.diameter) ?? 1.75,
+        // Variants should inherit diameter from the parent when left blank;
+        // only apply the 1.75 fallback for standalone filaments (GH #106).
+        diameter: parseNum(form.diameter) ?? (form.parentId ? null : 1.75),
         temperatures: {
           nozzle: parseNum(form.temperatures.nozzle),
           nozzleFirstLayer: parseNum(form.temperatures.nozzleFirstLayer),
@@ -730,6 +732,19 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
       {fetchErrors.length > 0 && (
         <div className="px-3 py-2 bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded text-sm text-yellow-700 dark:text-yellow-300">
           {t("form.fetchError", { items: fetchErrors.join(", ") })}
+        </div>
+      )}
+      {form.parentId && initialData?._parent && (
+        // Variant banner — without this users edit a clone, see the parent's
+        // values pre-filled (as they used to before GH #106 was fixed), and
+        // don't realise that clicking Save copies every field onto the
+        // child. Now the edit form fetches ?raw=true and shows only the
+        // variant's own overrides; inherited fields render blank. This
+        // banner spells that out so the empty inputs don't look buggy.
+        <div className="px-3 py-2 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded text-sm text-blue-800 dark:text-blue-200">
+          {t("form.variantHint", {
+            parent: (initialData._parent as { name?: string }).name ?? "parent",
+          })}
         </div>
       )}
 

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -219,7 +219,13 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
     colorName: initialData?.colorName || "",
     cost: initialData?.cost?.toString() || "",
     density: initialData?.density?.toString() || "",
-    diameter: initialData?.diameter?.toString() || "1.75",
+    // Variants leave diameter blank when inheriting from the parent — falling
+    // back to "1.75" here would paint a value into the input that the user
+    // never typed, and saving would persist 1.75 as an explicit override
+    // (even if the parent's diameter is e.g. 2.85). The submit-side fallback
+    // in handleSubmit keeps 1.75 as the default for standalone filaments.
+    diameter:
+      initialData?.diameter?.toString() || (initialData?.parentId ? "" : "1.75"),
     temperatures: {
       nozzle: initialData?.temperatures?.nozzle?.toString() || "",
       nozzleFirstLayer: initialData?.temperatures?.nozzleFirstLayer?.toString() || "",

--- a/src/app/filaments/[id]/edit/page.tsx
+++ b/src/app/filaments/[id]/edit/page.tsx
@@ -26,7 +26,12 @@ export default function EditFilament() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetch(`/api/filaments/${params.id}`, { signal: controller.signal })
+    // ?raw=true skips variant inheritance resolution on the server so the
+    // form sees only this filament's own overrides. Without it, the form
+    // prefill would include parent-inherited values and a Save would
+    // persist them as explicit overrides — severing the live parent link
+    // (GH #106).
+    fetch(`/api/filaments/${params.id}?raw=true`, { signal: controller.signal })
       .then((r) => {
         if (r.status === 404) { setNotFound(true); return null; }
         if (!r.ok) { setFetchError(true); return null; }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -773,6 +773,7 @@
   "new.toast.populatedFromClone": "Formular aus Klon befüllt",
 
   "form.fetchError": "{items} konnten nicht geladen werden. Einige Auswahlfelder sind möglicherweise leer. Prüfen Sie, ob der Server läuft.",
+  "form.variantHint": "Dies ist eine Variante von \"{parent}\". Felder, die du leer lässt, werden vom übergeordneten Filament geerbt — bearbeite das übergeordnete Filament, um alle Varianten auf einmal zu aktualisieren. Hier eingegebene Werte überschreiben nur diese Variante.",
   "form.name": "Name",
   "form.parentFilament": "Übergeordnetes Filament",
   "form.parentFilamentHint": "optional — für Farbvarianten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -773,6 +773,7 @@
   "new.toast.populatedFromClone": "Form populated from clone",
 
   "form.fetchError": "Could not load {items}. Some dropdowns may be empty. Check that the server is running.",
+  "form.variantHint": "This is a variant of \"{parent}\". Any field you leave blank inherits from the parent — edit the parent to update all variants at once. Values you fill in here override the parent for this variant only.",
   "form.name": "Name",
   "form.parentFilament": "Parent Filament",
   "form.parentFilamentHint": "optional — for color variants",

--- a/src/lib/resolveFilament.ts
+++ b/src/lib/resolveFilament.ts
@@ -97,8 +97,21 @@ export function resolveFilament(
     }
   }
 
-  // Resolve compatibleNozzles — use variant's if defined (even empty), otherwise parent's
-  if (filament.compatibleNozzles !== undefined) {
+  // Array fields (compatibleNozzles / optTags / bedTypeTemps / calibrations /
+  // presets) inherit from the parent when the variant's array is empty.
+  //
+  // We used to treat `undefined` as "inherit" and `[]` as "explicit override
+  // to empty", but Mongoose always materialises array schema fields as `[]`
+  // at load time — `undefined` was unreachable in practice, so variants
+  // silently failed to inherit any array field. Treating empty === inherit
+  // matches what users expect (GH #106 — "clone should track parent
+  // ongoing, not snapshot once").
+  //
+  // Trade-off: there's no way to explicitly say "this variant has zero
+  // calibrations even though the parent has some". That's a rare case —
+  // when it comes up, either drop the parent link or add a sentinel
+  // override field in a future iteration.
+  if (filament.compatibleNozzles && filament.compatibleNozzles.length > 0) {
     resolved.compatibleNozzles = filament.compatibleNozzles;
   } else {
     resolved.compatibleNozzles = parent.compatibleNozzles || [];
@@ -107,8 +120,7 @@ export function resolveFilament(
     }
   }
 
-  // Resolve optTags — use variant's if defined (even empty), otherwise parent's
-  if (filament.optTags !== undefined) {
+  if (filament.optTags && filament.optTags.length > 0) {
     resolved.optTags = filament.optTags;
   } else {
     resolved.optTags = parent.optTags || [];
@@ -117,8 +129,7 @@ export function resolveFilament(
     }
   }
 
-  // Resolve bedTypeTemps — use variant's if defined (even empty), otherwise parent's
-  if (filament.bedTypeTemps !== undefined) {
+  if (filament.bedTypeTemps && filament.bedTypeTemps.length > 0) {
     resolved.bedTypeTemps = filament.bedTypeTemps;
   } else {
     resolved.bedTypeTemps = parent.bedTypeTemps || [];
@@ -127,8 +138,7 @@ export function resolveFilament(
     }
   }
 
-  // Resolve calibrations — use variant's if defined (even empty), otherwise parent's
-  if (filament.calibrations !== undefined) {
+  if (filament.calibrations && filament.calibrations.length > 0) {
     resolved.calibrations = filament.calibrations;
   } else {
     resolved.calibrations = parent.calibrations || [];
@@ -137,8 +147,7 @@ export function resolveFilament(
     }
   }
 
-  // Resolve presets — use variant's if defined (even empty), otherwise parent's
-  if (filament.presets !== undefined) {
+  if (filament.presets && filament.presets.length > 0) {
     resolved.presets = filament.presets;
   } else {
     resolved.presets = parent.presets || [];

--- a/tests/resolveFilament.test.ts
+++ b/tests/resolveFilament.test.ts
@@ -348,50 +348,65 @@ describe("resolveFilament", () => {
     expect(result.totalWeight).toBe(800);
   });
 
-  // --- #57: explicit empty array does NOT inherit from parent ---
+  // --- GH #106: empty array on a variant inherits from parent ---
+  //
+  // Previously a variant's empty array (e.g. calibrations: []) was treated
+  // as an explicit "override to empty" — but Mongoose always materialises
+  // array fields as [] at load time, so variants silently lost inheritance
+  // the moment they were fetched. Treating empty === inherit fixes the
+  // ongoing parent→variant relationship reported in issue #106.
 
-  it("does not inherit compatibleNozzles when variant has explicit empty array", () => {
+  it("inherits compatibleNozzles when variant has empty array", () => {
     const parent = makeParent({ compatibleNozzles: ["nozzle-1", "nozzle-2"] });
     const variant = makeVariant({ compatibleNozzles: [] });
     const result = resolveFilament(variant, parent);
-    expect(result.compatibleNozzles).toEqual([]);
-    expect(result._inherited).not.toContain("compatibleNozzles");
+    expect(result.compatibleNozzles).toEqual(["nozzle-1", "nozzle-2"]);
+    expect(result._inherited).toContain("compatibleNozzles");
   });
 
-  it("does not inherit optTags when variant has explicit empty array", () => {
+  it("inherits optTags when variant has empty array", () => {
     const parent = makeParent({ optTags: [1, 2, 4] });
     const variant = makeVariant({ optTags: [] });
     const result = resolveFilament(variant, parent);
-    expect(result.optTags).toEqual([]);
-    expect(result._inherited).not.toContain("optTags");
+    expect(result.optTags).toEqual([1, 2, 4]);
+    expect(result._inherited).toContain("optTags");
   });
 
-  it("does not inherit calibrations when variant has explicit empty array", () => {
+  it("inherits calibrations when variant has empty array", () => {
     const parent = makeParent();
     const variant = makeVariant({ calibrations: [] });
     const result = resolveFilament(variant, parent);
-    expect(result.calibrations).toEqual([]);
-    expect(result._inherited).not.toContain("calibrations");
+    // Parent's calibrations were one entry per the makeParent helper.
+    expect(result.calibrations).toHaveLength(1);
+    expect(result._inherited).toContain("calibrations");
   });
 
-  it("does not inherit presets when variant has explicit empty array", () => {
+  it("inherits presets when variant has empty array", () => {
     const parent = makeParent({
       presets: [{ label: "Default", extrusionMultiplier: 0.95, temperatures: {} }],
     });
     const variant = makeVariant({ presets: [] });
     const result = resolveFilament(variant, parent);
-    expect(result.presets).toEqual([]);
-    expect(result._inherited).not.toContain("presets");
+    expect(result.presets).toHaveLength(1);
+    expect(result._inherited).toContain("presets");
   });
 
-  it("does not inherit bedTypeTemps when variant has explicit empty array", () => {
+  it("inherits bedTypeTemps when variant has empty array", () => {
     const parent = makeParent({
       bedTypeTemps: [{ bedType: "Textured PEI", temperature: 85 }],
     });
     const variant = makeVariant({ bedTypeTemps: [] });
     const result = resolveFilament(variant, parent);
-    expect(result.bedTypeTemps).toEqual([]);
-    expect(result._inherited).not.toContain("bedTypeTemps");
+    expect(result.bedTypeTemps).toHaveLength(1);
+    expect(result._inherited).toContain("bedTypeTemps");
+  });
+
+  it("variant's non-empty array overrides the parent's", () => {
+    const parent = makeParent({ compatibleNozzles: ["nozzle-1", "nozzle-2"] });
+    const variant = makeVariant({ compatibleNozzles: ["nozzle-3"] });
+    const result = resolveFilament(variant, parent);
+    expect(result.compatibleNozzles).toEqual(["nozzle-3"]);
+    expect(result._inherited).not.toContain("compatibleNozzles");
   });
 });
 

--- a/tests/variant-edit-preserves-inheritance.test.ts
+++ b/tests/variant-edit-preserves-inheritance.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import mongoose from "mongoose";
 import { NextRequest } from "next/server";
 import { GET as getFilament, PUT as putFilament } from "@/app/api/filaments/[id]/route";
+import { POST as createFilament } from "@/app/api/filaments/route";
 
 /**
  * GH #106 regression guard.
@@ -163,6 +164,103 @@ describe("variant edit round-trip preserves inheritance", () => {
     const resolved = await resolvedRes.json();
     expect(resolved.cost).toBe(40); // variant's own override wins
     expect(resolved._inherited).not.toContain("cost");
+  });
+
+  it("diameter inheritance survives a variant edit round-trip (parent has non-default diameter)", async () => {
+    // Guard against a Codex-flagged regression: with raw=true the variant's
+    // diameter arrives as null; if the form defaulted null → "1.75" in its
+    // initial state and then submitted it as a number, any parent diameter
+    // other than 1.75 (say a 2.85mm filament) would be silently overridden
+    // on the variant on the very next save.
+    const parent = await Filament.create({
+      name: "Parent 2.85mm",
+      vendor: "Test",
+      type: "PLA",
+      diameter: 2.85,
+    });
+    const variant = await Filament.create({
+      name: "Variant of 2.85mm",
+      vendor: "Test",
+      type: "PLA",
+      parentId: parent._id,
+      // `diameter: null` mirrors what POST /api/filaments writes for a
+      // variant when the client doesn't supply an explicit diameter
+      // (Mongoose's schema default of 1.75 is bypassed there). Without
+      // this, the schema default would kick in and the variant would be
+      // created with diameter: 1.75 already overriding the parent — the
+      // very regression this test guards against.
+      diameter: null,
+    });
+
+    // Raw fetch returns diameter as null for the variant.
+    const rawReq = new NextRequest(`http://localhost/api/filaments/${variant._id}?raw=true`);
+    const rawRes = await getFilament(rawReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const rawBody = await rawRes.json();
+    expect(rawBody.diameter).toBeNull();
+
+    // Save the raw payload back unchanged — must not coerce null → 1.75.
+    const putReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(rawBody),
+    });
+    await putFilament(putReq, { params: Promise.resolve({ id: String(variant._id) }) });
+
+    const fresh = await Filament.findById(variant._id);
+    expect(fresh.diameter).toBeNull();
+
+    // Resolved view still inherits the parent's 2.85.
+    const resolvedReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`);
+    const resolvedRes = await getFilament(resolvedReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const resolved = await resolvedRes.json();
+    expect(resolved.diameter).toBe(2.85);
+    expect(resolved._inherited).toContain("diameter");
+  });
+
+  it("POST /api/filaments does not apply the 1.75 diameter default to variants", async () => {
+    // Covers the route-level half of the fix: creating a variant via the
+    // real API endpoint without passing a diameter must not trigger the
+    // Mongoose schema default. If it did, every newly-cloned variant would
+    // immediately override the parent's diameter.
+    const parent = await Filament.create({
+      name: "Route Parent 2.85mm",
+      vendor: "Test",
+      type: "PLA",
+      diameter: 2.85,
+    });
+
+    const req = new NextRequest("http://localhost/api/filaments", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Route Variant (no diameter)",
+        vendor: "Test",
+        type: "PLA",
+        color: "#ff0000",
+        parentId: String(parent._id),
+      }),
+    });
+    const res = await createFilament(req);
+    expect(res.status).toBe(201);
+    const created = await res.json();
+
+    const fresh = await Filament.findById(created._id);
+    expect(fresh.diameter).toBeNull();
+
+    // Non-variants are unaffected: the schema default still fills in 1.75.
+    const standaloneReq = new NextRequest("http://localhost/api/filaments", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Standalone (no diameter)",
+        vendor: "Test",
+        type: "PLA",
+      }),
+    });
+    const standaloneRes = await createFilament(standaloneReq);
+    const standalone = await standaloneRes.json();
+    const freshStandalone = await Filament.findById(standalone._id);
+    expect(freshStandalone.diameter).toBe(1.75);
   });
 
   it("PUT strips server-only response fields (_parent, _variants, _inherited) from the body", async () => {

--- a/tests/variant-edit-preserves-inheritance.test.ts
+++ b/tests/variant-edit-preserves-inheritance.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as getFilament, PUT as putFilament } from "@/app/api/filaments/[id]/route";
+
+/**
+ * GH #106 regression guard.
+ *
+ * Scenario: user creates a parent filament with real settings, clones it
+ * as a color variant, then goes into the variant's edit page and clicks
+ * Save without changing anything.
+ *
+ * Before the fix, the edit page fetched the variant via GET without
+ * ?raw=true. The server ran resolveFilament(), the form prefilled with
+ * the *parent's* values, and the subsequent PUT persisted those values
+ * onto the variant — severing the live parent link. From that point on,
+ * parent edits were invisible to the variant.
+ *
+ * After the fix, the edit page fetches with ?raw=true, the form sees
+ * only the variant's own (empty) overrides, and the PUT writes the
+ * variant back with inheritable fields as null/empty. A later GET (with
+ * inheritance resolution) still shows the parent's values because the
+ * variant is inheriting them — exactly what the user wants.
+ */
+describe("variant edit round-trip preserves inheritance", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    // Models that GET populates — without these registered the
+    // populate() call throws "Schema hasn't been registered".
+    for (const name of ["Nozzle", "Printer", "BedType"] as const) {
+      if (!mongoose.models[name]) {
+        const mod = await import(`@/models/${name}`);
+        mongoose.model(name, mod.default.schema);
+      }
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  async function seed() {
+    const parent = await Filament.create({
+      name: "Prusament PC Blend",
+      vendor: "Prusament",
+      type: "PC",
+      color: "#333333",
+      cost: 35,
+      density: 1.22,
+      temperatures: { nozzle: 275, bed: 110 },
+      maxVolumetricSpeed: 8,
+    });
+    const variant = await Filament.create({
+      name: "Prusament PC Blend — Galaxy Black",
+      vendor: "Prusament",
+      type: "PC",
+      color: "#1a1a2e",
+      parentId: parent._id,
+      // All inheritable fields left blank — the form would submit them as
+      // nulls after a fresh raw-mode fetch.
+    });
+    return { parent, variant };
+  }
+
+  it("GET without ?raw resolves inheritance (baseline)", async () => {
+    const { variant } = await seed();
+    const req = new NextRequest(`http://localhost/api/filaments/${variant._id}`);
+    const res = await getFilament(req, { params: Promise.resolve({ id: String(variant._id) }) });
+    const body = await res.json();
+    expect(body.temperatures.nozzle).toBe(275);
+    expect(body.cost).toBe(35);
+    expect(body._inherited).toContain("cost");
+  });
+
+  it("GET with ?raw=true returns variant's own (empty) values plus _parent", async () => {
+    const { parent, variant } = await seed();
+    const req = new NextRequest(`http://localhost/api/filaments/${variant._id}?raw=true`);
+    const res = await getFilament(req, { params: Promise.resolve({ id: String(variant._id) }) });
+    const body = await res.json();
+    expect(body.temperatures.nozzle).toBeNull();
+    expect(body.cost).toBeNull();
+    expect(body._parent).toBeDefined();
+    expect(body._parent.name).toBe("Prusament PC Blend");
+    expect(body._parent._id.toString()).toBe(String(parent._id));
+  });
+
+  it("PUT of the raw payload does NOT copy parent values onto the variant", async () => {
+    const { variant } = await seed();
+
+    // Simulate the edit flow: fetch raw, then PUT the body back unchanged.
+    const rawReq = new NextRequest(`http://localhost/api/filaments/${variant._id}?raw=true`);
+    const rawRes = await getFilament(rawReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const rawBody = await rawRes.json();
+
+    const putReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(rawBody),
+    });
+    const putRes = await putFilament(putReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    expect(putRes.status).toBe(200);
+
+    // Read the raw variant back and verify it still has null inheritable fields.
+    const fresh = await Filament.findById(variant._id);
+    expect(fresh.temperatures.nozzle).toBeNull();
+    expect(fresh.cost).toBeNull();
+    expect(fresh.density).toBeNull();
+  });
+
+  it("after PUT, a subsequent parent edit is still reflected in the variant (live link)", async () => {
+    const { parent, variant } = await seed();
+
+    // Simulate the edit round-trip on the variant.
+    const rawReq = new NextRequest(`http://localhost/api/filaments/${variant._id}?raw=true`);
+    const rawRes = await getFilament(rawReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const rawBody = await rawRes.json();
+    const putReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(rawBody),
+    });
+    await putFilament(putReq, { params: Promise.resolve({ id: String(variant._id) }) });
+
+    // Now update the parent's nozzle temperature.
+    await Filament.findByIdAndUpdate(parent._id, {
+      $set: { "temperatures.nozzle": 280 },
+    });
+
+    // The variant should see the new parent value via inheritance.
+    const resolvedReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`);
+    const resolvedRes = await getFilament(resolvedReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const resolved = await resolvedRes.json();
+    expect(resolved.temperatures.nozzle).toBe(280);
+    expect(resolved._inherited).toContain("temperatures.nozzle");
+  });
+
+  it("explicit overrides on the variant are preserved across the round-trip", async () => {
+    const { parent, variant } = await seed();
+
+    // Variant sets its own cost override.
+    await Filament.findByIdAndUpdate(variant._id, { $set: { cost: 40 } });
+
+    const rawReq = new NextRequest(`http://localhost/api/filaments/${variant._id}?raw=true`);
+    const rawRes = await getFilament(rawReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const rawBody = await rawRes.json();
+    expect(rawBody.cost).toBe(40);
+
+    const putReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(rawBody),
+    });
+    await putFilament(putReq, { params: Promise.resolve({ id: String(variant._id) }) });
+
+    // Parent's cost shouldn't leak through the override.
+    await Filament.findByIdAndUpdate(parent._id, { $set: { cost: 50 } });
+
+    const resolvedReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`);
+    const resolvedRes = await getFilament(resolvedReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const resolved = await resolvedRes.json();
+    expect(resolved.cost).toBe(40); // variant's own override wins
+    expect(resolved._inherited).not.toContain("cost");
+  });
+
+  it("PUT strips server-only response fields (_parent, _variants, _inherited) from the body", async () => {
+    const { variant } = await seed();
+
+    // Client sends the whole response echo back, including the fields the
+    // raw GET added for UI convenience.
+    const putReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        _parent: { name: "injected" },
+        _variants: [{ _id: "fake" }],
+        _inherited: ["cost"],
+        name: "Prusament PC Blend — Galaxy Black",
+      }),
+    });
+    const putRes = await putFilament(putReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    expect(putRes.status).toBe(200);
+
+    const fresh = await Filament.findById(variant._id);
+    expect(fresh._parent).toBeUndefined();
+    expect(fresh._variants).toBeUndefined();
+    expect(fresh._inherited).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #106.

## The bug

Reported by @tonysurma with a clear repro:
1. Filament A has settings set.
2. Clone A to B.
3. Update B's name/color/colorName and Save.
4. B inherits from A.
5. Edit A.
6. **B doesn't reflect the edit** ← broken

## Root cause

The edit page (`/filaments/{id}/edit`) fetches via `GET /api/filaments/{id}`, which always calls `resolveFilament()` and merges parent values into the response. The `FilamentForm` prefills with those **resolved** values, so clicking Save persists copies of every parent field onto the variant — silently severing the live link.

On top of that, the array-field resolver used `variant.calibrations !== undefined ? variant : parent`. Because Mongoose materialises array schema fields as `[]` at load time, `undefined` was unreachable in practice: a fresh variant's `calibrations: []` was treated as "explicit override to empty" and never inherited.

## The fix

Three coordinated changes.

**1. New `?raw=true` on `GET /api/filaments/{id}`**
Skips inheritance resolution. Returns the variant's own overrides (mostly `null` for inheritable fields). For variants, the response also includes the populated parent doc as `_parent` so UI can render helpful placeholders without a second round-trip.

**2. Edit page uses `?raw=true`**
Form now sees blank inputs for inherited fields. A Save with no changes leaves those blank — inheritance preserved.

**3. Array-field inheritance: empty === inherit**
`compatibleNozzles`, `optTags`, `bedTypeTemps`, `calibrations`, `presets` now all inherit from the parent when the variant's array is empty. This matches what users expect and closes the silent-break. Trade-off: no way to explicitly say "this variant has zero calibrations but parent has some" — rare; add a sentinel if/when it comes up.

## Supporting changes

- `PUT` strips server-only response fields (`_parent`, `_variants`, `_inherited`) in case a client echoes the raw GET response back.
- `FilamentForm` no longer hardcodes `diameter ?? 1.75` for variants — they inherit now too.
- New `form.variantHint` i18n banner at the top of the edit form for variants explaining the blank=inherit behaviour.

## Tests

- `tests/variant-edit-preserves-inheritance.test.ts` (new, 6 tests): full round-trip guarding the regression
- `tests/resolveFilament.test.ts` (5 tests inverted): now asserts empty arrays inherit
- 647 tests pass, typecheck + lint clean

## Not addressed (issue #107)

This PR only fixes #106. The separate #107 (per-printer filament settings) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)