### PR TITLE
Make filament list helpers consistent on retired spools

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,59 +12,9 @@ import QuickFilterChips, { type QuickFilter } from "@/components/QuickFilterChip
 import { useCurrency } from "@/hooks/useCurrency";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import type { FilamentSummary } from "@/types/filament";
+import { getRemainingGrams, getRemainingPct, getSpoolCount } from "@/lib/inventoryStats";
 
 type Filament = FilamentSummary;
-
-function getRemainingPct(f: Filament): number | null {
-  // Multi-spool: aggregate across all spools
-  if (f.spools?.length > 0 && f.spoolWeight != null && f.netFilamentWeight != null && f.netFilamentWeight > 0) {
-    let totalRemaining = 0;
-    let validCount = 0;
-    for (const spool of f.spools) {
-      if (spool.totalWeight != null) {
-        totalRemaining += Math.max(0, spool.totalWeight - f.spoolWeight);
-        validCount++;
-      }
-    }
-    if (validCount === 0) return null;
-    const totalNet = f.netFilamentWeight * validCount;
-    return Math.min(100, Math.max(0, Math.round((totalRemaining / totalNet) * 100)));
-  }
-  // Legacy single-spool
-  if (f.totalWeight == null || f.spoolWeight == null || f.netFilamentWeight == null || f.netFilamentWeight <= 0) return null;
-  return Math.min(100, Math.max(0, Math.round(((f.totalWeight - f.spoolWeight) / f.netFilamentWeight) * 100)));
-}
-
-function getSpoolCount(f: Filament): number {
-  if (f.spools?.length > 0) return f.spools.length;
-  return f.totalWeight != null ? 1 : 0;
-}
-
-/**
- * Grams of filament remaining across all *non-retired* spools. Null if the
- * filament isn't weight-tracked (no spool weight or no netFilamentWeight).
- * Used for the low-stock chip + badge.
- */
-function getRemainingGrams(f: Filament): number | null {
-  if (
-    !f.spools ||
-    f.spools.length === 0 ||
-    f.spoolWeight == null ||
-    f.netFilamentWeight == null
-  ) {
-    return null;
-  }
-  let grams = 0;
-  let any = false;
-  for (const s of f.spools) {
-    if (s.retired) continue;
-    if (s.totalWeight != null) {
-      grams += Math.max(0, s.totalWeight - f.spoolWeight);
-      any = true;
-    }
-  }
-  return any ? grams : null;
-}
 
 function isLowStock(f: Filament): boolean {
   const threshold = f.lowStockThreshold;

--- a/src/lib/inventoryStats.ts
+++ b/src/lib/inventoryStats.ts
@@ -1,0 +1,95 @@
+/**
+ * Inventory math for the filament list page (and any other consumer
+ * that needs to render remaining %, gram totals, or spool counts the
+ * same way).
+ *
+ * All three helpers exclude spools where `retired: true`. The helpers
+ * have to agree on this rule — the low-stock badge already skipped
+ * retired spools, but the percentage and the spool-count chip didn't,
+ * so a filament with one active and one retired spool would render
+ * as "2 spools, looking healthy" while the low-stock logic considered
+ * it a single nearly-empty roll.
+ */
+
+export interface InventorySpool {
+  totalWeight: number | null;
+  retired?: boolean;
+}
+
+export interface InventoryFilament {
+  spools?: InventorySpool[];
+  spoolWeight: number | null;
+  netFilamentWeight: number | null;
+  /** Legacy single-spool fallback used when `spools` is empty. */
+  totalWeight: number | null;
+}
+
+/** Number of *active* (non-retired) spools. Falls back to the legacy
+ * single-spool shape when `spools` is empty but `totalWeight` is set. */
+export function getSpoolCount(f: InventoryFilament): number {
+  if (f.spools && f.spools.length > 0) {
+    return f.spools.filter((s) => !s.retired).length;
+  }
+  return f.totalWeight != null ? 1 : 0;
+}
+
+/** Grams of filament remaining across all non-retired spools. Returns
+ * null when the filament isn't weight-tracked. */
+export function getRemainingGrams(f: InventoryFilament): number | null {
+  if (
+    !f.spools ||
+    f.spools.length === 0 ||
+    f.spoolWeight == null ||
+    f.netFilamentWeight == null
+  ) {
+    return null;
+  }
+  let grams = 0;
+  let any = false;
+  for (const s of f.spools) {
+    if (s.retired) continue;
+    if (s.totalWeight != null) {
+      grams += Math.max(0, s.totalWeight - f.spoolWeight);
+      any = true;
+    }
+  }
+  return any ? grams : null;
+}
+
+/** Percentage remaining (0-100, integer). Excludes retired spools so
+ * the bar matches the low-stock chip. Falls back to legacy
+ * single-spool math when `spools` is empty. */
+export function getRemainingPct(f: InventoryFilament): number | null {
+  if (
+    f.spools &&
+    f.spools.length > 0 &&
+    f.spoolWeight != null &&
+    f.netFilamentWeight != null &&
+    f.netFilamentWeight > 0
+  ) {
+    let totalRemaining = 0;
+    let validCount = 0;
+    for (const spool of f.spools) {
+      if (spool.retired) continue;
+      if (spool.totalWeight != null) {
+        totalRemaining += Math.max(0, spool.totalWeight - f.spoolWeight);
+        validCount++;
+      }
+    }
+    if (validCount === 0) return null;
+    const totalNet = f.netFilamentWeight * validCount;
+    return Math.min(100, Math.max(0, Math.round((totalRemaining / totalNet) * 100)));
+  }
+  if (
+    f.totalWeight == null ||
+    f.spoolWeight == null ||
+    f.netFilamentWeight == null ||
+    f.netFilamentWeight <= 0
+  ) {
+    return null;
+  }
+  return Math.min(
+    100,
+    Math.max(0, Math.round(((f.totalWeight - f.spoolWeight) / f.netFilamentWeight) * 100)),
+  );
+}

--- a/tests/inventoryStats.test.ts
+++ b/tests/inventoryStats.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  getSpoolCount,
+  getRemainingGrams,
+  getRemainingPct,
+  type InventoryFilament,
+} from "@/lib/inventoryStats";
+
+/**
+ * Pre-fix bug: getRemainingGrams skipped retired spools but
+ * getRemainingPct and getSpoolCount didn't, so the list rendered
+ * inflated remaining% and an extra spool chip for any filament with a
+ * retired roll. The three helpers now agree.
+ */
+describe("inventoryStats", () => {
+  const baseTracked: Pick<InventoryFilament, "spoolWeight" | "netFilamentWeight"> = {
+    spoolWeight: 200,
+    netFilamentWeight: 800,
+  };
+
+  describe("getSpoolCount", () => {
+    it("counts only non-retired spools", () => {
+      const f: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [
+          { totalWeight: 800 },
+          { totalWeight: 800, retired: true },
+          { totalWeight: 600 },
+        ],
+      };
+      expect(getSpoolCount(f)).toBe(2);
+    });
+
+    it("returns 0 when every spool is retired", () => {
+      const f: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [
+          { totalWeight: 800, retired: true },
+          { totalWeight: 600, retired: true },
+        ],
+      };
+      expect(getSpoolCount(f)).toBe(0);
+    });
+
+    it("falls back to legacy single-spool shape when spools is empty", () => {
+      expect(getSpoolCount({ ...baseTracked, totalWeight: 600, spools: [] })).toBe(1);
+      expect(getSpoolCount({ ...baseTracked, totalWeight: null, spools: [] })).toBe(0);
+    });
+  });
+
+  describe("getRemainingGrams", () => {
+    it("excludes retired spools from the gram total", () => {
+      const f: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [
+          { totalWeight: 800 }, // 600g remaining
+          { totalWeight: 800, retired: true }, // would add 600g if not retired
+        ],
+      };
+      expect(getRemainingGrams(f)).toBe(600);
+    });
+
+    it("returns null when only retired spools have weight info", () => {
+      const f: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [{ totalWeight: 800, retired: true }],
+      };
+      expect(getRemainingGrams(f)).toBeNull();
+    });
+  });
+
+  describe("getRemainingPct", () => {
+    it("excludes retired spools from the percentage calculation", () => {
+      const f: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [
+          { totalWeight: 400 }, // 200g remaining of 800g net = 25%
+          { totalWeight: 1000, retired: true }, // would skew to ~62% if counted
+        ],
+      };
+      // Only the active spool contributes: 200/800 = 25%
+      expect(getRemainingPct(f)).toBe(25);
+    });
+
+    it("returns null when only retired spools remain", () => {
+      const f: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [
+          { totalWeight: 1000, retired: true },
+          { totalWeight: 600, retired: true },
+        ],
+      };
+      expect(getRemainingPct(f)).toBeNull();
+    });
+
+    it("matches getRemainingGrams for an all-active set", () => {
+      const f: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [{ totalWeight: 600 }, { totalWeight: 1000 }],
+      };
+      // remaining = (600-200) + (1000-200) = 1200; net = 800*2 = 1600
+      // 1200/1600 = 75%
+      expect(getRemainingPct(f)).toBe(75);
+      expect(getRemainingGrams(f)).toBe(1200);
+    });
+
+    it("falls back to legacy single-spool math when spools is empty", () => {
+      expect(
+        getRemainingPct({ ...baseTracked, totalWeight: 600, spools: [] }),
+      ).toBe(50); // (600-200)/800 = 50%
+      expect(
+        getRemainingPct({ ...baseTracked, totalWeight: null, spools: [] }),
+      ).toBeNull();
+    });
+
+    it("clamps to 0..100", () => {
+      // Over-full spool (e.g. brand new + extra) should clamp to 100, not 110+
+      const over: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [{ totalWeight: 1100 }], // would be (1100-200)/800 = 112.5%
+      };
+      expect(getRemainingPct(over)).toBe(100);
+
+      // Under-empty (totalWeight < spoolWeight) should clamp to 0
+      const under: InventoryFilament = {
+        ...baseTracked,
+        totalWeight: null,
+        spools: [{ totalWeight: 100 }], // would be -12.5%
+      };
+      expect(getRemainingPct(under)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
The list page already excluded retired spools from `getRemainingGrams` (so the low-stock badge worked correctly), but `getRemainingPct` and `getSpoolCount` still counted them. A filament with one active spool and one retired spool would render as "2 spools, 75% remaining" while the low-stock logic considered it a single nearly-empty roll.

- Extract the three helpers from `src/app/page.tsx` into `src/lib/inventoryStats.ts`.
- Exclude retired spools in all three. Filaments with no retired spools behave identically.
- Behaviour for the legacy single-spool fallback (where `spools` is empty but `totalWeight` is set) is preserved.

## Test plan
- [x] New `tests/inventoryStats.test.ts` (10 tests) — covers retired exclusion in each helper, all-active baselines, the legacy single-spool fallback, and the 0..100 clamp.
- [x] Full `npm test` — 827/827 pass.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)