### PR TITLE
Fix #136: OpenPrintTag fetch fails in Docker (curl not in image)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "swagger-ui-react": "^5.32.1",
+        "tar": "^7.5.0",
         "yaml": "^2.8.3"
       },
       "devDependencies": {
@@ -798,6 +799,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1641,6 +1643,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1663,6 +1666,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1685,6 +1689,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1701,6 +1706,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1717,6 +1723,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1733,6 +1740,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1749,6 +1757,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1765,6 +1774,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1781,6 +1791,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1797,6 +1808,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1813,6 +1825,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1829,6 +1842,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1845,6 +1859,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1867,6 +1882,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1889,6 +1905,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1911,6 +1928,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1933,6 +1951,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1955,6 +1974,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1977,6 +1997,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1999,6 +2020,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2021,6 +2043,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2040,6 +2063,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2059,6 +2083,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2078,6 +2103,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2094,7 +2120,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -6129,7 +6154,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -10845,7 +10869,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10855,7 +10878,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -13812,7 +13834,6 @@
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
       "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -13845,7 +13866,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "19.2.4",
         "swagger-ui-react": "^5.32.1",
         "tar": "^7.5.0",
+        "undici": "^6.25.0",
         "yaml": "^2.8.3"
       },
       "devDependencies": {
@@ -14463,7 +14464,6 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
       "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dom": "19.2.4",
     "swagger-ui-react": "^5.32.1",
     "tar": "^7.5.0",
+    "undici": "^6.25.0",
     "yaml": "^2.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "swagger-ui-react": "^5.32.1",
+    "tar": "^7.5.0",
     "yaml": "^2.8.3"
   },
   "devDependencies": {

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -19,7 +19,34 @@ import { tmpdir } from "os";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import * as tar from "tar";
+import { EnvHttpProxyAgent, type Dispatcher } from "undici";
 import { OPT_TAG } from "@/lib/openprinttag";
+
+/**
+ * Build an undici dispatcher that honours `HTTP_PROXY` / `HTTPS_PROXY` /
+ * `NO_PROXY` env vars when the deployment sets them.
+ *
+ * Background: the previous `curl -L` shell call automatically respected
+ * those variables, but Node's built-in fetch ignores them by default
+ * (you'd otherwise need `NODE_USE_ENV_PROXY=1` or `--use-env-proxy`).
+ * On the corporate / air-gapped Docker setups that motivated #136, that
+ * regression would silently break OpenPrintTag refresh even though the
+ * curl path used to work. Returning a dispatcher only when a proxy is
+ * actually configured keeps the no-proxy fast path identical.
+ */
+export function getProxyDispatcher(
+  env: Partial<Record<string, string | undefined>> = process.env,
+): Dispatcher | undefined {
+  const hasProxy = Boolean(
+    env.HTTP_PROXY ||
+      env.http_proxy ||
+      env.HTTPS_PROXY ||
+      env.https_proxy ||
+      env.ALL_PROXY ||
+      env.all_proxy,
+  );
+  return hasProxy ? new EnvHttpProxyAgent() : undefined;
+}
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -337,6 +364,10 @@ export async function fetchOpenPrintTagDatabase(): Promise<OPTDatabase> {
     const tarballUrl =
       "https://api.github.com/repos/OpenPrintTag/openprinttag-database/tarball/main";
 
+    // Pass the proxy dispatcher when one is configured. `dispatcher` is an
+    // undici-flavoured option not present on the standard RequestInit type,
+    // hence the cast — it's a documented Node fetch extension.
+    const dispatcher = getProxyDispatcher();
     const response = await fetch(tarballUrl, {
       headers: {
         Accept: "application/vnd.github+json",
@@ -346,7 +377,8 @@ export async function fetchOpenPrintTagDatabase(): Promise<OPTDatabase> {
       // 60s matches the previous execSync timeout. AbortSignal.timeout
       // produces a TypeError-shaped abort if exceeded.
       signal: AbortSignal.timeout(60_000),
-    });
+      ...(dispatcher ? { dispatcher } : {}),
+    } as RequestInit & { dispatcher?: Dispatcher });
     if (!response.ok) {
       throw new Error(
         `GitHub tarball request failed: ${response.status} ${response.statusText}`,

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -13,10 +13,12 @@
  */
 
 import { parse as parseYaml } from "yaml";
-import { execSync } from "child_process";
 import { mkdtempSync, readFileSync, rmSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import * as tar from "tar";
 import { OPT_TAG } from "@/lib/openprinttag";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -326,13 +328,42 @@ export async function fetchOpenPrintTagDatabase(): Promise<OPTDatabase> {
   const tmpDir = mkdtempSync(join(tmpdir(), "openprinttag-"));
 
   try {
-    // Download tarball via GitHub API
+    // Download and extract the tarball via the GitHub tarball API. Earlier
+    // versions shelled out to `curl ... | tar xz`, but the production
+    // Docker image (node:22-alpine) doesn't ship curl, so users got
+    // "/bin/sh: curl: not found" the moment they tried to browse the OPT
+    // database (GH #136). Doing it in pure Node removes the dep on host
+    // tools and works the same in dev, Electron, and Docker.
     const tarballUrl =
       "https://api.github.com/repos/OpenPrintTag/openprinttag-database/tarball/main";
 
-    execSync(
-      `curl -sL -H "Accept: application/vnd.github+json" "${tarballUrl}" | tar xz -C "${tmpDir}"`,
-      { timeout: 60_000, maxBuffer: 50 * 1024 * 1024 },
+    const response = await fetch(tarballUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        // GitHub returns 403 on unauthenticated requests with no UA.
+        "User-Agent": "filament-db",
+      },
+      // 60s matches the previous execSync timeout. AbortSignal.timeout
+      // produces a TypeError-shaped abort if exceeded.
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub tarball request failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    if (!response.body) {
+      throw new Error("GitHub tarball response had no body");
+    }
+
+    // tar.x is a Writable transform that auto-detects gzip; pipeline()
+    // resolves once the entire tarball has been extracted to disk.
+    await pipeline(
+      // Cast: response.body is a Web ReadableStream, Readable.fromWeb wants
+      // the same shape but the type lib for streams/web is a bit loose
+      // across Node versions. Functionally identical.
+      Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+      tar.x({ cwd: tmpDir }),
     );
 
     // The tarball extracts to a subdirectory like OpenPrintTag-openprinttag-database-<sha>/

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -1,14 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mkdirSync, writeFileSync } from "fs";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, createReadStream } from "fs";
 import { join } from "path";
-
-const { mockExecSync } = vi.hoisted(() => ({
-  mockExecSync: vi.fn(),
-}));
-vi.mock("child_process", async (importOriginal) => {
-  const orig = await importOriginal<typeof import("child_process")>();
-  return { ...orig, execSync: mockExecSync };
-});
+import { tmpdir } from "os";
+import * as tar from "tar";
 
 import {
   computeCompletenessScore,
@@ -20,6 +14,66 @@ import {
   fetchOpenPrintTagDatabase,
   clearCache,
 } from "@/lib/openprinttagBrowser";
+
+/**
+ * Build a gzipped tarball on disk from the given file map and return the
+ * file path. The map's keys are paths relative to the tar root; values are
+ * file contents. Used by the fetchOpenPrintTagDatabase tests to simulate
+ * GitHub's tarball API response without actually hitting the network.
+ */
+function buildTarball(files: Record<string, string>): string {
+  const stagingDir = mkdtempSync(join(tmpdir(), "opt-tar-staging-"));
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = join(stagingDir, relPath);
+    const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+  const tarballPath = join(tmpdir(), `opt-tarball-${Date.now()}-${Math.random()}.tgz`);
+  tar.c(
+    {
+      gzip: true,
+      file: tarballPath,
+      cwd: stagingDir,
+      sync: true,
+    },
+    ["."],
+  );
+  rmSync(stagingDir, { recursive: true, force: true });
+  return tarballPath;
+}
+
+/**
+ * Mock global fetch to stream a gzipped tarball constructed from `files`.
+ * Returns the path to the tarball so the test can clean it up.
+ */
+function mockFetchTarball(files: Record<string, string>): string {
+  const tarballPath = buildTarball(files);
+  vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+    // Bridge the on-disk tarball to a Web ReadableStream the route handler
+    // can pipe through. Node's createReadStream gives us a Node Readable;
+    // wrap it in the minimal Response shape the production code consumes.
+    const nodeStream = createReadStream(tarballPath);
+    const webStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        nodeStream.on("data", (chunk: Buffer | string) => {
+          controller.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : new Uint8Array(chunk));
+        });
+        nodeStream.on("end", () => controller.close());
+        nodeStream.on("error", (err) => controller.error(err));
+      },
+      cancel() {
+        nodeStream.destroy();
+      },
+    });
+    return new Response(webStream, {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/x-gzip" },
+    });
+  });
+  return tarballPath;
+}
 
 describe("computeCompletenessScore", () => {
   it("returns 0 for empty material", () => {
@@ -433,31 +487,28 @@ describe("clearCache", () => {
 });
 
 describe("fetchOpenPrintTagDatabase", () => {
+  let tarballsToCleanup: string[] = [];
+
   beforeEach(() => {
     clearCache();
-    mockExecSync.mockReset();
+    tarballsToCleanup = [];
   });
 
-  it("fetches and parses the database from a mock tarball", async () => {
-    mockExecSync.mockImplementation((_cmd: string) => {
-      const match = String(_cmd).match(/-C "([^"]+)"/);
-      if (!match) return Buffer.from("");
-      const tmpDir = match[1];
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const p of tarballsToCleanup) {
+      try { rmSync(p, { force: true }); } catch { /* swallow */ }
+    }
+  });
 
-      const repoDir = join(tmpDir, "OpenPrintTag-openprinttag-database-abc123");
-      const brandsDir = join(repoDir, "data", "brands");
-      const materialsDir = join(repoDir, "data", "materials", "prusament");
-
-      mkdirSync(brandsDir, { recursive: true });
-      mkdirSync(materialsDir, { recursive: true });
-
-      writeFileSync(
-        join(brandsDir, "prusament.yaml"),
-        `slug: prusament\nname: Prusament\ncountry: CZ`
-      );
-
-      writeFileSync(
-        join(materialsDir, "prusament-pla-galaxy-black.yaml"),
+  it("fetches and parses the database from a streamed tarball", async () => {
+    // GitHub's tarball API extracts to a top-level dir like
+    // OpenPrintTag-openprinttag-database-<sha>/. We mirror that here so
+    // the production code's "first entry under tmpDir" assumption holds.
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-abc123/data/brands/prusament.yaml":
+        "slug: prusament\nname: Prusament\ncountry: CZ\n",
+      "OpenPrintTag-abc123/data/materials/prusament/prusament-pla-galaxy-black.yaml":
         `uuid: test-uuid-1234
 slug: prusament-pla-galaxy-black
 brand:
@@ -473,22 +524,19 @@ properties:
   min_print_temperature: 205
   max_print_temperature: 225
   min_bed_temperature: 40
-  max_bed_temperature: 60`
-      );
-
-      writeFileSync(
-        join(materialsDir, "some-resin.yaml"),
+  max_bed_temperature: 60
+`,
+      "OpenPrintTag-abc123/data/materials/prusament/some-resin.yaml":
         `uuid: resin-uuid
 slug: some-resin
 brand:
   slug: prusament
 name: Some Resin
 class: SLA
-type: Resin`
-      );
-
-      return Buffer.from("");
+type: Resin
+`,
     });
+    tarballsToCleanup.push(tarballPath);
 
     const db = await fetchOpenPrintTagDatabase();
 
@@ -502,30 +550,30 @@ type: Resin`
     expect(db.cachedAt).toBeTruthy();
   });
 
-  it("returns cached result on second call", async () => {
-    let callCount = 0;
-    mockExecSync.mockImplementation((_cmd: string) => {
-      callCount++;
-      const match = String(_cmd).match(/-C "([^"]+)"/);
-      if (!match) return Buffer.from("");
-      const tmpDir = match[1];
-
-      const repoDir = join(tmpDir, "OpenPrintTag-abc");
-      const materialsDir = join(repoDir, "data", "materials");
-      mkdirSync(materialsDir, { recursive: true });
-      mkdirSync(join(repoDir, "data", "brands"), { recursive: true });
-
-      writeFileSync(
-        join(materialsDir, "test.yaml"),
-        `uuid: u1\nslug: test\nbrand:\n  slug: test\nname: Test\nclass: FFF\ntype: PLA`
-      );
-
-      return Buffer.from("");
+  it("returns cached result on second call without re-fetching", async () => {
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-abc/data/brands/.gitkeep": "",
+      "OpenPrintTag-abc/data/materials/test.yaml":
+        "uuid: u1\nslug: test\nbrand:\n  slug: test\nname: Test\nclass: FFF\ntype: PLA\n",
     });
+    tarballsToCleanup.push(tarballPath);
 
     await fetchOpenPrintTagDatabase();
     await fetchOpenPrintTagDatabase();
 
-    expect(callCount).toBe(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a 4xx/5xx response as a thrown error", async () => {
+    // Regression: pre-fix the curl command failed silently in the docker
+    // image (curl missing), leaving the user with a generic "Failed to
+    // fetch" toast and a tar parse error in logs. With pure Node fetch we
+    // get an actual response status to surface to the user.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("not found", { status: 404, statusText: "Not Found" }),
+    );
+    await expect(fetchOpenPrintTagDatabase()).rejects.toThrow(
+      /404|Not Found|GitHub tarball/,
+    );
   });
 });

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -12,8 +12,10 @@ import {
   parseMaterialYaml,
   mapToFilamentPayload,
   fetchOpenPrintTagDatabase,
+  getProxyDispatcher,
   clearCache,
 } from "@/lib/openprinttagBrowser";
+import { EnvHttpProxyAgent } from "undici";
 
 /**
  * Build a gzipped tarball on disk from the given file map and return the
@@ -486,6 +488,34 @@ describe("clearCache", () => {
   });
 });
 
+describe("getProxyDispatcher", () => {
+  // Pure-function test that doesn't touch fetch — covers the env-var
+  // matrix the Codex feedback flagged. Each call passes its own env so
+  // we don't have to mutate process.env.
+
+  it("returns undefined when no proxy env vars are set", () => {
+    expect(getProxyDispatcher({})).toBeUndefined();
+  });
+
+  for (const key of [
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+  ] as const) {
+    it(`returns an EnvHttpProxyAgent when ${key} is set`, () => {
+      const dispatcher = getProxyDispatcher({ [key]: "http://proxy.example.invalid:8080" });
+      expect(dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+    });
+  }
+
+  it("treats an empty proxy string as unset", () => {
+    expect(getProxyDispatcher({ HTTPS_PROXY: "" })).toBeUndefined();
+  });
+});
+
 describe("fetchOpenPrintTagDatabase", () => {
   let tarballsToCleanup: string[] = [];
 
@@ -562,6 +592,62 @@ type: Resin
     await fetchOpenPrintTagDatabase();
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches an EnvHttpProxyAgent dispatcher when HTTPS_PROXY is set", async () => {
+    // Regression for the Codex P2 on PR #137: bare fetch() ignores
+    // HTTP_PROXY/HTTPS_PROXY by default, so any proxy-restricted
+    // deployment that worked through the old curl pipeline would silently
+    // fail after the migration. We ship a dispatcher when those env vars
+    // are present.
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-x/data/brands/.gitkeep": "",
+      "OpenPrintTag-x/data/materials/p.yaml":
+        "uuid: p\nslug: p\nbrand:\n  slug: x\nname: P\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    process.env.HTTPS_PROXY = "http://proxy.example.invalid:8080";
+    try {
+      await fetchOpenPrintTagDatabase();
+      const initArg = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+        dispatcher?: unknown;
+      };
+      expect(initArg.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+    } finally {
+      delete process.env.HTTPS_PROXY;
+    }
+  });
+
+  it("does not attach a dispatcher when no proxy env var is set", async () => {
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-y/data/brands/.gitkeep": "",
+      "OpenPrintTag-y/data/materials/p.yaml":
+        "uuid: p\nslug: p\nbrand:\n  slug: y\nname: P\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    // Make sure no proxy var leaks in from the parent shell.
+    const saved = {
+      HTTP_PROXY: process.env.HTTP_PROXY,
+      HTTPS_PROXY: process.env.HTTPS_PROXY,
+      http_proxy: process.env.http_proxy,
+      https_proxy: process.env.https_proxy,
+      ALL_PROXY: process.env.ALL_PROXY,
+      all_proxy: process.env.all_proxy,
+    };
+    for (const k of Object.keys(saved)) delete process.env[k];
+    try {
+      await fetchOpenPrintTagDatabase();
+      const initArg = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+        dispatcher?: unknown;
+      };
+      expect(initArg.dispatcher).toBeUndefined();
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v !== undefined) process.env[k] = v;
+      }
+    }
   });
 
   it("propagates a 4xx/5xx response as a thrown error", async () => {


### PR DESCRIPTION
Closes #136. Thanks @gertlind for the diagnostic container logs.

## The bug

The community-database fetch shelled out to:

```sh
curl -sL "$tarballUrl" | tar xz -C "$tmpDir"
```

which works in dev (curl is everywhere) but fails in our production Docker image because `node:22-alpine` doesn't include curl. Users on the Pi 5 ARM64 build (and any other Docker deployment) saw:

```
/bin/sh: curl: not found
tar: invalid magic
tar: short read
OpenPrintTag fetch error
```

…and the only workaround was `apk add --no-cache curl tar gzip` inside the running container.

## The fix

Replace the shell pipeline with a pure-Node fetch + tar extraction stream:

```ts
const response = await fetch(tarballUrl, {
  headers: { Accept: "application/vnd.github+json", "User-Agent": "filament-db" },
  signal: AbortSignal.timeout(60_000),
});
if (!response.ok) throw new Error(\`GitHub tarball request failed: \${response.status}\`);
await pipeline(
  Readable.fromWeb(response.body),
  tar.x({ cwd: tmpDir }),
);
```

Same on-disk effect, no host-tool dependency. Works identically in dev, Electron, and the Docker image. As a bonus, a 4xx/5xx response is now a thrown error with the status code instead of a downstream tar parse failure.

## Why we don't need to patch the Dockerfile

By eliminating the shell call, no host-side curl/tar is ever needed. Adding curl to the image would only paper over the underlying portability problem.

## Dependency

`tar@7` was already in `node_modules` as a transitive of `swagger-ui-react` and `mongodb-memory-server-core`. Promoted it to a direct dep in `package.json` so future transitive churn doesn't break OpenPrintTag fetch.

## Tests

Rewrote the two integration tests that mocked `execSync`. They now build a real gzipped tarball on disk, stream it back through a mocked global `fetch`, and assert the same end-to-end behaviour. Added a third test covering the new explicit 404 error path.

- 691 tests pass
- Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)