### PR TITLE
embed-check redirect SSRF guard + per-filament TDS state isolation + sticky offset fix

### DIFF
--- a/src/app/api/embed-check/route.ts
+++ b/src/app/api/embed-check/route.ts
@@ -15,41 +15,82 @@ import { errorResponse, getErrorMessage } from "@/lib/apiErrorHandler";
  *   { embeddable: boolean, reason?: string, contentType?: string | null }
  *
  * SSRF: URL goes through assertExternalUrl (loopback / RFC1918 / metadata IPs
- * blocked, http(s) only). Same residual-redirect caveat as tdsExtractor.
+ * blocked, http(s) only). Redirects are followed *manually* with the same
+ * guard re-applied on every hop, so a public host that 30x-redirects to a
+ * private IP is rejected — closes the redirect-based SSRF gap that the
+ * earlier `redirect: "follow"` implementation left open.
  *
  * Network failures (timeout, DNS, 4xx/5xx) collapse to `embeddable: false`
  * with an explanatory `reason` rather than a 5xx — the frontend should fall
  * back to the same "open in new tab" affordance either way, so a single
  * failure mode keeps the UI simple.
  */
+
+/** Cap redirect chains. Real-world TDS hosts rarely chain more than 2-3. */
+const MAX_REDIRECTS = 5;
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const url = req.nextUrl.searchParams.get("url");
   if (!url) {
     return errorResponse("Missing required query parameter: url", 400);
   }
 
