### PR TITLE
Mobile: fix typecheck + gate CI on it

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -33,9 +33,39 @@ permissions:
   contents: write
 
 jobs:
+  typecheck:
+    name: Mobile typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # Mobile imports from @filament-db/shared, which is a workspace
+      # link (file:../shared). Install root first so the link resolves.
+      - name: Install PC/SC development headers
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
+
+      - name: Install root + shared dependencies
+        run: npm ci
+
+      - name: Install mobile dependencies
+        working-directory: packages/mobile
+        run: npm install
+
+      - name: Typecheck mobile
+        working-directory: packages/mobile
+        run: npm run typecheck
+
   build:
     name: Build ${{ matrix.platform }}
     runs-on: ubuntu-latest
+    needs: typecheck
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +108,10 @@ jobs:
             echo "profile=preview" >> "$GITHUB_OUTPUT"
           fi
 
-      # Android: wait for build, download APK, and upload to GitHub release
+      # Android: wait for build, fail the job on EAS error so a broken
+      # build doesn't pass CI. Result JSON is captured for the artifact
+      # step; if the build itself fails we exit early before attempting
+      # the artifact step.
       - name: Build Android (${{ steps.profile.outputs.profile }})
         if: matrix.platform == 'android'
         working-directory: packages/mobile
@@ -88,7 +121,7 @@ jobs:
             --profile ${{ steps.profile.outputs.profile }} \
             --non-interactive \
             --wait \
-            --json > /tmp/eas-build-result.json 2>/dev/null || true
+            --json > /tmp/eas-build-result.json
           cat /tmp/eas-build-result.json
 
       - name: Download Android APK
@@ -114,7 +147,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # iOS: submit to EAS (no artifact download — distributed via TestFlight)
+      # iOS: wait for the build so EAS-side failures (signing, archive,
+      # provisioning) surface as CI failures rather than silent successes.
+      # Distributed via TestFlight; no artifact download here.
       - name: Build iOS (${{ steps.profile.outputs.profile }})
         if: matrix.platform == 'ios'
         working-directory: packages/mobile
@@ -123,7 +158,7 @@ jobs:
             --platform ios \
             --profile ${{ steps.profile.outputs.profile }} \
             --non-interactive \
-            --no-wait
+            --wait
 
       - name: Summary
         run: |

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -10,7 +10,8 @@
     "android": "expo run:android",
     "build:dev": "eas build --profile development",
     "build:preview": "eas build --profile preview",
-    "build:prod": "eas build --profile production"
+    "build:prod": "eas build --profile production",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@filament-db/shared": "file:../shared",

--- a/packages/mobile/services/atlas.ts
+++ b/packages/mobile/services/atlas.ts
@@ -17,6 +17,16 @@ import { sanitizeFields } from "@filament-db/shared/logic/validation";
 // Default database name — matches the existing web/desktop app
 const DB_NAME = "filament-db";
 
