### PR TITLE
Mobile: restore Atlas credentials on app start

### DIFF
--- a/packages/mobile/providers/AtlasProvider.tsx
+++ b/packages/mobile/providers/AtlasProvider.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
 import * as SecureStore from "expo-secure-store";
+import { atlasService } from "../services/atlas";
 
 interface AtlasConfig {
   appId: string;
@@ -9,6 +10,10 @@ interface AtlasConfig {
 interface AtlasContextValue {
   config: AtlasConfig | null;
   isConnected: boolean;
+  /** True while the on-mount restore attempt is in-flight. Lets consumers
+   * differentiate "not connected" from "haven't tried yet" so they don't
+   * flash a setup screen during the cold-start reconnect. */
+  isRestoring: boolean;
   setConfig: (config: AtlasConfig) => Promise<void>;
   clearConfig: () => Promise<void>;
 }
@@ -19,6 +24,7 @@ const STORAGE_KEY_API_KEY = "filamentdb-atlas-api-key";
 const AtlasContext = createContext<AtlasContextValue>({
   config: null,
   isConnected: false,
+  isRestoring: false,
   setConfig: async () => {},
   clearConfig: async () => {},
 });
@@ -26,6 +32,38 @@ const AtlasContext = createContext<AtlasContextValue>({
 export function AtlasProvider({ children }: { children: ReactNode }) {
   const [config, setConfigState] = useState<AtlasConfig | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(true);
+
+  // On mount, pull credentials out of SecureStore and reconnect to Atlas.
+  // Without this the user has to re-enter their App ID + API key on every
+  // cold launch — the connect screen wrote them to SecureStore but nothing
+  // ever read them back. Failures (network, revoked key) leave isConnected
+  // false; the connect screen is the recovery path.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [appId, apiKey] = await Promise.all([
+          SecureStore.getItemAsync(STORAGE_KEY_APP_ID),
+          SecureStore.getItemAsync(STORAGE_KEY_API_KEY),
+        ]);
+        if (cancelled) return;
+        if (appId && apiKey) {
+          try {
+            await atlasService.connect(appId, apiKey);
+            if (cancelled) return;
+            setConfigState({ appId, apiKey });
+            setIsConnected(true);
+          } catch (err) {
+            console.warn("Atlas auto-reconnect failed:", err);
+          }
+        }
+      } finally {
+        if (!cancelled) setIsRestoring(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   const setConfig = useCallback(async (c: AtlasConfig) => {
     await SecureStore.setItemAsync(STORAGE_KEY_APP_ID, c.appId);
@@ -37,12 +75,13 @@ export function AtlasProvider({ children }: { children: ReactNode }) {
   const clearConfig = useCallback(async () => {
     await SecureStore.deleteItemAsync(STORAGE_KEY_APP_ID);
     await SecureStore.deleteItemAsync(STORAGE_KEY_API_KEY);
+    atlasService.disconnect();
     setConfigState(null);
     setIsConnected(false);
   }, []);
 
   return (
-    <AtlasContext.Provider value={{ config, isConnected, setConfig, clearConfig }}>
+    <AtlasContext.Provider value={{ config, isConnected, isRestoring, setConfig, clearConfig }}>
       {children}
     </AtlasContext.Provider>
   );

--- a/packages/mobile/providers/AtlasProvider.tsx
+++ b/packages/mobile/providers/AtlasProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from "react";
 import * as SecureStore from "expo-secure-store";
 import { atlasService } from "../services/atlas";
 
@@ -34,6 +34,14 @@ export function AtlasProvider({ children }: { children: ReactNode }) {
   const [isConnected, setIsConnected] = useState(false);
   const [isRestoring, setIsRestoring] = useState(true);
 
+  // Cancellation token for the on-mount restore. If the user reaches the
+  // connect screen and submits new credentials (or signs out) before our
+  // SecureStore-read + atlasService.connect chain settles, we must NOT
+  // flip the provider back to the stale stored values — that race would
+  // sign them back into the old account. setConfig/clearConfig invalidate
+  // the in-flight restore by flipping this flag.
+  const restoreInvalidated = useRef(false);
+
   // On mount, pull credentials out of SecureStore and reconnect to Atlas.
   // Without this the user has to re-enter their App ID + API key on every
   // cold launch — the connect screen wrote them to SecureStore but nothing
@@ -47,11 +55,16 @@ export function AtlasProvider({ children }: { children: ReactNode }) {
           SecureStore.getItemAsync(STORAGE_KEY_APP_ID),
           SecureStore.getItemAsync(STORAGE_KEY_API_KEY),
         ]);
-        if (cancelled) return;
+        if (cancelled || restoreInvalidated.current) return;
         if (appId && apiKey) {
           try {
             await atlasService.connect(appId, apiKey);
-            if (cancelled) return;
+            // Re-check both flags AFTER the await — a slow auto-reconnect
+            // could resolve while the user is on the connect screen
+            // submitting fresh credentials. Without this guard the stale
+            // restored creds would race in and overwrite the newer
+            // manual connection's state.
+            if (cancelled || restoreInvalidated.current) return;
             setConfigState({ appId, apiKey });
             setIsConnected(true);
           } catch (err) {
@@ -66,6 +79,11 @@ export function AtlasProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const setConfig = useCallback(async (c: AtlasConfig) => {
+    // Any in-flight restore is now stale — the user has explicitly
+    // chosen these credentials. Set the flag BEFORE the awaits so a
+    // restore that resolves between here and the state writes still
+    // sees the invalidation.
+    restoreInvalidated.current = true;
     await SecureStore.setItemAsync(STORAGE_KEY_APP_ID, c.appId);
     await SecureStore.setItemAsync(STORAGE_KEY_API_KEY, c.apiKey);
     setConfigState(c);
@@ -73,6 +91,7 @@ export function AtlasProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const clearConfig = useCallback(async () => {
+    restoreInvalidated.current = true;
     await SecureStore.deleteItemAsync(STORAGE_KEY_APP_ID);
     await SecureStore.deleteItemAsync(STORAGE_KEY_API_KEY);
     atlasService.disconnect();


### PR DESCRIPTION
**Stacks on top of [#151](https://github.com/hyiger/filament-db/pull/151)** (mobile typecheck + CI gate). Final target is `feature/mobile-app`. Once #151 lands, this PR's base will be retargeted automatically by GitHub.

## Summary
`AtlasProvider` wrote App ID + API key to SecureStore on connect but never read them back on app start. Every cold launch left `config: null` and `isConnected: false`, so users had to re-enter the same credentials each time and re-tap Connect to use any data screen.

- On-mount `useEffect` pulls both keys from SecureStore, calls `atlasService.connect(...)`, and flips connected state when both succeed.
- Auto-reconnect failures (network down, key revoked) log a warning but leave `isConnected` false — the existing connect screen is the documented recovery path.
- New `isRestoring` flag on the context lets consumers tell the cold-start reconnect window apart from a steady-state "not connected" so they don't flash a setup prompt during boot.
- `clearConfig` now calls `atlasService.disconnect()` too — without it a signed-out user kept their cached Realm session live.

## Test plan
- [x] `cd packages/mobile && npm run typecheck` — clean.
- Manual verify on a build (cold start with stored creds → connects without re-entry; without creds → restore window completes, app sits at not-connected; clearConfig → service.disconnect actually fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)