### PR TITLE
Project filament list to summary shape; wire missing-calibration filter

### DIFF
--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -39,6 +39,21 @@ export async function GET(request: NextRequest) {
     const filaments = await Filament.aggregate([
       { $match: filter },
       { $sort: { name: 1 } },
+      // Look up parent's calibrations so hasCalibrations reflects the
+      // *effective* state rather than the variant's own array. Variants
+      // with empty calibrations inherit from their parent (see
+      // resolveFilament in src/lib/resolveFilament.ts), so projecting
+      // only the variant's own array would falsely flag inheriting
+      // variants under the noCalibration filter.
+      {
+        $lookup: {
+          from: "filaments",
+          localField: "parentId",
+          foreignField: "_id",
+          as: "_parent",
+          pipeline: [{ $project: { calibrations: 1 } }],
+        },
+      },
       {
         $project: {
           name: 1,
@@ -56,7 +71,22 @@ export async function GET(request: NextRequest) {
           "temperatures.nozzle": 1,
           "temperatures.bed": 1,
           hasCalibrations: {
-            $gt: [{ $size: { $ifNull: ["$calibrations", []] } }, 0],
+            $or: [
+              { $gt: [{ $size: { $ifNull: ["$calibrations", []] } }, 0] },
+              {
+                $gt: [
+                  {
+                    $size: {
+                      $ifNull: [
+                        { $arrayElemAt: ["$_parent.calibrations", 0] },
+                        [],
+                      ],
+                    },
+                  },
+                  0,
+                ],
+              },
+            ],
           },
           spools: {
             $map: {

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -25,7 +25,46 @@ export async function GET(request: NextRequest) {
     if (vendor) filter.vendor = vendor;
     if (search) filter.name = { $regex: escapeRegex(search), $options: "i" };
 
-    const filaments = await Filament.find(filter).sort({ name: 1 }).lean();
+    // Project to FilamentSummary shape: drop heavy spool subfields
+    // (photoDataUrl, usageHistory, dryCycles), keep only the temperatures
+    // the list renders, and surface `hasCalibrations` so the noCalibration
+    // quick filter has a signal it can act on without fetching every doc.
+    // The full document is still available via /api/filaments/{id}.
+    const filaments = await Filament.aggregate([
+      { $match: filter },
+      { $sort: { name: 1 } },
+      {
+        $project: {
+          name: 1,
+          vendor: 1,
+          type: 1,
+          color: 1,
+          cost: 1,
+          density: 1,
+          parentId: 1,
+          spoolWeight: 1,
+          netFilamentWeight: 1,
+          totalWeight: 1,
+          lowStockThreshold: 1,
+          "temperatures.nozzle": 1,
+          "temperatures.bed": 1,
+          hasCalibrations: {
+            $gt: [{ $size: { $ifNull: ["$calibrations", []] } }, 0],
+          },
+          spools: {
+            $map: {
+              input: { $ifNull: ["$spools", []] },
+              as: "s",
+              in: {
+                _id: "$$s._id",
+                totalWeight: "$$s.totalWeight",
+                retired: "$$s.retired",
+              },
+            },
+          },
+        },
+      },
+    ]);
     return NextResponse.json(filaments);
   } catch (err) {
     return errorResponse("Failed to fetch filaments", 500, getErrorMessage(err));

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -30,6 +30,12 @@ export async function GET(request: NextRequest) {
     // the list renders, and surface `hasCalibrations` so the noCalibration
     // quick filter has a signal it can act on without fetching every doc.
     // The full document is still available via /api/filaments/{id}.
+    //
+    // tdsUrl is included on top of FilamentSummary because FilamentForm
+    // (src/app/filaments/FilamentForm.tsx) calls this endpoint with
+    // ?vendor=... to derive vendor-keyed TDS suggestions and reads
+    // f.tdsUrl off each result. Dropping the field silently empties the
+    // suggestion list on create/edit.
     const filaments = await Filament.aggregate([
       { $match: filter },
       { $sort: { name: 1 } },
@@ -46,6 +52,7 @@ export async function GET(request: NextRequest) {
           netFilamentWeight: 1,
           totalWeight: 1,
           lowStockThreshold: 1,
+          tdsUrl: 1,
           "temperatures.nozzle": 1,
           "temperatures.bed": 1,
           hasCalibrations: {

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -64,6 +64,11 @@ export async function GET(request: NextRequest) {
               as: "s",
               in: {
                 _id: "$$s._id",
+                // PrinterForm's AMS slot picker renders each option as
+                // `s.label || s._id.slice(-4)`, so dropping label degrades
+                // every choice to a 4-char id and breaks multi-spool
+                // identification.
+                label: "$$s.label",
                 totalWeight: "$$s.totalWeight",
                 retired: "$$s.retired",
               },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -349,6 +349,7 @@ export default function Home() {
     for (const f of filaments) {
       if (isLowStock(f)) counts.lowStock++;
       if ((f.spools?.length ?? 0) > 0) counts.hasSpools++;
+      if (!f.hasCalibrations) counts.noCalibration++;
     }
     return counts;
   }, [filaments]);
@@ -358,8 +359,7 @@ export default function Home() {
     return filaments.filter((f) => {
       if (quickFilter === "lowStock") return isLowStock(f);
       if (quickFilter === "hasSpools") return (f.spools?.length ?? 0) > 0;
-      // noCalibration can't be determined from FilamentSummary alone —
-      // keeping the chip for future use (detail API would be needed).
+      if (quickFilter === "noCalibration") return !f.hasCalibrations;
       return true;
     });
   }, [filaments, quickFilter]);

--- a/src/types/filament.ts
+++ b/src/types/filament.ts
@@ -152,4 +152,9 @@ export interface FilamentSummary {
     nozzle: number | null;
     bed: number | null;
   };
+  /** True when the filament has at least one nozzle calibration. Used by
+   * the noCalibration quick filter on the list page; computed in the
+   * aggregation projection so the full calibrations array doesn't need
+   * to ship with every list row. */
+  hasCalibrations?: boolean;
 }

--- a/tests/filaments-list-route.test.ts
+++ b/tests/filaments-list-route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as listFilaments } from "@/app/api/filaments/route";
+
+/**
+ * Verify the list endpoint projects to FilamentSummary shape (no
+ * heavy spool subfields, presence of `hasCalibrations`) instead of
+ * returning every field on every doc.
+ *
+ * Coupled to the noCalibration quick filter on the list page: the
+ * page reads `hasCalibrations` to decide whether to count/show a
+ * filament under that filter. Before this projection landed the field
+ * didn't exist and the filter was a no-op.
+ */
+describe("GET /api/filaments — projection to FilamentSummary", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const mod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", mod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  async function seed() {
+    const noCalNoSpools = await Filament.create({
+      name: "Bare PLA",
+      vendor: "Test",
+      type: "PLA",
+    });
+    const withCalibration = await Filament.create({
+      name: "Calibrated PLA",
+      vendor: "Test",
+      type: "PLA",
+      calibrations: [
+        { nozzle: new mongoose.Types.ObjectId(), extrusionMultiplier: 0.95 },
+      ],
+    });
+    const withSpoolPhoto = await Filament.create({
+      name: "Photo PLA",
+      vendor: "Test",
+      type: "PLA",
+      spools: [
+        {
+          totalWeight: 800,
+          // The big-blob field that should NOT make it into list output.
+          photoDataUrl: "data:image/png;base64,AAAA",
+        },
+      ],
+    });
+    return { noCalNoSpools, withCalibration, withSpoolPhoto };
+  }
+
+  it("strips spool.photoDataUrl and other heavy subfields from the list payload", async () => {
+    await seed();
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments"),
+    );
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+
+    const photoEntry = body.find((f: { name: string }) => f.name === "Photo PLA");
+    expect(photoEntry).toBeDefined();
+    expect(photoEntry.spools).toHaveLength(1);
+    // Only summary fields per FilamentSummary
+    expect(photoEntry.spools[0]).not.toHaveProperty("photoDataUrl");
+    expect(photoEntry.spools[0]).not.toHaveProperty("usageHistory");
+    expect(photoEntry.spools[0]).not.toHaveProperty("dryCycles");
+    expect(photoEntry.spools[0]).toHaveProperty("totalWeight", 800);
+    expect(photoEntry.spools[0]).toHaveProperty("_id");
+  });
+
+  it("computes hasCalibrations true/false per row", async () => {
+    await seed();
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments"),
+    );
+    const body = await res.json();
+
+    const bare = body.find((f: { name: string }) => f.name === "Bare PLA");
+    const cal = body.find((f: { name: string }) => f.name === "Calibrated PLA");
+    expect(bare.hasCalibrations).toBe(false);
+    expect(cal.hasCalibrations).toBe(true);
+  });
+
+  it("does not include the full calibrations array (only the boolean)", async () => {
+    await seed();
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments"),
+    );
+    const body = await res.json();
+    const cal = body.find((f: { name: string }) => f.name === "Calibrated PLA");
+    // Verify the heavy field isn't in the list payload — detail endpoint
+    // remains the source of truth for the array.
+    expect(cal).not.toHaveProperty("calibrations");
+  });
+
+  it("preserves type/vendor filters across the projection", async () => {
+    await seed();
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments?vendor=Test&type=PLA"),
+    );
+    const body = await res.json();
+    expect(body).toHaveLength(3);
+  });
+});

--- a/tests/filaments-list-route.test.ts
+++ b/tests/filaments-list-route.test.ts
@@ -98,6 +98,54 @@ describe("GET /api/filaments — projection to FilamentSummary", () => {
     expect(entry.spools[1].label).toBe("Backup");
   });
 
+  it("hasCalibrations reflects effective state — a variant with no own calibrations inherits from parent", async () => {
+    // Codex round-3 P2: variants with empty calibrations[] inherit from
+    // their parent (see resolveFilament). The list projection used to
+    // compute hasCalibrations from only the variant's own array, so
+    // every inheriting variant was falsely flagged as missing calibration.
+    const Filament = (await import("@/models/Filament")).default;
+    const parent = await Filament.create({
+      name: "Inheritance Parent",
+      vendor: "Test",
+      type: "PLA",
+      calibrations: [
+        { nozzle: new mongoose.Types.ObjectId(), extrusionMultiplier: 0.95 },
+      ],
+    });
+    await Filament.create({
+      name: "Inheriting Variant",
+      vendor: "Test",
+      type: "PLA",
+      parentId: parent._id,
+      // empty calibrations — inherits from parent
+    });
+    await Filament.create({
+      name: "Override Variant",
+      vendor: "Test",
+      type: "PLA",
+      parentId: parent._id,
+      calibrations: [
+        { nozzle: new mongoose.Types.ObjectId(), extrusionMultiplier: 1.0 },
+      ],
+    });
+    await Filament.create({
+      name: "Standalone Bare",
+      vendor: "Test",
+      type: "PLA",
+    });
+
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments"),
+    );
+    const body = await res.json();
+
+    const find = (name: string) => body.find((f: { name: string }) => f.name === name);
+    expect(find("Inheritance Parent").hasCalibrations).toBe(true);
+    expect(find("Inheriting Variant").hasCalibrations).toBe(true); // <-- the bug fix
+    expect(find("Override Variant").hasCalibrations).toBe(true);
+    expect(find("Standalone Bare").hasCalibrations).toBe(false);
+  });
+
   it("computes hasCalibrations true/false per row", async () => {
     await seed();
     const res = await listFilaments(

--- a/tests/filaments-list-route.test.ts
+++ b/tests/filaments-list-route.test.ts
@@ -73,6 +73,31 @@ describe("GET /api/filaments — projection to FilamentSummary", () => {
     expect(photoEntry.spools[0]).toHaveProperty("_id");
   });
 
+  it("includes spools[].label so PrinterForm's AMS slot picker doesn't degrade to short IDs", async () => {
+    // PrinterForm renders each spool choice as `s.label || s._id.slice(-4)`,
+    // so the projection must keep label even though the list page itself
+    // doesn't render it.
+    const Filament = (await import("@/models/Filament")).default;
+    await Filament.create({
+      name: "Labeled Spools",
+      vendor: "Test",
+      type: "PLA",
+      spools: [
+        { label: "AMS slot 1", totalWeight: 800 },
+        { label: "Backup", totalWeight: 1000 },
+      ],
+    });
+
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments"),
+    );
+    const body = await res.json();
+    const entry = body.find((f: { name: string }) => f.name === "Labeled Spools");
+    expect(entry.spools).toHaveLength(2);
+    expect(entry.spools[0].label).toBe("AMS slot 1");
+    expect(entry.spools[1].label).toBe("Backup");
+  });
+
   it("computes hasCalibrations true/false per row", async () => {
     await seed();
     const res = await listFilaments(

--- a/tests/filaments-list-route.test.ts
+++ b/tests/filaments-list-route.test.ts
@@ -98,6 +98,33 @@ describe("GET /api/filaments — projection to FilamentSummary", () => {
     expect(cal).not.toHaveProperty("calibrations");
   });
 
+  it("includes tdsUrl in the projection so FilamentForm vendor suggestions still work", async () => {
+    // FilamentForm calls /api/filaments?vendor=... and reads tdsUrl off
+    // each row to populate vendor-keyed TDS suggestions. Codex flagged
+    // that dropping the field silently empties the suggestion list.
+    const Filament = (await import("@/models/Filament")).default;
+    await Filament.create({
+      name: "Has TDS",
+      vendor: "Test",
+      type: "PLA",
+      tdsUrl: "https://example.com/tds.pdf",
+    });
+    await Filament.create({
+      name: "No TDS",
+      vendor: "Test",
+      type: "PLA",
+    });
+
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments?vendor=Test"),
+    );
+    const body = await res.json();
+    const withTds = body.find((f: { name: string }) => f.name === "Has TDS");
+    const withoutTds = body.find((f: { name: string }) => f.name === "No TDS");
+    expect(withTds.tdsUrl).toBe("https://example.com/tds.pdf");
+    expect(withoutTds.tdsUrl).toBeNull();
+  });
+
   it("preserves type/vendor filters across the projection", async () => {
     await seed();
     const res = await listFilaments(


### PR DESCRIPTION
## Summary
The list endpoint was returning the full Mongoose document for every filament — including each spool's `photoDataUrl` (a base64 image up to a couple hundred KB), `usageHistory`, and `dryCycles` — even though the list page only consumes ~10 summary fields (`FilamentSummary` in `src/types/filament.ts`).

This PR also fixes the "Missing calibration" quick filter on the list page, which was effectively a no-op: the chip was reachable, but the `noCalibration` count was hardcoded to zero and the filter case fell through to `return true` because `FilamentSummary` had no signal to test against.

- `GET /api/filaments` now uses a Mongoose aggregation pipeline that projects exactly the FilamentSummary fields, strips heavy spool subfields, and computes a single boolean `hasCalibrations` (`$gt: [{ $size: { $ifNull: ["$calibrations", []] } }, 0]`).
- `FilamentSummary` gains `hasCalibrations?: boolean`.
- `src/app/page.tsx` counts filaments with `!hasCalibrations` and filters by the same predicate.

The detail endpoint (`GET /api/filaments/{id}`) still returns the full document and remains the source of truth for fields not in the summary.

## Test plan
- [x] New `tests/filaments-list-route.test.ts` (4 tests):
  - spool.photoDataUrl / usageHistory / dryCycles stripped from list payload
  - hasCalibrations is `true` for a filament with calibrations, `false` for a bare one
  - full `calibrations` array not included in the list payload
  - existing vendor/type filters still work
- [x] Full `npm test` — 821/821 pass on this branch (4 new tests; 0 regressions).
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)