### PR TITLE
Light-mode + a11y polish: select-all label, button + sync-pill light variants

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -744,7 +744,7 @@ export default function Home() {
           <div className="relative" ref={importExportRef}>
             <button
               onClick={() => setShowImportExport((s) => !s)}
-              className="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600 text-sm flex items-center gap-1.5"
+              className="px-4 py-2 bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 rounded text-sm flex items-center gap-1.5"
             >
               {t("filaments.importExport")}
               <svg className={`w-3.5 h-3.5 transition-transform ${showImportExport ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -129,8 +129,8 @@ export default function SyncStatusIndicator() {
     return (
       <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs ${
         online
-          ? "bg-green-900/40 text-green-400"
-          : "bg-red-900/40 text-red-400"
+          ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-400"
+          : "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400"
       }`}>
         <span className={`w-1.5 h-1.5 rounded-full ${online ? "bg-green-500" : "bg-red-500"}`} />
         {online ? t("sync.status.connected") : t("sync.status.offline")}
@@ -141,7 +141,7 @@ export default function SyncStatusIndicator() {
   // Electron: offline mode
   if (mode === "offline") {
     return (
-      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-gray-700 text-gray-300">
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
         <span className="w-1.5 h-1.5 rounded-full bg-gray-500" />
         {t("sync.status.local")}
       </span>
@@ -155,8 +155,8 @@ export default function SyncStatusIndicator() {
     return (
       <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs ${
         connected
-          ? "bg-green-900/40 text-green-400"
-          : "bg-amber-900/40 text-amber-400"
+          ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-400"
+          : "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400"
       }`}>
         <span className={`w-1.5 h-1.5 rounded-full ${connected ? "bg-green-500" : "bg-amber-500"}`} />
         {connected ? t("sync.status.connected") : t("sync.status.noConnection")}
@@ -170,41 +170,41 @@ export default function SyncStatusIndicator() {
   const pill = (() => {
     if (!online || isFallback) {
       return {
-        bg: "bg-amber-900/40",
+        bg: "bg-amber-100 dark:bg-amber-900/40",
         dot: "bg-amber-500",
-        text: "text-amber-400",
+        text: "text-amber-800 dark:text-amber-400",
         label: isFallback ? t("sync.status.offlineLocalData") : t("sync.status.offline"),
       };
     }
     switch (status.state) {
       case "syncing":
         return {
-          bg: "bg-blue-900/40",
+          bg: "bg-blue-100 dark:bg-blue-900/40",
           dot: "bg-blue-400 animate-pulse",
-          text: "text-blue-300",
+          text: "text-blue-800 dark:text-blue-300",
           label: status.progress || t("sync.status.syncing"),
         };
       case "error":
         return {
-          bg: "bg-red-900/40",
+          bg: "bg-red-100 dark:bg-red-900/40",
           dot: "bg-red-500",
-          text: "text-red-300",
+          text: "text-red-800 dark:text-red-300",
           label: t("sync.status.syncError"),
         };
       case "idle":
         return {
-          bg: "bg-green-900/40",
+          bg: "bg-green-100 dark:bg-green-900/40",
           dot: "bg-green-500",
-          text: "text-green-400",
+          text: "text-green-800 dark:text-green-400",
           label: status.lastSyncAt
             ? t("sync.status.synced", { time: formatRelativeTime(status.lastSyncAt, t) })
             : t("sync.status.connected"),
         };
       default:
         return {
-          bg: "bg-gray-700",
+          bg: "bg-gray-200 dark:bg-gray-700",
           dot: "bg-gray-500",
-          text: "text-gray-300",
+          text: "text-gray-700 dark:text-gray-300",
           label: t("sync.status.hybrid"),
         };
     }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -51,6 +51,7 @@
   "filaments.stats.byType": "Nach Typ",
   "filaments.stats.byVendor": "Nach Hersteller",
   "filaments.stats.colors": "Farben ({count})",
+  "filaments.bulk.selectAll": "Alle Filamente auswählen",
   "filaments.bulk.selected": "{count} ausgewählt",
   "filaments.bulk.delete": "{count} löschen",
   "filaments.bulk.deleting": "Wird gelöscht…",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -51,6 +51,7 @@
   "filaments.stats.byType": "By Type",
   "filaments.stats.byVendor": "By Vendor",
   "filaments.stats.colors": "Colors ({count})",
+  "filaments.bulk.selectAll": "Select all filaments",
   "filaments.bulk.selected": "{count} selected",
   "filaments.bulk.delete": "Delete {count}",
   "filaments.bulk.deleting": "Deleting...",


### PR DESCRIPTION
Three small fixes from a v1.11.6 smoke test pass.

## Fixes

**#1 — Filaments list: missing \`filaments.bulk.selectAll\` translation.** The "select all" checkbox in the table header has \`aria-label={t("filaments.bulk.selectAll") || "Select all"}\` but the key didn't exist in either \`en.json\` or \`de.json\`. Screen readers were announcing the literal key. Added: "Select all filaments" / "Alle Filamente auswählen".

**#3 — Import / Export button stays dark in light mode.** Trigger button on the filaments list was \`bg-gray-700 text-white hover:bg-gray-600\` with no \`dark:\` prefix, so a user on light mode saw the dark blue-gray button on a white page. Switched to \`bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600\`.

**#4 — SyncStatusIndicator pills wash out in light mode.** Every state (web online/offline, electron offline/atlas/hybrid/syncing/error/idle) used \`bg-X-900/40 text-X-400\` only — bright color-on-dark-color reads fine on a black background and becomes nearly invisible on white. Added \`bg-X-100 text-X-800\` light variants for green/red/amber/blue/gray states; \`dark:\` variants keep the existing tones.

## Not changed

A fourth bug from the smoke report — "Import/Export menu clips off the right edge" — turned out to be a **screenshot rendering artifact** in the preview MCP, not a real layout bug. Verified by checking \`getBoundingClientRect()\` at viewport widths 932 and 1280: \`right-0\` correctly anchors the menu, \`overflowsRight\` is false in both. The original screenshot was rendered at the preview tool's narrower internal resolution (~407px) which doesn't match what users actually see.

## Verification

In dev preview at 1280×800:
- Light mode: Import/Export button is light gray with dark text, "Connected" pill is pale green w/ dark green text — both readable
- Dark mode: identical to before (pill bg `oklab(0.39, ...)` and text `lab(78.5, ...)` unchanged)
- Select-all checkbox now reports `aria-label="Select all filaments"` to assistive tech

Lint + tsc clean. Will tag v1.11.7 immediately after merge so the patch reaches existing v1.11.6 installs via auto-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)