### PR TITLE
embed-check: ignore stale responses to fix A→B navigation race

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -80,6 +80,14 @@ export default function FilamentDetail() {
     filament?.inherits && inheritsLookup?.inheritsName === filament.inherits
       ? inheritsLookup.targetId
       : null;
+  /**
+   * AbortController for the in-flight embed-check fetch. Lets a new toggle
+   * (e.g. user navigates A→B and opens B's preview before A's probe has
+   * resolved) cancel the previous request and ignore its eventual reply,
+   * so a late-arriving response can't overwrite a newer in-flight or
+   * already-resolved verdict.
+   */
+  const embedCheckAbortRef = useRef<AbortController | null>(null);
   const { isElectron, status: nfcStatus, writing: nfcWriting, writeTag } = useNfcContext();
   const [nfcWriteSuccess, setNfcWriteSuccess] = useState<boolean | null>(null);
   const nfcWriteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -162,13 +170,29 @@ export default function FilamentDetail() {
     setPreviewOpenFor(tdsUrl);
     // Skip if we already have a verdict for this exact tdsUrl this session.
     if (embedCheck?.tdsUrl === tdsUrl) return;
+
+    // Cancel any in-flight probe so a late response from the *previous*
+    // toggle (different filament, different tdsUrl) can't overwrite this
+    // one's verdict and snap the open preview back to "idle".
+    embedCheckAbortRef.current?.abort();
+    const ac = new AbortController();
+    embedCheckAbortRef.current = ac;
+
     setEmbedCheck({ tdsUrl, state: "checking" });
     try {
-      const res = await fetch(`/api/embed-check?url=${encodeURIComponent(tdsUrl)}`);
+      const res = await fetch(`/api/embed-check?url=${encodeURIComponent(tdsUrl)}`, {
+        signal: ac.signal,
+      });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data: { embeddable: boolean } = await res.json();
+      // Defence in depth: even if the abort raced and we read the body,
+      // skip the write if our controller is no longer the latest one.
+      if (embedCheckAbortRef.current !== ac) return;
       setEmbedCheck({ tdsUrl, state: data.embeddable ? "allowed" : "blocked" });
-    } catch {
+    } catch (err) {
+      // Aborted requests are intentional, not errors — just drop them.
+      if ((err as { name?: string })?.name === "AbortError") return;
+      if (embedCheckAbortRef.current !== ac) return;
       setEmbedCheck({ tdsUrl, state: "error" });
     }
   };


### PR DESCRIPTION
Codex P2 follow-up to PR [#124](https://github.com/hyiger/filament-db/pull/124).

## The race

1. User opens TDS preview on filament A → fetch starts
2. User navigates to filament B before A's probe resolves
3. User opens B's preview → fetch starts, \`embedCheck = { B.url, "checking" }\`
4. B's probe resolves → \`embedCheck = { B.url, "allowed"|"blocked" }\`
5. A's probe resolves **later** → \`embedCheck = { A.url, ... }\` ← clobbers B's verdict
6. \`tdsEmbedState\` is derived by matching \`embedCheck.tdsUrl\` to the current filament's tdsUrl. \`A.url ≠ B.url\` → derived = \`"idle"\`
7. The open preview pane renders **blank** (no checking, no iframe, no fallback panel)

PR #124 fixed the *navigation* leak via key-stamping but didn't address out-of-order async resolves stamping the wrong key.

## The fix

Store an \`AbortController\` for the in-flight probe in a ref. Each new toggle aborts the previous request before starting its own. The late response from the previous probe arrives as an \`AbortError\` and falls into a no-op catch branch. Defence in depth: even if the abort races and we read the body anyway, an \`abortRef.current !== ac\` check skips the setState write so a stale verdict can never overwrite a newer one.

## Verification

In dev preview against both real URLs:
- Easy PA (Overture PDF, no XFO) → iframe renders ✓
- Polymaker (XFO: SAMEORIGIN) → blocked panel renders, no Overture iframe leak ✓

Lint + tsc clean. Full suite (run pending) — no test code changed.

## No regression test

The project has no React Testing Library or jsdom setup, so adding one race-specific test would mean introducing a meaningful test-infrastructure dependency for a single test. Skipping for now; the fix is small enough that careful inline comments + manual verification + Codex's continuing review carry the weight. Happy to revisit if more state-related races surface in this component.

## Release plan

Will tag v1.11.10 immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)