### PR TITLE
Codex P2 round 2: currency hydration / autoselect / CSV round-trip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.12.10",
+  "version": "1.12.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.12.10",
+      "version": "1.12.11",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.12.10",
+  "version": "1.12.11",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/src/app/api/spools/import/route.ts
+++ b/src/app/api/spools/import/route.ts
@@ -4,6 +4,7 @@ import Filament from "@/models/Filament";
 import Location from "@/models/Location";
 import { parseCsv } from "@/lib/parseCsv";
 import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { unsanitizeCsvCell } from "@/lib/csvWriter";
 
 /**
  * POST /api/spools/import — bulk-create spools from CSV.
@@ -101,8 +102,12 @@ export async function POST(request: NextRequest) {
 
     for (let i = 0; i < rows.length; i++) {
       const r = rows[i];
-      const filamentName = (r.filament || "").trim();
-      const vendor = (r.vendor || "").trim();
+      // Strip the formula guard apostrophe (`csvCell` adds `'` in front
+      // of cells starting with =, +, -, @, tab, CR) so a row exported
+      // by `/api/spools/export-csv` round-trips cleanly. Codex P2
+      // follow-up to PR #144.
+      const filamentName = unsanitizeCsvCell((r.filament || "").trim());
+      const vendor = unsanitizeCsvCell((r.vendor || "").trim());
       const weightStr = (r.totalWeight || "").trim();
 
       if (!filamentName) {
@@ -147,7 +152,9 @@ export async function POST(request: NextRequest) {
         continue;
       }
 
-      const locationId = await resolveLocationId((r.location || "").trim());
+      const locationId = await resolveLocationId(
+        unsanitizeCsvCell((r.location || "").trim()),
+      );
 
       const purchaseDate = r.purchaseDate ? new Date(r.purchaseDate) : null;
       const openedDate = r.openedDate ? new Date(r.openedDate) : null;
@@ -157,9 +164,9 @@ export async function POST(request: NextRequest) {
       // to avoid the direct `any` eslint rule while still satisfying the
       // push signature.
       filament.spools.push({
-        label: r.label || "",
+        label: unsanitizeCsvCell(r.label || ""),
         totalWeight: weight,
-        lotNumber: r.lotNumber || null,
+        lotNumber: r.lotNumber ? unsanitizeCsvCell(r.lotNumber) : null,
         purchaseDate: purchaseDate && !isNaN(+purchaseDate) ? purchaseDate : null,
         openedDate: openedDate && !isNaN(+openedDate) ? openedDate : null,
         locationId: locationId || null,

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -70,9 +70,11 @@ export default function SettingsPage() {
       setNewCurrError(err);
       return;
     }
-    // Success: reset form, hide, select the just-added code
+    // `addCustom` auto-selects the new currency on success — calling
+    // `setCurrency` here additionally would race React's state batching
+    // and reject the new code on the first click (Codex P2 follow-up
+    // to PR #142). Just reset the form.
     setNewCurrError(null);
-    setCurrency(newCurrCode.trim().toUpperCase());
     setNewCurrCode("");
     setNewCurrSymbol("");
     setNewCurrName("");

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -117,16 +117,38 @@ export function useCurrency() {
       .getConfig()
       .then((cfg) => {
         const c = cfg as Record<string, unknown>;
-        const customJson = typeof c.customCurrencies === "string" ? c.customCurrencies : "";
-        const parsed = parseCustomCurrencies(customJson, BUILTIN_CODES);
-        if (parsed.length > 0) setCustomCurrenciesState(parsed);
+
+        // Resolve the authoritative custom list for this hydration:
+        //   - Electron-store has the key (typeof === "string"): apply it
+        //     verbatim, INCLUDING the empty array. Otherwise a desktop
+        //     user who cleared their list could see localStorage-cached
+        //     entries resurrect on next launch (Codex P2 follow-up to
+        //     PR #142).
+        //   - Key absent (undefined): leave the localStorage-initialised
+        //     state alone — first run on desktop after web use survives.
+        let resolvedList: CustomCurrency[] | null = null;
+        if (typeof c.customCurrencies === "string") {
+          resolvedList = parseCustomCurrencies(c.customCurrencies, BUILTIN_CODES);
+          setCustomCurrenciesState(resolvedList);
+        }
 
         const saved = typeof c.currency === "string" ? c.currency : "";
-        if (saved && isKnownCode(saved, parsed)) {
-          setCurrencyState(saved);
+        if (saved) {
+          // Validate against the just-resolved list so an electron-side
+          // entry that still exists in `c.customCurrencies` is accepted
+          // even on the first render after mount. Falling back to the
+          // closure's `customCurrencies` is correct only when electron
+          // didn't override (resolvedList === null).
+          const validateAgainst = resolvedList ?? customCurrencies;
+          if (isKnownCode(saved, validateAgainst)) {
+            setCurrencyState(saved);
+          }
         }
       })
       .catch(() => {});
+    // Mount-only hydration; we deliberately do not re-run when the
+    // localStorage-initialised customCurrencies value churns.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const persistCurrency = useCallback((code: string) => {
@@ -179,9 +201,18 @@ export function useCurrency() {
       const next = addCC(customCurrencies, entry);
       setCustomCurrenciesState(next);
       persistCustom(next);
+      // Auto-select the just-added code. Doing it here closes the
+      // closure-stale-state hole: a separate setCurrency() call from the
+      // caller would validate against the pre-add `customCurrencies`
+      // captured in setCurrency's useCallback memo, and reject the new
+      // code (Codex P2 follow-up to PR #142). Since the ergonomic flow
+      // is "user adds a currency to use", autoselect is also the right
+      // default behaviour.
+      setCurrencyState(entry.code);
+      persistCurrency(entry.code);
       return null;
     },
-    [customCurrencies, persistCustom],
+    [customCurrencies, persistCurrency, persistCustom],
   );
 
   const removeCustom = useCallback(

--- a/src/lib/csvWriter.ts
+++ b/src/lib/csvWriter.ts
@@ -64,3 +64,30 @@ export function isFormulaCandidate(value: unknown): boolean {
     FORMULA_TRIGGERS.includes(value[0])
   );
 }
+
+/**
+ * Inverse of `csvCell`'s formula guard: strip a leading `'` if it's
+ * sitting in front of a formula-trigger character. This is what the CSV
+ * importers run user-supplied string fields through so a value exported
+ * with the guard (`'=foo`) round-trips back to its original form (`=foo`).
+ *
+ * The strip is conservative — it only fires on the exact `'` + trigger
+ * pattern that `csvCell` produces. A value that genuinely starts with `'`
+ * followed by a non-trigger character (e.g. `'70s blue`) is left alone.
+ *
+ * Codex P2 follow-up to PR #144: without this, exporting then re-
+ * importing a row whose filament name / vendor / location starts with
+ * a trigger char would either fail to match an existing filament (the
+ * import is exact-string-match on `filament`) or persist the apostrophe
+ * verbatim into the document.
+ */
+export function unsanitizeCsvCell(value: string): string {
+  if (
+    value.length >= 2 &&
+    value[0] === "'" &&
+    FORMULA_TRIGGERS.includes(value[1])
+  ) {
+    return value.slice(1);
+  }
+  return value;
+}

