### PR TITLE
Fix #143: actionable error when Atlas user lacks write permission

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -25,6 +25,35 @@ export function getDbNameFromUri(uri: string): string {
   }
 }
 
+/**
+ * Wrap a sync error into a user-facing message, redacting connection
+ * strings. When the error is the MongoDB driver's "Unauthorized" shape
+ * (raised when the Atlas user lacks `readWrite`), swap the raw driver
+ * text for an actionable hint that points the user at the fix —
+ * regenerating the connection string from a writable Atlas user.
+ *
+ * Detects the auth shape two ways: by message regex (matches the driver's
+ * `user is not allowed to do action [update] on [db.coll]`) and by code 13
+ * (the more reliable signal, but not always populated on every wrapped
+ * error path). Either is sufficient. See GH #143.
+ */
+export function wrapSyncErrorMessage(err: unknown, dbName: string): string {
+  const message = err instanceof Error ? err.message : "Sync failed";
+  const code =
+    err && typeof err === "object" && "code" in err
+      ? (err as { code: unknown }).code
+      : undefined;
+
+  const isAuthError =
+    /user is not allowed to do action/i.test(message) || code === 13;
+
+  if (isAuthError) {
+    return `The Atlas user in your connection string only has read permission for "${dbName}". Update the user's role to one that includes readWrite (or change the connection string to one that does), then try again. You can re-enter the connection string in Settings → Connection.`;
+  }
+
+  return message.replace(/mongodb(\+srv)?:\/\/[^\s]+/g, "mongodb://***");
+}
+
 export interface SyncStatus {
   state: "idle" | "syncing" | "error" | "offline";
   lastSyncAt: string | null;
@@ -262,8 +291,7 @@ export class SyncService extends EventEmitter {
       this.emit("syncComplete", results);
       return results;
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Sync failed";
-      const safe = message.replace(/mongodb(\+srv)?:\/\/[^\s]+/g, "mongodb://***");
+      const safe = wrapSyncErrorMessage(err, getDbNameFromUri(this.atlasUri));
       this.updateStatus({ state: "error", error: safe, progress: null });
       this.emit("syncError", safe);
       return [];

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getDbNameFromUri } from "../electron/sync-service";
+import { getDbNameFromUri, wrapSyncErrorMessage } from "../electron/sync-service";
 
 describe("getDbNameFromUri", () => {
   it("extracts db name from a basic mongodb URI with explicit path", () => {
@@ -50,5 +50,51 @@ describe("getDbNameFromUri", () => {
     expect(getDbNameFromUri("mongodb://localhost/my-db_v2.prod")).toBe(
       "my-db_v2.prod"
     );
+  });
+});
+
+describe("wrapSyncErrorMessage", () => {
+  it("wraps the Atlas read-only driver message into an actionable hint", () => {
+    const err = new Error(
+      "user is not allowed to do action [update] on [filament-db.filaments]"
+    );
+    const wrapped = wrapSyncErrorMessage(err, "filament-db");
+
+    expect(wrapped).toContain("filament-db");
+    expect(wrapped).toContain("readWrite");
+    expect(wrapped).toContain("Settings → Connection");
+    expect(wrapped).not.toContain("user is not allowed to do action");
+  });
+
+  it("wraps errors carrying MongoDB code 13 (Unauthorized) even without the matching message", () => {
+    // Real MongoServerError shape: a plain Error decorated with a numeric code
+    const err = Object.assign(new Error("Unauthorized"), { code: 13 });
+    const wrapped = wrapSyncErrorMessage(err, "prod-db");
+
+    expect(wrapped).toContain("prod-db");
+    expect(wrapped).toContain("readWrite");
+  });
+
+  it("redacts mongodb URIs in non-auth error messages", () => {
+    const err = new Error(
+      "connection failed to mongodb+srv://user:secret@cluster.mongodb.net/db"
+    );
+    const wrapped = wrapSyncErrorMessage(err, "filament-db");
+
+    expect(wrapped).not.toContain("secret");
+    expect(wrapped).not.toContain("user:");
+    expect(wrapped).toContain("mongodb://***");
+  });
+
+  it("falls back to a generic message for non-Error throws", () => {
+    expect(wrapSyncErrorMessage("oops", "filament-db")).toBe("Sync failed");
+    expect(wrapSyncErrorMessage(undefined, "filament-db")).toBe("Sync failed");
+  });
+
+  it("does not match the auth regex on incidental text", () => {
+    const err = new Error("network reset while updating filament cache");
+    const wrapped = wrapSyncErrorMessage(err, "filament-db");
+    // No rewrite — message passes through (with URI redaction, n/a here)
+    expect(wrapped).toBe("network reset while updating filament cache");
   });
 });


### PR DESCRIPTION
Closes #143.

## Summary
- New `wrapSyncErrorMessage(err, dbName)` helper in `electron/sync-service.ts` detects the MongoDB driver's unauthorized shape (regex on `user is not allowed to do action` **or** `code === 13`) and replaces the raw text with an actionable hint that names the DB, recommends a `readWrite` role, and points users at Settings → Connection.
- Non-auth errors still get the existing `mongodb://` URI redaction.
- Used inside `sync()`'s catch block — so the wrapped message flows through `syncError` → SyncStatusIndicator tooltip and toast.

## Test plan
- [x] `npm test -- tests/sync-service.test.ts` — 5 new tests cover regex match, code-13 match, URI redaction passthrough, non-Error fallback, and that the regex doesn't false-match on incidental text. 12/12 pass.
- [x] Full `npm test` — 822/822 pass.
- [x] `npm run lint` — clean (only pre-existing mobile-package warnings).

The bonus deep-link button to Settings → Connection from the issue is left as a follow-up — the wrapped message text already directs the user there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)