### PR TITLE
Sync repair: gate parentId fix on freshly-inserted (Codex P2 follow-up)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -203,6 +203,19 @@ export class SyncService extends EventEmitter {
       const localFilamentBySyncId = new Map(localFilaments.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
       const remoteFilamentBySyncId = new Map(remoteFilaments.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
 
+      // Snapshot the set of pre-existing filament _ids on each side so the
+      // post-sync repair pass can tell "freshly inserted in this cycle"
+      // from "already existed". The repair pass uses this signal instead
+      // of timestamp guesses — the only safe time to overwrite a null
+      // parentId is when this row was JUST created by the pull (the bug
+      // path) and not edited by the user since (the v1.12.2 follow-up).
+      const localFilamentIdsBeforeSync = new Set(
+        localFilaments.map((f) => f._id.toString()),
+      );
+      const remoteFilamentIdsBeforeSync = new Set(
+        remoteFilaments.map((f) => f._id.toString()),
+      );
+
       // Sync filaments with nozzle, printer, parent, and spool-location remapping
       this.updateStatus({ progress: "Syncing filaments..." });
       const filamentTransform = this.buildFilamentRefsTransform(
@@ -224,7 +237,10 @@ export class SyncService extends EventEmitter {
       // parent+variant pair pulled in the same cycle. This pass projects
       // the truth from the *other* side via syncId maps that are now
       // built against the post-sync state of both DBs.
-      await this.repairFilamentParentIds(localDb, remoteDb);
+      await this.repairFilamentParentIds(
+        localDb, remoteDb,
+        localFilamentIdsBeforeSync, remoteFilamentIdsBeforeSync,
+      );
 
       const results = [nozzleResult, printerResult, locationResult, filamentResult];
       this.updateStatus({
@@ -560,6 +576,8 @@ export class SyncService extends EventEmitter {
   private async repairFilamentParentIds(
     localDb: ReturnType<MongoClient["db"]>,
     remoteDb: ReturnType<MongoClient["db"]>,
+    localIdsBeforeSync: Set<string>,
+    remoteIdsBeforeSync: Set<string>,
   ): Promise<void> {
     const lf = await localDb.collection("filaments").find({}).toArray();
     const rf = await remoteDb.collection("filaments").find({}).toArray();
@@ -581,8 +599,14 @@ export class SyncService extends EventEmitter {
       }
     }
 
-    await this.repairSideParentIds(localDb, lf, localBySyncId, remoteBySyncId, remoteIdToSyncId, "local");
-    await this.repairSideParentIds(remoteDb, rf, remoteBySyncId, localBySyncId, localIdToSyncId, "remote");
+    await this.repairSideParentIds(
+      localDb, lf, localBySyncId, remoteBySyncId, remoteIdToSyncId,
+      localIdsBeforeSync, "local",
+    );
+    await this.repairSideParentIds(
+      remoteDb, rf, remoteBySyncId, localBySyncId, localIdToSyncId,
+      remoteIdsBeforeSync, "remote",
+    );
   }
 
   private async repairSideParentIds(
@@ -591,6 +615,12 @@ export class SyncService extends EventEmitter {
     sideBySyncId: Map<string, Document>,
     otherBySyncId: Map<string, Document>,
     otherIdToSyncId: Map<string, string>,
+    /** Set of _ids that existed on this side BEFORE this sync cycle's
+     * filament step ran. Anything not in this set was just inserted by
+     * the pull and is the only safe target for a null→something repair —
+     * an existing row's null is either user intent or already-correct,
+     * and overriding it would race the user's edits (GH #127 / Codex P2). */
+    idsBeforeSync: Set<string>,
     sideLabel: "local" | "remote",
   ): Promise<void> {
     const validIds = new Set(sideFilaments.map((f) => f._id.toString()));
@@ -617,34 +647,19 @@ export class SyncService extends EventEmitter {
       const isCurrentDangling =
         currentParentIdStr != null && !validIds.has(currentParentIdStr);
       const expectedStr = expected ? expected.toString() : null;
+      const wasFreshlyInserted = !idsBeforeSync.has(f._id.toString());
 
-      // Match local↔remote updatedAt to ms. Equal timestamps mean the row
-      // is "in sync as far as edits go" — no user mutation has happened on
-      // this side since the last sync. A null parentId in that state is
-      // the fresh-install bug; a null parentId where local.updatedAt is
-      // *newer* (Mongoose bumps it on save) is an intentional "make this
-      // standalone" edit, and the repair must NOT undo it.
-      const sideUpdatedAt = f.updatedAt instanceof Date
-        ? f.updatedAt.getTime()
-        : (typeof f.updatedAt === "string" ? Date.parse(f.updatedAt) : NaN);
-      const otherUpdatedAt = counterpart?.updatedAt instanceof Date
-        ? counterpart.updatedAt.getTime()
-        : (typeof counterpart?.updatedAt === "string" ? Date.parse(counterpart.updatedAt) : NaN);
-      const timestampsMatch =
-        Number.isFinite(sideUpdatedAt) && Number.isFinite(otherUpdatedAt) &&
-        sideUpdatedAt === otherUpdatedAt;
-
-      // Conservative: only repair the two clear-bug shapes. Don't touch
-      // valid-but-different parentIds (those are legitimate user edits and
-      // belong to the next last-write-wins cycle).
+      // Conservative: only repair the two clear-bug shapes.
       const shouldFix =
-        // Fresh-install null leak: should have a parent, currently null,
-        // AND timestamps match (so we know this side hasn't been touched
-        // since sync). A null with mismatched timestamps is an intentional
-        // detach (GH #128 follow-up).
-        (currentParentIdStr == null && expected != null && timestampsMatch) ||
+        // Fresh-install null leak: row was just inserted by this sync's
+        // pull, and its parentId came back null because the target id map
+        // was empty when the transform ran. Pre-existing rows with null
+        // parentId are either intentional detaches or already-correct
+        // standalones — leave them to syncCollection's last-write-wins
+        // (Codex P2 on the v1.12.1 repair pass).
+        (currentParentIdStr == null && expected != null && wasFreshlyInserted) ||
         // Stale id pointing at nothing on this side. Always broken state,
-        // repair regardless of timestamp.
+        // repair regardless of when the row was inserted.
         (isCurrentDangling && currentParentIdStr !== expectedStr);
 
       if (!shouldFix) continue;

--- a/tests/sync-service-locations.test.ts
+++ b/tests/sync-service-locations.test.ts
@@ -526,12 +526,12 @@ describe("SyncService — locations and spool.locationId remap", () => {
     expect(remoteVariant!.parentId.toString()).toBe(remoteParentBFresh!._id.toString());
   });
 
-  // Codex P2 follow-up to PR #129. The repair pass used to fire on EVERY
-  // null-parentId-with-non-null-counterpart combination, which would
-  // silently undo a legitimate "detach this variant" edit if both sides
-  // happened to share a timestamp at that moment. The fix gates the
-  // null→something branch on equal updatedAt, so user-initiated detaches
-  // (which Mongoose stamps with a fresher updatedAt) aren't reverted.
+  // Codex P2 follow-up to PR #129 / #130. The repair pass used to fire on
+  // EVERY null-parentId-with-non-null-counterpart combination, which would
+  // silently undo a legitimate "detach this variant" edit. The PR-#130 fix
+  // gated on equal updatedAt; the PR-#131 fix narrowed it further to
+  // "this row was just inserted by THIS sync's pull" — only the pull-path
+  // bug warrants override; pre-existing rows are always user territory.
   it("does not re-attach a deliberately-detached variant when local.updatedAt is newer than remote's", async () => {
     const localDb = localClient.db("filament-db");
     const remoteDb = remoteClient.db("filament-db");
@@ -586,5 +586,61 @@ describe("SyncService — locations and spool.locationId remap", () => {
     const remoteV = await remoteDb.collection("filaments").findOne({ syncId: variantSyncId });
     expect(localV?.parentId).toBeNull();
     expect(remoteV?.parentId).toBeNull();
+  });
+
+  // Same Codex P2 — but the meaner shape: local detached, remote still
+  // attached, equal updatedAt (e.g. a manual DB edit that didn't bump the
+  // timestamp, or two devices that happened to write at the same ms).
+  // The v1.12.2 timestamp guard would still re-attach this; v1.12.3's
+  // freshly-inserted-only guard preserves the local null because the
+  // local row pre-existed this sync cycle.
+  it("does not re-attach a pre-existing variant whose null parentId persists across equal-timestamp sync", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    const parentSyncId = "p-equal";
+    const variantSyncId = "v-equal";
+    const sharedTimestamp = new Date();
+
+    // Seed the same parent + variant on both sides. Local detached the
+    // variant somehow without bumping updatedAt (the edge case Codex
+    // flagged: external script, manual mongo edit, or perfectly-
+    // simultaneous concurrent edit).
+    await localDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: parentSyncId,
+      name: "Parent", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: sharedTimestamp, updatedAt: sharedTimestamp,
+      parentId: null,
+    });
+    await remoteDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: parentSyncId,
+      name: "Parent", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: sharedTimestamp, updatedAt: sharedTimestamp,
+      parentId: null,
+    });
+
+    const remoteParentDoc = await remoteDb.collection("filaments").findOne({ syncId: parentSyncId });
+
+    await localDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: variantSyncId,
+      name: "Variant", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: sharedTimestamp, updatedAt: sharedTimestamp,
+      parentId: null, // detached
+    });
+    await remoteDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: variantSyncId,
+      name: "Variant", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: sharedTimestamp, updatedAt: sharedTimestamp,
+      parentId: remoteParentDoc!._id,
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    // Equal updatedAt across the board → syncCollection's tie skip fires.
+    // The repair pass must respect that and leave local's null alone
+    // because local's variant row pre-existed this sync's pull.
+    const localV = await localDb.collection("filaments").findOne({ syncId: variantSyncId });
+    expect(localV?.parentId).toBeNull();
   });
 });


### PR DESCRIPTION
Tightening the v1.12.2 fix in response to a [Codex P2 follow-up](https://github.com/hyiger/filament-db/pull/130).

## What v1.12.2 did

Gated the null→something branch of \`repairFilamentParentIds\` on \`local.updatedAt === remote.updatedAt\`. Closed the obvious intentional-detach path because Mongoose bumps \`updatedAt\` on save → mismatched timestamps → no repair fires.

## What it left uncovered

A meaner shape: an intentional detach via an external tool that didn't bump \`updatedAt\`, OR two devices writing at the exact same millisecond. In that case \`syncCollection\`'s last-write-wins explicitly does nothing (equal-timestamp tie), but the repair pass would still re-attach — silently overriding the user.

Codex's exact framing: "this bypasses the equal-updatedAt tie behavior in syncCollection and can overwrite intentional 'make standalone' edits."

## The better signal

**Was this row freshly inserted by THIS sync's pull?**

- Snapshot the pre-existing \`_id\` set on each side before the filament \`syncCollection\` call.
- Pass it to the repair pass.
- The null→something branch fires only when the row's \`_id\` is NOT in the pre-sync set — i.e., it was just created by the pull and its null \`parentId\` is a direct symptom of the GH #128 transform-built-empty-maps bug.
- Any pre-existing row's null \`parentId\` is now user territory; last-write-wins handles divergence.

The dangling branch (current id points at nothing on this side) stays unconditional — broken state regardless of when the row appeared.

## Tests

[\`tests/sync-service-locations.test.ts\`](tests/sync-service-locations.test.ts) gains a case where local already has a detached variant with equal \`updatedAt\` to remote's still-attached counterpart. Pre-fix the v1.12.2 guard would have re-attached it; with the fresh-insert guard the local null is preserved and LWW handles propagation. The existing newer-timestamp test still passes (its assertion didn't depend on which guard was active). **13/13 in the file.**

## Release plan

Will tag v1.12.3 immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)