+/** Permissive doc shape for the Realm MongoDB driver. The Realm SDK
+ * defaults `collection()` to bson `Document<unknown>`, which only
+ * exposes `_id` and strips every other field. We don't model schemas
+ * here — every read converts to a typed shape from @filament-db/shared
+ * before being returned — so the loose index signature below is the
+ * smallest change that lets the call sites compile. `_id` is required
+ * to satisfy the bson Document constraint. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AtlasDoc = { [key: string]: any; _id: Realm.BSON.ObjectId };
+
 /** Convert a string ID to a BSON ObjectId for Atlas queries. */
 function oid(id: string): Realm.BSON.ObjectId {
   return new Realm.BSON.ObjectId(id);
@@ -24,11 +34,17 @@ function oid(id: string): Realm.BSON.ObjectId {
 
 class AtlasService {
   private app: Realm.App | null = null;
-  private _db: globalThis.Realm.Services.MongoDB.MongoDBDatabase | null = null;
+  private _db: Realm.Services.MongoDBDatabase | null = null;
 
   private get db() {
     if (!this._db) throw new Error("Not connected to Atlas. Call connect() first.");
     return this._db;
+  }
+
+  /** Typed access to a collection — narrows the default `Document<unknown>`
+   * generic so reads and writes can use the AtlasDoc fields. */
+  private col(name: string) {
+    return this.db.collection<AtlasDoc>(name);
   }
 
   /**
@@ -67,7 +83,7 @@ class AtlasService {
         query.name = { $regex: filter.search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), $options: "i" };
       }
 
-      const docs = await this.db.collection("filaments").find(query, {
+      const docs = await this.col("filaments").find(query, {
         sort: { vendor: 1, name: 1 },
         projection: {
           name: 1, vendor: 1, type: 1, color: 1, cost: 1, density: 1,
@@ -80,7 +96,7 @@ class AtlasService {
     },
 
     get: async (id: string): Promise<FilamentDetail> => {
-      const doc = await this.db.collection("filaments").findOne({
+      const doc = await this.col("filaments").findOne({
         _id: oid(id),
         _deletedAt: null,
       });
@@ -89,12 +105,15 @@ class AtlasService {
       // Resolve inheritance if this is a variant
       let resolved = doc;
       if (doc.parentId) {
-        const parent = await this.db.collection("filaments").findOne({
+        const parent = await this.col("filaments").findOne({
           _id: doc.parentId,
           _deletedAt: null,
         });
         if (parent) {
-          resolved = resolveFilament(doc as Record<string, unknown>, parent as Record<string, unknown>);
+          resolved = resolveFilament(
+            doc as Record<string, unknown>,
+            parent as Record<string, unknown>,
+          ) as unknown as AtlasDoc;
         }
       }
 
@@ -103,7 +122,7 @@ class AtlasService {
         const nozzleIds = resolved.compatibleNozzles.map((n: unknown) =>
           typeof n === "string" ? oid(n) : n
         );
-        const nozzles = await this.db.collection("nozzles").find({
+        const nozzles = await this.col("nozzles").find({
           _id: { $in: nozzleIds },
           _deletedAt: null,
         });
@@ -114,13 +133,13 @@ class AtlasService {
       if (resolved.calibrations?.length) {
         for (const cal of resolved.calibrations) {
           if (cal.nozzle) {
-            const nozzle = await this.db.collection("nozzles").findOne({
+            const nozzle = await this.col("nozzles").findOne({
               _id: typeof cal.nozzle === "string" ? oid(cal.nozzle) : cal.nozzle,
             });
             if (nozzle) cal.nozzle = nozzle;
           }
           if (cal.printer) {
-            const printer = await this.db.collection("printers").findOne({
+            const printer = await this.col("printers").findOne({
               _id: typeof cal.printer === "string" ? oid(cal.printer) : cal.printer,
             });
             if (printer) cal.printer = printer;
@@ -130,7 +149,7 @@ class AtlasService {
 
       // Fetch variants if this is a parent
       if (!doc.parentId) {
-        const variants = await this.db.collection("filaments").find(
+        const variants = await this.col("filaments").find(
           { parentId: doc._id, _deletedAt: null },
           { projection: { name: 1, color: 1, cost: 1 } },
         );
@@ -144,7 +163,7 @@ class AtlasService {
 
     create: async (data: Partial<FilamentDetail>): Promise<FilamentDetail> => {
       const clean = sanitizeFields(data as Record<string, unknown>);
-      const result = await this.db.collection("filaments").insertOne({
+      const result = await this.col("filaments").insertOne({
         ...clean,
         _deletedAt: null,
         createdAt: new Date(),
@@ -155,7 +174,7 @@ class AtlasService {
 
     update: async (id: string, data: Partial<FilamentDetail>): Promise<FilamentDetail> => {
       const clean = sanitizeFields(data as Record<string, unknown>);
-      await this.db.collection("filaments").updateOne(
+      await this.col("filaments").updateOne(
         { _id: oid(id) },
         { $set: { ...clean, updatedAt: new Date() } },
       );
@@ -164,35 +183,35 @@ class AtlasService {
 
     delete: async (id: string): Promise<void> => {
       // Check for variants
-      const variantCount = await this.db.collection("filaments").count({
+      const variantCount = await this.col("filaments").count({
         parentId: oid(id),
         _deletedAt: null,
       });
       if (variantCount > 0) {
         throw new Error(`Cannot delete: filament has ${variantCount} variant(s)`);
       }
-      await this.db.collection("filaments").updateOne(
+      await this.col("filaments").updateOne(
         { _id: oid(id) },
         { $set: { _deletedAt: new Date() } },
       );
     },
 
     vendors: async (): Promise<string[]> => {
-      const docs = await this.db.collection("filaments").aggregate([
+      const docs = (await this.col("filaments").aggregate([
         { $match: { _deletedAt: null } },
         { $group: { _id: "$vendor" } },
         { $sort: { _id: 1 } },
-      ]);
-      return docs.map((d: { _id: string }) => d._id).filter(Boolean);
+      ])) as { _id: string }[];
+      return docs.map((d) => d._id).filter(Boolean);
     },
 
     types: async (): Promise<string[]> => {
-      const docs = await this.db.collection("filaments").aggregate([
+      const docs = (await this.col("filaments").aggregate([
         { $match: { _deletedAt: null } },
         { $group: { _id: "$type" } },
         { $sort: { _id: 1 } },
-      ]);
-      return docs.map((d: { _id: string }) => d._id).filter(Boolean);
+      ])) as { _id: string }[];
+      return docs.map((d) => d._id).filter(Boolean);
     },
   };
 
@@ -200,7 +219,7 @@ class AtlasService {
 
   spools = {
     add: async (filamentId: string, data: { label: string; totalWeight?: number | null }): Promise<void> => {
-      await this.db.collection("filaments").updateOne(
+      await this.col("filaments").updateOne(
         { _id: oid(filamentId) },
         {
           $push: {
@@ -221,14 +240,14 @@ class AtlasService {
       if (data.label !== undefined) setFields["spools.$.label"] = data.label;
       if (data.totalWeight !== undefined) setFields["spools.$.totalWeight"] = data.totalWeight;
 
-      await this.db.collection("filaments").updateOne(
+      await this.col("filaments").updateOne(
         { _id: oid(filamentId), "spools._id": oid(spoolId) },
         { $set: setFields },
       );
     },
 
     delete: async (filamentId: string, spoolId: string): Promise<void> => {
-      await this.db.collection("filaments").updateOne(
+      await this.col("filaments").updateOne(
         { _id: oid(filamentId) },
         {
           $pull: { spools: { _id: oid(spoolId) } },
@@ -246,14 +265,14 @@ class AtlasService {
       if (filter?.diameter) query.diameter = filter.diameter;
       if (filter?.type) query.type = filter.type;
 
-      const docs = await this.db.collection("nozzles").find(query, {
+      const docs = await this.col("nozzles").find(query, {
         sort: { diameter: 1, type: 1 },
       });
       return docs as unknown as NozzleDetail[];
     },
 
     get: async (id: string): Promise<NozzleDetail> => {
-      const doc = await this.db.collection("nozzles").findOne({
+      const doc = await this.col("nozzles").findOne({
         _id: oid(id),
         _deletedAt: null,
       });
@@ -263,7 +282,7 @@ class AtlasService {
 
     create: async (data: Partial<NozzleDetail>): Promise<NozzleDetail> => {
       const clean = sanitizeFields(data as Record<string, unknown>);
-      const result = await this.db.collection("nozzles").insertOne({
+      const result = await this.col("nozzles").insertOne({
         ...clean,
         _deletedAt: null,
         createdAt: new Date(),
@@ -274,7 +293,7 @@ class AtlasService {
 
     update: async (id: string, data: Partial<NozzleDetail>): Promise<NozzleDetail> => {
       const clean = sanitizeFields(data as Record<string, unknown>);
-      await this.db.collection("nozzles").updateOne(
+      await this.col("nozzles").updateOne(
         { _id: oid(id) },
         { $set: { ...clean, updatedAt: new Date() } },
       );
@@ -283,7 +302,7 @@ class AtlasService {
 
     delete: async (id: string): Promise<void> => {
       // Referential integrity check
-      const filamentRef = await this.db.collection("filaments").count({
+      const filamentRef = await this.col("filaments").count({
         _deletedAt: null,
         $or: [
           { compatibleNozzles: oid(id) },
@@ -294,7 +313,7 @@ class AtlasService {
         throw new Error(`Cannot delete: nozzle is referenced by ${filamentRef} filament(s)`);
       }
 
-      const printerRef = await this.db.collection("printers").count({
+      const printerRef = await this.col("printers").count({
         _deletedAt: null,
         installedNozzles: oid(id),
       });
@@ -302,7 +321,7 @@ class AtlasService {
         throw new Error(`Cannot delete: nozzle is installed in ${printerRef} printer(s)`);
       }
 
-      await this.db.collection("nozzles").updateOne(
+      await this.col("nozzles").updateOne(
         { _id: oid(id) },
         { $set: { _deletedAt: new Date() } },
       );
@@ -316,14 +335,14 @@ class AtlasService {
       const query: Record<string, unknown> = { _deletedAt: null };
       if (filter?.manufacturer) query.manufacturer = filter.manufacturer;
 
-      const docs = await this.db.collection("printers").find(query, {
+      const docs = await this.col("printers").find(query, {
         sort: { manufacturer: 1, name: 1 },
       });
 
       // Populate installed nozzles
       for (const doc of docs) {
         if (doc.installedNozzles?.length) {
-          const nozzles = await this.db.collection("nozzles").find({
+          const nozzles = await this.col("nozzles").find({
             _id: { $in: doc.installedNozzles },
             _deletedAt: null,
           });
@@ -335,7 +354,7 @@ class AtlasService {
     },
 
     get: async (id: string): Promise<PrinterDetail> => {
-      const doc = await this.db.collection("printers").findOne({
+      const doc = await this.col("printers").findOne({
         _id: oid(id),
         _deletedAt: null,
       });
@@ -343,7 +362,7 @@ class AtlasService {
 
       // Populate installed nozzles
       if (doc.installedNozzles?.length) {
-        const nozzles = await this.db.collection("nozzles").find({
+        const nozzles = await this.col("nozzles").find({
           _id: { $in: doc.installedNozzles },
           _deletedAt: null,
         });
@@ -355,7 +374,7 @@ class AtlasService {
 
     create: async (data: Partial<PrinterDetail>): Promise<PrinterDetail> => {
       const clean = sanitizeFields(data as Record<string, unknown>);
-      const result = await this.db.collection("printers").insertOne({
+      const result = await this.col("printers").insertOne({
         ...clean,
         _deletedAt: null,
         createdAt: new Date(),
@@ -366,7 +385,7 @@ class AtlasService {
 
     update: async (id: string, data: Partial<PrinterDetail>): Promise<PrinterDetail> => {
       const clean = sanitizeFields(data as Record<string, unknown>);
-      await this.db.collection("printers").updateOne(
+      await this.col("printers").updateOne(
         { _id: oid(id) },
         { $set: { ...clean, updatedAt: new Date() } },
       );
@@ -375,7 +394,7 @@ class AtlasService {
 
     delete: async (id: string): Promise<void> => {
       // Referential integrity check
-      const filamentRef = await this.db.collection("filaments").count({
+      const filamentRef = await this.col("filaments").count({
         _deletedAt: null,
         "calibrations.printer": oid(id),
       });
@@ -383,7 +402,7 @@ class AtlasService {
         throw new Error(`Cannot delete: printer is referenced by ${filamentRef} filament(s)`);
       }
 
-      await this.db.collection("printers").updateOne(
+      await this.col("printers").updateOne(
         { _id: oid(id) },
         { $set: { _deletedAt: new Date() } },
       );

--- a/packages/mobile/services/nfc.ts
+++ b/packages/mobile/services/nfc.ts
@@ -45,7 +45,7 @@ class MobileNfcService {
     try {
       // Request NFC-V technology
       if (Platform.OS === "ios") {
-        await NfcManager.requestTechnology(NfcTech.Iso15693ICode);
+        await NfcManager.requestTechnology(NfcTech.Iso15693IOS);
       } else {
         await NfcManager.requestTechnology(NfcTech.NfcV);
       }
@@ -81,7 +81,7 @@ class MobileNfcService {
 
       // Request NFC-V technology
       if (Platform.OS === "ios") {
-        await NfcManager.requestTechnology(NfcTech.Iso15693ICode);
+        await NfcManager.requestTechnology(NfcTech.Iso15693IOS);
       } else {
         await NfcManager.requestTechnology(NfcTech.NfcV);
       }
@@ -122,7 +122,7 @@ class MobileNfcService {
   ): Promise<void> {
     try {
       if (Platform.OS === "ios") {
-        await NfcManager.requestTechnology(NfcTech.Iso15693ICode);
+        await NfcManager.requestTechnology(NfcTech.Iso15693IOS);
       } else {
         await NfcManager.requestTechnology(NfcTech.NfcV);
       }
@@ -155,7 +155,7 @@ class MobileNfcService {
   async formatTag(onProgress?: (percent: number) => void): Promise<void> {
     try {
       if (Platform.OS === "ios") {
-        await NfcManager.requestTechnology(NfcTech.Iso15693ICode);
+        await NfcManager.requestTechnology(NfcTech.Iso15693IOS);
       } else {
         await NfcManager.requestTechnology(NfcTech.NfcV);
       }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,6 @@
     "./logic": "./src/logic/index.ts",
     "./logic/*": "./src/logic/*.ts",
     "./i18n": "./src/i18n/index.ts",
-    "./i18n/locales/*": "./src/i18n/locales/*.json"
+    "./i18n/locales/*.json": "./src/i18n/locales/*.json"
   }
 }


### PR DESCRIPTION
**Targets `feature/mobile-app`** (PR #94's branch) since the changes live in `packages/mobile/`.

## Summary
Mobile package was failing typecheck and CI didn't notice because the workflow never ran tsc. Fixing the type errors and the CI gap together so a green build means a working build.

### Type errors fixed
1. **Locale JSON imports** — `packages/shared/package.json` exports `"./i18n/locales/*": "./src/i18n/locales/*.json"` stripped the extension on resolution. `@filament-db/shared/i18n/locales/en.json` resolved to a nonexistent `en.json.json`. Pattern changed to `"./i18n/locales/*.json": "./src/i18n/locales/*.json"` — both Mobile (Metro/strict) and Next can now import the same path.
2. **Realm Atlas** — `services/atlas.ts` referenced `Realm.Services.MongoDB.MongoDBDatabase` (doesn't exist in the current Realm SDK; the type is `Realm.Services.MongoDBDatabase`). Typed all `db.collection()` calls via a permissive `AtlasDoc` generic so reads/writes type-check; cast `aggregate()` results (SDK returns `Promise<unknown>`).
3. **NFC tech enum** — `services/nfc.ts` used `NfcTech.Iso15693ICode` (4 sites); the constant is `NfcTech.Iso15693IOS`.

### CI gate
- Added `npm run typecheck` script in `packages/mobile` (`tsc --noEmit`).
- New `typecheck` job in `.github/workflows/mobile.yml`; build matrix `needs: typecheck`.
- Removed `|| true` from the Android EAS step — broken builds were silently passing.
- Switched iOS EAS step from `--no-wait` to `--wait` so signing / archive / provisioning failures surface as CI failures.

## Test plan
- [x] `cd packages/mobile && npm run typecheck` — clean.
- [x] Root `npm test` — 817/817 pass (no test additions; typecheck is the verification).
- [x] Root `npm run lint` — only pre-existing mobile-app warnings unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)