--- a/tests/csvWriter.test.ts
+++ b/tests/csvWriter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { csvCell, isFormulaCandidate } from "@/lib/csvWriter";
+import { csvCell, isFormulaCandidate, unsanitizeCsvCell } from "@/lib/csvWriter";
 
 /**
  * Codex P2 on PR #141 — without sanitisation, an attacker who controls
@@ -67,6 +67,50 @@ describe("csvCell — formula injection neutralisation", () => {
 
   it("does NOT prefix the empty string", () => {
     expect(csvCell("")).toBe("");
+  });
+});
+
+describe("unsanitizeCsvCell — inverse of csvCell's formula guard", () => {
+  it("strips the leading apostrophe when followed by a formula trigger", () => {
+    expect(unsanitizeCsvCell("'=foo")).toBe("=foo");
+    expect(unsanitizeCsvCell("'+evil()")).toBe("+evil()");
+    expect(unsanitizeCsvCell("'-1+2")).toBe("-1+2");
+    expect(unsanitizeCsvCell("'@SUM(A1)")).toBe("@SUM(A1)");
+    expect(unsanitizeCsvCell("'\tinject")).toBe("\tinject");
+    expect(unsanitizeCsvCell("'\rinject")).toBe("\rinject");
+  });
+
+  it("leaves apostrophe-prefixed strings alone when the next char is benign", () => {
+    expect(unsanitizeCsvCell("'70s blue")).toBe("'70s blue");
+    expect(unsanitizeCsvCell("'apostrophe")).toBe("'apostrophe");
+    expect(unsanitizeCsvCell("'a")).toBe("'a");
+  });
+
+  it("leaves non-apostrophe-prefixed values alone", () => {
+    expect(unsanitizeCsvCell("Generic PLA")).toBe("Generic PLA");
+    expect(unsanitizeCsvCell("=foo")).toBe("=foo"); // no leading apostrophe → no change
+    expect(unsanitizeCsvCell("")).toBe("");
+  });
+
+  it("round-trips with csvCell for formula-leading values", () => {
+    const original = "=cmd|'/C calc'!A0";
+    // csvCell wraps in quotes because of the comma; unsanitize handles
+    // the un-wrapped value the parser would hand back.
+    const exported = csvCell(original);
+    // Strip the RFC4180 quote wrap that csvCell applied because of the
+    // embedded comma: the parseCsv layer would have already done that
+    // before handing the cell to unsanitizeCsvCell.
+    const unwrapped = exported.startsWith('"') && exported.endsWith('"')
+      ? exported.slice(1, -1).replace(/""/g, '"')
+      : exported;
+    expect(unsanitizeCsvCell(unwrapped)).toBe(original);
+  });
+
+  it("round-trips with csvCell for plain formula triggers (no embedded commas)", () => {
+    expect(unsanitizeCsvCell(csvCell("=A1+B1"))).toBe("=A1+B1");
+    expect(unsanitizeCsvCell(csvCell("+1"))).toBe("+1");
+    expect(unsanitizeCsvCell(csvCell("-1"))).toBe("-1");
+    expect(unsanitizeCsvCell(csvCell("@SUM"))).toBe("@SUM");
   });
 });
 

--- a/tests/spools-import-route.test.ts
+++ b/tests/spools-import-route.test.ts
@@ -193,4 +193,66 @@ describe("/api/spools/import", () => {
     expect(body.results[0].error).toMatch(/non-negative/);
     expect(body.results[1].error).toMatch(/non-negative/);
   });
+
+  // Codex P2 follow-up to PR #144 — `csvCell` prefixes formula-leading
+  // STRING cells with a `'` so spreadsheets read them as text. The
+  // importer must strip that guard so a row exported with a name like
+  // `=Eval` round-trips back to the original filament without keeping
+  // the apostrophe in the matched/persisted text.
+  it("strips the formula-guard apostrophe so an exported '=Name' row matches its filament on re-import", async () => {
+    const f = await Filament.create({
+      name: "=Generic", // legit-but-formula-shaped filament name
+      vendor: "Test",
+      type: "PLA",
+    });
+    // Simulate a row produced by /api/spools/export-csv: the exporter
+    // wrote `'=Generic` (apostrophe prefix). The importer must match
+    // back to the original filament.
+    const csv = "filament,totalWeight\n'=Generic,950\n";
+    const res = await importSpools(csvRequest(csv));
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+    expect(body.failed).toBe(0);
+
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.spools).toHaveLength(1);
+    expect(fresh.spools[0].totalWeight).toBe(950);
+  });
+
+  it("strips the formula-guard apostrophe from label / lotNumber / location when present", async () => {
+    const f = await Filament.create({ name: "Strip", vendor: "Test", type: "PLA" });
+    // Label, lotNumber, and location all start with `=` originally.
+    // After export they'd be `'=label` / `'=LOT-1` / `'=Drybox` and
+    // re-import must restore the original strings — otherwise the
+    // matched location name would be `'=Drybox` (a different row from
+    // the original) and analytics on label / lot would diverge.
+    const csv =
+      "filament,totalWeight,label,lotNumber,location\n" +
+      `Strip,500,'=Lab Use,'=LOT-1,'=Drybox\n`;
+    const res = await importSpools(csvRequest(csv));
+    const body = await res.json();
+    expect(body.imported).toBe(1);
+
+    const fresh = await Filament.findById(f._id);
+    const spool = fresh.spools[0];
+    expect(spool.label).toBe("=Lab Use");
+    expect(spool.lotNumber).toBe("=LOT-1");
+    // resolveLocationId used the unsanitized name; the row should now
+    // reference a location with that exact name, not "'=Drybox".
+    const Location = (await import("@/models/Location")).default;
+    const loc = await Location.findOne({ name: "=Drybox" });
+    expect(loc).not.toBeNull();
+    expect(spool.locationId.toString()).toBe(loc!._id.toString());
+  });
+
+  it("leaves apostrophe-prefixed values alone when the next char isn't a formula trigger ('70s blue)", async () => {
+    await Filament.create({ name: "'70s Style", vendor: "Test", type: "PLA" });
+    const csv = "filament,totalWeight\n'70s Style,800\n";
+    const res = await importSpools(csvRequest(csv));
+    const body = await res.json();
+    // Should match — the leading `'` followed by `7` is not a guard
+    // pattern, so unsanitize leaves it intact and the filament lookup
+    // finds the seeded row.
+    expect(body.imported).toBe(1);
+  });
 });


### PR DESCRIPTION
Three more P2s Codex flagged after [#142](https://github.com/hyiger/filament-db/pull/142) and [#144](https://github.com/hyiger/filament-db/pull/144) landed.

## 1. Electron `customCurrencies` hydration ignored empty arrays

The mount-effect skipped `setCustomCurrenciesState()` when `getConfig()` returned an empty list, leaving the localStorage-initialised state alive — meaning a desktop user who cleared their custom list could see entries resurrect from stale browser storage on the next launch. The electron value is now treated as authoritative whenever the key is present (`typeof === "string"`), including `[]` which clears the list. Falls back to the localStorage-initialised state only when the key is genuinely absent (first run on desktop after web use).

## 2. `addCustom` rejected its own creation on the same render

`setCurrency` validates against `customCurrencies` captured in the current render's `useCallback` memo, so calling `addCustom(newCode)` and `setCurrency(newCode)` back-to-back in the Settings handler always rejected the new code — the state update hadn't rendered yet. Fix: `addCustom` now auto-selects the just-added entry atomically with the add, closing the closure-stale window. The Settings handler dropped its now-redundant `setCurrency()` call.

(Auto-select is also the right ergonomic default — when a user adds a currency they almost always want to use it.)

## 3. CSV round-trip break for formula-leading values

`csvCell` prefixes formula-leading STRING cells with `'` so spreadsheets render them as text. The spool importer does exact string matching on the `filament` column, so an exported `'=Generic` row would fail to find its parent filament on re-import (or persist the apostrophe into `label` / `lotNumber` / `location` text fields).

Fix: new `unsanitizeCsvCell()` helper strips the apostrophe iff it's followed by a formula trigger char, applied in the importer to `filament` / `vendor` / `label` / `lotNumber` / `location`. Conservative — values like `'70s blue` (apostrophe followed by a non-trigger) are left alone.

## Test plan

- [x] `npx vitest run tests/csvWriter.test.ts` — 19 tests (was 14, +5 for `unsanitizeCsvCell` including a full csvCell ↔ unsanitize round-trip)
- [x] `npx vitest run tests/spools-import-route.test.ts` — 11 tests (was 8, +3 for round-trip strip on filament name; on label/lotNumber/location; legitimate-apostrophe leave-alone)
- [x] `npm test` — full suite green (817 tests, 43 files)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)