### PR TITLE
TDS preview: detect frame-blocking, show graceful fallback

### DIFF
--- a/src/app/api/embed-check/route.ts
+++ b/src/app/api/embed-check/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { assertExternalUrl } from "@/lib/externalUrlGuard";
+import { errorResponse, getErrorMessage } from "@/lib/apiErrorHandler";
+
+/**
+ * GET /api/embed-check?url=<https-url>
+ *
+ * Probes a remote URL's response headers to decide whether it can be rendered
+ * inside an <iframe>. Used by the filament detail page so we can show a
+ * graceful fallback instead of a blank embed when the source site sets
+ * `X-Frame-Options: DENY|SAMEORIGIN` or `Content-Security-Policy:
+ * frame-ancestors` directives that would block embedding.
+ *
+ * Response shape:
+ *   { embeddable: boolean, reason?: string, contentType?: string | null }
+ *
+ * SSRF: URL goes through assertExternalUrl (loopback / RFC1918 / metadata IPs
+ * blocked, http(s) only). Same residual-redirect caveat as tdsExtractor.
+ *
+ * Network failures (timeout, DNS, 4xx/5xx) collapse to `embeddable: false`
+ * with an explanatory `reason` rather than a 5xx — the frontend should fall
+ * back to the same "open in new tab" affordance either way, so a single
+ * failure mode keeps the UI simple.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const url = req.nextUrl.searchParams.get("url");
+  if (!url) {
+    return errorResponse("Missing required query parameter: url", 400);
+  }
+
+  try {
+    await assertExternalUrl(url);
+  } catch (err) {
+    return NextResponse.json({ embeddable: false, reason: getErrorMessage(err) });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8_000);
+  try {
+    // Use GET, not HEAD: many servers (Shopify, Cloudflare-fronted sites)
+    // reply to HEAD with stripped headers or 405. We only read headers and
+    // discard the body, but we set a User-Agent so picky CDNs don't gate
+    // us out.
+    const res = await fetch(url, {
+      method: "GET",
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; FilamentDB/1.0)",
+        Accept: "text/html,application/xhtml+xml,application/pdf,*/*",
+      },
+      redirect: "follow",
+    });
+    // Discard body — we only care about headers.
+    res.body?.cancel().catch(() => {});
+
+    if (!res.ok) {
+      return NextResponse.json({
+        embeddable: false,
+        reason: `HTTP ${res.status} ${res.statusText}`,
+        contentType: res.headers.get("content-type") || null,
+      });
+    }
+
+    const xfo = (res.headers.get("x-frame-options") || "").toLowerCase();
+    const csp = (res.headers.get("content-security-policy") || "").toLowerCase();
+
+    const blockedByXfo =
+      xfo.includes("deny") || xfo.includes("sameorigin");
+
+    // CSP frame-ancestors blocks framing when set to anything but '*' or a
+    // host list that includes us. We can't know the rendering origin from
+    // here, so any directive other than '*' is treated as "blocked" — false
+    // positives for permissive CSPs that happen to whitelist our origin are
+    // acceptable: the user still gets the "open in new tab" fallback, which
+    // is the same affordance.
+    const faMatch = csp.match(/frame-ancestors\s+([^;]+)/);
+    const blockedByCsp = faMatch
+      ? !faMatch[1].trim().split(/\s+/).includes("*")
+      : false;
+
+    return NextResponse.json({
+      embeddable: !blockedByXfo && !blockedByCsp,
+      contentType: res.headers.get("content-type") || null,
+      ...(blockedByXfo ? { reason: `X-Frame-Options: ${xfo}` } : {}),
+      ...(blockedByCsp ? { reason: `CSP frame-ancestors: ${faMatch?.[1].trim()}` } : {}),
+    });
+  } catch (err) {
+    return NextResponse.json({
+      embeddable: false,
+      reason: getErrorMessage(err),
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -46,6 +46,16 @@ export default function FilamentDetail() {
   const [filament, setFilament] = useState<Filament | null>(null);
   const [showAllSettings, setShowAllSettings] = useState(false);
   const [showTdsPreview, setShowTdsPreview] = useState(false);
+  /**
+   * Result of /api/embed-check for the current filament's tdsUrl.
+   *  - "idle":     not requested yet (preview hasn't been opened)
+   *  - "checking": probe in flight
+   *  - "allowed":  server says headers permit framing
+   *  - "blocked":  X-Frame-Options or CSP frame-ancestors will refuse
+   *  - "error":    network or guard failure (treat like blocked, fall back)
+   */
+  const [tdsEmbedState, setTdsEmbedState] =
+    useState<"idle" | "checking" | "allowed" | "blocked" | "error">("idle");
   const { isElectron, status: nfcStatus, writing: nfcWriting, writeTag } = useNfcContext();
   const [nfcWriteSuccess, setNfcWriteSuccess] = useState<boolean | null>(null);
   const nfcWriteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -90,6 +100,30 @@ export default function FilamentDetail() {
       .catch(() => {});
     return () => ac.abort();
   }, []);
+
+  // Probe whether the TDS URL allows iframe embedding. Done in a click
+  // handler (not an effect) because the "set state to 'checking' then
+  // fetch" pattern in an effect would re-fire the effect on the very
+  // state change it just made, aborting its own request.
+  // Plain function (no useCallback) so React Compiler can memoize it
+  // — the manual deps would have to spell out `filament` to match the
+  // compiler's inference, which leaks more than we read.
+  const handleToggleTdsPreview = async () => {
+    const next = !showTdsPreview;
+    setShowTdsPreview(next);
+    if (!next) return;
+    if (!filament?.tdsUrl) return;
+    if (tdsEmbedState !== "idle") return; // already checked this session
+    setTdsEmbedState("checking");
+    try {
+      const res = await fetch(`/api/embed-check?url=${encodeURIComponent(filament.tdsUrl)}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: { embeddable: boolean } = await res.json();
+      setTdsEmbedState(data.embeddable ? "allowed" : "blocked");
+    } catch {
+      setTdsEmbedState("error");
+    }
+  };
 
   const handleNfcWrite = async () => {
     if (!filament) return;
@@ -893,7 +927,7 @@ export default function FilamentDetail() {
       {filament.tdsUrl && (
         <div className="mb-6">
           <button
-            onClick={() => setShowTdsPreview(!showTdsPreview)}
+            onClick={handleToggleTdsPreview}
             className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -910,14 +944,55 @@ export default function FilamentDetail() {
             {t("detail.tds.openNewTab")}
           </a>
           {showTdsPreview && (
-            <div className="mt-3 border border-gray-300 dark:border-gray-700 rounded overflow-hidden">
-              <iframe
-                src={filament.tdsUrl}
-                className="w-full bg-white"
-                style={{ height: "80vh" }}
-                title={t("detail.tds.title")}
-                sandbox="allow-same-origin allow-scripts"
-              />
+            <div className="mt-3">
+              {tdsEmbedState === "checking" && (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {t("detail.tds.checking")}
+                </p>
+              )}
+              {tdsEmbedState === "allowed" && (
+                <div className="border border-gray-300 dark:border-gray-700 rounded overflow-hidden">
+                  <iframe
+                    src={filament.tdsUrl}
+                    className="w-full bg-white"
+                    style={{ height: "80vh" }}
+                    title={t("detail.tds.title")}
+                    sandbox="allow-same-origin allow-scripts"
+                  />
+                </div>
+              )}
+              {(tdsEmbedState === "blocked" || tdsEmbedState === "error") && (
+                <div className="border border-amber-300 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-900/10 rounded p-4">
+                  <div className="flex items-start gap-3">
+                    <svg className="w-5 h-5 text-amber-600 dark:text-amber-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                        {tdsEmbedState === "blocked"
+                          ? t("detail.tds.blockedTitle")
+                          : t("detail.tds.errorTitle")}
+                      </p>
+                      <p className="text-sm text-amber-800 dark:text-amber-200/80 mt-1">
+                        {tdsEmbedState === "blocked"
+                          ? t("detail.tds.blockedBody")
+                          : t("detail.tds.errorBody")}
+                      </p>
+                      <a
+                        href={filament.tdsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 mt-3 px-3 py-1.5 text-sm font-medium bg-amber-600 hover:bg-amber-700 text-white rounded"
+                      >
+                        {t("detail.tds.openExternal")}
+                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -711,6 +711,12 @@
   "detail.tds.hide": "Technisches Datenblatt ausblenden",
   "detail.tds.openNewTab": "In neuem Tab öffnen",
   "detail.tds.title": "Technisches Datenblatt",
+  "detail.tds.checking": "Prüfe, ob die Seite Einbettung erlaubt…",
+  "detail.tds.blockedTitle": "Dieser Hersteller blockiert eingebettete Vorschauen",
+  "detail.tds.blockedBody": "Die Website des Herstellers verweigert das Einbetten (X-Frame-Options oder Content-Security-Policy). Öffne das Datenblatt direkt, um es anzusehen.",
+  "detail.tds.errorTitle": "Datenblatt nicht erreichbar",
+  "detail.tds.errorBody": "Die URL konnte nicht geprüft werden. Die Seite ist möglicherweise offline oder hinter einer Firewall. Versuche, sie direkt zu öffnen.",
+  "detail.tds.openExternal": "Datenblatt öffnen",
 
   "detail.settings.show": "Alle PrusaSlicer-Einstellungen anzeigen",
   "detail.settings.hide": "Alle PrusaSlicer-Einstellungen ausblenden",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -711,6 +711,12 @@
   "detail.tds.hide": "Hide Technical Data Sheet",
   "detail.tds.openNewTab": "Open in new tab",
   "detail.tds.title": "Technical Data Sheet",
+  "detail.tds.checking": "Checking whether this site allows embedding…",
+  "detail.tds.blockedTitle": "This vendor blocks in-page previews",
+  "detail.tds.blockedBody": "The vendor's site refuses to be embedded in another page (X-Frame-Options or Content-Security-Policy). Open the data sheet directly to view it.",
+  "detail.tds.errorTitle": "Couldn't reach the data sheet",
+  "detail.tds.errorBody": "We couldn't probe the URL. The site may be offline or behind a firewall. Try opening it directly.",
+  "detail.tds.openExternal": "Open data sheet",
 
   "detail.settings.show": "Show all PrusaSlicer settings",
   "detail.settings.hide": "Hide all PrusaSlicer settings",

--- a/src/lib/externalUrlGuard.ts
+++ b/src/lib/externalUrlGuard.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared SSRF guard for any code path that fetches a user-supplied URL.
+ *
+ * Used by:
+ *   - src/lib/tdsExtractor.ts — TDS document fetcher
+ *   - src/app/api/embed-check/route.ts — iframe-embeddability probe
+ *
+ * Both validate the *initial* URL only. Catching redirect-based SSRF
+ * requires `redirect: "manual"` plus per-hop validation; intentionally
+ * out of scope here to avoid breaking shorteners/CDNs. Callers that
+ * need stronger guarantees should also re-check the response URL after
+ * following redirects.
+ */
+
+import { lookup } from "node:dns/promises";
+
+/**
+ * Block-list for SSRF defence: loopback, RFC1918 private, link-local,
+ * cloud-metadata IPs, multicast, and the IPv6 equivalents. Returns true
+ * when an address must NOT be fetched.
+ *
+ * Conservative on parse failure (treat unparseable as private). Relies on
+ * the OS DNS resolver to expand hostnames; does not attempt to defeat DNS
+ * rebinding, which would require re-resolving and comparing against the
+ * connection's actual peer address.
+ */
+export function isPrivateIp(ip: string): boolean {
+  if (ip.includes(".")) {
+    const parts = ip.split(".").map((n) => Number(n));
+    if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) {
+      return true; // unparseable → block conservatively
+    }
+    const [a, b] = parts;
+    if (a === 0) return true;                              // 0.0.0.0/8
+    if (a === 10) return true;                             // 10.0.0.0/8 (RFC1918)
+    if (a === 127) return true;                            // 127.0.0.0/8 (loopback)
+    if (a === 169 && b === 254) return true;               // 169.254.0.0/16 (link-local + AWS/GCP/Azure metadata)
+    if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12 (RFC1918)
+    if (a === 192 && b === 168) return true;               // 192.168.0.0/16 (RFC1918)
+    if (a === 100 && b >= 64 && b <= 127) return true;     // 100.64.0.0/10 (CG-NAT, RFC6598)
+    if (a >= 224) return true;                             // 224.0.0.0/4 multicast + 240/4 reserved
+    return false;
+  }
+  // IPv6
+  const lc = ip.toLowerCase();
+  if (lc === "::" || lc === "::1") return true;
+  if (lc.startsWith("fe80:")) return true;                 // link-local
+  if (lc.startsWith("fc") || lc.startsWith("fd")) return true; // unique-local fc00::/7
+  if (lc.startsWith("ff")) return true;                    // multicast
+  if (lc.startsWith("::ffff:")) {
+    return isPrivateIp(lc.slice(7)); // IPv4-mapped IPv6 → recurse on the v4 form
+  }
+  return false;
+}
+
+/**
+ * Validate a user-supplied URL for outbound fetch. Throws on:
+ *   - non-http(s) schemes (file:, gopher:, ftp:, …)
+ *   - hostnames that resolve to loopback / private / link-local / metadata IPs
+ *
+ * Returns the parsed URL on success so callers don't need to parse twice.
+ */
+export async function assertExternalUrl(url: string): Promise<URL> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Disallowed URL scheme "${parsed.protocol}" — only http(s) is supported.`);
+  }
+  if (!parsed.hostname) throw new Error("URL has no hostname");
+
+  const looksLikeIp = /^(\d+\.){3}\d+$|^\[?[\da-f:]+\]?$/i.test(parsed.hostname);
+  let ips: string[];
+  if (looksLikeIp) {
+    ips = [parsed.hostname.replace(/^\[|\]$/g, "")];
+  } else {
+    const records = await lookup(parsed.hostname, { all: true }).catch(() => []);
+    if (records.length === 0) {
+      throw new Error(`URL hostname does not resolve: ${parsed.hostname}`);
+    }
+    ips = records.map((r) => r.address);
+  }
+  for (const ip of ips) {
+    if (isPrivateIp(ip)) {
+      throw new Error("URL resolves to a private/internal address — only public hosts are allowed.");
+    }
+  }
+  return parsed;
+}

--- a/src/lib/tdsExtractor.ts
+++ b/src/lib/tdsExtractor.ts
@@ -7,7 +7,7 @@
  * Supported providers: Google Gemini, Anthropic Claude, OpenAI ChatGPT.
  */
 
-import { lookup } from "node:dns/promises";
+import { assertExternalUrl } from "@/lib/externalUrlGuard";
 
 export type AiProvider = "gemini" | "claude" | "openai";
 
@@ -111,88 +111,16 @@ interface TdsContent {
 }
 
 /**
- * Block-list for SSRF defence: loopback, RFC1918 private, link-local, multicast,
- * cloud metadata IPs. Returns true when an address must NOT be fetched.
- *
- * Covers IPv4 dotted quads and the most common IPv6 ranges. Relies on the OS
- * DNS resolver to expand hostnames; does not attempt to defeat DNS rebinding
- * (rechecking after fetch would help against that — see assertExternalUrl
- * caller for residual-risk note).
- */
-function isPrivateIp(ip: string): boolean {
-  if (ip.includes(".")) {
-    const parts = ip.split(".").map((n) => Number(n));
-    if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) {
-      return true; // unparseable → block conservatively
-    }
-    const [a, b] = parts;
-    if (a === 0) return true;                              // 0.0.0.0/8
-    if (a === 10) return true;                             // 10.0.0.0/8 (RFC1918)
-    if (a === 127) return true;                            // 127.0.0.0/8 (loopback)
-    if (a === 169 && b === 254) return true;               // 169.254.0.0/16 (link-local + AWS/GCP/Azure metadata)
-    if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12 (RFC1918)
-    if (a === 192 && b === 168) return true;               // 192.168.0.0/16 (RFC1918)
-    if (a === 100 && b >= 64 && b <= 127) return true;     // 100.64.0.0/10 (CG-NAT, RFC6598)
-    if (a >= 224) return true;                             // 224.0.0.0/4 multicast + 240/4 reserved
-    return false;
-  }
-  // IPv6 — keep this conservative; literal v6 in user URLs is rare.
-  const lc = ip.toLowerCase();
-  if (lc === "::" || lc === "::1") return true;
-  if (lc.startsWith("fe80:")) return true;                 // link-local
-  if (lc.startsWith("fc") || lc.startsWith("fd")) return true; // unique-local fc00::/7
-  if (lc.startsWith("ff")) return true;                    // multicast
-  if (lc.startsWith("::ffff:")) {
-    // IPv4-mapped IPv6 — recurse on the embedded v4 form
-    return isPrivateIp(lc.slice(7));
-  }
-  return false;
-}
-
-/**
- * Pre-flight a user-supplied URL for the TDS fetcher. Throws on:
- *  - non-http(s) schemes (file:, gopher:, ftp:, …)
- *  - hostnames that resolve to loopback / private / link-local / metadata IPs
- *
- * Residual risk: this only validates the *initial* URL. The TDS fetch sets
- * `redirect: "follow"`, so a hostile public host could redirect into private
- * space. Catching that requires `redirect: "manual"` plus per-hop validation;
- * skipped here to avoid breaking legitimate shortener/CDN redirects, with the
- * understanding that the AI-key gate already restricts who can reach this code.
- */
-async function assertExternalUrl(url: string): Promise<void> {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error("Invalid TDS URL");
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`Disallowed URL scheme "${parsed.protocol}" — only http(s) is supported.`);
-  }
-  if (!parsed.hostname) throw new Error("TDS URL has no hostname");
-
-  const looksLikeIp = /^(\d+\.){3}\d+$|^\[?[\da-f:]+\]?$/i.test(parsed.hostname);
-  let ips: string[];
-  if (looksLikeIp) {
-    ips = [parsed.hostname.replace(/^\[|\]$/g, "")];
-  } else {
-    const records = await lookup(parsed.hostname, { all: true }).catch(() => []);
-    if (records.length === 0) {
-      throw new Error(`TDS URL hostname does not resolve: ${parsed.hostname}`);
-    }
-    ips = records.map((r) => r.address);
-  }
-  for (const ip of ips) {
-    if (isPrivateIp(ip)) {
-      throw new Error("TDS URL resolves to a private/internal address — only public hosts are allowed.");
-    }
-  }
-}
-
-/**
  * Fetch TDS content from a URL.
  * Returns the content as either base64 PDF data or plain text.
+ *
+ * Uses the shared SSRF guard from @/lib/externalUrlGuard. Residual risk:
+ * only the *initial* URL is validated. The fetch below sets
+ * `redirect: "follow"`, so a hostile public host could redirect into
+ * private space. Catching that requires `redirect: "manual"` plus per-hop
+ * validation; skipped here to avoid breaking legitimate shortener/CDN
+ * redirects, with the understanding that the AI-key gate already
+ * restricts who can reach this code.
  */
 async function fetchTdsContent(url: string): Promise<TdsContent> {
   await assertExternalUrl(url);

--- a/tests/embed-check-route.test.ts
+++ b/tests/embed-check-route.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock dns.lookup at the module level so the SSRF guard treats public-looking
+// hostnames as actually resolvable without hitting real DNS during tests.
+// Reject paths use literal IPs or non-http schemes that short-circuit before
+// reaching the lookup.
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]),
+}));
+
+describe("/api/embed-check", () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  async function callRoute(url: string | null) {
+    const { GET } = await import("@/app/api/embed-check/route");
+    const target = url == null
+      ? "http://localhost/api/embed-check"
+      : `http://localhost/api/embed-check?url=${encodeURIComponent(url)}`;
+    const res = await GET(new NextRequest(target));
+    return { status: res.status, body: await res.json() };
+  }
+
+  it("returns 400 when url query param is missing", async () => {
+    const { status, body } = await callRoute(null);
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/url/i);
+  });
+
+  it("returns embeddable=false when the SSRF guard rejects loopback URLs", async () => {
+    const { status, body } = await callRoute("http://127.0.0.1/foo");
+    expect(status).toBe(200);
+    expect(body.embeddable).toBe(false);
+    expect(body.reason).toMatch(/private|internal/i);
+  });
+
+  it("returns embeddable=false when the URL scheme isn't http(s)", async () => {
+    const { status, body } = await callRoute("file:///etc/passwd");
+    expect(status).toBe(200);
+    expect(body.embeddable).toBe(false);
+    expect(body.reason).toMatch(/scheme/i);
+  });
+
+  it("flags X-Frame-Options: DENY as not embeddable (Siraya / Shopify pattern)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "x-frame-options": "DENY", "content-type": "text/html" }),
+      body: { cancel: () => Promise.resolve() },
+    }));
+    const { body } = await callRoute("https://siraya.example.com/tds");
+    expect(body.embeddable).toBe(false);
+    expect(body.reason).toMatch(/x-frame-options/i);
+  });
+
+  it("flags X-Frame-Options: SAMEORIGIN as not embeddable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: "OK",
+      headers: new Headers({ "x-frame-options": "SAMEORIGIN" }),
+      body: { cancel: () => Promise.resolve() },
+    }));
+    const { body } = await callRoute("https://example.com/tds");
+    expect(body.embeddable).toBe(false);
+  });
+
+  it("flags CSP frame-ancestors 'none' as not embeddable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: "OK",
+      headers: new Headers({
+        "content-security-policy":
+          "block-all-mixed-content; frame-ancestors 'none'; upgrade-insecure-requests;",
+      }),
+      body: { cancel: () => Promise.resolve() },
+    }));
+    const { body } = await callRoute("https://example.com/tds");
+    expect(body.embeddable).toBe(false);
+    expect(body.reason).toMatch(/frame-ancestors/i);
+  });
+
+  it("returns embeddable=true when neither X-Frame-Options nor CSP block framing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: "OK",
+      headers: new Headers({ "content-type": "application/pdf" }),
+      body: { cancel: () => Promise.resolve() },
+    }));
+    const { body } = await callRoute("https://cdn.example.com/tds.pdf");
+    expect(body.embeddable).toBe(true);
+    expect(body.contentType).toBe("application/pdf");
+    expect(body.reason).toBeUndefined();
+  });
+
+  it("treats CSP frame-ancestors '*' as embeddable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: "OK",
+      headers: new Headers({ "content-security-policy": "frame-ancestors *" }),
+      body: { cancel: () => Promise.resolve() },
+    }));
+    const { body } = await callRoute("https://example.com/tds");
+    expect(body.embeddable).toBe(true);
+  });
+
+  it("returns embeddable=false with HTTP status reason on 404", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false, status: 404, statusText: "Not Found",
+      headers: new Headers(),
+      body: { cancel: () => Promise.resolve() },
+    }));
+    const { body } = await callRoute("https://example.com/missing");
+    expect(body.embeddable).toBe(false);
+    expect(body.reason).toMatch(/404/);
+  });
+
+  it("returns embeddable=false on network failure (treats like blocked, not 5xx)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+    const { status, body } = await callRoute("https://example.com/tds");
+    expect(status).toBe(200); // intentional: frontend handles uniformly
+    expect(body.embeddable).toBe(false);
+    expect(body.reason).toMatch(/ECONNREFUSED/);
+  });
+});


