### PR TITLE
Re-validate every redirect hop in TDS extractor (close SSRF gap)

### DIFF
--- a/src/lib/tdsExtractor.ts
+++ b/src/lib/tdsExtractor.ts
@@ -110,33 +110,67 @@ interface TdsContent {
   mimeType?: string;
 }
 
+/** Cap redirect chains. Real-world TDS hosts rarely chain more than 2-3.
+ * Matches the embed-check route limit so the two SSRF-guarded fetchers
+ * behave consistently. */
+const MAX_REDIRECTS = 5;
+
 /**
  * Fetch TDS content from a URL.
  * Returns the content as either base64 PDF data or plain text.
  *
- * Uses the shared SSRF guard from @/lib/externalUrlGuard. Residual risk:
- * only the *initial* URL is validated. The fetch below sets
- * `redirect: "follow"`, so a hostile public host could redirect into
- * private space. Catching that requires `redirect: "manual"` plus per-hop
- * validation; skipped here to avoid breaking legitimate shortener/CDN
- * redirects, with the understanding that the AI-key gate already
- * restricts who can reach this code.
+ * SSRF: every redirect hop re-runs assertExternalUrl, so a public host
+ * can't bounce us into RFC1918/loopback/metadata space via a 3xx. Same
+ * pattern as src/app/api/embed-check/route.ts. The previous
+ * `redirect: "follow"` left the gap that an attacker who could plant a
+ * hostile TDS URL plus the AI-key gate could pivot to private infra.
  */
 async function fetchTdsContent(url: string): Promise<TdsContent> {
-  await assertExternalUrl(url);
-
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 30_000);
 
   try {
-    const res = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        "User-Agent": "Mozilla/5.0 (compatible; FilamentDB/1.0)",
-        Accept: "text/html,application/xhtml+xml,application/pdf,*/*",
-      },
-      redirect: "follow",
-    });
+    let currentUrl = url;
+    let res: Response | null = null;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      // Re-validate every hop so a hostile public host can't bounce us into
+      // private space via 30x. assertExternalUrl throws on disallowed
+      // schemes / loopback / RFC1918 / metadata IPs.
+      await assertExternalUrl(currentUrl);
+
+      const hopRes = await fetch(currentUrl, {
+        signal: controller.signal,
+        headers: {
+          "User-Agent": "Mozilla/5.0 (compatible; FilamentDB/1.0)",
+          Accept: "text/html,application/xhtml+xml,application/pdf,*/*",
+        },
+        redirect: "manual",
+      });
+
+      // Treat 3xx (except 304) as a redirect we follow ourselves so the
+      // next hop is re-validated.
+      const isRedirect = hopRes.status >= 300 && hopRes.status < 400 && hopRes.status !== 304;
+      if (!isRedirect) {
+        res = hopRes;
+        break;
+      }
+      const loc = hopRes.headers.get("location");
+      hopRes.body?.cancel().catch(() => {});
+      if (!loc) {
+        throw new Error(`Failed to fetch TDS: HTTP ${hopRes.status} with no Location header`);
+      }
+      if (hop === MAX_REDIRECTS) {
+        throw new Error(`Failed to fetch TDS: too many redirects (>${MAX_REDIRECTS})`);
+      }
+      // Resolve relative redirects against the URL we just fetched.
+      currentUrl = new URL(loc, currentUrl).toString();
+    }
+
+    if (!res) {
+      // Defensive: shouldn't happen because the loop either breaks on a
+      // non-redirect or throws on too-many-redirects.
+      throw new Error("Failed to fetch TDS: no final response");
+    }
 
     if (!res.ok) {
       throw new Error(`Failed to fetch TDS: HTTP ${res.status} ${res.statusText}`);

--- a/tests/tdsExtractor.test.ts
+++ b/tests/tdsExtractor.test.ts
@@ -69,6 +69,141 @@ describe("tdsExtractor", () => {
     });
   });
 
