### PR TITLE
Sync: reconcile locations by name + repair dangling spool refs (Codex follow-ups to #118)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -163,7 +163,15 @@ export class SyncService extends EventEmitter {
       // Locations are referenced from filaments[].spools[].locationId — a
       // missing remap would either drop the reference or, worse, point at a
       // wrong location on the target DB (GH #116).
+      //
+      // Reconcile by name first: locations existed on both sides before sync
+      // was added (v1.11.3). On the very first sync each side has its own
+      // locally-minted syncId, so a naive push would `insertOne` a row whose
+      // name collides with the partial-unique index on Location and abort
+      // the entire sync cycle. Pairing matching-name rows and unifying their
+      // syncIds turns the duplicates into a no-op last-write-wins merge.
       this.updateStatus({ progress: "Syncing locations..." });
+      await this.reconcileLocationsByName(localDb, remoteDb);
       const locationResult = await this.syncCollection(localDb, remoteDb, "locations");
 
       // Build location syncId→ID maps for spool reference remapping
@@ -171,6 +179,19 @@ export class SyncService extends EventEmitter {
       const remoteLocations = await remoteDb.collection("locations").find({ _deletedAt: null }).toArray();
       const localLocationBySyncId = new Map(localLocations.filter(l => l.syncId).map(l => [l.syncId as string, l._id]));
       const remoteLocationBySyncId = new Map(remoteLocations.filter(l => l.syncId).map(l => [l.syncId as string, l._id]));
+
+      // Repair dangling spool.locationId references left behind by pre-#116
+      // sync cycles. Filaments synced before the locationId remap landed
+      // carry spools[].locationId values that point at the *other side's*
+      // ObjectId (which obviously doesn't exist on this side). The normal
+      // filament sync path can't fix them: those filaments often have equal
+      // updatedAt on both sides, so syncCollection's last-write-wins skip
+      // never re-runs the transform on them. Patch them in-place using the
+      // freshly-built location maps; bumps updatedAt so subsequent syncs
+      // notice the rewrite.
+      await this.repairDanglingSpoolLocations(
+        localDb, remoteDb, localLocationBySyncId, remoteLocationBySyncId,
+      );
 
       // Backfill filament syncIds before building maps (syncCollection does this too, but we need maps first)
       await this.backfillSyncIds(localDb.collection("filaments"));
@@ -356,6 +377,147 @@ export class SyncService extends EventEmitter {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { _id: _stripId, __v: _stripV, ...rest } = doc;
     return rest;
+  }
+
+  /**
+   * Pair locations by name across DBs and unify their syncIds before the
+   * collection sync runs. Without this step the very first sync after the
+   * GH #116 fix lands hits Location's partial unique-name index whenever a
+   * user has independently created the same location ("Drybox #1") on a
+   * desktop and on Docker — both rows have local-only syncIds, so the
+   * insertOne in syncCollection's "local-only" branch raises E11000 and
+   * aborts the whole cycle.
+   *
+   * Tie-break for picking the surviving syncId, in order:
+   *   1. Both already share a syncId → no-op.
+   *   2. Exactly one side has a syncId → propagate to the other.
+   *   3. Neither has a syncId → mint a fresh UUID, assign to both.
+   *   4. Both have syncIds and they differ → keep local's, overwrite remote's.
+   *      (Local wins so the owning desktop's sync history stays intact;
+   *      remote rows get re-keyed onto the local id.)
+   *
+   * Defensive in case 2/4: if the chosen syncId is already in use by a
+   * *different* doc on the target side, skip the pair and log — this
+   * indicates pre-existing corruption that needs human attention rather
+   * than another silent overwrite.
+   */
+  private async reconcileLocationsByName(
+    localDb: ReturnType<MongoClient["db"]>,
+    remoteDb: ReturnType<MongoClient["db"]>,
+  ): Promise<void> {
+    const localCol = localDb.collection("locations");
+    const remoteCol = remoteDb.collection("locations");
+    const localActive = await localCol.find({ _deletedAt: null }).toArray();
+    const remoteActive = await remoteCol.find({ _deletedAt: null }).toArray();
+
+    const remoteByName = new Map(remoteActive.map((d) => [d.name as string, d]));
+
+    for (const local of localActive) {
+      const remote = remoteByName.get(local.name as string);
+      if (!remote) continue;
+
+      const localSyncId = local.syncId as string | undefined;
+      const remoteSyncId = remote.syncId as string | undefined;
+
+      if (localSyncId && remoteSyncId && localSyncId === remoteSyncId) continue;
+
+      const winningSyncId = localSyncId || remoteSyncId || randomUUID();
+
+      if (localSyncId !== winningSyncId) {
+        const conflict = await localCol.findOne({ syncId: winningSyncId, _id: { $ne: local._id } });
+        if (conflict) {
+          console.warn(`reconcileLocationsByName: local syncId conflict for "${local.name}" — skipping`);
+          continue;
+        }
+        await localCol.updateOne({ _id: local._id }, { $set: { syncId: winningSyncId } });
+      }
+      if (remoteSyncId !== winningSyncId) {
+        const conflict = await remoteCol.findOne({ syncId: winningSyncId, _id: { $ne: remote._id } });
+        if (conflict) {
+          console.warn(`reconcileLocationsByName: remote syncId conflict for "${local.name}" — skipping`);
+          continue;
+        }
+        await remoteCol.updateOne({ _id: remote._id }, { $set: { syncId: winningSyncId } });
+      }
+    }
+  }
+
+  /**
+   * Walk both sides' active filaments and patch any spool whose locationId
+   * doesn't match a current location ObjectId on that side.
+   *
+   * Pre-#116 sync cycles copied filaments wholesale across DBs without
+   * remapping spools[].locationId, so a filament on Atlas can be carrying
+   * a desktop-side ObjectId (and vice versa). The normal filament sync
+   * doesn't fix these — both sides have equal updatedAt for those rows,
+   * so syncCollection's last-write-wins skip never re-runs the transform.
+   *
+   * Recovery uses the syncId maps already built from this cycle's location
+   * sync: a dangling id on one side gets looked up via the *other* side's
+   * id→syncId map, then resolved to the correct local id via this side's
+   * syncId→id map. Orphans (id not present on either side) clear to null
+   * rather than persist as a permanent dangling reference.
+   */
+  private async repairDanglingSpoolLocations(
+    localDb: ReturnType<MongoClient["db"]>,
+    remoteDb: ReturnType<MongoClient["db"]>,
+    localLocationBySyncId: Map<string, ObjectId>,
+    remoteLocationBySyncId: Map<string, ObjectId>,
+  ): Promise<void> {
+    const localActiveIds = new Set(Array.from(localLocationBySyncId.values()).map((id) => id.toString()));
+    const remoteActiveIds = new Set(Array.from(remoteLocationBySyncId.values()).map((id) => id.toString()));
+
+    const localIdToSyncId = new Map<string, string>();
+    for (const [syncId, id] of localLocationBySyncId) localIdToSyncId.set(id.toString(), syncId);
+    const remoteIdToSyncId = new Map<string, string>();
+    for (const [syncId, id] of remoteLocationBySyncId) remoteIdToSyncId.set(id.toString(), syncId);
+
+    await this.repairSideSpoolLocations(localDb, localActiveIds, localLocationBySyncId, remoteIdToSyncId, "local");
+    await this.repairSideSpoolLocations(remoteDb, remoteActiveIds, remoteLocationBySyncId, localIdToSyncId, "remote");
+  }
+
+  private async repairSideSpoolLocations(
+    db: ReturnType<MongoClient["db"]>,
+    sideActiveIds: Set<string>,
+    sideSyncIdToId: Map<string, ObjectId>,
+    otherSideIdToSyncId: Map<string, string>,
+    sideLabel: "local" | "remote",
+  ): Promise<void> {
+    const filaments = await db
+      .collection("filaments")
+      .find({ _deletedAt: null, "spools.locationId": { $ne: null } })
+      .toArray();
+
+    let repaired = 0;
+    for (const f of filaments) {
+      const spools: Document[] = Array.isArray(f.spools) ? f.spools : [];
+      let changed = false;
+      const newSpools = spools.map((spool) => {
+        if (!spool.locationId) return spool;
+        const idStr = spool.locationId.toString();
+        if (sideActiveIds.has(idStr)) return spool; // already valid
+
+        const syncId = otherSideIdToSyncId.get(idStr);
+        const correctId = syncId ? sideSyncIdToId.get(syncId) : null;
+        if (!correctId) {
+          changed = true;
+          return { ...spool, locationId: null };
+        }
+        if (correctId.toString() === idStr) return spool;
+        changed = true;
+        return { ...spool, locationId: correctId };
+      });
+      if (changed) {
+        await db.collection("filaments").updateOne(
+          { _id: f._id },
+          { $set: { spools: newSpools, updatedAt: new Date() } },
+        );
+        repaired++;
+      }
+    }
+    if (repaired > 0) {
+      console.log(`repairDanglingSpoolLocations: fixed ${repaired} ${sideLabel} filament(s)`);
+    }
   }
 
   /**

--- a/tests/sync-service-locations.test.ts
+++ b/tests/sync-service-locations.test.ts
@@ -47,6 +47,19 @@ describe("SyncService — locations and spool.locationId remap", () => {
     ]);
   });
 
+  beforeAll(async () => {
+    // Reproduce Mongoose's partial-unique name index on locations so the
+    // duplicate-name reconciliation tests actually exercise the constraint
+    // SyncService is guarding against. Without this, raw insertOne calls
+    // wouldn't trip E11000 even on conflicting names.
+    for (const db of [localClient.db("filament-db"), remoteClient.db("filament-db")]) {
+      await db.collection("locations").createIndex(
+        { name: 1 },
+        { unique: true, partialFilterExpression: { _deletedAt: null } },
+      ).catch(() => {});
+    }
+  }, 120_000);
+
   afterEach(async () => {
     // Reset both databases between tests so syncId state from one test
     // doesn't bleed into the next.
@@ -192,6 +205,151 @@ describe("SyncService — locations and spool.locationId remap", () => {
     await sync.sync();
 
     const remoteFilament = await remoteDb.collection("filaments").findOne({ name: "Filament with orphan loc" });
+    expect(remoteFilament?.spools[0].locationId).toBeNull();
+  });
+
+  // Codex P1 follow-up to PR #118.
+  it("reconciles same-name locations across DBs without tripping the unique-name index", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // Two locally-minted "Drybox #1" rows with different syncIds, exactly the
+    // shape produced when v1.11.2 desktops independently created locations
+    // before sync was added in v1.11.3. A naive insertOne push would throw
+    // E11000 on the partial-unique name index and abort the whole sync cycle.
+    await localDb.collection("locations").insertOne({
+      _id: new ObjectId(), syncId: "local-syncid",
+      name: "Drybox #1", kind: "drybox", humidity: 20, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(Date.now() - 60_000),
+    });
+    await remoteDb.collection("locations").insertOne({
+      _id: new ObjectId(), syncId: "remote-syncid",
+      name: "Drybox #1", kind: "drybox", humidity: 25, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    sync = makeSync();
+    const results = await sync.sync();
+
+    // Sync completes (didn't error) and locations collapsed to one row per side.
+    expect(results.find((r) => r.collection === "locations")).toBeDefined();
+    const localCount = await localDb.collection("locations").countDocuments({ name: "Drybox #1", _deletedAt: null });
+    const remoteCount = await remoteDb.collection("locations").countDocuments({ name: "Drybox #1", _deletedAt: null });
+    expect(localCount).toBe(1);
+    expect(remoteCount).toBe(1);
+
+    // Both sides now share the local syncId (local-wins tie-break).
+    const local = await localDb.collection("locations").findOne({ name: "Drybox #1" });
+    const remote = await remoteDb.collection("locations").findOne({ name: "Drybox #1" });
+    expect(local?.syncId).toBe("local-syncid");
+    expect(remote?.syncId).toBe("local-syncid");
+
+    // Last-write-wins picked the newer (remote) row's payload across the merge.
+    expect(local?.humidity).toBe(25);
+    expect(remote?.humidity).toBe(25);
+  });
+
+  it("reconciles same-name locations when neither side has a syncId yet", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // Pre-sync state: both sides have a "Top shelf" with no syncId field at all
+    // (i.e. created before sync was even thinking about locations).
+    await localDb.collection("locations").insertOne({
+      _id: new ObjectId(),
+      name: "Top shelf", kind: "shelf", humidity: null, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+    });
+    await remoteDb.collection("locations").insertOne({
+      _id: new ObjectId(),
+      name: "Top shelf", kind: "shelf", humidity: null, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    const local = await localDb.collection("locations").findOne({ name: "Top shelf" });
+    const remote = await remoteDb.collection("locations").findOne({ name: "Top shelf" });
+    expect(local?.syncId).toBeTruthy();
+    expect(remote?.syncId).toBeTruthy();
+    expect(local?.syncId).toBe(remote?.syncId); // shared minted UUID
+    // Still one row per side — no duplicate from the push.
+    expect(await localDb.collection("locations").countDocuments({ name: "Top shelf" })).toBe(1);
+    expect(await remoteDb.collection("locations").countDocuments({ name: "Top shelf" })).toBe(1);
+  });
+
+  // Codex P2 follow-up to PR #118.
+  it("repairs filaments left with stale spool.locationId by pre-#116 syncs (equal updatedAt)", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // Same location on both sides, sharing a syncId — i.e. already reconciled.
+    const sharedSyncId = "shared-loc";
+    const localLocId = new ObjectId();
+    const remoteLocId = new ObjectId();
+    const sameTimestamp = new Date();
+    await localDb.collection("locations").insertOne({
+      _id: localLocId, syncId: sharedSyncId,
+      name: "Drybox", kind: "drybox", humidity: null, notes: "",
+      _deletedAt: null, createdAt: sameTimestamp, updatedAt: sameTimestamp,
+    });
+    await remoteDb.collection("locations").insertOne({
+      _id: remoteLocId, syncId: sharedSyncId,
+      name: "Drybox", kind: "drybox", humidity: null, notes: "",
+      _deletedAt: null, createdAt: sameTimestamp, updatedAt: sameTimestamp,
+    });
+
+    // A filament that was synced by the *old* (pre-#116) code: identical
+    // updatedAt on both sides, both pointing the spool at the LOCAL ObjectId.
+    // The remote copy is dangling — that locationId doesn't exist on remote.
+    // The new filament-sync transform won't touch this row because the equal
+    // timestamps short-circuit syncCollection's "no action needed" path.
+    const sharedFilamentSyncId = "shared-filament";
+    await localDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: sharedFilamentSyncId,
+      name: "PLA Black", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: sameTimestamp, updatedAt: sameTimestamp,
+      spools: [{ _id: new ObjectId(), label: "Spool A", totalWeight: 1000, locationId: localLocId }],
+    });
+    await remoteDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: sharedFilamentSyncId,
+      name: "PLA Black", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: sameTimestamp, updatedAt: sameTimestamp,
+      spools: [{ _id: new ObjectId(), label: "Spool A", totalWeight: 1000, locationId: localLocId }],
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    // Remote filament's spool should now point at the REMOTE location id,
+    // not the leftover localLocId. (Local was already correct.)
+    const remoteFilament = await remoteDb.collection("filaments").findOne({ syncId: sharedFilamentSyncId });
+    expect(remoteFilament?.spools[0].locationId.toString()).toBe(remoteLocId.toString());
+    expect(remoteFilament?.spools[0].locationId.toString()).not.toBe(localLocId.toString());
+
+    const localFilament = await localDb.collection("filaments").findOne({ syncId: sharedFilamentSyncId });
+    expect(localFilament?.spools[0].locationId.toString()).toBe(localLocId.toString());
+  });
+
+  it("clears spool.locationId to null when the dangling reference has no syncId match anywhere", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // No locations at all on either side — but a remote filament still
+    // carries an arbitrary locationId from some long-deleted row.
+    const orphanId = new ObjectId();
+    await remoteDb.collection("filaments").insertOne({
+      _id: new ObjectId(),
+      name: "PLA w/ orphan ref", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      spools: [{ _id: new ObjectId(), label: "Spool", totalWeight: 1000, locationId: orphanId }],
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    const remoteFilament = await remoteDb.collection("filaments").findOne({ name: "PLA w/ orphan ref" });
     expect(remoteFilament?.spools[0].locationId).toBeNull();
   });
 });


### PR DESCRIPTION
Two follow-ups to PR #118 caught by Codex review.

## P1 — name-based reconciliation before location sync (blocking)

**Symptom**: anyone with locations created on both Docker and desktop before v1.11.3 — e.g. a "Drybox #1" on each — has two rows with different locally-minted syncIds. PR #118's syncCollection sees no syncId match and tries to \`insertOne\` the local row onto remote. That trips Location's partial-unique name index ([\`src/models/Location.ts\`](src/models/Location.ts)) with E11000, which the catch block in \`sync()\` swallows by aborting the **entire** cycle — taking nozzles, printers, and filaments down with it.

**Fix**: \`reconcileLocationsByName\` runs before \`syncCollection("locations")\`. It pairs active rows by name and unifies syncIds with this tie-break:

1. Both share a syncId → no-op
2. Exactly one has a syncId → propagate to the other
3. Neither has one → mint a UUID, assign to both
4. Both differ → keep local's, overwrite remote's

Defensive in cases 2/4: if the chosen syncId is already in use by a *different* row on the target side, skip and \`console.warn\`. We don't paper over pre-existing corruption with another silent overwrite.

## P2 — repair dangling spool.locationId after sync

**Symptom**: filaments synced **before** #116 (i.e. with the old code that didn't remap \`spools[].locationId\`) carry the *other side's* ObjectId in their spool refs. PR #118's new transform doesn't reach them — \`syncCollection\` skips when local/remote have equal \`updatedAt\`, which is exactly the state every previously-synced filament is in. The bad refs would persist forever without an explicit edit on every affected filament.

**Fix**: \`repairDanglingSpoolLocations\` runs after the location maps are built. For each side, walks active filaments. For each spool whose \`locationId\` doesn't match a current Location ObjectId on that side, looks it up via the *other* side's id→syncId map and rewrites via this side's syncId→id map. Orphans (id not in either map) clear to \`null\`. Bumps \`updatedAt\` on rewrites so subsequent verifications notice them.

## Tests

[\`tests/sync-service-locations.test.ts\`](tests/sync-service-locations.test.ts) gains 4 cases — and now creates the partial-unique name index on the in-memory mongods in \`beforeAll\` so the duplicate-name reconciliation test actually exercises the constraint we're guarding against:

- Same-name reconciliation with differing syncIds → merge succeeds, both sides share local syncId, last-write-wins picks newer payload
- Same-name reconciliation when neither side has a syncId yet → both get the same fresh UUID
- Dangling spool.locationId repair when both filaments share equal updatedAt (the case \`syncCollection\` skips)
- Orphan \`locationId\` with no syncId match anywhere → cleared to null

8/8 in that file, full suite 664/664 (was 660), lint + tsc clean.

## Out of scope

- The same name-collision shape in principle exists for nozzles / printers / bed types (any unique-named, formerly-not-synced collection). Those have always synced, so the only at-risk window was the very first sync after their addition. Skipping for now; if a user reports it, the same \`reconcileXByName\` pattern applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)