-  try {
-    await assertExternalUrl(url);
-  } catch (err) {
-    return NextResponse.json({ embeddable: false, reason: getErrorMessage(err) });
-  }
-
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 8_000);
   try {
-    // Use GET, not HEAD: many servers (Shopify, Cloudflare-fronted sites)
-    // reply to HEAD with stripped headers or 405. We only read headers and
-    // discard the body, but we set a User-Agent so picky CDNs don't gate
-    // us out.
-    const res = await fetch(url, {
-      method: "GET",
-      signal: controller.signal,
-      headers: {
-        "User-Agent": "Mozilla/5.0 (compatible; FilamentDB/1.0)",
-        Accept: "text/html,application/xhtml+xml,application/pdf,*/*",
-      },
-      redirect: "follow",
-    });
+    let currentUrl = url;
+    let res: Response | null = null;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      // Re-validate every hop so a hostile public host can't bounce us into
+      // private space via 30x. assertExternalUrl throws on disallowed
+      // schemes / loopback / RFC1918 / metadata IPs; the outer catch turns
+      // that into embeddable: false.
+      await assertExternalUrl(currentUrl);
+
+      // Use GET, not HEAD: many servers (Shopify, Cloudflare-fronted sites)
+      // reply to HEAD with stripped headers or 405. We only read headers
+      // and discard the body, but a UA helps with picky CDNs.
+      const hopRes = await fetch(currentUrl, {
+        method: "GET",
+        signal: controller.signal,
+        headers: {
+          "User-Agent": "Mozilla/5.0 (compatible; FilamentDB/1.0)",
+          Accept: "text/html,application/xhtml+xml,application/pdf,*/*",
+        },
+        redirect: "manual",
+      });
+
+      // Treat 3xx (except 304) as a redirect we follow ourselves.
+      const isRedirect = hopRes.status >= 300 && hopRes.status < 400 && hopRes.status !== 304;
+      if (!isRedirect) {
+        res = hopRes;
+        break;
+      }
+      const loc = hopRes.headers.get("location");
+      hopRes.body?.cancel().catch(() => {});
+      if (!loc) {
+        // 3xx with no Location header — treat as terminal failure.
+        return NextResponse.json({
+          embeddable: false,
+          reason: `HTTP ${hopRes.status} with no Location header`,
+        });
+      }
+      if (hop === MAX_REDIRECTS) {
+        return NextResponse.json({
+          embeddable: false,
+          reason: `Too many redirects (>${MAX_REDIRECTS})`,
+        });
+      }
+      // Resolve relative redirects against the URL we just fetched.
+      currentUrl = new URL(loc, currentUrl).toString();
+    }
+
+    if (!res) {
+      // Defensive: shouldn't happen because the loop either breaks on a non-
+      // redirect or returns early on too-many-redirects.
+      return NextResponse.json({ embeddable: false, reason: "No final response" });
+    }
+
     // Discard body — we only care about headers.
     res.body?.cancel().catch(() => {});
 

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -45,17 +45,30 @@ export default function FilamentDetail() {
   const params = useParams();
   const [filament, setFilament] = useState<Filament | null>(null);
   const [showAllSettings, setShowAllSettings] = useState(false);
-  const [showTdsPreview, setShowTdsPreview] = useState(false);
   /**
-   * Result of /api/embed-check for the current filament's tdsUrl.
-   *  - "idle":     not requested yet (preview hasn't been opened)
-   *  - "checking": probe in flight
-   *  - "allowed":  server says headers permit framing
-   *  - "blocked":  X-Frame-Options or CSP frame-ancestors will refuse
-   *  - "error":    network or guard failure (treat like blocked, fall back)
+   * Both `previewOpenFor` and `embedCheck` are keyed to the tdsUrl they
+   * apply to. Navigating between filaments (same route, different params)
+   * keeps the component mounted and therefore preserves state — keying on
+   * tdsUrl means the *derived* `showTdsPreview` and `tdsEmbedState` below
+   * naturally reset when the loaded filament changes, instead of leaking a
+   * previous filament's "allowed"/"blocked" verdict to the new one.
+   *
+   * Done as derived state (not useEffect) because React Compiler's lint
+   * rule discourages calling setState inside an effect on a state-dep
+   * cycle — a cascading-render anti-pattern.
    */
-  const [tdsEmbedState, setTdsEmbedState] =
-    useState<"idle" | "checking" | "allowed" | "blocked" | "error">("idle");
+  const [previewOpenFor, setPreviewOpenFor] = useState<string | null>(null);
+  const [embedCheck, setEmbedCheck] = useState<
+    | { tdsUrl: string; state: "checking" | "allowed" | "blocked" | "error" }
+    | null
+  >(null);
+
+  const showTdsPreview =
+    !!filament?.tdsUrl && previewOpenFor === filament.tdsUrl;
+  const tdsEmbedState: "idle" | "checking" | "allowed" | "blocked" | "error" =
+    filament?.tdsUrl && embedCheck?.tdsUrl === filament.tdsUrl
+      ? embedCheck.state
+      : "idle";
   /** ID of the filament whose `name` matches the current filament's
    *  `inherits` field, if any — used to render Inherits-from as a link. */
   const [inheritsTargetId, setInheritsTargetId] = useState<string | null>(null);
@@ -130,19 +143,23 @@ export default function FilamentDetail() {
   // — the manual deps would have to spell out `filament` to match the
   // compiler's inference, which leaks more than we read.
   const handleToggleTdsPreview = async () => {
-    const next = !showTdsPreview;
-    setShowTdsPreview(next);
-    if (!next) return;
     if (!filament?.tdsUrl) return;
-    if (tdsEmbedState !== "idle") return; // already checked this session
-    setTdsEmbedState("checking");
+    const tdsUrl = filament.tdsUrl;
+    if (showTdsPreview) {
+      setPreviewOpenFor(null);
+      return;
+    }
+    setPreviewOpenFor(tdsUrl);
+    // Skip if we already have a verdict for this exact tdsUrl this session.
+    if (embedCheck?.tdsUrl === tdsUrl) return;
+    setEmbedCheck({ tdsUrl, state: "checking" });
     try {
-      const res = await fetch(`/api/embed-check?url=${encodeURIComponent(filament.tdsUrl)}`);
+      const res = await fetch(`/api/embed-check?url=${encodeURIComponent(tdsUrl)}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data: { embeddable: boolean } = await res.json();
-      setTdsEmbedState(data.embeddable ? "allowed" : "blocked");
+      setEmbedCheck({ tdsUrl, state: data.embeddable ? "allowed" : "blocked" });
     } catch {
-      setTdsEmbedState("error");
+      setEmbedCheck({ tdsUrl, state: "error" });
     }
   };
 

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -69,9 +69,17 @@ export default function FilamentDetail() {
     filament?.tdsUrl && embedCheck?.tdsUrl === filament.tdsUrl
       ? embedCheck.state
       : "idle";
-  /** ID of the filament whose `name` matches the current filament's
-   *  `inherits` field, if any — used to render Inherits-from as a link. */
-  const [inheritsTargetId, setInheritsTargetId] = useState<string | null>(null);
+  /** Lookup result for the current filament's `inherits` PrusaSlicer-style
+   *  parent name. Stamped with the inheritsName the lookup was for so a
+   *  filament-prop change can't expose a stale (wrong) target id while the
+   *  next fetch is still in flight — same pattern as embedCheck above. */
+  const [inheritsLookup, setInheritsLookup] = useState<
+    { inheritsName: string; targetId: string | null } | null
+  >(null);
+  const inheritsTargetId =
+    filament?.inherits && inheritsLookup?.inheritsName === filament.inherits
+      ? inheritsLookup.targetId
+      : null;
   const { isElectron, status: nfcStatus, writing: nfcWriting, writeTag } = useNfcContext();
   const [nfcWriteSuccess, setNfcWriteSuccess] = useState<boolean | null>(null);
   const nfcWriteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -118,9 +126,11 @@ export default function FilamentDetail() {
   }, []);
 
   // If this filament has an `inherits` PrusaSlicer-style parent name, look up
-  // whether any filament in the DB matches it exactly so we can render the
-  // line as a clickable link to that filament's detail page. The state stays
-  // null until the fetch resolves; the render falls back to plain text.
+  // whether any filament in the DB matches it exactly. The result is stored
+  // stamped with the inheritsName it was for, and the derived
+  // `inheritsTargetId` above only returns it when the stamp matches the
+  // *current* filament's inherits — so a same-route navigation can't render
+  // a stale link to the previous filament's parent.
   useEffect(() => {
     if (!filament?.inherits) return;
     const inheritsName = filament.inherits;
@@ -129,7 +139,7 @@ export default function FilamentDetail() {
       .then((r) => (r.ok ? r.json() : []))
       .then((rows: { _id: string; name: string }[]) => {
         const match = rows.find((row) => row.name === inheritsName);
-        if (match?._id) setInheritsTargetId(match._id);
+        setInheritsLookup({ inheritsName, targetId: match?._id ?? null });
       })
       .catch(() => {});
     return () => ac.abort();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,11 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  /* Height of the persistent global AppHeader (rendered by app/layout.tsx).
+   * Pages with their own sticky toolbars reference this so they don't slide
+   * under the global header — e.g. `top-[var(--app-header-h)]`. Keep in
+   * sync with AppHeader.tsx's container class (currently `h-12` = 3rem). */
+  --app-header-h: 3rem;
 }
 
 @theme inline {

--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -449,7 +449,7 @@ export default function OpenPrintTagBrowser() {
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       {/* Header */}
-      <div className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 sticky top-0 z-20">
+      <div className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 sticky top-[var(--app-header-h)] z-20">
         <div className="max-w-[1600px] mx-auto px-4 py-3">
           <div className="flex items-center justify-between flex-wrap gap-3">
             <div className="flex items-center gap-3">
@@ -498,7 +498,7 @@ export default function OpenPrintTagBrowser() {
 
       <div className="max-w-[1600px] mx-auto flex">
         {/* Sidebar */}
-        <aside className="w-64 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 h-[calc(100vh-64px)] sticky top-[64px] overflow-y-auto">
+        <aside className="w-64 flex-shrink-0 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 h-[calc(100vh-var(--app-header-h)-64px)] sticky top-[calc(var(--app-header-h)+64px)] overflow-y-auto">
           {/* Search */}
           <div className="p-3 border-b border-gray-200 dark:border-gray-700">
             <input
@@ -624,7 +624,7 @@ export default function OpenPrintTagBrowser() {
         {/* Main content */}
         <main className="flex-1 min-w-0">
           {/* Toolbar */}
-          <div className="px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30 flex items-center justify-between sticky top-[64px] z-10">
+          <div className="px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/30 flex items-center justify-between sticky top-[calc(var(--app-header-h)+64px)] z-10">
             <div className="flex items-center gap-3">
               <label className="flex items-center gap-2 text-sm">
                 <input

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -727,7 +727,7 @@ export default function Home() {
           className="hidden"
         />
       )}
-      <div ref={stickyHeaderRef} className="sticky top-0 z-20 bg-white dark:bg-gray-950 pb-3 -mt-8 pt-8 border-b border-gray-200 dark:border-gray-800 shadow-sm">
+      <div ref={stickyHeaderRef} className="sticky top-[var(--app-header-h)] z-20 bg-white dark:bg-gray-950 pb-3 -mt-8 pt-8 border-b border-gray-200 dark:border-gray-800 shadow-sm">
       <div className="flex items-start justify-between gap-4 mb-6 flex-wrap">
         <div className="min-w-0">
           <div className="flex items-center gap-3 flex-wrap">

--- a/tests/embed-check-route.test.ts
+++ b/tests/embed-check-route.test.ts
@@ -118,4 +118,127 @@ describe("/api/embed-check", () => {
     expect(body.embeddable).toBe(false);
     expect(body.reason).toMatch(/ECONNREFUSED/);
   });
+
+  // Codex P1 follow-up: redirect-based SSRF.
+  describe("redirect handling (manual, per-hop revalidation)", () => {
+    it("rejects a public URL that 302-redirects to a private IP (the SSRF gap)", async () => {
+      // First fetch: public host returns 302 → http://10.0.0.5/secret
+      // The route should re-run assertExternalUrl on the redirect target,
+      // which throws because 10.0.0.5 is RFC1918 — and never issue the
+      // second fetch.
+      const fetchMock = vi.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: "http://10.0.0.5/secret" }),
+          body: { cancel: () => Promise.resolve() },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const { body } = await callRoute("https://attacker.example.com/start");
+      expect(body.embeddable).toBe(false);
+      expect(body.reason).toMatch(/private|internal/i);
+      // Critical: the second fetch (to the private IP) must NOT have happened.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a redirect to the AWS/GCP/Azure metadata IP", async () => {
+      const fetchMock = vi.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: "http://169.254.169.254/latest/meta-data/" }),
+          body: { cancel: () => Promise.resolve() },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const { body } = await callRoute("https://example.com/innocuous");
+      expect(body.embeddable).toBe(false);
+      expect(body.reason).toMatch(/private|internal/i);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a redirect to a non-http(s) scheme (e.g. file://)", async () => {
+      const fetchMock = vi.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: "file:///etc/passwd" }),
+          body: { cancel: () => Promise.resolve() },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const { body } = await callRoute("https://example.com/innocuous");
+      expect(body.embeddable).toBe(false);
+      expect(body.reason).toMatch(/scheme/i);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("follows a public→public redirect chain and inspects the final response's headers", async () => {
+      // 302 → 301 → 200 (with X-Frame-Options: DENY on the final response).
+      // dns.lookup is mocked to return a public IP for any hostname.
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: new Headers({ location: "https://b.example.com/redirected" }),
+          body: { cancel: () => Promise.resolve() },
+        })
+        .mockResolvedValueOnce({
+          status: 301,
+          headers: new Headers({ location: "https://c.example.com/final" }),
+          body: { cancel: () => Promise.resolve() },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: new Headers({ "x-frame-options": "DENY" }),
+          body: { cancel: () => Promise.resolve() },
+        });
+      vi.stubGlobal("fetch", fetchMock);
+      const { body } = await callRoute("https://a.example.com/start");
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(body.embeddable).toBe(false);
+      expect(body.reason).toMatch(/x-frame-options/i);
+    });
+
+    it("resolves a relative Location header against the previous URL", async () => {
+      // First fetch: 302 with Location: "/redirected" (no scheme/host).
+      // Should be resolved against the request URL.
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: new Headers({ location: "/elsewhere" }),
+          body: { cancel: () => Promise.resolve() },
+        })
+        .mockResolvedValueOnce({
+          ok: true, status: 200, statusText: "OK",
+          headers: new Headers(),
+          body: { cancel: () => Promise.resolve() },
+        });
+      vi.stubGlobal("fetch", fetchMock);
+      await callRoute("https://example.com/path/start");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const secondCallUrl = fetchMock.mock.calls[1][0];
+      expect(secondCallUrl).toBe("https://example.com/elsewhere");
+    });
+
+    it("aborts after MAX_REDIRECTS (5) hops", async () => {
+      // Always redirect to the next hop. Should stop after 5 follow attempts
+      // and return embeddable: false with a "too many redirects" reason.
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        const next = url.replace(/\/(\d+)$/, (_, n) => `/${Number(n) + 1}`);
+        return Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: next }),
+          body: { cancel: () => Promise.resolve() },
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const { body } = await callRoute("https://example.com/0");
+      expect(body.embeddable).toBe(false);
+      expect(body.reason).toMatch(/too many redirects/i);
+      // 6 calls = initial + MAX_REDIRECTS (5) follow attempts before bailing.
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    });
+  });
 });


### PR DESCRIPTION
Four follow-ups on the same Codex review thread for v1.11.6 / v1.11.8.

## P1 (security) — manual redirect handling in /api/embed-check

The route validated the *initial* URL with \`assertExternalUrl\` but then fetched with \`redirect: "follow"\`, so a hostile public host could 302 → \`http://10.0.0.5/\` (or 169.254.169.254 metadata) and the unauthenticated probe would happily issue the internal request. **Real SSRF reintroduction.**

Now: \`redirect: "manual"\` with a hand-rolled follow loop (max 5 hops). Every hop re-runs \`assertExternalUrl\` on the new target before fetching, so a redirect into private space throws and short-circuits to \`embeddable: false\` without ever issuing the internal request. Relative \`Location\` headers resolve against the previous URL via \`new URL(loc, prev)\`.

## P2 (correctness) — TDS embed state was leaking between filaments

Both \`showTdsPreview\` and \`tdsEmbedState\` were stored as raw bools/strings with no link to which filament they applied to. Same-route navigation between filaments (the page component stays mounted) meant filament B inherited filament A's "allowed" or "blocked" verdict — showing the fallback panel for an embeddable URL or trying to iframe a blocked one.

Replaced with two key-stamped pieces of state: \`previewOpenFor\` (the tdsUrl the preview was opened on) and \`embedCheck\` (the tdsUrl the verdict applies to plus the verdict). The component derives both \`showTdsPreview\` and \`tdsEmbedState\` from those by comparing to the *current* filament's tdsUrl. Navigation invalidates them implicitly.

## P2 (correctness) — \`inheritsTargetId\` had the same leak

Same pattern: the lookup effect set state on positive matches and never cleared on misses or filament prop change, so filament B could render an "Inherits from" link pointing at filament A's parent. Stamped the lookup as \`{ inheritsName, targetId }\`; the rendered targetId is now derived against the current filament's inherits string.

## P2 (layout) — global AppHeader was hiding existing sticky bars

PR [#123](https://github.com/hyiger/filament-db/pull/123) added a sticky AppHeader (\`h-12\`) at the root layout, but existing pages with their own sticky toolbars still used \`top-0\` / \`top-[64px]\`, so they slid under the new global bar. Introduced \`--app-header-h: 3rem\` in \`globals.css\` and rewrote each affected sticky to reference it:

- home page toolbar → \`top-[var(--app-header-h)]\`
- openprinttag header → \`top-[var(--app-header-h)]\`
- openprinttag sidebar / content toolbar → \`top-[calc(var(--app-header-h)+64px)]\` with sidebar height adjusted to \`h-[calc(100vh-var(--app-header-h)-64px)]\`

If AppHeader's height ever changes, only the CSS var needs updating.

## Tests

[\`tests/embed-check-route.test.ts\`](tests/embed-check-route.test.ts) gains 6 redirect cases:

- 302 to RFC1918 (10.0.0.5) → rejected at hop 2, second fetch never made
- 302 to AWS/GCP/Azure metadata IP (169.254.169.254) → rejected
- 302 to file:// → rejected at scheme check
- public→public→public 3-hop chain → final response's headers used
- relative Location resolves correctly against previous URL
- cycle stopped after MAX_REDIRECTS (5) with explanatory reason

Each "rejected" test asserts the next-hop fetch was NOT made. **16/16 in that file**, full suite **681/681**, lint + tsc clean.

## Verification

- Embed redirect SSRF: covered by tests above
- TDS state isolation: end-to-end in preview, navigated Easy PA (XFO=none) ↔ Polymaker (XFO: SAMEORIGIN) — neither verdict leaked
- Sticky offsets at 1280×800: AppHeader (0–49) → home toolbar (48+); openprinttag stacks AppHeader → opt header (48–117) → sidebar/toolbar (112+) cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)