### PR TITLE
Restrict external URLs to http(s) in Electron + render + storage

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -79,7 +79,20 @@ function createWindow(urlPath = "/") {
     }
   });
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    // Only forward http(s) targets to the OS shell. Anything else
+    // (file:, javascript:, data:, custom protocol handlers) could be
+    // used by injected/imported content to launch local apps or
+    // exfiltrate data via a registered handler.
+    try {
+      const proto = new URL(url).protocol;
+      if (proto === "http:" || proto === "https:") {
+        shell.openExternal(url);
+      } else {
+        console.warn(`Refused to open external URL with disallowed scheme: ${proto}`);
+      }
+    } catch {
+      console.warn(`Refused to open malformed external URL: ${url}`);
+    }
     return { action: "deny" };
   });
 

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import NfcStatus from "@/components/NfcStatus";
 import { useNfcContext } from "@/components/NfcProvider";
 import { generateOpenPrintTagBinary } from "@/lib/openprinttag";
+import { safeHttpUrl } from "@/lib/safeRenderUrl";
 import { useToast } from "@/components/Toast";
 import { useCurrency } from "@/hooks/useCurrency";
 import PrusamentImportDialog from "@/components/PrusamentImportDialog";
@@ -1106,14 +1107,16 @@ export default function FilamentDetail() {
             </svg>
             {showTdsPreview ? t("detail.tds.hide") : t("detail.tds.view")}
           </button>
-          <a
-            href={filament.tdsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-3 text-xs text-gray-500 hover:underline"
-          >
-            {t("detail.tds.openNewTab")}
-          </a>
+          {safeHttpUrl(filament.tdsUrl) && (
+            <a
+              href={safeHttpUrl(filament.tdsUrl)!}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-3 text-xs text-gray-500 hover:underline"
+            >
+              {t("detail.tds.openNewTab")}
+            </a>
+          )}
           {showTdsPreview && (
             <div className="mt-3">
               {tdsEmbedState === "checking" && (
@@ -1121,10 +1124,10 @@ export default function FilamentDetail() {
                   {t("detail.tds.checking")}
                 </p>
               )}
-              {tdsEmbedState === "allowed" && (
+              {tdsEmbedState === "allowed" && safeHttpUrl(filament.tdsUrl) && (
                 <div className="border border-gray-300 dark:border-gray-700 rounded overflow-hidden">
                   <iframe
-                    src={filament.tdsUrl}
+                    src={safeHttpUrl(filament.tdsUrl)!}
                     className="w-full bg-white"
                     style={{ height: "80vh" }}
                     title={t("detail.tds.title")}
@@ -1149,17 +1152,19 @@ export default function FilamentDetail() {
                           ? t("detail.tds.blockedBody")
                           : t("detail.tds.errorBody")}
                       </p>
-                      <a
-                        href={filament.tdsUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 mt-3 px-3 py-1.5 text-sm font-medium bg-amber-600 hover:bg-amber-700 text-white rounded"
-                      >
-                        {t("detail.tds.openExternal")}
-                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                        </svg>
-                      </a>
+                      {safeHttpUrl(filament.tdsUrl) && (
+                        <a
+                          href={safeHttpUrl(filament.tdsUrl)!}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 mt-3 px-3 py-1.5 text-sm font-medium bg-amber-600 hover:bg-amber-700 text-white rounded"
+                        >
+                          {t("detail.tds.openExternal")}
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                          </svg>
+                        </a>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { useToast } from "@/components/Toast";
 import { useTranslation } from "@/i18n/TranslationProvider";
+import { safeHttpUrl } from "@/lib/safeRenderUrl";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -221,11 +222,11 @@ function MaterialDetail({ m }: { m: OPTMaterial }) {
           <DetailField label={t("openprinttag.detail.photo")} value={m.photoUrl ? t("openprinttag.detail.yes") : null} />
           <DetailField label={t("openprinttag.detail.productUrl")} value={m.productUrl ? t("openprinttag.detail.yes") : null} />
 
-          {(m.productUrl || m.photoUrl) && (
+          {(safeHttpUrl(m.productUrl) || safeHttpUrl(m.photoUrl)) && (
             <div className="mt-2 flex flex-col gap-1">
-              {m.productUrl && (
+              {safeHttpUrl(m.productUrl) && (
                 <a
-                  href={m.productUrl}
+                  href={safeHttpUrl(m.productUrl)!}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-blue-600 dark:text-blue-400 hover:underline truncate"
@@ -233,9 +234,9 @@ function MaterialDetail({ m }: { m: OPTMaterial }) {
                   {t("openprinttag.detail.productPageLink")}
                 </a>
               )}
-              {m.photoUrl && (
+              {safeHttpUrl(m.photoUrl) && (
                 <a
-                  href={m.photoUrl}
+                  href={safeHttpUrl(m.photoUrl)!}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-blue-600 dark:text-blue-400 hover:underline truncate"

--- a/src/lib/safeRenderUrl.ts
+++ b/src/lib/safeRenderUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * Synchronous scheme check for URLs that get rendered as `<a href>` /
+ * `<iframe src>` / passed to `shell.openExternal`. Returns true only for
+ * http and https URLs.
+ *
+ * This is an XSS / Electron-safety guard, not an SSRF guard. SSRF (DNS
+ * resolution + private-IP block) lives in `externalUrlGuard.ts` and is
+ * async + only relevant for server-side fetches. Here we just need to
+ * stop `javascript:`, `file:`, `data:` and friends from reaching the
+ * browser/Electron — those can either execute script in the page origin
+ * or trick the OS shell into opening a local resource.
+ */
+export function isHttpUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** Convenience: returns the URL if safe, otherwise null. */
+export function safeHttpUrl(url: string | null | undefined): string | null {
+  return isHttpUrl(url) ? (url as string) : null;
+}

--- a/src/models/Filament.ts
+++ b/src/models/Filament.ts
@@ -276,7 +276,22 @@ const FilamentSchema = new Schema<IFilament>(
     maxPrintSpeed: { type: Number, default: null },
     spoolType: { type: String, default: null },
     optTags: { type: [Number], default: [] },
-    tdsUrl: { type: String, default: null },
+    tdsUrl: {
+      type: String,
+      default: null,
+      validate: {
+        validator: (v: string | null) => {
+          if (v == null || v === "") return true;
+          try {
+            const proto = new URL(v).protocol;
+            return proto === "http:" || proto === "https:";
+          } catch {
+            return false;
+          }
+        },
+        message: "tdsUrl must be a valid http(s) URL",
+      },
+    },
     inherits: { type: String, default: null },
     parentId: { type: Schema.Types.ObjectId, ref: "Filament", default: null, index: true },
     settings: { type: Schema.Types.Mixed, default: {} },

--- a/src/models/Filament.ts
+++ b/src/models/Filament.ts
@@ -6,6 +6,23 @@ function generateInstanceId(): string {
   return crypto.randomBytes(5).toString("hex");
 }
 
+/** Reject anything but http(s). Empty/null are allowed (field is optional).
+ * Used both as the schema validator (catches save/create) and via the
+ * pre('updateOne'|'findOneAndUpdate'|'updateMany') hooks below — Mongoose
+ * skips schema validators on bare update queries unless the caller passes
+ * `runValidators: true`, and the CSV/atlas-import paths don't, so the hook
+ * is what actually keeps a `javascript:`/`file:` URL out of storage on the
+ * import-update branch. */
+function isValidTdsUrl(v: string | null | undefined): boolean {
+  if (v == null || v === "") return true;
+  try {
+    const proto = new URL(v).protocol;
+    return proto === "http:" || proto === "https:";
+  } catch {
+    return false;
+  }
+}
+
 export interface IDryCycle {
   _id?: mongoose.Types.ObjectId;
   date: Date;
@@ -280,15 +297,7 @@ const FilamentSchema = new Schema<IFilament>(
       type: String,
       default: null,
       validate: {
-        validator: (v: string | null) => {
-          if (v == null || v === "") return true;
-          try {
-            const proto = new URL(v).protocol;
-            return proto === "http:" || proto === "https:";
-          } catch {
-            return false;
-          }
-        },
+        validator: isValidTdsUrl,
         message: "tdsUrl must be a valid http(s) URL",
       },
     },
@@ -315,6 +324,28 @@ FilamentSchema.pre("save", function () {
     this.instanceId = generateInstanceId();
   }
 });
+
+// Validate tdsUrl on every update path. Mongoose runs schema validators
+// only on save() / create() by default; bare updateOne / findOneAndUpdate
+// (used by the CSV import path in src/lib/importFilaments.ts) skip them
+// unless the caller passes `runValidators: true`. Hook them all here so
+// an imported javascript:/file: URL can't bypass the scheme guard.
+function validateTdsUrlInUpdate(this: mongoose.Query<unknown, unknown>) {
+  const update = this.getUpdate() as Record<string, unknown> | null;
+  if (!update) return;
+  const $set = (update.$set ?? {}) as Record<string, unknown>;
+  // tdsUrl can appear as either a top-level key (replacement-style update)
+  // or under $set (the form import / CSV import / atlas import paths use)
+  for (const candidate of [update.tdsUrl, $set.tdsUrl]) {
+    if (candidate === undefined) continue;
+    if (!isValidTdsUrl(candidate as string | null)) {
+      throw new Error("tdsUrl must be a valid http(s) URL");
+    }
+  }
+}
+FilamentSchema.pre("updateOne", validateTdsUrlInUpdate);
+FilamentSchema.pre("updateMany", validateTdsUrlInUpdate);
+FilamentSchema.pre("findOneAndUpdate", validateTdsUrlInUpdate);
 
 const Filament: Model<IFilament> =
   mongoose.models.Filament || mongoose.model<IFilament>("Filament", FilamentSchema);

--- a/tests/Filament.test.ts
+++ b/tests/Filament.test.ts
@@ -855,6 +855,42 @@ describe("Filament Model — v1.11 spool fields", () => {
     ).rejects.toThrow();
   });
 
+  it("accepts http(s) tdsUrl values and rejects non-http schemes", async () => {
+    const ok = await Filament.create({
+      name: "TDS HTTPS",
+      vendor: "Test",
+      type: "PLA",
+      tdsUrl: "https://example.com/tds.pdf",
+    });
+    expect(ok.tdsUrl).toBe("https://example.com/tds.pdf");
+
+    // null and empty string are still allowed (field is optional)
+    const empty = await Filament.create({
+      name: "TDS Empty",
+      vendor: "Test",
+      type: "PLA",
+      tdsUrl: "",
+    });
+    expect(empty.tdsUrl).toBe("");
+
+    for (const bad of [
+      "javascript:alert(1)",
+      "file:///etc/passwd",
+      "data:text/html,<script>",
+      "ftp://example.com",
+      "not a url",
+    ]) {
+      await expect(
+        Filament.create({
+          name: `Bad TDS ${bad}`,
+          vendor: "Test",
+          type: "PLA",
+          tdsUrl: bad,
+        }),
+      ).rejects.toThrow(/tdsUrl/);
+    }
+  });
+
   it("stores lowStockThreshold and rejects negatives", async () => {
     const filament = await Filament.create({
       name: "Low Stock",

--- a/tests/Filament.test.ts
+++ b/tests/Filament.test.ts
@@ -891,6 +891,42 @@ describe("Filament Model — v1.11 spool fields", () => {
     }
   });
 
+  it("rejects disallowed tdsUrl schemes on update queries (not just create)", async () => {
+    // Mongoose skips schema validators on bare updateOne / findOneAndUpdate
+    // unless `runValidators: true` is passed. The CSV import path in
+    // src/lib/importFilaments.ts doesn't pass it, so we wired pre-update
+    // hooks instead — verify they fire across the three Mongoose update
+    // entry points and that the original value isn't overwritten on reject.
+    const f = await Filament.create({
+      name: "TDS Update Test",
+      vendor: "Test",
+      type: "PLA",
+      tdsUrl: "https://example.com/ok",
+    });
+
+    await expect(
+      Filament.updateOne({ _id: f._id }, { $set: { tdsUrl: "javascript:alert(1)" } }),
+    ).rejects.toThrow(/tdsUrl/);
+
+    await expect(
+      Filament.findOneAndUpdate({ _id: f._id }, { $set: { tdsUrl: "file:///etc/passwd" } }),
+    ).rejects.toThrow(/tdsUrl/);
+
+    await expect(
+      Filament.updateMany({}, { $set: { tdsUrl: "ftp://example.com" } }),
+    ).rejects.toThrow(/tdsUrl/);
+
+    // Original value untouched after the rejected updates
+    const reread = await Filament.findById(f._id).lean();
+    expect(reread!.tdsUrl).toBe("https://example.com/ok");
+
+    // http(s) updates still pass through; empty/null are allowed clears
+    await Filament.updateOne({ _id: f._id }, { $set: { tdsUrl: "https://other.example.com/new" } });
+    expect((await Filament.findById(f._id).lean())!.tdsUrl).toBe("https://other.example.com/new");
+    await Filament.updateOne({ _id: f._id }, { $set: { tdsUrl: "" } });
+    await Filament.updateOne({ _id: f._id }, { $set: { tdsUrl: null } });
+  });
+
   it("stores lowStockThreshold and rejects negatives", async () => {
     const filament = await Filament.create({
       name: "Low Stock",

--- a/tests/safeRenderUrl.test.ts
+++ b/tests/safeRenderUrl.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isHttpUrl, safeHttpUrl } from "@/lib/safeRenderUrl";
+
+describe("isHttpUrl", () => {
+  it("accepts http and https", () => {
+    expect(isHttpUrl("http://example.com")).toBe(true);
+    expect(isHttpUrl("https://example.com/path?q=1")).toBe(true);
+  });
+
+  it("rejects javascript:, data:, file:, and other schemes", () => {
+    expect(isHttpUrl("javascript:alert(1)")).toBe(false);
+    expect(isHttpUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isHttpUrl("file:///etc/passwd")).toBe(false);
+    expect(isHttpUrl("ftp://example.com/x")).toBe(false);
+    expect(isHttpUrl("ms-msdt:foo")).toBe(false);
+  });
+
+  it("rejects malformed and empty inputs", () => {
+    expect(isHttpUrl("")).toBe(false);
+    expect(isHttpUrl(null)).toBe(false);
+    expect(isHttpUrl(undefined)).toBe(false);
+    expect(isHttpUrl("not a url")).toBe(false);
+    expect(isHttpUrl("//example.com")).toBe(false); // protocol-relative — no scheme
+  });
+});
+
+describe("safeHttpUrl", () => {
+  it("returns the URL when safe", () => {
+    expect(safeHttpUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("returns null for unsafe URLs", () => {
+    expect(safeHttpUrl("javascript:alert(1)")).toBeNull();
+    expect(safeHttpUrl(null)).toBeNull();
+    expect(safeHttpUrl(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
`setWindowOpenHandler` was sending **any** target="_blank" URL straight to `shell.openExternal`, and `tdsUrl`/`productUrl`/`photoUrl` are rendered as `<a href>` and `<iframe src>` without scheme validation. Imported or AI-suggested values could plant `javascript:`, `file:`, `data:`, or custom-protocol URLs that would either execute script in the page origin or hand the OS shell control over which app launches. Three coordinated changes:

1. **`electron/main.ts`** — window-open handler parses the URL and only forwards `http:` / `https:` to `shell.openExternal`; everything else is denied with a console warning.
2. **`src/lib/safeRenderUrl.ts`** — synchronous `isHttpUrl` / `safeHttpUrl` helpers, used at every TDS/photo/product render site (`src/app/filaments/[id]/page.tsx`, `src/app/openprinttag/page.tsx`) so unsafe stored values aren't rendered as live links.
3. **`src/models/Filament.ts`** — Mongoose validator on `tdsUrl` rejects any value whose scheme isn't `http(s)` at write time. Empty/null still allowed.

## Test plan
- [x] `tests/safeRenderUrl.test.ts` — covers http/https accept, javascript:/data:/file:/ftp: reject, malformed/empty inputs.
- [x] `tests/Filament.test.ts` — new test covers the `tdsUrl` validator on http(s)/empty accept and 5 disallowed-scheme reject cases.
- [x] Full `npm test` — 823/823 pass.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)