### PR TITLE
Feat #139: bulk CSV export of every spool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.12.7",
+      "version": "1.12.8",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",
@@ -800,7 +800,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1644,7 +1643,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1667,7 +1665,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1690,7 +1687,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1707,7 +1703,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1724,7 +1719,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1741,7 +1735,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1758,7 +1751,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1775,7 +1767,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1792,7 +1783,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1809,7 +1799,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1826,7 +1815,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1843,7 +1831,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1860,7 +1847,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1883,7 +1869,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1906,7 +1891,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1929,7 +1913,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1952,7 +1935,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1975,7 +1957,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1998,7 +1979,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2021,7 +2001,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2044,7 +2023,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2064,7 +2042,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2084,7 +2061,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2104,7 +2080,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/src/app/api/spools/export-csv/route.ts
+++ b/src/app/api/spools/export-csv/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getSpoolExportRows, SPOOL_EXPORT_COLUMNS } from "@/lib/exportSpools";
+import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+
+/**
+ * GET /api/spools/export-csv — bulk export every spool as CSV (GH #139).
+ *
+ * Mirrors the filament export route: emit a flat CSV one row per spool. The
+ * leading columns intentionally use the same headers as `/api/spools/import`
+ * (filament, vendor, label, totalWeight, lotNumber, purchaseDate, openedDate,
+ * location) so the file is round-trippable without column renaming.
+ */
+
+function escapeCsv(value: string | number | boolean | null): string {
+  if (value == null) return "";
+  const str = typeof value === "boolean" ? (value ? "true" : "false") : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export async function GET() {
+  try {
+    const rows = await getSpoolExportRows();
+
+    const header = SPOOL_EXPORT_COLUMNS.map((c) => escapeCsv(c.header)).join(",");
+    const dataLines = rows.map((row) =>
+      SPOOL_EXPORT_COLUMNS.map((c) => escapeCsv(row[c.key])).join(","),
+    );
+
+    const csv = [header, ...dataLines].join("\n");
+
+    return new NextResponse(csv, {
+      headers: {
+        "Content-Type": "text/csv",
+        "Content-Disposition": 'attachment; filename="spools.csv"',
+      },
+    });
+  } catch (err) {
+    return errorResponse("Failed to export spools CSV", 500, getErrorMessage(err));
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -830,6 +830,18 @@ export default function Home() {
                   <span className="w-2 h-2 rounded-full bg-green-500" />
                   {t("filaments.export.xlsx")}
                 </a>
+                <div className="border-t border-gray-600 my-1" />
+                <div className="px-4 py-1">
+                  <span className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">{t("spools.export")}</span>
+                </div>
+                <a
+                  href="/api/spools/export-csv"
+                  className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  onClick={() => setShowImportExport(false)}
+                >
+                  <span className="w-2 h-2 rounded-full bg-green-500" />
+                  {t("spools.export.csv")}
+                </a>
               </div>
             )}
           </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -11,6 +11,8 @@
   "filaments.export.ini": "INI (PrusaSlicer)",
   "filaments.export.csv": "CSV",
   "filaments.export.xlsx": "Excel (XLSX)",
+  "spools.export": "Spulendaten",
+  "spools.export.csv": "CSV (eine Zeile pro Spule)",
   "filaments.table.color": "Farbe",
   "filaments.table.name": "Name",
   "filaments.table.vendor": "Hersteller",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -11,6 +11,8 @@
   "filaments.export.ini": "INI (PrusaSlicer)",
   "filaments.export.csv": "CSV",
   "filaments.export.xlsx": "Excel (XLSX)",
+  "spools.export": "Spool data",
+  "spools.export.csv": "CSV (one row per spool)",
   "filaments.table.color": "Color",
   "filaments.table.name": "Name",
   "filaments.table.vendor": "Vendor",

--- a/src/lib/exportSpools.ts
+++ b/src/lib/exportSpools.ts
@@ -1,0 +1,168 @@
+import dbConnect from "@/lib/mongodb";
+import Filament from "@/models/Filament";
+import Location from "@/models/Location";
+import { resolveFilament } from "@/lib/resolveFilament";
+
+/**
+ * Row shape for the spool CSV export. Column ORDER below is chosen so the
+ * leading columns round-trip through `/api/spools/import` (same headers the
+ * importer recognises): `filament`, `vendor`, `label`, `totalWeight`,
+ * `lotNumber`, `purchaseDate`, `openedDate`, `location`. Trailing columns
+ * are export-only context the importer ignores (read-only metadata, ids).
+ *
+ * Filament-level fields (vendor, type, spoolWeight, netFilamentWeight) are
+ * resolved through `resolveFilament` so variants emit their parent's
+ * inherited values rather than blank cells. The variant's own name is kept
+ * verbatim — that's the row's natural label and what the importer matches
+ * against to re-attach a spool to a specific filament.
+ */
+export interface SpoolExportRow {
+  /** Filament name as stored on the filament doc (variant name for variants). */
+  filament: string;
+  vendor: string;
+  type: string;
+  color: string;
+  label: string;
+  /** Current remaining grams. The Filament schema treats `totalWeight` on a
+   * spool as the live remaining figure, not the original net weight. */
+  totalWeight: number | null;
+  /** Empty spool weight in grams (typically inherited from the filament). */
+  spoolWeight: number | null;
+  /** Net filament weight at full spool (typically inherited from the filament). */
+  netFilamentWeight: number | null;
+  lotNumber: string | null;
+  /** ISO date string ("YYYY-MM-DD") or null. */
+  purchaseDate: string | null;
+  openedDate: string | null;
+  location: string | null;
+  retired: boolean;
+  dryCyclesCount: number;
+  /** ISO datetime of the most recent dry cycle, or null if never dried. */
+  lastDriedAt: string | null;
+  /** Sum of grams consumed across this spool's usageHistory. */
+  usedGrams: number;
+  createdAt: string | null;
+  instanceId: string;
+  filamentId: string;
+  spoolId: string;
+}
+
+export const SPOOL_EXPORT_COLUMNS: { key: keyof SpoolExportRow; header: string }[] = [
+  // Round-trippable columns first — these match `/api/spools/import` exactly.
+  { key: "filament", header: "filament" },
+  { key: "vendor", header: "vendor" },
+  { key: "label", header: "label" },
+  { key: "totalWeight", header: "totalWeight" },
+  { key: "lotNumber", header: "lotNumber" },
+  { key: "purchaseDate", header: "purchaseDate" },
+  { key: "openedDate", header: "openedDate" },
+  { key: "location", header: "location" },
+  // Export-only context columns.
+  { key: "type", header: "type" },
+  { key: "color", header: "color" },
+  { key: "spoolWeight", header: "spoolWeight" },
+  { key: "netFilamentWeight", header: "netFilamentWeight" },
+  { key: "retired", header: "retired" },
+  { key: "dryCyclesCount", header: "dryCyclesCount" },
+  { key: "lastDriedAt", header: "lastDriedAt" },
+  { key: "usedGrams", header: "usedGrams" },
+  { key: "createdAt", header: "createdAt" },
+  { key: "instanceId", header: "instanceId" },
+  { key: "filamentId", header: "filamentId" },
+  { key: "spoolId", header: "spoolId" },
+];
+
+function isoDateOnly(d: Date | string | null | undefined): string | null {
+  if (!d) return null;
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+function isoDateTime(d: Date | string | null | undefined): string | null {
+  if (!d) return null;
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+export async function getSpoolExportRows(): Promise<SpoolExportRow[]> {
+  await dbConnect();
+
+  const [filaments, locations] = await Promise.all([
+    Filament.find({ _deletedAt: null }).sort({ name: 1 }).lean(),
+    Location.find({ _deletedAt: null }).lean(),
+  ]);
+
+  // Build parent lookup so variants resolve inherited filament-level fields
+  // (vendor, type, spoolWeight, netFilamentWeight). Spool-level fields are
+  // never inherited — they belong to the spool subdoc itself.
+  const parentMap = new Map<string, (typeof filaments)[number]>();
+  for (const f of filaments) {
+    if (!f.parentId) {
+      parentMap.set(f._id.toString(), f);
+    }
+  }
+
+  const locationNameById = new Map<string, string>();
+  for (const l of locations) {
+    locationNameById.set(l._id.toString(), l.name as string);
+  }
+
+  const rows: SpoolExportRow[] = [];
+  for (const filament of filaments) {
+    const resolved = filament.parentId
+      ? resolveFilament(filament, parentMap.get(filament.parentId.toString()))
+      : filament;
+
+    for (const spool of filament.spools || []) {
+      // Sum grams used (positive deltas only — the schema enforces grams >= 0).
+      const usedGrams = (spool.usageHistory || []).reduce(
+        (sum: number, u: { grams: number }) => sum + (u.grams || 0),
+        0,
+      );
+
+      // Latest dry cycle by date — entries are pushed chronologically by the
+      // UI but tolerate manual reordering by picking the max explicitly.
+      let lastDried: Date | null = null;
+      for (const c of spool.dryCycles || []) {
+        const d = c.date instanceof Date ? c.date : new Date(c.date);
+        if (Number.isNaN(d.getTime())) continue;
+        if (!lastDried || d > lastDried) lastDried = d;
+      }
+
+      const locationName = spool.locationId
+        ? locationNameById.get(spool.locationId.toString()) ?? null
+        : null;
+
+      rows.push({
+        filament: filament.name,
+        vendor: resolved.vendor ?? "",
+        type: resolved.type ?? "",
+        color: filament.color ?? "",
+        label: spool.label ?? "",
+        totalWeight: typeof spool.totalWeight === "number" ? spool.totalWeight : null,
+        spoolWeight:
+          typeof resolved.spoolWeight === "number" ? resolved.spoolWeight : null,
+        netFilamentWeight:
+          typeof resolved.netFilamentWeight === "number"
+            ? resolved.netFilamentWeight
+            : null,
+        lotNumber: spool.lotNumber ?? null,
+        purchaseDate: isoDateOnly(spool.purchaseDate),
+        openedDate: isoDateOnly(spool.openedDate),
+        location: locationName,
+        retired: !!spool.retired,
+        dryCyclesCount: (spool.dryCycles || []).length,
+        lastDriedAt: isoDateTime(lastDried),
+        usedGrams,
+        createdAt: isoDateTime(spool.createdAt),
+        instanceId: filament.instanceId ?? "",
+        filamentId: filament._id.toString(),
+        spoolId: spool._id ? spool._id.toString() : "",
+      });
+    }
+  }
+
+  return rows;
+}

--- a/tests/exportSpools.test.ts
+++ b/tests/exportSpools.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { getSpoolExportRows, SPOOL_EXPORT_COLUMNS } from "@/lib/exportSpools";
+
+/**
+ * GH #139 — bulk CSV export of every spool. The leading column headers must
+ * match `/api/spools/import` so the file is round-trippable, and filament-
+ * level fields (vendor / type / spoolWeight / netFilamentWeight) must resolve
+ * through the parent for variants.
+ */
+describe("getSpoolExportRows", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Location: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    const locationMod = await import("@/models/Location");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    if (!mongoose.models.Location) {
+      mongoose.model("Location", locationMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+    Location = mongoose.models.Location;
+  });
+
+  it("returns an empty array when no filaments exist", async () => {
+    const rows = await getSpoolExportRows();
+    expect(rows).toEqual([]);
+  });
+
+  it("emits one row per spool with the round-trippable importer headers as leading columns", async () => {
+    // The importer's required columns are `filament` + `totalWeight`; optional
+    // columns are vendor/label/lotNumber/purchaseDate/openedDate/location.
+    // Pin the column order so a future reorder accidentally breaking
+    // round-trip parity fails this test loudly.
+    const headers = SPOOL_EXPORT_COLUMNS.slice(0, 8).map((c) => c.header);
+    expect(headers).toEqual([
+      "filament",
+      "vendor",
+      "label",
+      "totalWeight",
+      "lotNumber",
+      "purchaseDate",
+      "openedDate",
+      "location",
+    ]);
+  });
+
+  it("exports per-spool fields including label, totalWeight, lotNumber, purchase/opened dates, retired flag", async () => {
+    await Filament.create({
+      name: "Test PLA",
+      vendor: "TestVendor",
+      type: "PLA",
+      color: "#ff0000",
+      spoolWeight: 230,
+      netFilamentWeight: 1000,
+      spools: [
+        {
+          label: "Spool A",
+          totalWeight: 850,
+          lotNumber: "LOT-42",
+          purchaseDate: new Date("2026-01-15T00:00:00Z"),
+          openedDate: new Date("2026-02-01T00:00:00Z"),
+          retired: false,
+        },
+        {
+          label: "Spool B",
+          totalWeight: 0,
+          retired: true,
+        },
+      ],
+    });
+
+    const rows = await getSpoolExportRows();
+    expect(rows).toHaveLength(2);
+
+    const a = rows.find((r) => r.label === "Spool A")!;
+    expect(a.filament).toBe("Test PLA");
+    expect(a.vendor).toBe("TestVendor");
+    expect(a.type).toBe("PLA");
+    expect(a.color).toBe("#ff0000");
+    expect(a.totalWeight).toBe(850);
+    expect(a.spoolWeight).toBe(230);
+    expect(a.netFilamentWeight).toBe(1000);
+    expect(a.lotNumber).toBe("LOT-42");
+    expect(a.purchaseDate).toBe("2026-01-15");
+    expect(a.openedDate).toBe("2026-02-01");
+    expect(a.retired).toBe(false);
+
+    const b = rows.find((r) => r.label === "Spool B")!;
+    expect(b.totalWeight).toBe(0);
+    expect(b.lotNumber).toBeNull();
+    expect(b.purchaseDate).toBeNull();
+    expect(b.retired).toBe(true);
+  });
+
+  it("resolves nullable filament-level fields from the parent for variants (spoolWeight, netFilamentWeight)", async () => {
+    // The schema marks vendor/type as required strings, so variants always
+    // store concrete copies of those — there's nothing to inherit. The
+    // export's inheritance value lives in the *nullable* numeric fields:
+    // spoolWeight and netFilamentWeight typically live on the parent and
+    // come through as null on each variant.
+    const parent = await Filament.create({
+      name: "Generic PETG",
+      vendor: "ParentVendor",
+      type: "PETG",
+      spoolWeight: 250,
+      netFilamentWeight: 1000,
+    });
+    await Filament.create({
+      name: "Generic PETG — Forest Green",
+      vendor: "ParentVendor", // schema requires non-empty
+      type: "PETG",
+      parentId: parent._id,
+      // spoolWeight + netFilamentWeight intentionally unset → must inherit
+      spools: [{ label: "V Spool", totalWeight: 950 }],
+    });
+
+    const rows = await getSpoolExportRows();
+    const variant = rows.find((r) => r.label === "V Spool")!;
+    expect(variant.filament).toBe("Generic PETG — Forest Green"); // variant own name
+    expect(variant.spoolWeight).toBe(250); // inherited
+    expect(variant.netFilamentWeight).toBe(1000); // inherited
+  });
+
+  it("resolves location ObjectIds to location names; missing locations come through as null", async () => {
+    const drybox = await Location.create({ name: "Drybox #1", kind: "drybox" });
+    await Filament.create({
+      name: "PETG",
+      vendor: "Test",
+      type: "PETG",
+      spools: [
+        { label: "Located", totalWeight: 1000, locationId: drybox._id },
+        { label: "Unlocated", totalWeight: 1000 }, // no locationId
+      ],
+    });
+
+    const rows = await getSpoolExportRows();
+    expect(rows.find((r) => r.label === "Located")!.location).toBe("Drybox #1");
+    expect(rows.find((r) => r.label === "Unlocated")!.location).toBeNull();
+  });
+
+  it("aggregates dry cycles (count + most recent ISO timestamp) and usage history (grams sum)", async () => {
+    await Filament.create({
+      name: "PA",
+      vendor: "Test",
+      type: "PA",
+      spools: [
+        {
+          label: "Heavy use",
+          totalWeight: 600,
+          dryCycles: [
+            { date: new Date("2026-03-01T08:00:00Z"), tempC: 80, durationMin: 480, notes: "" },
+            { date: new Date("2026-04-15T08:00:00Z"), tempC: 80, durationMin: 480, notes: "" },
+            { date: new Date("2026-02-10T08:00:00Z"), tempC: 80, durationMin: 480, notes: "" },
+          ],
+          usageHistory: [
+            { grams: 120, jobLabel: "test job", date: new Date(), source: "manual" },
+            { grams: 80, jobLabel: "another", date: new Date(), source: "job" },
+          ],
+        },
+      ],
+    });
+
+    const rows = await getSpoolExportRows();
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.dryCyclesCount).toBe(3);
+    expect(row.lastDriedAt).toBe("2026-04-15T08:00:00.000Z"); // picks max date even out-of-order
+    expect(row.usedGrams).toBe(200);
+  });
+
+  it("emits ISO date-only strings for purchase/opened, and null for never-dried spools", async () => {
+    await Filament.create({
+      name: "PLA",
+      vendor: "Test",
+      type: "PLA",
+      spools: [
+        { label: "Untouched", totalWeight: 1000 },
+      ],
+    });
+
+    const rows = await getSpoolExportRows();
+    const row = rows[0];
+    expect(row.purchaseDate).toBeNull();
+    expect(row.openedDate).toBeNull();
+    expect(row.lastDriedAt).toBeNull();
+    expect(row.dryCyclesCount).toBe(0);
+    expect(row.usedGrams).toBe(0);
+    expect(row.retired).toBe(false);
+  });
+
+  it("includes filamentId / spoolId / instanceId so exported rows can be cross-referenced back", async () => {
+    const filament = await Filament.create({
+      name: "Linkable",
+      vendor: "Test",
+      type: "PLA",
+      spools: [{ label: "S", totalWeight: 1000 }],
+    });
+
+    const rows = await getSpoolExportRows();
+    const row = rows[0];
+    expect(row.filamentId).toBe(filament._id.toString());
+    expect(row.spoolId).toBe(filament.spools[0]._id.toString());
+    expect(row.instanceId).toBe(filament.instanceId);
+    expect(row.instanceId.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #139.

## Summary

- New `GET /api/spools/export-csv` route, mirroring the existing filament export pattern.
- New row builder in [`src/lib/exportSpools.ts`](src/lib/exportSpools.ts) — one row per spool, includes label / totalWeight / spoolWeight / netFilamentWeight / location name / dry-cycle count + last dried / used grams / lot number / purchase + opened dates / retired flag / ids.
- New "Spool data → CSV (one row per spool)" link in the home page's Import / Export dropdown, with `en` + `de` translations.

## Round-trip parity

The leading 8 columns reuse the exact header names the existing spool *importer* (`POST /api/spools/import`) recognises:

```
filament, vendor, label, totalWeight, lotNumber, purchaseDate, openedDate, location
```

So the exported CSV imports back without column renaming. Trailing columns are export-only context (type / color / spool weights / retired / dry-cycle aggregates / used grams / createdAt / ids) — the importer ignores them.

## Inheritance

Variants resolve through the same `resolveFilament()` helper used elsewhere — so a variant whose `spoolWeight` / `netFilamentWeight` live on the parent emits the inherited values rather than blank cells. The variant's own name is kept verbatim so importer round-trips re-attach to the correct filament.

## Test plan

- [x] `npx vitest run tests/exportSpools.test.ts` — 8 tests, all pass (empty case; round-trip header parity; per-spool fields; parent-inheritance for nullable filament fields; location resolution + null fallback; dry-cycle aggregation with out-of-order dates; usage-history grams sum; never-touched defaults; id columns)
- [x] `npm test` — full suite green (773 tests, 41 files)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)