### PR TITLE
Fix #128: parent/child links lost on fresh hybrid install

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -216,6 +216,16 @@ export class SyncService extends EventEmitter {
         filamentTransform,
       );
 
+      // Repair filaments whose parentId was dropped (or stale) when the
+      // syncCollection transform ran. The transform builds its target id
+      // map BEFORE the sync inserts — so on a fresh install the local map
+      // is empty and every variant's parentId gets nulled on first pull
+      // (GH #128). Same shape can also happen for any newly-created
+      // parent+variant pair pulled in the same cycle. This pass projects
+      // the truth from the *other* side via syncId maps that are now
+      // built against the post-sync state of both DBs.
+      await this.repairFilamentParentIds(localDb, remoteDb);
+
       const results = [nozzleResult, printerResult, locationResult, filamentResult];
       this.updateStatus({
         state: "idle",
@@ -525,6 +535,109 @@ export class SyncService extends EventEmitter {
     }
     if (repaired > 0) {
       console.log(`repairDanglingSpoolLocations: fixed ${repaired} ${sideLabel} filament(s)`);
+    }
+  }
+
+  /**
+   * Restore filament parentId references that the in-line transform couldn't
+   * resolve when syncCollection ran. The transform builds its target id map
+   * once at sync start — on a fresh install the local map is empty, so when
+   * a variant is pulled, the lookup `localFilamentBySyncId.get(syncId)` for
+   * its parent returns undefined and the variant gets `parentId: null` on
+   * first insert. Subsequent syncs see equal updatedAt and skip the row, so
+   * the wrong null persists forever (GH #128).
+   *
+   * This pass runs AFTER the main filament sync and uses freshly-rebuilt
+   * id maps. It projects the truth from the *other* side via the syncId
+   * map so a fresh install gets the parent links it should have. Conservative:
+   * only writes when current parentId is null-but-should-be-set, OR is set
+   * but dangling (points at a non-existent id on this side). Existing valid
+   * parentIds are left alone — last-write-wins on the next sync handles
+   * intentional user edits.
+   *
+   * Does NOT bump updatedAt — same rationale as repairDanglingSpoolLocations.
+   */
+  private async repairFilamentParentIds(
+    localDb: ReturnType<MongoClient["db"]>,
+    remoteDb: ReturnType<MongoClient["db"]>,
+  ): Promise<void> {
+    const lf = await localDb.collection("filaments").find({}).toArray();
+    const rf = await remoteDb.collection("filaments").find({}).toArray();
+
+    const localBySyncId = new Map<string, Document>();
+    const localIdToSyncId = new Map<string, string>();
+    for (const f of lf) {
+      if (f.syncId) {
+        localBySyncId.set(f.syncId as string, f);
+        localIdToSyncId.set(f._id.toString(), f.syncId as string);
+      }
+    }
+    const remoteBySyncId = new Map<string, Document>();
+    const remoteIdToSyncId = new Map<string, string>();
+    for (const f of rf) {
+      if (f.syncId) {
+        remoteBySyncId.set(f.syncId as string, f);
+        remoteIdToSyncId.set(f._id.toString(), f.syncId as string);
+      }
+    }
+
+    await this.repairSideParentIds(localDb, lf, localBySyncId, remoteBySyncId, remoteIdToSyncId, "local");
+    await this.repairSideParentIds(remoteDb, rf, remoteBySyncId, localBySyncId, localIdToSyncId, "remote");
+  }
+
+  private async repairSideParentIds(
+    db: ReturnType<MongoClient["db"]>,
+    sideFilaments: Document[],
+    sideBySyncId: Map<string, Document>,
+    otherBySyncId: Map<string, Document>,
+    otherIdToSyncId: Map<string, string>,
+    sideLabel: "local" | "remote",
+  ): Promise<void> {
+    const validIds = new Set(sideFilaments.map((f) => f._id.toString()));
+    let fixed = 0;
+
+    for (const f of sideFilaments) {
+      if (!f.syncId) continue;
+
+      const currentParentIdStr: string | null = f.parentId
+        ? f.parentId.toString()
+        : null;
+
+      // What should parentId be on this side, projected from the other side?
+      const counterpart = otherBySyncId.get(f.syncId as string);
+      let expected: ObjectId | null = null;
+      if (counterpart?.parentId) {
+        const parentSyncId = otherIdToSyncId.get(counterpart.parentId.toString());
+        if (parentSyncId) {
+          const sideParent = sideBySyncId.get(parentSyncId);
+          expected = (sideParent?._id as ObjectId | undefined) ?? null;
+        }
+      }
+
+      const isCurrentDangling =
+        currentParentIdStr != null && !validIds.has(currentParentIdStr);
+      const expectedStr = expected ? expected.toString() : null;
+
+      // Conservative: only repair the two clear-bug shapes. Don't touch
+      // valid-but-different parentIds (those are legitimate user edits and
+      // belong to the next last-write-wins cycle).
+      const shouldFix =
+        // Fresh-install null leak: should have a parent, currently null.
+        (currentParentIdStr == null && expected != null) ||
+        // Stale id pointing at nothing on this side.
+        (isCurrentDangling && currentParentIdStr !== expectedStr);
+
+      if (!shouldFix) continue;
+
+      await db.collection("filaments").updateOne(
+        { _id: f._id },
+        { $set: { parentId: expected } },
+      );
+      fixed++;
+    }
+
+    if (fixed > 0) {
+      console.log(`repairFilamentParentIds: fixed ${fixed} ${sideLabel} filament(s)`);
     }
   }
 

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -639,7 +639,7 @@ export default function FilamentDetail() {
         <InfoCard label={t("detail.field.bedFirstLayer")} value={filament.temperatures.bedFirstLayer ? `${filament.temperatures.bedFirstLayer}°C` : "—"} inherited={inherited.has("temperatures.bedFirstLayer")} />
         <InfoCard label={t("detail.field.cost")} value={filament.cost != null ? `${currencySymbol}${filament.cost.toFixed(2)}/kg` : "—"} inherited={inherited.has("cost")} />
         <InfoCard label={t("detail.field.density")} value={filament.density ? `${filament.density.toFixed(2)} g/cm³` : "—"} inherited={inherited.has("density")} />
-        <InfoCard label={t("detail.field.diameter")} value={`${filament.diameter.toFixed(2)} mm`} inherited={inherited.has("diameter")} />
+        <InfoCard label={t("detail.field.diameter")} value={filament.diameter != null ? `${filament.diameter.toFixed(2)} mm` : "—"} inherited={inherited.has("diameter")} />
         <InfoCard label={t("detail.field.maxVolSpeed")} value={filament.maxVolumetricSpeed ? `${filament.maxVolumetricSpeed} mm³/s` : "—"} inherited={inherited.has("maxVolumetricSpeed")} />
       </div>
 

--- a/tests/sync-service-locations.test.ts
+++ b/tests/sync-service-locations.test.ts
@@ -478,6 +478,14 @@ describe("SyncService — locations and spool.locationId remap", () => {
     const localVariantId = new ObjectId();
     const remoteVariantId = new ObjectId();
 
+    // CRITICAL: every row uses the SAME timestamp — corresponding local and
+    // remote rows must have exactly equal updatedAt so syncCollection's
+    // last-write-wins skip fires (no merge), leaving the repair pass as the
+    // ONLY thing that could change parentId. With per-row `new Date()` calls
+    // the timestamps drift by milliseconds and Node 22 was fast enough to
+    // make remote slightly newer, which silently triggered LWW and made the
+    // assertion flap.
+    const sharedTimestamp = new Date();
     for (const [db, parentAId, parentBId, variantId, variantParentId] of [
       [localDb, localParentAId, localParentBId, localVariantId, localParentAId],
       [remoteDb, remoteParentAId, remoteParentBId, remoteVariantId, remoteParentBId],
@@ -485,19 +493,19 @@ describe("SyncService — locations and spool.locationId remap", () => {
       await db.collection("filaments").insertOne({
         _id: parentAId, syncId: parentASyncId,
         name: "Parent A", vendor: "Test", type: "PLA",
-        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+        _deletedAt: null, createdAt: sharedTimestamp, updatedAt: sharedTimestamp,
         parentId: null,
       });
       await db.collection("filaments").insertOne({
         _id: parentBId, syncId: parentBSyncId,
         name: "Parent B", vendor: "Test", type: "PLA",
-        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+        _deletedAt: null, createdAt: sharedTimestamp, updatedAt: sharedTimestamp,
         parentId: null,
       });
       await db.collection("filaments").insertOne({
         _id: variantId, syncId: variantSyncId,
         name: "Variant", vendor: "Test", type: "PLA",
-        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+        _deletedAt: null, createdAt: sharedTimestamp, updatedAt: sharedTimestamp,
         parentId: variantParentId,
       });
     }

--- a/tests/sync-service-locations.test.ts
+++ b/tests/sync-service-locations.test.ts
@@ -416,4 +416,105 @@ describe("SyncService — locations and spool.locationId remap", () => {
     expect(localF?.spools[0].locationId.toString()).toBe(localLocId.toString());
     expect(remoteF?.spools[0].locationId.toString()).toBe(remoteLocId.toString());
   });
+
+  // GH #128 — fresh hybrid install pulled all filaments but lost every
+  // parent/child link. The transform's `localFilamentBySyncId` map was
+  // built before the inserts, so on first sync every variant's parentId
+  // remap returned undefined and got nulled.
+  it("preserves parent/child links when a fresh-install pulls a parent + variant from remote", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // Remote has a parent and a variant referencing it. Local has nothing.
+    const parentRemoteId = new ObjectId();
+    const variantRemoteId = new ObjectId();
+    const parentSyncId = "parent-sync";
+    const variantSyncId = "variant-sync";
+
+    await remoteDb.collection("filaments").insertOne({
+      _id: parentRemoteId, syncId: parentSyncId,
+      name: "Prusament PC Blend", vendor: "Prusament", type: "PC",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      parentId: null,
+    });
+    await remoteDb.collection("filaments").insertOne({
+      _id: variantRemoteId, syncId: variantSyncId,
+      name: "Prusament PC Blend — Galaxy Black", vendor: "Prusament", type: "PC",
+      _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      parentId: parentRemoteId, // <- references remote's parent _id
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    // Both filaments should now exist locally with DIFFERENT _ids than remote
+    // (insertOne mints a fresh _id per side), but the variant's parentId must
+    // still point at the local parent's _id — recovered by the post-sync
+    // repair pass.
+    const localParent = await localDb.collection("filaments").findOne({ syncId: parentSyncId });
+    const localVariant = await localDb.collection("filaments").findOne({ syncId: variantSyncId });
+
+    expect(localParent).not.toBeNull();
+    expect(localVariant).not.toBeNull();
+    expect(localParent!._id.toString()).not.toBe(parentRemoteId.toString()); // sanity: ids differ across DBs
+    expect(localVariant!.parentId).not.toBeNull();
+    expect(localVariant!.parentId.toString()).toBe(localParent!._id.toString());
+  });
+
+  it("does not overwrite a valid parentId that diverges from the remote (last-write-wins owns that)", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    // Two parents, A and B. Local variant points at A, remote variant points at B.
+    // The repair pass should leave local alone — divergence is a real edit and
+    // belongs to syncCollection's last-write-wins comparison, not to repair.
+    const parentASyncId = "parent-a";
+    const parentBSyncId = "parent-b";
+    const variantSyncId = "v-sync";
+    const localParentAId = new ObjectId();
+    const remoteParentAId = new ObjectId();
+    const localParentBId = new ObjectId();
+    const remoteParentBId = new ObjectId();
+    const localVariantId = new ObjectId();
+    const remoteVariantId = new ObjectId();
+
+    for (const [db, parentAId, parentBId, variantId, variantParentId] of [
+      [localDb, localParentAId, localParentBId, localVariantId, localParentAId],
+      [remoteDb, remoteParentAId, remoteParentBId, remoteVariantId, remoteParentBId],
+    ] as const) {
+      await db.collection("filaments").insertOne({
+        _id: parentAId, syncId: parentASyncId,
+        name: "Parent A", vendor: "Test", type: "PLA",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+        parentId: null,
+      });
+      await db.collection("filaments").insertOne({
+        _id: parentBId, syncId: parentBSyncId,
+        name: "Parent B", vendor: "Test", type: "PLA",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+        parentId: null,
+      });
+      await db.collection("filaments").insertOne({
+        _id: variantId, syncId: variantSyncId,
+        name: "Variant", vendor: "Test", type: "PLA",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+        parentId: variantParentId,
+      });
+    }
+
+    sync = makeSync();
+    await sync.sync();
+
+    // After sync, the filament-sync syncCollection or repair shouldn't have
+    // forced local's parentId to point at parentB. Whichever side's
+    // updatedAt is newer wins — the test seeds equal timestamps so neither
+    // wins; both should retain their original (valid) parentIds.
+    const localVariant = await localDb.collection("filaments").findOne({ syncId: variantSyncId });
+    const remoteVariant = await remoteDb.collection("filaments").findOne({ syncId: variantSyncId });
+    // Local variant's parentId resolves through the local map for parent A's syncId.
+    const localParentAFresh = await localDb.collection("filaments").findOne({ syncId: parentASyncId });
+    const remoteParentBFresh = await remoteDb.collection("filaments").findOne({ syncId: parentBSyncId });
+    expect(localVariant!.parentId.toString()).toBe(localParentAFresh!._id.toString());
+    expect(remoteVariant!.parentId.toString()).toBe(remoteParentBFresh!._id.toString());
+  });
 });


### PR DESCRIPTION
Closes #128.

## The bug

Tony reported on a fresh hybrid desktop install: all filaments synced down from Atlas, but every parent/child relationship was lost — variants showed no parent link on the list, the detail page, or the edit form. As a knock-on, child variants without their own diameter then crashed the detail page with `Cannot read properties of null (reading 'toFixed')`.

## Root cause

\`syncCollection\` builds its target id maps **once at sync start** and passes them into the per-doc transform. On a fresh local install \`localFilamentBySyncId\` is empty when sync starts, so when a remote variant is pulled, the transform's parentId remap (\`localFilamentBySyncId.get(parentSyncId)\`) returns \`undefined\` and the variant gets inserted with \`parentId: null\`.

Subsequent syncs see equal \`updatedAt\` on both sides and skip the row entirely, so the wrong null persists forever.

The crash on render is a separate but related issue: \`filament.diameter.toFixed(2)\` was unguarded on the detail page. Variants intentionally have \`diameter: null\` so they inherit from the parent — but with \`parentId\` wrongly null, the resolver can't fill it in and \`.toFixed\` blows up.

## The fix

Two coordinated changes:

1. **New \`repairFilamentParentIds\` post-sync pass** projects the truth from the *other* side via syncId maps that are now built against the post-sync state of both DBs. Conservative — only writes when:
   - current \`parentId\` is null but the counterpart on the other side has a valid one (the v1.12.0 fresh-install bug), or
   - current \`parentId\` points at a non-existent id on this side (corruption recovery).
   Doesn't override valid-but-divergent parentIds — those are real user edits and belong to syncCollection's last-write-wins. Doesn't bump \`updatedAt\` for the same reason as \`repairDanglingSpoolLocations\` (preserve the conflict-resolution timestamp).

2. **Detail-page render hardened**: \`filament.diameter\` now renders \`—\` when null instead of crashing. Other \`.toFixed\` sites on this page were already guarded.

## Tests

[\`tests/sync-service-locations.test.ts\`](tests/sync-service-locations.test.ts) gains two cases:

- **Fresh-install parent + variant**: seed a parent + variant on remote only. After sync, the local variant's \`parentId\` must point at the *local* parent's \`_id\` (different from the remote one) — the bug fix. Pre-fix this came back as null.
- **Conservative no-override**: local variant points at parent A, remote variant points at parent B. After sync the repair pass must not force one side to match the other — divergence belongs to last-write-wins. Both sides retain their original parentIds.

11/11 pass in that file. Will tag v1.12.1 immediately after merge — anyone on a fresh hybrid install needs this fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)