### PR TITLE
Fix #112, #113, #115: dashboard back link + variant edit/clone polish

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -58,9 +58,18 @@ export default function DashboardPage() {
     return () => ac.abort();
   }, []);
 
+  const backLink = (
+    <div className="mb-4">
+      <Link href="/" className="text-blue-600 hover:underline text-sm">
+        &larr; {t("dashboard.backToFilaments")}
+      </Link>
+    </div>
+  );
+
   if (error) {
     return (
       <main className="max-w-5xl mx-auto px-4 py-8">
+        {backLink}
         <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
       </main>
     );
@@ -69,6 +78,7 @@ export default function DashboardPage() {
   if (!data) {
     return (
       <main className="max-w-5xl mx-auto px-4 py-8">
+        {backLink}
         <p className="text-sm text-gray-500">{t("common.loading")}</p>
       </main>
     );
@@ -78,6 +88,7 @@ export default function DashboardPage() {
 
   return (
     <main className="max-w-5xl mx-auto px-4 py-8">
+      {backLink}
       <h1 className="text-3xl font-bold mb-6">{t("dashboard.title")}</h1>
 
       {/* Top metrics */}

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -616,18 +616,16 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
     settings.end_filament_gcode = form.endGcode ? `"${form.endGcode}"` : undefined;
     settings.filament_notes = form.notes ? `"${form.notes}"` : undefined;
 
-    // Handle start G-code: if the user edited it directly, use that; otherwise manage PA injection
+    // Handle start G-code: user-typed text wins; else inject PA-only line; else
+    // drop the override entirely so a variant inherits from its parent (GH #113).
+    // Without the trailing `else`, an inherited (or pre-existing) gcode that
+    // contained no `M572` line could never be cleared from the form.
     if (form.startGcode) {
       settings.start_filament_gcode = `"${form.startGcode}"`;
     } else if (form.pressureAdvance) {
       settings.start_filament_gcode = `"M572 S${form.pressureAdvance}"`;
-    } else if (settings.start_filament_gcode) {
-      // PA cleared — remove M572 line if it's a simple one
-      const gcode = settings.start_filament_gcode as string;
-      if (gcode.match(/M572\s+S[\d.]+/) && !gcode.includes("{if")) {
-        const cleaned = gcode.replace(/\\n?M572\s+S[\d.]+/, "").replace(/^"\\n/, '"');
-        settings.start_filament_gcode = cleaned === '""' ? undefined : cleaned;
-      }
+    } else {
+      settings.start_filament_gcode = undefined;
     }
 
     try {

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -161,7 +161,12 @@ function NewFilamentContent() {
     }
   }, [parentId]);
 
-  // Initialize from ?cloneId= query param (full clone from detail page)
+  // Initialize from ?cloneId= query param (full clone from detail page).
+  // Only copy identification fields (name, color, vendor, type) so the new
+  // variant inherits all settings (calibration, temps, gcode, …) from the
+  // parent. Spreading the whole resolved doc would persist parent values as
+  // explicit overrides on the variant and silently sever inheritance — same
+  // failure mode as GH #106 / GH #115.
   useEffect(() => {
     if (cloneId) {
       const ac = new AbortController();
@@ -169,12 +174,15 @@ function NewFilamentContent() {
         .then((r) => (r.ok ? r.json() : null))
         .then((filament) => {
           if (filament) {
-            // Strip identity fields, but inherit the source's parent (or use source as parent)
-            // so the clone is registered as a variant.
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { _id, _variants, _inherited, parentId: srcParentId, createdAt, updatedAt, __v, ...rest } = filament;
-            const parentId = srcParentId || _id;
-            setInitialData({ ...rest, parentId, name: `${rest.name} (${t("new.copySuffix")})` });
+            const parentId = filament.parentId || filament._id;
+            setInitialData({
+              parentId,
+              name: `${filament.name} (${t("new.copySuffix")})`,
+              color: filament.color || "#808080",
+              colorName: filament.colorName || null,
+              vendor: filament.vendor || "",
+              type: filament.type || "PLA",
+            });
             setTitleKey("new.cloneTitle");
             setFormKey((k) => k + 1);
           }
@@ -487,13 +495,16 @@ function NewFilamentContent() {
       return;
     }
     const filament = await res.json();
-    // Strip identity fields — keep everything else as a template.
-    // Inherit the source's parent if it has one, otherwise use the source as the parent
-    // so the clone is registered as a variant.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { _id, _variants, _inherited, parentId: srcParentId, createdAt, updatedAt, __v, ...rest } = filament;
-    const parentId = srcParentId || _id;
-    setInitialData({ ...rest, parentId, name: `${rest.name} (${t("new.copySuffix")})` });
+    // See the cloneId useEffect above for why we whitelist instead of spread.
+    const parentId = filament.parentId || filament._id;
+    setInitialData({
+      parentId,
+      name: `${filament.name} (${t("new.copySuffix")})`,
+      color: filament.color || "#808080",
+      colorName: filament.colorName || null,
+      vendor: filament.vendor || "",
+      type: filament.type || "PLA",
+    });
     setTitleKey("new.cloneTitle");
     setFormKey((k) => k + 1);
     toast(t("new.toast.populatedFromClone"));

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -82,6 +82,7 @@
   "compare.row.printSpeed": "Druckgeschwindigkeit",
   "compare.row.onHand": "Vorrat",
   "dashboard.title": "Dashboard",
+  "dashboard.backToFilaments": "Zurück zu Filamenten",
   "dashboard.filaments": "Filamente",
   "dashboard.spools": "Aktive Spulen",
   "dashboard.totalWeight": "Gesamt verbleibend",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -82,6 +82,7 @@
   "compare.row.printSpeed": "Print speed",
   "compare.row.onHand": "On hand",
   "dashboard.title": "Dashboard",
+  "dashboard.backToFilaments": "Back to filaments",
   "dashboard.filaments": "Filaments",
   "dashboard.spools": "Active Spools",
   "dashboard.totalWeight": "Total Remaining",

--- a/tests/variant-edit-preserves-inheritance.test.ts
+++ b/tests/variant-edit-preserves-inheritance.test.ts
@@ -263,6 +263,133 @@ describe("variant edit round-trip preserves inheritance", () => {
     expect(freshStandalone.diameter).toBe(1.75);
   });
 
+  it("clearing start_filament_gcode on a variant restores inheritance from the parent (GH #113)", async () => {
+    // Repro: parent has a real start G-code; variant was created (e.g. via
+    // the pre-fix clone path) with the parent's value baked into its own
+    // settings bag. The user clears the textarea and saves. Before the fix,
+    // the form's submit conditional only stripped a simple inline `M572` —
+    // an inherited multi-line gcode silently survived as an explicit override.
+    const parent = await Filament.create({
+      name: "Parent w/ start gcode",
+      vendor: "Test",
+      type: "PLA",
+      settings: {
+        start_filament_gcode: '"G92 E0\\nM104 S{first_layer_temperature}"',
+        filament_density: "1.24",
+      },
+    });
+    const variant = await Filament.create({
+      name: "Variant w/ baked-in override",
+      vendor: "Test",
+      type: "PLA",
+      color: "#ff0000",
+      parentId: parent._id,
+      settings: {
+        start_filament_gcode: '"G92 E0\\nM104 S{first_layer_temperature}"',
+      },
+    });
+
+    // The fixed form omits start_filament_gcode from the settings bag when
+    // both the textarea and the Pressure Advance field are empty.
+    const putReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: variant.name,
+        vendor: variant.vendor,
+        type: variant.type,
+        color: variant.color,
+        parentId: parent._id,
+        settings: {}, // user cleared the only key the variant had
+      }),
+    });
+    const putRes = await putFilament(putReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    expect(putRes.status).toBe(200);
+
+    // Variant's own settings no longer carry start_filament_gcode.
+    const fresh = await Filament.findById(variant._id).lean();
+    expect(fresh?.settings?.start_filament_gcode).toBeUndefined();
+
+    // Resolved view falls through to the parent's value.
+    const resolvedReq = new NextRequest(`http://localhost/api/filaments/${variant._id}`);
+    const resolvedRes = await getFilament(resolvedReq, { params: Promise.resolve({ id: String(variant._id) }) });
+    const resolved = await resolvedRes.json();
+    expect(resolved.settings.start_filament_gcode).toBe(
+      '"G92 E0\\nM104 S{first_layer_temperature}"'
+    );
+  });
+
+  it("a whitelist-only clone POST creates a variant that inherits everything else (GH #115)", async () => {
+    // Repro: pre-fix, the new-filament page spread the entire resolved parent
+    // doc into the form when cloning, so saving wrote every inheritable field
+    // back as an explicit override (severing the parent link). The fixed page
+    // only sends identification fields. This test pins down the API contract
+    // the page now relies on: posting a minimal body must produce a variant
+    // with null/empty inheritable fields that resolves through to the parent.
+    const parent = await Filament.create({
+      name: "Loaded Parent",
+      vendor: "Test",
+      type: "PLA",
+      color: "#000000",
+      cost: 30,
+      density: 1.24,
+      diameter: 1.75,
+      temperatures: { nozzle: 215, bed: 60 },
+      maxVolumetricSpeed: 12,
+      settings: {
+        start_filament_gcode: '"G92 E0"',
+        filament_density: "1.24",
+      },
+    });
+
+    const req = new NextRequest("http://localhost/api/filaments", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        parentId: String(parent._id),
+        name: "Loaded Parent (copy)",
+        color: "#ff0000",
+        colorName: "Red",
+        vendor: "Test",
+        type: "PLA",
+      }),
+    });
+    const res = await createFilament(req);
+    expect(res.status).toBe(201);
+    const created = await res.json();
+
+    // Variant's own row has only what the whitelist sent — everything
+    // inheritable is left null/empty.
+    const fresh = await Filament.findById(created._id).lean();
+    expect(fresh?.cost).toBeNull();
+    expect(fresh?.density).toBeNull();
+    expect(fresh?.diameter).toBeNull();
+    expect(fresh?.temperatures?.nozzle).toBeNull();
+    expect(fresh?.maxVolumetricSpeed).toBeNull();
+    expect(Object.keys(fresh?.settings ?? {})).toHaveLength(0);
+
+    // Resolved GET threads the parent's values through.
+    const resolvedReq = new NextRequest(`http://localhost/api/filaments/${created._id}`);
+    const resolvedRes = await getFilament(resolvedReq, { params: Promise.resolve({ id: String(created._id) }) });
+    const resolved = await resolvedRes.json();
+    expect(resolved.cost).toBe(30);
+    expect(resolved.density).toBe(1.24);
+    expect(resolved.diameter).toBe(1.75);
+    expect(resolved.temperatures.nozzle).toBe(215);
+    expect(resolved.maxVolumetricSpeed).toBe(12);
+    expect(resolved.settings.start_filament_gcode).toBe('"G92 E0"');
+    expect(resolved._inherited).toEqual(
+      expect.arrayContaining(["cost", "density", "diameter", "maxVolumetricSpeed", "settings"])
+    );
+
+    // And the link stays live: bumping the parent updates the resolved view.
+    await Filament.findByIdAndUpdate(parent._id, { $set: { cost: 35 } });
+    const reResolvedReq = new NextRequest(`http://localhost/api/filaments/${created._id}`);
+    const reResolvedRes = await getFilament(reResolvedReq, { params: Promise.resolve({ id: String(created._id) }) });
+    const reResolved = await reResolvedRes.json();
+    expect(reResolved.cost).toBe(35);
+  });
+
   it("PUT strips server-only response fields (_parent, _variants, _inherited) from the body", async () => {
     const { variant } = await seed();
 


### PR DESCRIPTION
Closes #112, #113, #115. Each is a small follow-up to PR #111 (variant inheritance fix) plus the missing dashboard nav.

## #112 — Dashboard had no back link
[`/dashboard`](src/app/dashboard/page.tsx) was the one v1.11 page that rendered no `← Back to filaments` link, so users hit a dead end. Added the standard pattern + matching `dashboard.backToFilaments` key in `en` and `de`.

## #113 — Start G-Code wouldn't clear on a variant
[`FilamentForm.tsx:620`](src/app/filaments/FilamentForm.tsx#L620) — the submit ladder only stripped a simple inline `M572 S<n>` line. An inherited *multi-line* gcode (e.g. one that PR #111's predecessor flow baked into a variant) had no `M572`, so the third branch did nothing and the override survived. Once it survived, `resolveFilament`'s shallow settings-merge masked the parent forever — there was no UI affordance to bring it back.

The new branch is unconditional: if the textarea and Pressure Advance are both empty, the key drops out of the variant's settings bag and inheritance resumes on the next read.

## #115 — Clone copied resolved inherited values, severing the link
PR #111 fixed the edit page with `?raw=true`. The clone flow was missed: [`new/page.tsx`](src/app/filaments/new/page.tsx) spread the entire resolved parent doc into `initialData`, so saving wrote every inheritable field back as an explicit override — the exact shape of #106.

Replaced both clone paths (`?cloneId=` URL param + in-page picker) with a whitelist:

```
parentId, name (+ copy suffix), color, colorName, vendor, type
```

Everything else stays blank and resolves through the parent. Matches the pattern the `?parentId=` flow already uses.

## Tests

Extended `tests/variant-edit-preserves-inheritance.test.ts` with two regressions:

1. **start_filament_gcode clear restores inheritance** — seeds a parent with a multi-line gcode, a variant with the gcode baked in (mimicking pre-fix clone), simulates the submit body the fixed form now sends, asserts the variant's key is gone and the resolved view falls through.
2. **whitelist-only clone POST inherits everything else** — POSTs the minimal body the fixed page now constructs, asserts every inheritable field is `null`/empty on the variant, then asserts the resolved view matches the parent and a parent edit propagates live.

12/12 tests in that file pass; full suite 651/651; lint clean.

## Verification

Smoke-tested the dashboard back link in the dev server (curl confirmed `<a href="/">← Back to filaments</a>` is now in the SSR HTML). The form-flow fixes are pinned by the new API tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)