### PR TITLE
Audit fixes: print-history undo correctness, SSRF tests, length bounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ scripts/            CLI tools (read-nfc-tag, seed import, backfill)
 
 ## Testing
 
-- 635+ tests across 35+ files (unit + Mongoose model + Next.js route handlers)
+- 770+ tests across 40+ files (unit + Mongoose model + Next.js route handlers). Exact counts drift on every PR — run `npm test` for the current numbers.
 - Coverage thresholds: 80% lines/statements, 90% functions, 75% branches (enforced on `src/lib/**` and `src/models/**`; `src/lib/compressImage.ts` is excluded because its main flow is DOM-only)
 - Setup file: `tests/setup.ts` (mongodb-memory-server). **Caveat**: setup wipes `mongoose.models` between tests; route-level tests that use `.populate(...)` must re-register models in `beforeEach` by calling `mongoose.model(name, schema)` directly (see `tests/locations-route.test.ts` for the pattern).
 - Tests run in CI on Node 20 and 22

--- a/docs/api.md
+++ b/docs/api.md
@@ -813,8 +813,9 @@ Per-job ledger of print runs. Decrements spool weights, appends spool-level usag
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET`  | `/api/print-history` | List print jobs (desc by `startedAt`). Query: `filamentId`, `printerId`, `limit` (default 100, max 1000) |
-| `POST` | `/api/print-history` | Record a print job (see body below) |
+| `GET`    | `/api/print-history`      | List print jobs (desc by `startedAt`). Query: `filamentId`, `printerId`, `limit` (default 100, max 1000) |
+| `POST`   | `/api/print-history`      | Record a print job (see body below) |
+| `DELETE` | `/api/print-history/{id}` | Undo a print job — refund the spool weight and remove the matching `usageHistory` entries |
 
 ### POST /api/print-history
 
@@ -840,7 +841,19 @@ Validations:
 
 Every referenced filament is fetched and validated **before** any mutation. If any one is missing the whole request aborts with 404 and no spool weights are touched. The writes run inside a MongoDB transaction when the deployment supports it (Atlas always does), and fall back to sequential saves on standalone mongod.
 
+Each spool `usageHistory` entry the POST writes is stamped with `jobId` set to the new PrintHistory `_id`, so a later `DELETE` can match the exact entries to refund.
+
 Response: the created `PrintHistory` document, `201`.
+
+### DELETE /api/print-history/{id}
+
+Undo a job: for every `usage` entry on the record, find the matching spool, refund its `totalWeight` by the recorded grams, and remove the corresponding `usageHistory` entry. Then delete the `PrintHistory` document itself.
+
+Refund matching is by `usageHistory.jobId === entry._id` — unambiguous, so a manual usage log that happens to share `(grams, date)` with the job is **not** affected. Legacy entries written before `jobId` existed (pre-v1.12.7) fall back to a `(grams, date, source)` match that's still scoped to `source: "job" | "slicer"`, so manual logs survive that path too.
+
+Returns `200 { "message": "Deleted and refunded" }` on success, `404` if no PrintHistory with that id exists.
+
+Best-effort: if a referenced spool has since been deleted (or the filament soft-deleted), that entry is silently skipped — the rest of the refunds still apply and the PrintHistory document is removed.
 
 ---
 
@@ -1006,3 +1019,24 @@ Returns:
 Fetch multiple filaments for the comparison view in one round trip. `ids` is a comma-separated list (minimum 1, maximum 8). Returns filaments in the same order as the `ids` list, with `compatibleNozzles` and `calibrations.{nozzle,printer,bedType}` populated so the UI can render names directly.
 
 `400` if `ids` is missing, empty, or over 8.
+
+### GET /api/embed-check?url=…
+
+Probe whether a remote URL can be rendered inside an `<iframe>`. Used by the filament detail page to gracefully fall back to "open in new tab" when the source site sets `X-Frame-Options: DENY|SAMEORIGIN` or a restrictive `Content-Security-Policy: frame-ancestors`.
+
+The URL goes through the shared SSRF guard (loopback / RFC1918 / cloud metadata IPs blocked, http(s) only). Redirects are followed manually with the same guard re-applied on every hop, so a public host that 30x-redirects into private space is rejected. Capped at 5 redirects and an 8-second timeout.
+
+Response shape:
+```json
+{ "embeddable": true, "contentType": "text/html; charset=utf-8" }
+```
+or:
+```json
+{ "embeddable": false, "reason": "X-Frame-Options: deny", "contentType": "text/html" }
+```
+
+Network failures collapse to `{ embeddable: false, reason: <message> }` rather than a 5xx — the UI shows the same fallback either way.
+
+### GET /api/openapi
+
+Returns the OpenAPI 3.0 spec document used by the in-app Swagger UI. Version is injected dynamically from `package.json` so external consumers can verify the spec matches the running build.

--- a/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
@@ -24,6 +24,15 @@ export async function POST(
   if (body !== null && typeof body !== "object") {
     return errorResponse("body must be an object", 400);
   }
+  // Cap notes length so a malicious or accidental multi-MB POST can't
+  // bloat a spool subdocument. 1000 chars is generous for a freeform
+  // dry-cycle note; matches the spirit of the print-history `notes`
+  // bound (2000) without giving as much rope, since this entry sits
+  // inside an embedded subdocument array that's loaded on every spool
+  // fetch.
+  if (typeof body?.notes === "string" && body.notes.length > 1000) {
+    return errorResponse("notes must be 1000 characters or fewer", 400);
+  }
 
   const entry: Record<string, unknown> = {
     date: body?.date ? new Date(body.date) : new Date(),

--- a/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
@@ -64,6 +64,11 @@ export async function POST(
       jobLabel,
       date,
       source: "manual",
+      // No PrintHistory record backs a direct spool-UI usage log — the
+      // print-history undo path keys off this being null to skip the
+      // entry. Required by the IUsageEntry interface so the field is
+      // explicit at every call site.
+      jobId: null,
     });
     await filament.save();
     return NextResponse.json(filament.toObject(), { status: 201 });

--- a/src/app/api/print-history/[id]/route.ts
+++ b/src/app/api/print-history/[id]/route.ts
@@ -35,15 +35,30 @@ export async function DELETE(
       if (typeof spool.totalWeight === "number") {
         spool.totalWeight = spool.totalWeight + u.grams;
       }
-      // Remove the matching usageHistory entry (most recent with this grams+date)
+      // Remove the matching usageHistory entry by jobId. Older entries
+      // written before the v1.12.x audit don't carry a jobId; for those
+      // we fall back to the legacy (grams, startedAt) match — but only
+      // when the entry has source "job" or "slicer", which restricts
+      // the candidate set to print-history-driven rows and avoids
+      // accidentally clobbering a manual usage log that happens to
+      // share both fields.
       spool.usageHistory = (spool.usageHistory || []).filter(
         (h, idx, arr) => {
+          // New world: jobId match is unambiguous.
+          if (h.jobId && String(h.jobId) === String(entry._id)) return false;
+
+          // Legacy fallback (entries created before jobId existed).
+          if (h.jobId) return true;
+          if (h.source !== "job" && h.source !== "slicer") return true;
           if (h.grams !== u.grams) return true;
           if (h.date.getTime() !== entry.startedAt.getTime()) return true;
-          // Remove the first match only
+          // Remove only the first matching legacy entry per usage row.
           const firstMatch = arr.findIndex(
             (x) =>
-              x.grams === u.grams && x.date.getTime() === entry.startedAt.getTime(),
+              !x.jobId &&
+              (x.source === "job" || x.source === "slicer") &&
+              x.grams === u.grams &&
+              x.date.getTime() === entry.startedAt.getTime(),
           );
           return idx !== firstMatch;
         },

--- a/src/app/api/print-history/route.ts
+++ b/src/app/api/print-history/route.ts
@@ -160,6 +160,15 @@ export async function POST(request: NextRequest) {
     // Pass 2: apply mutations to in-memory docs. A single filament can be
     // referenced by multiple usage entries in one job, so we mutate the
     // shared doc instance and save each filament once at the end.
+    //
+    // Generate the PrintHistory _id up front so each spool usageHistory
+    // entry can carry a jobId pointing back at this job. The undo path
+    // (DELETE /api/print-history/{id}) uses that linkage to refund the
+    // exact entries this POST created — without it the undo previously
+    // matched by `(grams, date)` and silently removed the wrong entry
+    // when a manual usage log happened to share both.
+    const historyId = new mongoose.Types.ObjectId();
+
     const resolvedUsage: {
       filamentId: mongoose.Types.ObjectId;
       spoolId: mongoose.Types.ObjectId | null;
@@ -193,6 +202,7 @@ export async function POST(request: NextRequest) {
           // filters these out of the per-spool fallback so totals aren't
           // double-counted against the aggregated PrintHistory pass.
           source: "job",
+          jobId: historyId,
         });
         resolvedUsage.push({
           filamentId: filament._id,
@@ -227,6 +237,7 @@ export async function POST(request: NextRequest) {
           }
           const created = await PrintHistory.create(
             [{
+              _id: historyId,
               jobLabel: body.jobLabel.trim(),
               printerId,
               usage: resolvedUsage,
@@ -256,6 +267,7 @@ export async function POST(request: NextRequest) {
         await f.save();
       }
       history = await PrintHistory.create({
+        _id: historyId,
         jobLabel: body.jobLabel.trim(),
         printerId,
         usage: resolvedUsage,

--- a/src/models/Filament.ts
+++ b/src/models/Filament.ts
@@ -32,6 +32,17 @@ export interface IUsageEntry {
    *   - "nfc":    written by an NFC read.
    */
   source: "manual" | "slicer" | "job" | "nfc";
+  /**
+   * For entries created by `POST /api/print-history`, the _id of the
+   * matching PrintHistory document. The undo path (`DELETE
+   * /api/print-history/{id}`) uses this to find exactly which spool
+   * usageHistory entries to refund — without it, the previous logic
+   * matched by `(grams, date)` alone, which silently removed the wrong
+   * entry whenever a manual usage log happened to share both.
+   *
+   * Always null for `manual`/`nfc` entries (no PrintHistory record exists).
+   */
+  jobId: mongoose.Types.ObjectId | null;
 }
 
 export interface ISpool {
@@ -241,6 +252,9 @@ const FilamentSchema = new Schema<IFilament>(
               enum: ["manual", "slicer", "job", "nfc"],
               default: "manual",
             },
+            // Index so the undo path's `usageHistory.jobId === entry._id`
+            // filter doesn't full-scan every spool's array.
+            jobId: { type: Schema.Types.ObjectId, ref: "PrintHistory", default: null, index: true },
           },
         ],
       },

--- a/tests/externalUrlGuard.test.ts
+++ b/tests/externalUrlGuard.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockLookup } = vi.hoisted(() => ({
+  mockLookup: vi.fn(),
+}));
+
+// Stub dns.lookup so the IPv4/IPv6 matrix tests don't depend on the host
+// being able to resolve example.com / RFC2606 names. Real DNS would be
+// flaky in CI sandboxes anyway.
+vi.mock("node:dns/promises", () => ({
+  lookup: mockLookup,
+}));
+
+import { isPrivateIp, assertExternalUrl } from "@/lib/externalUrlGuard";
+
+/**
+ * SSRF guard tests. The module is security-critical (used by the TDS
+ * extractor and the iframe-embed checker) and previously had zero
+ * dedicated tests — caught by the v1.12.6 audit. Coverage focuses on
+ * the IP-block list and the `assertExternalUrl` resolution path.
+ */
+
+describe("isPrivateIp — IPv4 block list", () => {
+  // Cloud-metadata + RFC1918 + loopback + link-local + CG-NAT + multicast.
+  // Each row mirrors a real adversary surface; if any of these stops
+  // returning true an SSRF gap opens up immediately.
+  const blocked = [
+    ["0.0.0.0", "0.0.0.0/8 wildcard"],
+    ["10.0.0.1", "10.0.0.0/8 RFC1918"],
+    ["10.255.255.254", "10.0.0.0/8 upper bound"],
+    ["127.0.0.1", "loopback"],
+    ["127.255.255.254", "127.0.0.0/8 upper bound"],
+    ["169.254.169.254", "AWS/GCP/Azure metadata service"],
+    ["169.254.0.1", "link-local lower bound"],
+    ["172.16.0.1", "172.16/12 lower"],
+    ["172.31.255.254", "172.16/12 upper"],
+    ["192.168.0.1", "RFC1918"],
+    ["192.168.1.1", "RFC1918 home routers"],
+    ["100.64.0.1", "CG-NAT (RFC6598)"],
+    ["100.127.255.254", "CG-NAT upper bound"],
+    ["224.0.0.1", "multicast"],
+    ["239.255.255.255", "multicast upper"],
+    ["240.0.0.1", "240/4 reserved"],
+    ["255.255.255.255", "broadcast"],
+  ] as const;
+
+  it.each(blocked)("%s — %s", (ip) => {
+    expect(isPrivateIp(ip)).toBe(true);
+  });
+
+  // Public IPs that must pass through (otherwise legitimate fetches break).
+  const allowed = [
+    "8.8.8.8",
+    "1.1.1.1",
+    "172.15.255.255", // just below 172.16/12
+    "172.32.0.1", // just above 172.16/12
+    "172.31.255.255", // exact upper of 172.16/12 — wait, this is actually blocked (in range)
+    "100.63.255.254", // just below CG-NAT
+    "100.128.0.1", // just above CG-NAT
+    "192.169.0.1", // just above 192.168/16
+    "11.0.0.1", // just above 10/8
+    "9.255.255.255", // just below 10/8
+    "169.253.0.1", // just below link-local
+    "169.255.0.1", // just above link-local
+    "126.255.255.255", // just below loopback /8
+    "128.0.0.1", // just above loopback /8
+  ];
+
+  for (const ip of allowed) {
+    if (ip === "172.31.255.255") continue; // genuinely private, exclude from "allowed"
+    it(`${ip} — public, must not be blocked`, () => {
+      expect(isPrivateIp(ip)).toBe(false);
+    });
+  }
+
+  // Unparseable input should fail closed.
+  it("returns true (block) for unparseable IPv4 strings", () => {
+    expect(isPrivateIp("999.999.999.999")).toBe(true);
+    expect(isPrivateIp("1.2.3")).toBe(true);
+    expect(isPrivateIp("1.2.3.4.5")).toBe(true);
+    expect(isPrivateIp("a.b.c.d")).toBe(true);
+  });
+});
+
+describe("isPrivateIp — IPv6 block list", () => {
+  const blocked = [
+    ["::1", "loopback"],
+    ["::", "unspecified"],
+    ["fe80::1", "link-local"],
+    ["fe80:0000:0000:0000:0000:0000:0000:0001", "expanded link-local"],
+    ["fc00::1", "unique-local lower"],
+    ["fd00::1", "unique-local upper"],
+    ["ff00::1", "multicast"],
+    ["ff02::1", "all-nodes multicast"],
+  ] as const;
+
+  it.each(blocked)("%s — %s", (ip) => {
+    expect(isPrivateIp(ip)).toBe(true);
+  });
+
+  it("recurses into IPv4-mapped IPv6 (::ffff:10.0.0.1 must be blocked)", () => {
+    // RFC4291 IPv4-mapped form. An attacker-controlled DNS that returns
+    // this would otherwise smuggle an RFC1918 address past a v6-only check.
+    expect(isPrivateIp("::ffff:10.0.0.1")).toBe(true);
+    expect(isPrivateIp("::FFFF:127.0.0.1")).toBe(true);
+    expect(isPrivateIp("::ffff:169.254.169.254")).toBe(true);
+  });
+
+  it("allows public IPv6 (Google / Cloudflare DNS)", () => {
+    expect(isPrivateIp("2001:4860:4860::8888")).toBe(false);
+    expect(isPrivateIp("2606:4700:4700::1111")).toBe(false);
+  });
+});
+
+describe("assertExternalUrl", () => {
+  beforeEach(() => {
+    mockLookup.mockReset();
+  });
+
+  it("rejects invalid URL strings", async () => {
+    await expect(assertExternalUrl("not a url")).rejects.toThrow(/Invalid URL/);
+  });
+
+  it("rejects file:// scheme", async () => {
+    await expect(assertExternalUrl("file:///etc/passwd")).rejects.toThrow(/scheme/);
+  });
+
+  it("rejects gopher:// scheme", async () => {
+    await expect(assertExternalUrl("gopher://example.com/")).rejects.toThrow(/scheme/);
+  });
+
+  it("rejects ftp:// scheme", async () => {
+    await expect(assertExternalUrl("ftp://example.com/")).rejects.toThrow(/scheme/);
+  });
+
+  it("rejects javascript: scheme", async () => {
+    await expect(assertExternalUrl("javascript:alert(1)")).rejects.toThrow(/scheme/);
+  });
+
+  it("rejects data: scheme", async () => {
+    await expect(assertExternalUrl("data:text/html,<script>alert(1)</script>")).rejects.toThrow(/scheme/);
+  });
+
+  it("rejects URLs without a hostname", async () => {
+    // file: was already rejected by the scheme check; build a valid-but-
+    // hostnameless URL via the URL parser. Empty host on http is rejected
+    // by URL itself, so the closest we can hit is via the http: path
+    // when the URL parses to an empty hostname.
+    await expect(assertExternalUrl("http://")).rejects.toThrow();
+  });
+
+  it("rejects literal RFC1918 IPv4 address", async () => {
+    await expect(assertExternalUrl("http://10.0.0.1/foo")).rejects.toThrow(
+      /private\/internal/,
+    );
+  });
+
+  it("rejects literal AWS metadata IP", async () => {
+    await expect(assertExternalUrl("http://169.254.169.254/latest/meta-data/")).rejects.toThrow(
+      /private\/internal/,
+    );
+  });
+
+  it("rejects literal IPv6 loopback", async () => {
+    await expect(assertExternalUrl("http://[::1]/foo")).rejects.toThrow(
+      /private\/internal/,
+    );
+  });
+
+  it("rejects hostname that resolves to a private IP", async () => {
+    // Classic DNS-resolution SSRF: attacker registers
+    // example.com → A record 192.168.0.1. Without resolving, a
+    // string-only check would let it through.
+    mockLookup.mockResolvedValue([{ address: "192.168.0.1", family: 4 }]);
+    await expect(assertExternalUrl("https://attacker.example/")).rejects.toThrow(
+      /private\/internal/,
+    );
+  });
+
+  it("rejects hostname that resolves to multiple IPs if ANY is private", async () => {
+    // dual-stack attacker: returns a public v4 + a private v6 to bypass
+    // a naive "first record only" check.
+    mockLookup.mockResolvedValue([
+      { address: "8.8.8.8", family: 4 },
+      { address: "fd00::1", family: 6 },
+    ]);
+    await expect(assertExternalUrl("https://mixed.example/")).rejects.toThrow(
+      /private\/internal/,
+    );
+  });
+
+  it("rejects hostname that does not resolve at all", async () => {
+    mockLookup.mockResolvedValue([]);
+    await expect(assertExternalUrl("https://nonexistent.invalid/")).rejects.toThrow(
+      /does not resolve/,
+    );
+  });
+
+  it("returns the parsed URL for a public hostname", async () => {
+    mockLookup.mockResolvedValue([{ address: "8.8.8.8", family: 4 }]);
+    const url = await assertExternalUrl("https://example.com/path?q=1");
+    expect(url.protocol).toBe("https:");
+    expect(url.hostname).toBe("example.com");
+    expect(url.pathname).toBe("/path");
+  });
+
+  it("does not call DNS for a literal public IPv4 address", async () => {
+    const url = await assertExternalUrl("http://8.8.8.8/");
+    expect(url.hostname).toBe("8.8.8.8");
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("does not call DNS for a literal public IPv6 address", async () => {
+    const url = await assertExternalUrl("http://[2001:4860:4860::8888]/");
+    expect(url.hostname).toBe("[2001:4860:4860::8888]");
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+});

--- a/tests/print-history.test.ts
+++ b/tests/print-history.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import mongoose from "mongoose";
 import { NextRequest } from "next/server";
 import { POST as postPrintHistory } from "@/app/api/print-history/route";
+import { DELETE as deletePrintHistory } from "@/app/api/print-history/[id]/route";
 import { GET as getAnalytics } from "@/app/api/analytics/route";
 
 /**
@@ -192,6 +193,227 @@ describe("print-history POST", () => {
     // `source` — the PrintHistory record holds the job's provenance.
     expect(afterA.spools[0].usageHistory[0].source).toBe("job");
     expect(afterB.spools[0].usageHistory[0].source).toBe("job");
+  });
+
+  it("stamps each spool usageHistory entry with the new PrintHistory _id as jobId", async () => {
+    // Regression for the v1.12.x audit P0: the DELETE/undo path used to
+    // match by (grams, date) alone, which silently removed the wrong
+    // entry when a manual usage log shared both. The fix wires a jobId
+    // pointing back at the PrintHistory _id; this test locks down that
+    // POST writes it.
+    const f = await Filament.create({
+      name: "JobId Stamping",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    const res = await postPrintHistory(
+      makeReq({
+        jobLabel: "stamped",
+        source: "manual",
+        usage: [{ filamentId: String(f._id), grams: 50 }],
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+
+    const fresh = await Filament.findById(f._id);
+    const entry = fresh.spools[0].usageHistory[0];
+    expect(entry.jobId).toBeDefined();
+    expect(String(entry.jobId)).toBe(String(created._id));
+  });
+});
+
+describe("print-history DELETE (undo)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let PrintHistory: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    const printHistoryMod = await import("@/models/PrintHistory");
+    const printerMod = await import("@/models/Printer");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    if (!mongoose.models.PrintHistory) {
+      mongoose.model("PrintHistory", printHistoryMod.default.schema);
+    }
+    if (!mongoose.models.Printer) {
+      mongoose.model("Printer", printerMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+    PrintHistory = mongoose.models.PrintHistory;
+  });
+
+  async function postJob(filament: { _id: mongoose.Types.ObjectId }, jobLabel: string, grams: number, startedAt?: Date) {
+    const res = await postPrintHistory(
+      new NextRequest("http://localhost/api/print-history", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jobLabel,
+          source: "manual",
+          usage: [{ filamentId: String(filament._id), grams }],
+          ...(startedAt ? { startedAt: startedAt.toISOString() } : {}),
+        }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    return res.json();
+  }
+
+  function delReq(id: string) {
+    return new NextRequest(`http://localhost/api/print-history/${id}`, { method: "DELETE" });
+  }
+
+  it("refunds spool weight and removes the matching usageHistory entry", async () => {
+    const f = await Filament.create({
+      name: "Refund Basic",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    const job = await postJob(f, "benchy", 100);
+    const after = await Filament.findById(f._id);
+    expect(after.spools[0].totalWeight).toBe(900);
+
+    const delRes = await deletePrintHistory(delReq(job._id), { params: Promise.resolve({ id: job._id }) });
+    expect(delRes.status).toBe(200);
+
+    const refunded = await Filament.findById(f._id);
+    expect(refunded.spools[0].totalWeight).toBe(1000);
+    expect(refunded.spools[0].usageHistory).toHaveLength(0);
+  });
+
+  it("does not remove a manual usage log that shares (grams, date) with the job", async () => {
+    // The v1.12.x audit P0 regression. Prior code matched by
+    // (grams, startedAt) only; if the user had also logged a manual 50g
+    // usage at the exact same minute, that entry would be wrongly
+    // refunded along with the job. The jobId match avoids it.
+    const sharedDate = new Date("2026-04-30T10:00:00Z");
+    const f = await Filament.create({
+      name: "Manual Survives Undo",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [
+        {
+          label: "",
+          totalWeight: 1000,
+          usageHistory: [
+            // The "innocent bystander" — predates the job, no jobId.
+            { grams: 50, jobLabel: "calibration", date: sharedDate, source: "manual", jobId: null },
+          ],
+        },
+      ],
+    });
+
+    const job = await postJob(f, "ambiguous-job", 50, sharedDate);
+    const afterPost = await Filament.findById(f._id);
+    // Two entries now: one manual (no jobId) + one job-driven (with jobId).
+    expect(afterPost.spools[0].usageHistory).toHaveLength(2);
+
+    const delRes = await deletePrintHistory(delReq(job._id), { params: Promise.resolve({ id: job._id }) });
+    expect(delRes.status).toBe(200);
+
+    const refunded = await Filament.findById(f._id);
+    // Exactly one survivor: the manual entry. Pre-fix this would be 0.
+    expect(refunded.spools[0].usageHistory).toHaveLength(1);
+    const survivor = refunded.spools[0].usageHistory[0];
+    expect(survivor.source).toBe("manual");
+    expect(survivor.jobId).toBeNull();
+    expect(survivor.jobLabel).toBe("calibration");
+  });
+
+  it("falls back to (grams, date) match for legacy entries that pre-date jobId", async () => {
+    // Legacy data path: a row written before the v1.12.x audit doesn't
+    // have jobId. The fallback is restricted to source==="job"|"slicer"
+    // so it can't accidentally clobber a manual entry.
+    const startedAt = new Date("2026-04-30T11:30:00Z");
+    const f = await Filament.create({
+      name: "Legacy Refund",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [
+        {
+          label: "",
+          totalWeight: 850,
+          usageHistory: [
+            // Legacy job entry — has source "job" but no jobId.
+            { grams: 150, jobLabel: "old-job", date: startedAt, source: "job", jobId: null },
+          ],
+        },
+      ],
+    });
+    // Simulate the orphaned PrintHistory record that would normally
+    // accompany the legacy entry.
+    const orphan = await PrintHistory.create({
+      jobLabel: "old-job",
+      usage: [{ filamentId: f._id, spoolId: f.spools[0]._id, grams: 150 }],
+      startedAt,
+      source: "manual",
+    });
+
+    const delRes = await deletePrintHistory(delReq(String(orphan._id)), {
+      params: Promise.resolve({ id: String(orphan._id) }),
+    });
+    expect(delRes.status).toBe(200);
+
+    const refunded = await Filament.findById(f._id);
+    expect(refunded.spools[0].totalWeight).toBe(1000);
+    expect(refunded.spools[0].usageHistory).toHaveLength(0);
+  });
+
+  it("does not remove a manual entry even when fallback runs", async () => {
+    // Even on the legacy fallback path, source-restricted matching
+    // protects manual logs that happen to share (grams, date).
+    const startedAt = new Date("2026-04-30T12:00:00Z");
+    const f = await Filament.create({
+      name: "Legacy Manual Safe",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [
+        {
+          label: "",
+          totalWeight: 850,
+          usageHistory: [
+            { grams: 150, jobLabel: "manual-only", date: startedAt, source: "manual", jobId: null },
+          ],
+        },
+      ],
+    });
+    const orphan = await PrintHistory.create({
+      jobLabel: "ghost",
+      usage: [{ filamentId: f._id, spoolId: f.spools[0]._id, grams: 150 }],
+      startedAt,
+      source: "manual",
+    });
+
+    await deletePrintHistory(delReq(String(orphan._id)), {
+      params: Promise.resolve({ id: String(orphan._id) }),
+    });
+    const fresh = await Filament.findById(f._id);
+    // Manual entry must still be there — the fallback restricted by source
+    // protects it.
+    expect(fresh.spools[0].usageHistory).toHaveLength(1);
+    expect(fresh.spools[0].usageHistory[0].source).toBe("manual");
+  });
+
+  it("returns 404 for a missing PrintHistory id", async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await deletePrintHistory(delReq(fakeId), { params: Promise.resolve({ id: fakeId }) });
+    expect(res.status).toBe(404);
   });
 });
 

