### PR TITLE
Fix #116: sync locations and remap spool.locationId across DBs

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -43,7 +43,12 @@ interface SyncResult {
 /**
  * Bidirectional sync engine between local MongoDB and Atlas.
  * Uses last-write-wins conflict resolution based on updatedAt timestamps.
- * Nozzles are synced first so filament references can be remapped.
+ * Nozzles, printers, and locations are synced first so filaments (and their
+ * embedded spools) can have their references remapped onto the target DB's IDs.
+ *
+ * NOTE: bedtypes, printhistory, and sharedcatalogs are NOT synced yet — they
+ * were added in v1.11 alongside locations and have the same gap. They'll need
+ * the same treatment when their data starts diverging across desktops.
  */
 export class SyncService extends EventEmitter {
   private localUri: string;
@@ -154,6 +159,19 @@ export class SyncService extends EventEmitter {
       const localPrinterBySyncId = new Map(localPrinters.filter(p => p.syncId).map(p => [p.syncId as string, p._id]));
       const remotePrinterBySyncId = new Map(remotePrinters.filter(p => p.syncId).map(p => [p.syncId as string, p._id]));
 
+      // Sync locations before filaments so spool.locationId can be remapped.
+      // Locations are referenced from filaments[].spools[].locationId — a
+      // missing remap would either drop the reference or, worse, point at a
+      // wrong location on the target DB (GH #116).
+      this.updateStatus({ progress: "Syncing locations..." });
+      const locationResult = await this.syncCollection(localDb, remoteDb, "locations");
+
+      // Build location syncId→ID maps for spool reference remapping
+      const localLocations = await localDb.collection("locations").find({ _deletedAt: null }).toArray();
+      const remoteLocations = await remoteDb.collection("locations").find({ _deletedAt: null }).toArray();
+      const localLocationBySyncId = new Map(localLocations.filter(l => l.syncId).map(l => [l.syncId as string, l._id]));
+      const remoteLocationBySyncId = new Map(remoteLocations.filter(l => l.syncId).map(l => [l.syncId as string, l._id]));
+
       // Backfill filament syncIds before building maps (syncCollection does this too, but we need maps first)
       await this.backfillSyncIds(localDb.collection("filaments"));
       await this.backfillSyncIds(remoteDb.collection("filaments"));
@@ -164,19 +182,20 @@ export class SyncService extends EventEmitter {
       const localFilamentBySyncId = new Map(localFilaments.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
       const remoteFilamentBySyncId = new Map(remoteFilaments.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
 
-      // Sync filaments with nozzle, printer, and parent reference remapping
+      // Sync filaments with nozzle, printer, parent, and spool-location remapping
       this.updateStatus({ progress: "Syncing filaments..." });
       const filamentTransform = this.buildFilamentRefsTransform(
         localNozzleBySyncId, remoteNozzleBySyncId,
         localPrinterBySyncId, remotePrinterBySyncId,
         localFilamentBySyncId, remoteFilamentBySyncId,
+        localLocationBySyncId, remoteLocationBySyncId,
       );
       const filamentResult = await this.syncCollection(
         localDb, remoteDb, "filaments",
         filamentTransform,
       );
 
-      const results = [nozzleResult, printerResult, filamentResult];
+      const results = [nozzleResult, printerResult, locationResult, filamentResult];
       this.updateStatus({
         state: "idle",
         lastSyncAt: new Date().toISOString(),
@@ -382,6 +401,8 @@ export class SyncService extends EventEmitter {
     remotePrinterBySyncId: Map<string, ObjectId>,
     localFilamentBySyncId: Map<string, ObjectId>,
     remoteFilamentBySyncId: Map<string, ObjectId>,
+    localLocationBySyncId: Map<string, ObjectId>,
+    remoteLocationBySyncId: Map<string, ObjectId>,
   ): (doc: Document, direction: "toLocal" | "toRemote") => Document {
     // Build reverse maps once (source ID → syncId) for both directions
     const buildReverse = (map: Map<string, ObjectId>) => {
@@ -398,12 +419,16 @@ export class SyncService extends EventEmitter {
     const remotePrinterIdToSyncId = buildReverse(remotePrinterBySyncId);
     const localFilamentIdToSyncId = buildReverse(localFilamentBySyncId);
     const remoteFilamentIdToSyncId = buildReverse(remoteFilamentBySyncId);
+    const localLocationIdToSyncId = buildReverse(localLocationBySyncId);
+    const remoteLocationIdToSyncId = buildReverse(remoteLocationBySyncId);
 
     return (doc: Document, direction: "toLocal" | "toRemote"): Document => {
       const sourceNozzleIdToSyncId = direction === "toLocal" ? remoteNozzleIdToSyncId : localNozzleIdToSyncId;
       const targetNozzleMap = direction === "toLocal" ? localNozzleBySyncId : remoteNozzleBySyncId;
       const sourcePrinterIdToSyncId = direction === "toLocal" ? remotePrinterIdToSyncId : localPrinterIdToSyncId;
       const targetPrinterMap = direction === "toLocal" ? localPrinterBySyncId : remotePrinterBySyncId;
+      const sourceLocationIdToSyncId = direction === "toLocal" ? remoteLocationIdToSyncId : localLocationIdToSyncId;
+      const targetLocationMap = direction === "toLocal" ? localLocationBySyncId : remoteLocationBySyncId;
 
       // Remap compatibleNozzles
       if (Array.isArray(doc.compatibleNozzles)) {
@@ -446,6 +471,19 @@ export class SyncService extends EventEmitter {
         const parentSyncId = sourceFilamentIdToSyncId.get(doc.parentId.toString());
         const targetParentId = parentSyncId ? targetFilamentMap.get(parentSyncId) : null;
         doc.parentId = targetParentId || null;
+      }
+
+      // Remap spools[].locationId. Locations sync as their own collection but
+      // the ObjectIds differ across DBs, so each spool's locationId must be
+      // translated through the syncId map. Unknown locations clear to null
+      // rather than pointing at a wrong location on the target side.
+      if (Array.isArray(doc.spools)) {
+        doc.spools = doc.spools.map((spool: Document) => {
+          if (!spool.locationId) return spool;
+          const locSyncId = sourceLocationIdToSyncId.get(spool.locationId.toString());
+          const targetLocationId = locSyncId ? targetLocationMap.get(locSyncId) : null;
+          return { ...spool, locationId: targetLocationId || null };
+        });
       }
 
       return doc;

--- a/tests/sync-service-locations.test.ts
+++ b/tests/sync-service-locations.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, ObjectId } from "mongodb";
+import { SyncService } from "../electron/sync-service";
+
+/**
+ * GH #116 regression guard.
+ *
+ * Before the fix, SyncService only synced nozzles, printers, and filaments.
+ * Locations (added in v1.11) had no syncCollection call, so:
+ *   - A location created on a Docker instance never reached desktop apps
+ *     running in hybrid mode.
+ *   - A location created on a hybrid desktop never reached Atlas (and
+ *     therefore never reached other instances).
+ *   - Filaments did sync, but each spool's locationId was a local ObjectId
+ *     that didn't exist on the target side.
+ *
+ * The fix adds locations as a synced collection AND extends the filament
+ * transform to remap spools[].locationId through the syncId map. These tests
+ * pin both behaviors against two independent in-memory MongoDB instances
+ * standing in for the local and remote databases.
+ */
+describe("SyncService — locations and spool.locationId remap", () => {
+  let localServer: MongoMemoryServer;
+  let remoteServer: MongoMemoryServer;
+  let localClient: MongoClient;
+  let remoteClient: MongoClient;
+  let sync: SyncService;
+
+  beforeAll(async () => {
+    [localServer, remoteServer] = await Promise.all([
+      MongoMemoryServer.create(),
+      MongoMemoryServer.create(),
+    ]);
+    localClient = await new MongoClient(localServer.getUri()).connect();
+    remoteClient = await new MongoClient(remoteServer.getUri()).connect();
+  }, 120_000);
+
+  afterAll(async () => {
+    await Promise.all([
+      localClient?.close().catch(() => {}),
+      remoteClient?.close().catch(() => {}),
+    ]);
+    await Promise.all([
+      localServer?.stop().catch(() => {}),
+      remoteServer?.stop().catch(() => {}),
+    ]);
+  });
+
+  afterEach(async () => {
+    // Reset both databases between tests so syncId state from one test
+    // doesn't bleed into the next.
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+    for (const col of ["locations", "filaments", "nozzles", "printers"]) {
+      await localDb.collection(col).deleteMany({}).catch(() => {});
+      await remoteDb.collection(col).deleteMany({}).catch(() => {});
+    }
+    sync?.destroy();
+  });
+
+  function makeSync() {
+    return new SyncService(localServer.getUri(), remoteServer.getUri());
+  }
+
+  it("pushes a local-only location up to the remote DB", async () => {
+    const localDb = localClient.db("filament-db");
+    await localDb.collection("locations").insertOne({
+      name: "Drybox #1",
+      kind: "drybox",
+      humidity: 18,
+      notes: "",
+      _deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    sync = makeSync();
+    const results = await sync.sync();
+
+    const locationResult = results.find((r) => r.collection === "locations");
+    expect(locationResult).toBeDefined();
+    expect(locationResult?.pushed).toBe(1);
+
+    const remoteDb = remoteClient.db("filament-db");
+    const remoteLocation = await remoteDb.collection("locations").findOne({ name: "Drybox #1" });
+    expect(remoteLocation).not.toBeNull();
+    expect(remoteLocation?.kind).toBe("drybox");
+    // The push assigned a syncId to the source row that should now exist on both sides.
+    expect(remoteLocation?.syncId).toBeTruthy();
+    const localLocation = await localDb.collection("locations").findOne({ name: "Drybox #1" });
+    expect(localLocation?.syncId).toBe(remoteLocation?.syncId);
+  });
+
+  it("pulls a remote-only location down to the local DB", async () => {
+    const remoteDb = remoteClient.db("filament-db");
+    await remoteDb.collection("locations").insertOne({
+      name: "Top shelf",
+      kind: "shelf",
+      humidity: null,
+      notes: "made on Docker",
+      _deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    sync = makeSync();
+    const results = await sync.sync();
+    expect(results.find((r) => r.collection === "locations")?.pulled).toBe(1);
+
+    const localDb = localClient.db("filament-db");
+    const local = await localDb.collection("locations").findOne({ name: "Top shelf" });
+    expect(local).not.toBeNull();
+    expect(local?.notes).toBe("made on Docker");
+  });
+
+  it("remaps spools[].locationId so the reference points at the target DB's location ObjectId", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // Seed the same location on both sides with a shared syncId so the maps
+    // know they're the same row. The two ObjectIds intentionally differ —
+    // that's the whole point of the remap.
+    const sharedSyncId = "loc-shared-syncid";
+    const localLocId = new ObjectId();
+    const remoteLocId = new ObjectId();
+    await localDb.collection("locations").insertOne({
+      _id: localLocId, syncId: sharedSyncId,
+      name: "Cabinet", kind: "cabinet", humidity: null, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+    });
+    await remoteDb.collection("locations").insertOne({
+      _id: remoteLocId, syncId: sharedSyncId,
+      name: "Cabinet", kind: "cabinet", humidity: null, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    // Seed a filament locally whose spool references the *local* location ObjectId.
+    await localDb.collection("filaments").insertOne({
+      name: "Test PLA", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      spools: [
+        { _id: new ObjectId(), label: "Spool A", totalWeight: 1000, locationId: localLocId },
+      ],
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    // After sync the filament should have been pushed and its spool's
+    // locationId rewritten to point at the *remote* location's ObjectId.
+    const remoteFilament = await remoteDb.collection("filaments").findOne({ name: "Test PLA" });
+    expect(remoteFilament).not.toBeNull();
+    expect(remoteFilament?.spools).toHaveLength(1);
+    const remoteSpoolLocId = remoteFilament!.spools[0].locationId;
+    expect(remoteSpoolLocId).toBeInstanceOf(ObjectId);
+    expect(remoteSpoolLocId.toString()).toBe(remoteLocId.toString());
+    expect(remoteSpoolLocId.toString()).not.toBe(localLocId.toString());
+  });
+
+  it("clears spool.locationId to null when the source location doesn't exist on the target (no silent miswiring)", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // A local location that has NO counterpart on the remote (and won't get
+    // synced in the same cycle for this test we soft-delete it so it's
+    // excluded from the syncId map).
+    const orphanLocId = new ObjectId();
+    await localDb.collection("locations").insertOne({
+      _id: orphanLocId, syncId: "orphan-loc",
+      name: "Orphan", kind: "shelf", humidity: null, notes: "",
+      _deletedAt: new Date(), // soft-deleted → excluded from the active-location map
+      createdAt: new Date(), updatedAt: new Date(),
+    });
+    // Also delete-marked on the remote so the deletion stays on both sides.
+    await remoteDb.collection("locations").insertOne({
+      _id: new ObjectId(), syncId: "orphan-loc",
+      name: "Orphan", kind: "shelf", humidity: null, notes: "",
+      _deletedAt: new Date(),
+      createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    await localDb.collection("filaments").insertOne({
+      name: "Filament with orphan loc", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      spools: [
+        { _id: new ObjectId(), label: "Spool", totalWeight: 1000, locationId: orphanLocId },
+      ],
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    const remoteFilament = await remoteDb.collection("filaments").findOne({ name: "Filament with orphan loc" });
+    expect(remoteFilament?.spools[0].locationId).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #116.

## The bug

User on Docker + 2 hybrid-mode Windows desktops, all pointed at the same Atlas DB. Filaments / nozzles / printers all sync. **Locations don't.** Anything created on one instance stays there.

## Root cause

[`electron/sync-service.ts`](electron/sync-service.ts) hardcodes a 3-collection sync — nozzles, printers, filaments. Locations were added in v1.11 (snapshot/restore was updated, the sync engine was missed). With sync silently skipping the collection, hybrid-mode desktops just don't push or pull locations at all.

There's a second, sneakier bug downstream: even if the user manually duplicated a location across DBs, **filament sync would write the wrong locationId on the target side**. Each spool's `locationId` is a local ObjectId; pushing it to Atlas without remapping leaves a dangling reference (or, if location IDs happen to overlap across DBs in some pathological way, points at a different row entirely).

## The fix

Two coordinated changes:

1. **Sync `locations` as its own collection** right after printers, so the syncId→ID maps are ready before the filament transform runs. Same `syncCollection()` machinery already used for nozzles/printers — no new code path, just one more call.
2. **Extend `buildFilamentRefsTransform` to remap `spools[].locationId`** through the same syncId map used for nozzles, printers, and the variant `parentId`. If a spool references a location with no counterpart on the target side, the locationId clears to `null` rather than silently miswiring.

## Tests

New `tests/sync-service-locations.test.ts` spins up two `MongoMemoryServer` instances (true integration test, not a mock) and pins four behaviors:

- A local-only location pushes to remote (the original #116 symptom)
- A remote-only location pulls to local
- After sync, a filament's spool `locationId` matches the **remote** location's ObjectId — not the local one it started with
- A spool referencing a soft-deleted location clears to `null` on the target side rather than dangling

4/4 in the new file pass. Full suite 653/653 (was 651, +2 deltas vs main since this branch doesn't include PR #117's tests). Lint clean.

## Out of scope (follow-up)

`bedtypes`, `printhistory`, and `sharedcatalogs` were added in the same v1.11 wave and have the same gap — the sync service silently skips them too. No user has hit it yet, so I left them for a follow-up rather than expand the diff. Noted in a comment at the top of the sync class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)