### PR TITLE
Sync repair: preserve updatedAt to avoid clobbering newer edits (Codex P1 on #119)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -508,9 +508,17 @@ export class SyncService extends EventEmitter {
         return { ...spool, locationId: correctId };
       });
       if (changed) {
+        // CRITICAL: do NOT bump updatedAt. This repair runs before the
+        // filament-sync last-write-wins comparison; bumping the timestamp
+        // here would make the repaired side look "newest" purely because
+        // we touched it, and a subsequent push could overwrite genuinely
+        // newer edits on the *other* side that haven't synced yet.
+        // Preserving updatedAt lets the existing comparison resolve the
+        // sync correctly: equal timestamps → no action needed (both sides
+        // now consistent), unequal → real edit recency wins.
         await db.collection("filaments").updateOne(
           { _id: f._id },
-          { $set: { spools: newSpools, updatedAt: new Date() } },
+          { $set: { spools: newSpools } },
         );
         repaired++;
       }

--- a/tests/sync-service-locations.test.ts
+++ b/tests/sync-service-locations.test.ts
@@ -333,7 +333,6 @@ describe("SyncService — locations and spool.locationId remap", () => {
   });
 
   it("clears spool.locationId to null when the dangling reference has no syncId match anywhere", async () => {
-    const localDb = localClient.db("filament-db");
     const remoteDb = remoteClient.db("filament-db");
 
     // No locations at all on either side — but a remote filament still
@@ -351,5 +350,70 @@ describe("SyncService — locations and spool.locationId remap", () => {
 
     const remoteFilament = await remoteDb.collection("filaments").findOne({ name: "PLA w/ orphan ref" });
     expect(remoteFilament?.spools[0].locationId).toBeNull();
+  });
+
+  // Codex P1 follow-up to PR #119 — guards against data loss in the repair pass.
+  it("repair pass preserves updatedAt so subsequent filament sync respects real edit recency", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // Reconciled location on both sides (different ObjectIds, shared syncId).
+    const sharedLocSyncId = "shared-loc";
+    const localLocId = new ObjectId();
+    const remoteLocId = new ObjectId();
+    await localDb.collection("locations").insertOne({
+      _id: localLocId, syncId: sharedLocSyncId,
+      name: "Drybox", kind: "drybox", humidity: null, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+    });
+    await remoteDb.collection("locations").insertOne({
+      _id: remoteLocId, syncId: sharedLocSyncId,
+      name: "Drybox", kind: "drybox", humidity: null, notes: "",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+    });
+
+    // Setup: the user just edited filament F on LOCAL (newer updatedAt) — say
+    // they bumped nozzle temp from 215 to 220. Local's spool happens to be
+    // already correct.
+    // REMOTE has the older snapshot of F (nozzle 215) AND a dangling
+    // spool.locationId (carries localLocId from some pre-#116 sync).
+    //
+    // Pre-fix, the repair pass on remote bumped updatedAt to "now" — which
+    // would have made remote *appear* newer than local at the filament-sync
+    // step, pushing the stale nozzle=215 over local's correct nozzle=220.
+    // Test asserts that doesn't happen.
+    const sharedFilamentSyncId = "f-shared";
+    const remoteOlderTime = new Date(Date.now() - 60_000);
+    const localNewerTime = new Date();
+    await localDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: sharedFilamentSyncId,
+      name: "PLA Black", vendor: "Test", type: "PLA",
+      temperatures: { nozzle: 220 }, // user's recent edit
+      _deletedAt: null, createdAt: remoteOlderTime, updatedAt: localNewerTime,
+      spools: [{ _id: new ObjectId(), label: "Spool A", totalWeight: 1000, locationId: localLocId }],
+    });
+    await remoteDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: sharedFilamentSyncId,
+      name: "PLA Black", vendor: "Test", type: "PLA",
+      temperatures: { nozzle: 215 }, // stale value
+      _deletedAt: null, createdAt: remoteOlderTime, updatedAt: remoteOlderTime,
+      // Dangling: points at LOCAL's location ObjectId, which doesn't exist on remote.
+      spools: [{ _id: new ObjectId(), label: "Spool A", totalWeight: 1000, locationId: localLocId }],
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    // Local's newer nozzle temp must win the merge — both sides should now
+    // see 220, NOT remote's stale 215.
+    const localF = await localDb.collection("filaments").findOne({ syncId: sharedFilamentSyncId });
+    const remoteF = await remoteDb.collection("filaments").findOne({ syncId: sharedFilamentSyncId });
+    expect(localF?.temperatures?.nozzle).toBe(220);
+    expect(remoteF?.temperatures?.nozzle).toBe(220);
+
+    // And the spool ref ends up correct on both sides via the filament push
+    // transform (not via the repair, which never touched local at all).
+    expect(localF?.spools[0].locationId.toString()).toBe(localLocId.toString());
+    expect(remoteF?.spools[0].locationId.toString()).toBe(remoteLocId.toString());
   });
 });


### PR DESCRIPTION
Hotfix follow-up to PR [#119](https://github.com/hyiger/filament-db/pull/119) — caught by Codex review on the merged code. **Real data-loss vector.**

## The bug

\`repairDanglingSpoolLocations\` was bumping \`updatedAt: new Date()\` whenever it rewrote a spool's \`locationId\`. That same \`updatedAt\` is the key the very next step — \`syncCollection("filaments")\` — uses for last-write-wins conflict resolution.

Concrete failure:

1. User edits filament F on **local** at T1 (e.g. bumps nozzle temp 215 → 220). \`local.F.updatedAt = T1\`.
2. **Remote** still has the older snapshot of F at T0, AND a dangling \`spool.locationId\` left over from a pre-#116 sync. \`remote.F.updatedAt = T0\`.
3. Sync starts.
4. Repair pass walks remote, finds the dangling spool, rewrites it AND bumps \`remote.F.updatedAt = T2 (now)\`.
5. Filament sync runs: \`T2 > T1\` → "remote is newer, push remote → local."
6. Local's nozzle=220 gets clobbered by remote's stale nozzle=215.

## The fix

One line: drop \`updatedAt: new Date()\` from the repair \`updateOne\`. The engine uses raw \`MongoClient\` (not Mongoose), so timestamp middleware doesn't fire — \`updatedAt\` stays as it was. The subsequent \`syncCollection\` then sees the *real* edit recency, not an artifact of the repair touching the row.

The repair semantics still cover every scenario correctly (equal-timestamp + dangling, dangling-and-older, dangling-and-newer, etc.) — see commit message for the full case analysis.

## Tests

New regression in [\`tests/sync-service-locations.test.ts\`](tests/sync-service-locations.test.ts) pins the exact scenario above:

- Local has correct spool ref + newer nozzle=220
- Remote has dangling spool ref + stale nozzle=215 with older \`updatedAt\`
- After sync, both sides must show nozzle=220 (the real winner) AND have correctly-mapped spool refs

Pre-fix this test would have produced nozzle=215 on both sides (data loss). Post-fix, both converge on 220. 9/9 in that file, full suite 665/665, lint clean.

## Release plan

Will tag v1.11.5 immediately after merge so the auto-updater can push the fix to v1.11.4 installs before anyone hits the data-loss path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)