+  // Per-hop SSRF revalidation: a public host that 30x-redirects to a private
+  // IP must NOT pivot us into private space. Same pattern as embed-check.
+  describe("redirect handling (manual, per-hop revalidation)", () => {
+    it("rejects a public URL that 302-redirects to a private IP", async () => {
+      const fetchMock = vi.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: "http://10.0.0.5/secret" }),
+          body: { cancel: () => Promise.resolve() },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const { extractFromTds } = await import("@/lib/tdsExtractor");
+      const result = await extractFromTds("https://attacker.example.com/start", "fake-key");
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/private|internal/i);
+      // Critical: the second fetch (to the private IP) must NOT have happened.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a redirect to the AWS/GCP/Azure metadata IP", async () => {
+      const fetchMock = vi.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: "http://169.254.169.254/latest/meta-data/" }),
+          body: { cancel: () => Promise.resolve() },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const { extractFromTds } = await import("@/lib/tdsExtractor");
+      const result = await extractFromTds("https://example.com/innocuous", "fake-key");
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/private|internal/i);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a redirect to a non-http(s) scheme (e.g. file://)", async () => {
+      const fetchMock = vi.fn().mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: "file:///etc/passwd" }),
+          body: { cancel: () => Promise.resolve() },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const { extractFromTds } = await import("@/lib/tdsExtractor");
+      const result = await extractFromTds("https://example.com/innocuous", "fake-key");
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/scheme/i);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("follows a public→public redirect chain to the final response", async () => {
+      const geminiResponse = {
+        candidates: [{ content: { parts: [{ text: '{"name": "Chained PLA", "type": "PLA"}' }] } }],
+      };
+      // 302 → 301 → 200 (HTML) → Gemini
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: new Headers({ location: "https://b.example.com/redirected" }),
+          body: { cancel: () => Promise.resolve() },
+        })
+        .mockResolvedValueOnce({
+          status: 301,
+          headers: new Headers({ location: "https://c.example.com/final" }),
+          body: { cancel: () => Promise.resolve() },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "text/html" }),
+          text: () => Promise.resolve("<html><body>chained PLA</body></html>"),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(geminiResponse),
+        });
+      vi.stubGlobal("fetch", fetchMock);
+      const { extractFromTds } = await import("@/lib/tdsExtractor");
+      const result = await extractFromTds("https://a.example.com/start", "fake-key");
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBe("Chained PLA");
+      // 3 redirect/fetch hops + 1 Gemini call
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it("resolves a relative Location header against the previous URL", async () => {
+      const geminiResponse = {
+        candidates: [{ content: { parts: [{ text: '{"name": "Rel", "type": "PLA"}' }] } }],
+      };
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          status: 302,
+          headers: new Headers({ location: "/elsewhere" }),
+          body: { cancel: () => Promise.resolve() },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "text/html" }),
+          text: () => Promise.resolve("<html>x</html>"),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(geminiResponse),
+        });
+      vi.stubGlobal("fetch", fetchMock);
+      const { extractFromTds } = await import("@/lib/tdsExtractor");
+      await extractFromTds("https://example.com/path/start", "fake-key");
+      const secondCallUrl = fetchMock.mock.calls[1][0];
+      expect(secondCallUrl).toBe("https://example.com/elsewhere");
+    });
+
+    it("aborts after MAX_REDIRECTS (5) hops", async () => {
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        const next = url.replace(/\/(\d+)$/, (_, n) => `/${Number(n) + 1}`);
+        return Promise.resolve({
+          status: 302,
+          headers: new Headers({ location: next }),
+          body: { cancel: () => Promise.resolve() },
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const { extractFromTds } = await import("@/lib/tdsExtractor");
+      const result = await extractFromTds("https://example.com/0", "fake-key");
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/too many redirects/i);
+      // 6 calls = initial + MAX_REDIRECTS (5) follow attempts before bailing.
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    });
+  });
+
   describe("extractFromTds", () => {
     it("returns error when URL fetch fails", async () => {
       vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));


### PR DESCRIPTION
## Summary
`fetchTdsContent` in `src/lib/tdsExtractor.ts` was using `redirect: "follow"` after a single `assertExternalUrl` check. A public host could 30x-redirect to RFC1918 / loopback / cloud-metadata IPs and pivot the AI-key holder into private infra. The embed-check route already has the safer per-hop pattern (GH #135 follow-up); this mirrors it.

- Fetch with `redirect: "manual"` and a max-5-hop loop (`MAX_REDIRECTS = 5`, matching embed-check).
- Re-run `assertExternalUrl` on each Location target so disallowed schemes / private IPs throw before the next fetch.
- Resolve relative `Location` headers against the previous URL.
- Fail with "too many redirects" past the cap, surfaced through the existing catch path as `result.error`.

## Test plan
- [x] 6 new tests in `tests/tdsExtractor.test.ts` cover: redirect → private IP rejected (and second fetch never happens), metadata IP, `file://` scheme redirect, public→public chain reaches the final response (4 fetch calls including Gemini), relative `Location` resolution, and MAX_REDIRECTS=5 cap (6 calls before bailing).
- [x] Existing tests still pass — they all return non-3xx responses, which the new loop treats as terminal.
- [x] Full `npm test` — 823/823 pass.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)