### PR DESCRIPTION
Fixes the blank-iframe bug visible in the user's screenshot for Fibreheart PPA — and any other vendor whose site sets \`X-Frame-Options\` or CSP \`frame-ancestors\` (i.e. most of Shopify / Wix / Squarespace).

## Before / after

**Before**: clicking "View Technical Data Sheet" rendered an iframe pointed at the vendor's URL. If the vendor blocked framing, the browser silently displayed an empty white pane with no indication of what went wrong.

**After**: the toggle now first probes the URL via \`/api/embed-check\`. If the headers permit framing → render the iframe as before. If they don't → render an explanatory fallback with a prominent **"Open data sheet ↗"** button. Network failures collapse to the same fallback.

| State | UI |
|---|---|
| Allowed (e.g. Overture PDFs, no XFO) | iframe renders the PDF inline |
| Blocked (e.g. Polymaker, XFO: SAMEORIGIN) | warning panel + "Open data sheet" button |
| Probe failed | same warning panel, slightly different copy |

Verified end-to-end in dev against both real URLs (screenshots in the related comment thread).

## Implementation

- **\`src/lib/externalUrlGuard.ts\`** (new) — factors the SSRF guard out of \`tdsExtractor\`. Loopback / RFC1918 / link-local / cloud-metadata IPs blocked; http(s) only. Reused by both \`tdsExtractor\` and the new endpoint.
- **\`/api/embed-check?url=...\`** (new) — GET (HEAD is unreliable on Cloudflare/Shopify), reads \`X-Frame-Options\` and \`CSP frame-ancestors\`, collapses HTTP errors and network failures to \`{ embeddable: false, reason }\`. Frontend handles every non-allowed state with the same fallback.
- **Detail page** — adds a \`tdsEmbedState\` machine (\`idle\` / \`checking\` / \`allowed\` / \`blocked\` / \`error\`). Probe runs in the click handler, not a \`useEffect\` — the effect-based version re-fired on the state change it set (deps cycle), aborting its own request. Plain function (no \`useCallback\`) so React Compiler can infer memoization.
- **i18n** — 6 new keys in en + de.

## Tests

[\`tests/embed-check-route.test.ts\`](tests/embed-check-route.test.ts) — 10 tests covering:

- SSRF reject paths (loopback, \`file://\`)
- XFO DENY / SAMEORIGIN
- CSP \`frame-ancestors 'none'\` (and \`*\` as the embeddable case)
- HTTP error → \`embeddable: false\` with status reason
- Network failure → \`embeddable: false\` with error reason (NOT a 5xx — frontend handles uniformly)

Module-level \`dns.lookup\` mock keeps the suite off the network. Existing \`tdsExtractor\` tests (27) still pass against the shared-lib refactor. **Full suite 675/675, lint + tsc clean.**

## Ship plan

Will tag v1.11.6 immediately after merge — minor enhancement, no migration needed, auto-updater will deliver to existing v1.11.5 installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)