### PR TITLE
Sync repair: widen parentId fix to 'touched this cycle' (Codex P1 on #131)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -203,18 +203,28 @@ export class SyncService extends EventEmitter {
       const localFilamentBySyncId = new Map(localFilaments.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
       const remoteFilamentBySyncId = new Map(remoteFilaments.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
 
-      // Snapshot the set of pre-existing filament _ids on each side so the
-      // post-sync repair pass can tell "freshly inserted in this cycle"
-      // from "already existed". The repair pass uses this signal instead
-      // of timestamp guesses — the only safe time to overwrite a null
-      // parentId is when this row was JUST created by the pull (the bug
-      // path) and not edited by the user since (the v1.12.2 follow-up).
-      const localFilamentIdsBeforeSync = new Set(
-        localFilaments.map((f) => f._id.toString()),
-      );
-      const remoteFilamentIdsBeforeSync = new Set(
-        remoteFilaments.map((f) => f._id.toString()),
-      );
+      // Snapshot each side's pre-existing filaments as `_id → updatedAt(ms)`
+      // so the post-sync repair pass can tell whether THIS sync cycle wrote
+      // each row. Two shapes both qualify as "fair game to repair":
+      //   (a) row not in snapshot at all → freshly inserted by this pull
+      //       (the GH #128 fresh-install shape);
+      //   (b) row in snapshot but updatedAt has changed → rewritten by
+      //       this cycle's syncCollection update (the Codex P1 shape on
+      //       PR #131: pre-existing variant whose parentId got nulled
+      //       because the in-line transform's target map missed the parent
+      //       that's about to be inserted later in the same cycle).
+      // Anything else is a row this sync didn't touch — user territory,
+      // leave alone (Codex P2 on PR #130 / v1.12.1).
+      const localFilamentSnapshot = new Map<string, number | null>();
+      for (const f of localFilaments) {
+        const t = SyncService.readUpdatedAt(f);
+        localFilamentSnapshot.set(f._id.toString(), t ?? null);
+      }
+      const remoteFilamentSnapshot = new Map<string, number | null>();
+      for (const f of remoteFilaments) {
+        const t = SyncService.readUpdatedAt(f);
+        remoteFilamentSnapshot.set(f._id.toString(), t ?? null);
+      }
 
       // Sync filaments with nozzle, printer, parent, and spool-location remapping
       this.updateStatus({ progress: "Syncing filaments..." });
@@ -239,7 +249,7 @@ export class SyncService extends EventEmitter {
       // built against the post-sync state of both DBs.
       await this.repairFilamentParentIds(
         localDb, remoteDb,
-        localFilamentIdsBeforeSync, remoteFilamentIdsBeforeSync,
+        localFilamentSnapshot, remoteFilamentSnapshot,
       );
 
       const results = [nozzleResult, printerResult, locationResult, filamentResult];
@@ -576,8 +586,8 @@ export class SyncService extends EventEmitter {
   private async repairFilamentParentIds(
     localDb: ReturnType<MongoClient["db"]>,
     remoteDb: ReturnType<MongoClient["db"]>,
-    localIdsBeforeSync: Set<string>,
-    remoteIdsBeforeSync: Set<string>,
+    localSnapshot: Map<string, number | null>,
+    remoteSnapshot: Map<string, number | null>,
   ): Promise<void> {
     const lf = await localDb.collection("filaments").find({}).toArray();
     const rf = await remoteDb.collection("filaments").find({}).toArray();
@@ -601,11 +611,11 @@ export class SyncService extends EventEmitter {
 
     await this.repairSideParentIds(
       localDb, lf, localBySyncId, remoteBySyncId, remoteIdToSyncId,
-      localIdsBeforeSync, "local",
+      localSnapshot, "local",
     );
     await this.repairSideParentIds(
       remoteDb, rf, remoteBySyncId, localBySyncId, localIdToSyncId,
-      remoteIdsBeforeSync, "remote",
+      remoteSnapshot, "remote",
     );
   }
 
@@ -615,12 +625,12 @@ export class SyncService extends EventEmitter {
     sideBySyncId: Map<string, Document>,
     otherBySyncId: Map<string, Document>,
     otherIdToSyncId: Map<string, string>,
-    /** Set of _ids that existed on this side BEFORE this sync cycle's
-     * filament step ran. Anything not in this set was just inserted by
-     * the pull and is the only safe target for a null→something repair —
-     * an existing row's null is either user intent or already-correct,
-     * and overriding it would race the user's edits (GH #127 / Codex P2). */
-    idsBeforeSync: Set<string>,
+    /** Pre-sync snapshot of this side's filaments: `_id → updatedAt(ms)`,
+     * or null when the row had no recorded updatedAt. The repair only
+     * overrides null→expected for rows this cycle actually touched
+     * (inserted, or whose updatedAt changed). Untouched rows are user
+     * territory — last-write-wins handles real edits on the next pass. */
+    snapshot: Map<string, number | null>,
     sideLabel: "local" | "remote",
   ): Promise<void> {
     const validIds = new Set(sideFilaments.map((f) => f._id.toString()));
@@ -647,17 +657,38 @@ export class SyncService extends EventEmitter {
       const isCurrentDangling =
         currentParentIdStr != null && !validIds.has(currentParentIdStr);
       const expectedStr = expected ? expected.toString() : null;
-      const wasFreshlyInserted = !idsBeforeSync.has(f._id.toString());
+
+      // Was this row inserted OR rewritten by THIS sync cycle? If yes,
+      // the parentId we see now came from the just-run transform — fair
+      // game to repair against the freshly-built syncId maps. If no,
+      // leave it alone (intentional detach, or already-correct).
+      const id = f._id.toString();
+      const snapshotUpdatedAt = snapshot.get(id);
+      let wasTouchedThisCycle: boolean;
+      if (snapshotUpdatedAt === undefined) {
+        // Not in snapshot at all → freshly inserted by this sync's pull
+        // (GH #128 fresh-install shape).
+        wasTouchedThisCycle = true;
+      } else if (snapshotUpdatedAt === null) {
+        // Pre-existing but no recorded updatedAt — can't prove it changed.
+        // Default to "untouched" so we don't override potentially-intentional state.
+        wasTouchedThisCycle = false;
+      } else {
+        // Pre-existing with a known timestamp: compare against current.
+        // syncCollection's update propagates the source updatedAt, so a
+        // sync rewrite shows up as a value change here.
+        const currentUpdatedAt = SyncService.readUpdatedAt(f);
+        wasTouchedThisCycle =
+          currentUpdatedAt !== undefined && currentUpdatedAt !== snapshotUpdatedAt;
+      }
 
       // Conservative: only repair the two clear-bug shapes.
       const shouldFix =
-        // Fresh-install null leak: row was just inserted by this sync's
-        // pull, and its parentId came back null because the target id map
-        // was empty when the transform ran. Pre-existing rows with null
-        // parentId are either intentional detaches or already-correct
-        // standalones — leave them to syncCollection's last-write-wins
-        // (Codex P2 on the v1.12.1 repair pass).
-        (currentParentIdStr == null && expected != null && wasFreshlyInserted) ||
+        // Null parentId where projection says it should be set, and this
+        // row was created or rewritten by this cycle. Covers both the
+        // fresh-install pull (#128) and the pre-existing-variant-updated
+        // -before-its-parent shape (Codex P1 on PR #131).
+        (currentParentIdStr == null && expected != null && wasTouchedThisCycle) ||
         // Stale id pointing at nothing on this side. Always broken state,
         // repair regardless of when the row was inserted.
         (isCurrentDangling && currentParentIdStr !== expectedStr);
@@ -674,6 +705,22 @@ export class SyncService extends EventEmitter {
     if (fixed > 0) {
       console.log(`repairFilamentParentIds: fixed ${fixed} ${sideLabel} filament(s)`);
     }
+  }
+
+  /** Best-effort millisecond conversion of a Mongo `updatedAt` field.
+   * Mongoose schemas in this codebase always set Dates, but raw mongo
+   * inserts can store strings — handle both, and return undefined for
+   * anything we can't read. */
+  private static readUpdatedAt(doc: Document): number | undefined {
+    const u = doc.updatedAt;
+    if (!u) return undefined;
+    if (u instanceof Date) return u.getTime();
+    if (typeof u === "string") {
+      const t = Date.parse(u);
+      return Number.isNaN(t) ? undefined : t;
+    }
+    if (typeof u === "number") return u;
+    return undefined;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.12.3",
+      "version": "1.12.4",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",
@@ -798,7 +798,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1642,7 +1641,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1665,7 +1663,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1688,7 +1685,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1705,7 +1701,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1722,7 +1717,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1739,7 +1733,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1756,7 +1749,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1773,7 +1765,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1790,7 +1781,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1807,7 +1797,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1824,7 +1813,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1841,7 +1829,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1858,7 +1845,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1881,7 +1867,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1904,7 +1889,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1927,7 +1911,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1950,7 +1933,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1973,7 +1955,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1996,7 +1977,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2019,7 +1999,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2042,7 +2021,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2062,7 +2040,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2082,7 +2059,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2102,7 +2078,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/tests/sync-service-locations.test.ts
+++ b/tests/sync-service-locations.test.ts
@@ -588,6 +588,66 @@ describe("SyncService — locations and spool.locationId remap", () => {
     expect(remoteV?.parentId).toBeNull();
   });
 
+  // Codex P1 follow-up to PR #131. v1.12.3's freshly-inserted-only guard
+  // missed a real shape: pre-existing local variant pulls a NEWER copy
+  // from remote, syncCollection updates it before the parent (which only
+  // exists on remote) gets inserted, and the in-line transform's stale
+  // local target map yields parentId=null. Repair must fire because this
+  // sync cycle just rewrote the row — the null came from sync code, not
+  // user intent. v1.12.4 widens the gate to "touched this cycle" by
+  // comparing updatedAt against a pre-sync snapshot.
+  it("re-attaches a pre-existing variant whose remote update nulled parentId because the local target map missed the parent", async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+
+    const parentSyncId = "p-late-arrival";
+    const variantSyncId = "v-late-arrival";
+
+    // Local has a STANDALONE variant pre-existing (no parent locally yet).
+    // Remote has a NEWER variant attached to a parent that local lacks.
+    // syncCollection iterates an unordered Set — variant can be processed
+    // before the parent gets inserted on local. The transform looks up
+    // the parent's syncId in the localFilamentBySyncId map (built BEFORE
+    // the inserts), gets undefined, and writes parentId=null.
+    const oldLocalTime = new Date(Date.now() - 60_000);
+    const newRemoteTime = new Date();
+
+    await localDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: variantSyncId,
+      name: "Variant", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: oldLocalTime, updatedAt: oldLocalTime,
+      parentId: null, // standalone locally before sync runs
+    });
+    const remoteParentId = new ObjectId();
+    await remoteDb.collection("filaments").insertOne({
+      _id: remoteParentId, syncId: parentSyncId,
+      name: "Parent", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: newRemoteTime, updatedAt: newRemoteTime,
+      parentId: null,
+    });
+    await remoteDb.collection("filaments").insertOne({
+      _id: new ObjectId(), syncId: variantSyncId,
+      name: "Variant", vendor: "Test", type: "PLA",
+      _deletedAt: null, createdAt: newRemoteTime, updatedAt: newRemoteTime,
+      parentId: remoteParentId,
+    });
+
+    sync = makeSync();
+    await sync.sync();
+
+    const localParent = await localDb.collection("filaments").findOne({ syncId: parentSyncId });
+    const localVariant = await localDb.collection("filaments").findOne({ syncId: variantSyncId });
+
+    expect(localParent).not.toBeNull();
+    expect(localVariant).not.toBeNull();
+    // Repair must restore the parent link even though local's variant
+    // pre-existed this cycle — its updatedAt changed to remote's value
+    // when syncCollection's last-write-wins push fired, so the touched-
+    // this-cycle gate identifies it as a sync-rewritten row.
+    expect(localVariant!.parentId).not.toBeNull();
+    expect(localVariant!.parentId.toString()).toBe(localParent!._id.toString());
+  });
+
   // Same Codex P2 — but the meaner shape: local detached, remote still
   // attached, equal updatedAt (e.g. a manual DB edit that didn't bump the
   // timestamp, or two devices that happened to write at the same ms).


### PR DESCRIPTION
## Summary

- Replaces v1.12.3's freshly-inserted-only repair gate with a "touched this cycle" check that catches both inserted **and** updated rows.
- Snapshot widens from `Set<_id>` to `Map<_id, updatedAt(ms)>` so the repair pass can compare per-row updatedAt before/after sync.
- Adds regression test for the pre-existing-variant-updated-by-sync shape Codex flagged.

## Why

Codex's P1 review on PR #131 surfaced a concrete shape the freshly-inserted gate missed:

> Local already has variant `v`, remote has newer `v` attached to parent `p`, and local lacks `p`; syncCollection can update `v` before `p` is inserted (iteration is over prebuilt syncId sets), so `v.parentId` becomes null. With this condition, repair skips it forever because `v` existed pre-sync, leaving a persistent divergence that last-write-wins will not resolve on equal timestamps.

The new gate detects this because the variant's `updatedAt` changes (gets bumped to remote's value when LWW pushes the newer copy down). Untouched pre-existing rows (where `updatedAt` is unchanged from the snapshot) remain user territory — the Codex P2 on PR #130 still holds.

## Test plan

- [x] `npx vitest run tests/sync-service-locations.test.ts` — 14 tests pass (was 13; +1 new regression test)
- [x] `npm test` — full suite green (686 tests, 38 files)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)