### PR TITLE
Fix #133: dashboard dry-cycle list respects inherited drying temp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -6,6 +6,7 @@ import Printer from "@/models/Printer";
 import BedType from "@/models/BedType";
 import PrintHistory from "@/models/PrintHistory";
 import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { resolveFilament } from "@/lib/resolveFilament";
 
 /**
  * GET /api/dashboard — aggregate summary for the dashboard page.
@@ -78,8 +79,15 @@ export async function GET() {
       }
     }
 
-    // Spools due for a dry cycle — no dry cycle in the last 30 days and
-    // filament.dryingTemperature set (only materials that need drying).
+    // Spools due for a dry cycle — no dry cycle in the last 30 days and the
+    // filament needs drying. A variant with no own dryingTemperature must
+    // inherit from its parent; pre-v1.12.5 this branch only checked the
+    // variant's own field, so child filaments with inherited drying values
+    // were silently skipped (GH #133).
+    const parentMap = new Map<string, (typeof filaments)[number]>();
+    for (const f of filaments) {
+      if (!f.parentId) parentMap.set(f._id.toString(), f);
+    }
     const now = Date.now();
     const dryThresholdMs = 30 * 24 * 60 * 60 * 1000;
     const dryDue: {
@@ -90,7 +98,10 @@ export async function GET() {
       lastDried: string | null;
     }[] = [];
     for (const f of filaments) {
-      if (typeof f.dryingTemperature !== "number") continue;
+      const resolved = f.parentId
+        ? resolveFilament(f, parentMap.get(f.parentId.toString()))
+        : f;
+      if (typeof resolved.dryingTemperature !== "number") continue;
       for (const s of f.spools || []) {
         if (s.retired) continue;
         const cycles = s.dryCycles || [];

--- a/tests/dashboard-route.test.ts
+++ b/tests/dashboard-route.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { GET as getDashboard } from "@/app/api/dashboard/route";
+
+/**
+ * GH #133 regression guard.
+ *
+ * The dashboard's "Dry Cycle Due" list filters spools by whether their
+ * filament has a `dryingTemperature` set. Before v1.12.5, that check
+ * looked only at the variant's own field — so a child filament that
+ * inherited drying values from its parent never appeared in the list,
+ * even with a brand-new (never-dried) spool. The fix resolves the
+ * inherited value via `resolveFilament` before the gate.
+ */
+describe("/api/dashboard — dry-cycle inheritance", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    // Re-register models after setup.ts's afterEach wipes mongoose.models.
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  it("includes a never-dried spool whose filament inherits dryingTemperature from its parent (GH #133)", async () => {
+    const parent = await Filament.create({
+      name: "Generic PETG",
+      vendor: "Test",
+      type: "PETG",
+      dryingTemperature: 60,
+      dryingTime: 360,
+    });
+    const variant = await Filament.create({
+      name: "Generic PETG — Forest Green",
+      vendor: "Test",
+      type: "PETG",
+      parentId: parent._id,
+      // No dryingTemperature / dryingTime — must inherit from parent.
+      spools: [{ label: "Spool A", totalWeight: 1000 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+
+    const variantSpoolIds = (body.dryDue as { filamentId: string; spoolId: string }[])
+      .filter((d) => d.filamentId === String(variant._id))
+      .map((d) => d.spoolId);
+    expect(variantSpoolIds).toHaveLength(1);
+    expect(variantSpoolIds[0]).toBe(String(variant.spools[0]._id));
+  });
+
+  it("includes a never-dried spool on a standalone filament with its own dryingTemperature (positive baseline)", async () => {
+    const f = await Filament.create({
+      name: "Standalone PETG",
+      vendor: "Test",
+      type: "PETG",
+      dryingTemperature: 60,
+      dryingTime: 360,
+      spools: [{ label: "Spool", totalWeight: 1000 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+
+    const ids = (body.dryDue as { filamentId: string }[])
+      .map((d) => d.filamentId);
+    expect(ids).toContain(String(f._id));
+  });
+
+  it("excludes spools whose filament has no dryingTemperature (own or inherited)", async () => {
+    const f = await Filament.create({
+      name: "Plain PLA",
+      vendor: "Test",
+      type: "PLA",
+      // No dryingTemperature anywhere.
+      spools: [{ label: "Spool", totalWeight: 1000 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+
+    const ids = (body.dryDue as { filamentId: string }[])
+      .map((d) => d.filamentId);
+    expect(ids).not.toContain(String(f._id));
+  });
+
+  it("excludes a spool dried within the 30-day threshold even when the filament inherits drying temp", async () => {
+    const parent = await Filament.create({
+      name: "Generic PA-CF",
+      vendor: "Test",
+      type: "PA",
+      dryingTemperature: 80,
+      dryingTime: 480,
+    });
+    const variant = await Filament.create({
+      name: "Generic PA-CF — Black",
+      vendor: "Test",
+      type: "PA",
+      parentId: parent._id,
+      spools: [
+        {
+          label: "Recently dried",
+          totalWeight: 1000,
+          dryCycles: [
+            { date: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), tempC: 80, durationMin: 480, notes: "" },
+          ],
+        },
+      ],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+
+    const ids = (body.dryDue as { filamentId: string }[])
+      .map((d) => d.filamentId);
+    expect(ids).not.toContain(String(variant._id));
+  });
+});


### PR DESCRIPTION
Fixes #133.

## Summary

- The Dashboard "Dry Cycle Due" filter was checking the variant's own `dryingTemperature` field instead of the resolved (inherited) value. Child filaments with a parent's drying values silently dropped from the list, even when their spools had never been dried.
- Wire the existing `resolveFilament()` helper into the filter so inheritance applies — the same pattern already used by OpenPrintTag generation and CSV export.
- Adds [tests/dashboard-route.test.ts](tests/dashboard-route.test.ts) covering the bug shape plus three baseline cases (standalone with own drying temp, standalone with none, recently-dried spool with inherited temp).

## Test plan

- [x] `npx vitest run tests/dashboard-route.test.ts` — 4 tests, all pass
- [x] `npm test` — full suite green (690 tests, 39 files; was 686/38)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)