--- a/tests/spool-subroute.test.ts
+++ b/tests/spool-subroute.test.ts
@@ -178,6 +178,23 @@ describe("spool sub-routes", () => {
       );
       expect(res.status).toBe(404);
     });
+
+    it("rejects notes over 1000 chars (length-bounds guard)", async () => {
+      // Without the bound a malicious or accidental multi-MB POST would
+      // bloat the spool subdocument's dryCycles array — every fetch of
+      // that spool would then drag the bloat across the wire. v1.12.x
+      // audit P1.
+      const f = await seedFilament();
+      const sid = String(f.spools[0]._id);
+      const res = await postDryCycle(
+        postReq(
+          `http://localhost/api/filaments/${f._id}/spools/${sid}/dry-cycles`,
+          { tempC: 65, notes: "a".repeat(1001) },
+        ),
+        { params: Promise.resolve({ id: String(f._id), spoolId: sid }) },
+      );
+      expect(res.status).toBe(400);
+    });
   });
 
   describe("DELETE .../spools/{spoolId}", () => {


### PR DESCRIPTION
Findings from a full source + test + documentation audit pass. Three real issues plus the doc gaps that were tracked in the audit notes; each fix lands with its own regression test.

## 🔴 P0 — Print-history undo can refund the wrong entry

`DELETE /api/print-history/{id}` matched spool `usageHistory` entries by `(grams, startedAt)` alone. If a user happened to have a manual usage log that shared both fields with a job (e.g. a 100g calibration logged at the same minute), the undo silently deleted the manual entry instead of — or in addition to — the job entry, corrupting the spool ledger invisibly.

**Fix:** thread the new `PrintHistory._id` into every spool `usageHistory` entry the POST handler writes (new `IUsageEntry.jobId` field, indexed). The DELETE handler matches on `jobId` first; legacy entries written before this change fall back to `(grams, date, source)` where source is restricted to `\"job\" | \"slicer\"`, so manual logs survive that path too.

Generate the historyId up front and pass it as the explicit `_id` to `PrintHistory.create` on both the transaction and fallback paths.

## 🟡 P1 — Dry-cycle `notes` had no length bound

`POST /api/filaments/{id}/spools/{spoolId}/dry-cycles` accepted arbitrarily long notes. `\$push` into the spool subdocument array would bloat the filament document and drag that bloat across the wire on every subsequent fetch. Capped at 1000 chars.

## 🟡 P1 — SSRF guard had zero tests

`src/lib/externalUrlGuard.ts` (the primary SSRF mitigation, used by `tdsExtractor.ts` and `/api/embed-check`) had no dedicated test file. Added `tests/externalUrlGuard.test.ts` with 57 cases covering:
- IPv4 block list: RFC1918, loopback, link-local, AWS/GCP/Azure metadata, CG-NAT, multicast, broadcast, unparseable input fails closed
- IPv4 boundary cases (each /N just below + above)
- IPv6: loopback, unspecified, link-local, unique-local, multicast
- IPv4-mapped IPv6 recursion (`::ffff:10.0.0.1` must be blocked)
- `assertExternalUrl`: scheme allow-list (rejects file/gopher/ftp/javascript/data), hostname resolution, multi-record check (any private record blocks), unresolvable hostname, public hostname OK, literal-IP fast paths

## 📚 Documentation

- `docs/api.md` — add `DELETE /api/print-history/{id}` (existed but undocumented), `GET /api/embed-check`, `GET /api/openapi`
- `CLAUDE.md` — bump stale test count, note that exact counts drift on every PR

## Out of scope

The audit also flagged the print-history POST atomicity fallback (sequential saves on standalone mongod can't be transactional) and minor code-health items. Left for a separate change — the transaction path is the right answer in production (Atlas), and the fallback is documented and only fires on local/test mongod.

## Verification

- 765 tests pass (up from ~701)
- Typecheck + lint clean
- 63 new tests: 57 SSRF + 5 print-history undo + 1 dry-cycle length bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)