### PR TITLE
Sync expansion: bedtypes, printhistories, sharedcatalogs + bedType + amsSlots remap

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -43,12 +43,15 @@ interface SyncResult {
 /**
  * Bidirectional sync engine between local MongoDB and Atlas.
  * Uses last-write-wins conflict resolution based on updatedAt timestamps.
- * Nozzles, printers, and locations are synced first so filaments (and their
- * embedded spools) can have their references remapped onto the target DB's IDs.
+ * Nozzles, printers, locations, and bedtypes are synced first so filaments
+ * (and their embedded spools) can have their references remapped onto the
+ * target DB's IDs. Printhistories and sharedcatalogs sync after filaments.
  *
- * NOTE: bedtypes, printhistory, and sharedcatalogs are NOT synced yet — they
- * were added in v1.11 alongside locations and have the same gap. They'll need
- * the same treatment when their data starts diverging across desktops.
+ * Known limitation: spool subdocuments inside Filament don't have stable
+ * cross-side identifiers. Anything that references a spool by id —
+ * printer.amsSlots[].spoolId, printhistory.usage[].spoolId — clears that
+ * id during cross-side remap. Per-filament gram totals still reconcile;
+ * per-spool attribution is dropped pending a spool-syncId migration.
  */
 export class SyncService extends EventEmitter {
   private localUri: string;
@@ -193,6 +196,21 @@ export class SyncService extends EventEmitter {
         localDb, remoteDb, localLocationBySyncId, remoteLocationBySyncId,
       );
 
+      // Sync bedtypes before filaments so calibrations[].bedType can be
+      // remapped. Same partial-unique-name index trap as locations — bed
+      // types existed before sync was added in this collection set, and
+      // duplicate names on first sync would E11000 the cycle. Reconcile
+      // by name first to unify the syncIds.
+      this.updateStatus({ progress: "Syncing bed types..." });
+      await this.reconcileBedTypesByName(localDb, remoteDb);
+      const bedTypeResult = await this.syncCollection(localDb, remoteDb, "bedtypes");
+
+      // Build bedType syncId→ID maps for filament calibration remap
+      const localBedTypes = await localDb.collection("bedtypes").find({ _deletedAt: null }).toArray();
+      const remoteBedTypes = await remoteDb.collection("bedtypes").find({ _deletedAt: null }).toArray();
+      const localBedTypeBySyncId = new Map(localBedTypes.filter(b => b.syncId).map(b => [b.syncId as string, b._id]));
+      const remoteBedTypeBySyncId = new Map(remoteBedTypes.filter(b => b.syncId).map(b => [b.syncId as string, b._id]));
+
       // Backfill filament syncIds before building maps (syncCollection does this too, but we need maps first)
       await this.backfillSyncIds(localDb.collection("filaments"));
       await this.backfillSyncIds(remoteDb.collection("filaments"));
@@ -226,13 +244,15 @@ export class SyncService extends EventEmitter {
         remoteFilamentSnapshot.set(f._id.toString(), t ?? null);
       }
 
-      // Sync filaments with nozzle, printer, parent, and spool-location remapping
+      // Sync filaments with nozzle, printer, parent, spool-location, and
+      // bedType remapping
       this.updateStatus({ progress: "Syncing filaments..." });
       const filamentTransform = this.buildFilamentRefsTransform(
         localNozzleBySyncId, remoteNozzleBySyncId,
         localPrinterBySyncId, remotePrinterBySyncId,
         localFilamentBySyncId, remoteFilamentBySyncId,
         localLocationBySyncId, remoteLocationBySyncId,
+        localBedTypeBySyncId, remoteBedTypeBySyncId,
       );
       const filamentResult = await this.syncCollection(
         localDb, remoteDb, "filaments",
@@ -252,7 +272,54 @@ export class SyncService extends EventEmitter {
         localFilamentSnapshot, remoteFilamentSnapshot,
       );
 
-      const results = [nozzleResult, printerResult, locationResult, filamentResult];
+      // Rebuild filament syncId maps now that filament sync has settled —
+      // both the printer amsSlots repair below and the print-history
+      // transform need ids that exist on both sides post-sync.
+      const lFilPost = await localDb.collection("filaments").find({}).toArray();
+      const rFilPost = await remoteDb.collection("filaments").find({}).toArray();
+      const localFilPostBySyncId = new Map(lFilPost.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
+      const remoteFilPostBySyncId = new Map(rFilPost.filter(f => f.syncId).map(f => [f.syncId as string, f._id]));
+
+      // Repair printer amsSlots[].filamentId refs. Printers sync runs
+      // BEFORE filaments to break the calibrations[].printer ↔
+      // amsSlots[].filamentId cycle, but that means the printer transform
+      // can't remap amsSlots into filament ids that don't yet exist on
+      // the target side. Patch them in-place now via the post-sync
+      // filament syncId maps. amsSlots[].spoolId can't be remapped at
+      // all without spool syncIds (a separate schema migration); it gets
+      // cleared if the parent filamentId reference itself can't be
+      // resolved, otherwise left alone.
+      await this.repairPrinterAmsSlots(
+        localDb, remoteDb,
+        localFilPostBySyncId, remoteFilPostBySyncId,
+      );
+
+      // Sync print history. Top-level job ledger that references
+      // printerId + usage[].filamentId. usage[].spoolId can't be remapped
+      // (no spool syncIds) and is cleared on insert — the job total still
+      // reconciles via filamentId + grams; the per-spool attribution is
+      // dropped pending the spool-syncId migration.
+      this.updateStatus({ progress: "Syncing print history..." });
+      const printHistoryTransform = this.buildPrintHistoryTransform(
+        localPrinterBySyncId, remotePrinterBySyncId,
+        localFilPostBySyncId, remoteFilPostBySyncId,
+      );
+      const printHistoryResult = await this.syncCollection(
+        localDb, remoteDb, "printhistories", printHistoryTransform,
+      );
+
+      // Sync shared catalogs. Payload is denormalised at publish time so
+      // there are no outbound refs to remap — straight syncId-keyed
+      // last-write-wins between the two sides.
+      this.updateStatus({ progress: "Syncing shared catalogs..." });
+      const sharedCatalogResult = await this.syncCollection(
+        localDb, remoteDb, "sharedcatalogs",
+      );
+
+      const results = [
+        nozzleResult, printerResult, locationResult, bedTypeResult,
+        filamentResult, printHistoryResult, sharedCatalogResult,
+      ];
       this.updateStatus({
         state: "idle",
         lastSyncAt: new Date().toISOString(),
@@ -441,8 +508,35 @@ export class SyncService extends EventEmitter {
     localDb: ReturnType<MongoClient["db"]>,
     remoteDb: ReturnType<MongoClient["db"]>,
   ): Promise<void> {
-    const localCol = localDb.collection("locations");
-    const remoteCol = remoteDb.collection("locations");
+    await this.reconcileByName(localDb, remoteDb, "locations");
+  }
+
+  /**
+   * Same name-collision resolver used for locations, applied to bedtypes.
+   * BedType has a partial-unique index on `name` (non-deleted only), so two
+   * desktops that independently created "Textured PEI" before bedtype sync
+   * existed would E11000 on the very first sync push.
+   */
+  private async reconcileBedTypesByName(
+    localDb: ReturnType<MongoClient["db"]>,
+    remoteDb: ReturnType<MongoClient["db"]>,
+  ): Promise<void> {
+    await this.reconcileByName(localDb, remoteDb, "bedtypes");
+  }
+
+  /**
+   * Generic name-keyed syncId reconciliation. Used for any collection
+   * with a partial-unique-name index where the same logical row may have
+   * been created independently on both sides before sync was added —
+   * locations (v1.11.3) and bedtypes (this PR).
+   */
+  private async reconcileByName(
+    localDb: ReturnType<MongoClient["db"]>,
+    remoteDb: ReturnType<MongoClient["db"]>,
+    collectionName: string,
+  ): Promise<void> {
+    const localCol = localDb.collection(collectionName);
+    const remoteCol = remoteDb.collection(collectionName);
     const localActive = await localCol.find({ _deletedAt: null }).toArray();
     const remoteActive = await remoteCol.find({ _deletedAt: null }).toArray();
 
@@ -462,7 +556,7 @@ export class SyncService extends EventEmitter {
       if (localSyncId !== winningSyncId) {
         const conflict = await localCol.findOne({ syncId: winningSyncId, _id: { $ne: local._id } });
         if (conflict) {
-          console.warn(`reconcileLocationsByName: local syncId conflict for "${local.name}" — skipping`);
+          console.warn(`reconcileByName(${collectionName}): local syncId conflict for "${local.name}" — skipping`);
           continue;
         }
         await localCol.updateOne({ _id: local._id }, { $set: { syncId: winningSyncId } });
@@ -470,7 +564,7 @@ export class SyncService extends EventEmitter {
       if (remoteSyncId !== winningSyncId) {
         const conflict = await remoteCol.findOne({ syncId: winningSyncId, _id: { $ne: remote._id } });
         if (conflict) {
-          console.warn(`reconcileLocationsByName: remote syncId conflict for "${local.name}" — skipping`);
+          console.warn(`reconcileByName(${collectionName}): remote syncId conflict for "${local.name}" — skipping`);
           continue;
         }
         await remoteCol.updateOne({ _id: remote._id }, { $set: { syncId: winningSyncId } });
@@ -768,6 +862,8 @@ export class SyncService extends EventEmitter {
     remoteFilamentBySyncId: Map<string, ObjectId>,
     localLocationBySyncId: Map<string, ObjectId>,
     remoteLocationBySyncId: Map<string, ObjectId>,
+    localBedTypeBySyncId: Map<string, ObjectId>,
+    remoteBedTypeBySyncId: Map<string, ObjectId>,
   ): (doc: Document, direction: "toLocal" | "toRemote") => Document {
     // Build reverse maps once (source ID → syncId) for both directions
     const buildReverse = (map: Map<string, ObjectId>) => {
@@ -786,6 +882,8 @@ export class SyncService extends EventEmitter {
     const remoteFilamentIdToSyncId = buildReverse(remoteFilamentBySyncId);
     const localLocationIdToSyncId = buildReverse(localLocationBySyncId);
     const remoteLocationIdToSyncId = buildReverse(remoteLocationBySyncId);
+    const localBedTypeIdToSyncId = buildReverse(localBedTypeBySyncId);
+    const remoteBedTypeIdToSyncId = buildReverse(remoteBedTypeBySyncId);
 
     return (doc: Document, direction: "toLocal" | "toRemote"): Document => {
       const sourceNozzleIdToSyncId = direction === "toLocal" ? remoteNozzleIdToSyncId : localNozzleIdToSyncId;
@@ -794,6 +892,8 @@ export class SyncService extends EventEmitter {
       const targetPrinterMap = direction === "toLocal" ? localPrinterBySyncId : remotePrinterBySyncId;
       const sourceLocationIdToSyncId = direction === "toLocal" ? remoteLocationIdToSyncId : localLocationIdToSyncId;
       const targetLocationMap = direction === "toLocal" ? localLocationBySyncId : remoteLocationBySyncId;
+      const sourceBedTypeIdToSyncId = direction === "toLocal" ? remoteBedTypeIdToSyncId : localBedTypeIdToSyncId;
+      const targetBedTypeMap = direction === "toLocal" ? localBedTypeBySyncId : remoteBedTypeBySyncId;
 
       // Remap compatibleNozzles
       if (Array.isArray(doc.compatibleNozzles)) {
@@ -805,7 +905,8 @@ export class SyncService extends EventEmitter {
           .filter(Boolean);
       }
 
-      // Remap calibrations.nozzle and calibrations.printer
+      // Remap calibrations.nozzle, calibrations.printer, and
+      // calibrations.bedType
       if (Array.isArray(doc.calibrations)) {
         doc.calibrations = doc.calibrations
           .map((cal: Document) => {
@@ -821,6 +922,15 @@ export class SyncService extends EventEmitter {
               const printerSyncId = sourcePrinterIdToSyncId.get(cal.printer.toString());
               const targetPrinterId = printerSyncId ? targetPrinterMap.get(printerSyncId) : null;
               remapped.printer = targetPrinterId || null;
+            }
+
+            // Remap bedType reference if present. An unknown bedType on the
+            // target side clears to null rather than persisting a wrong-side
+            // ObjectId — same model as printer/location.
+            if (cal.bedType) {
+              const bedTypeSyncId = sourceBedTypeIdToSyncId.get(cal.bedType.toString());
+              const targetBedTypeId = bedTypeSyncId ? targetBedTypeMap.get(bedTypeSyncId) : null;
+              remapped.bedType = targetBedTypeId || null;
             }
 
             return remapped;
@@ -853,6 +963,155 @@ export class SyncService extends EventEmitter {
 
       return doc;
     };
+  }
+
+  /**
+   * Build a transform for printhistories. Remaps printerId and
+   * usage[].filamentId via syncId. usage[].spoolId is cleared on
+   * insert/update because spool subdocuments don't have stable
+   * cross-side identifiers (no spool syncIds yet — separate schema
+   * migration). The job's per-filament gram totals are still correct
+   * after the remap, but per-spool attribution is lost.
+   */
+  private buildPrintHistoryTransform(
+    localPrinterBySyncId: Map<string, ObjectId>,
+    remotePrinterBySyncId: Map<string, ObjectId>,
+    localFilamentBySyncId: Map<string, ObjectId>,
+    remoteFilamentBySyncId: Map<string, ObjectId>,
+  ): (doc: Document, direction: "toLocal" | "toRemote") => Document {
+    const buildReverse = (map: Map<string, ObjectId>) => {
+      const reverse = new Map<string, string>();
+      for (const [syncId, id] of map) reverse.set(id.toString(), syncId);
+      return reverse;
+    };
+
+    const localPrinterIdToSyncId = buildReverse(localPrinterBySyncId);
+    const remotePrinterIdToSyncId = buildReverse(remotePrinterBySyncId);
+    const localFilamentIdToSyncId = buildReverse(localFilamentBySyncId);
+    const remoteFilamentIdToSyncId = buildReverse(remoteFilamentBySyncId);
+
+    return (doc: Document, direction: "toLocal" | "toRemote"): Document => {
+      const sourcePrinterIdToSyncId = direction === "toLocal" ? remotePrinterIdToSyncId : localPrinterIdToSyncId;
+      const targetPrinterMap = direction === "toLocal" ? localPrinterBySyncId : remotePrinterBySyncId;
+      const sourceFilamentIdToSyncId = direction === "toLocal" ? remoteFilamentIdToSyncId : localFilamentIdToSyncId;
+      const targetFilamentMap = direction === "toLocal" ? localFilamentBySyncId : remoteFilamentBySyncId;
+
+      if (doc.printerId) {
+        const printerSyncId = sourcePrinterIdToSyncId.get(doc.printerId.toString());
+        doc.printerId = (printerSyncId ? targetPrinterMap.get(printerSyncId) : null) || null;
+      }
+
+      if (Array.isArray(doc.usage)) {
+        doc.usage = doc.usage
+          .map((entry: Document) => {
+            if (!entry.filamentId) return null; // schema requires filamentId
+            const filSyncId = sourceFilamentIdToSyncId.get(entry.filamentId.toString());
+            const targetFilId = filSyncId ? targetFilamentMap.get(filSyncId) : null;
+            if (!targetFilId) return null; // drop usage entry with unresolvable filament
+            return {
+              ...entry,
+              filamentId: targetFilId,
+              // Clear spoolId — no stable cross-side spool ids; per-spool
+              // attribution is dropped pending the spool-syncId migration.
+              spoolId: null,
+            };
+          })
+          .filter(Boolean);
+      }
+
+      return doc;
+    };
+  }
+
+  /**
+   * After the filament sync settles, walk both sides' printers and patch
+   * each amsSlots[].filamentId so it points at a filament that actually
+   * exists on this side. The forward path is necessary because printer
+   * sync runs BEFORE filament sync (to break the calibrations.printer ↔
+   * amsSlots.filamentId cycle): on push, the remote target may not yet
+   * have the filament id we're handing it; on pull, our local map didn't
+   * have the new filament when the printer transform ran.
+   *
+   * Resolution model:
+   *   - filamentId points at a current valid filament on this side → leave.
+   *   - filamentId is null → leave (intentional empty slot).
+   *   - filamentId is set but dangles → look up by other-side syncId and
+   *     swap in the correct local id; if the syncId can't be projected
+   *     (filament absent on other side too), clear to null. spoolId
+   *     follows the same fate as its parent filamentId — cleared if the
+   *     filamentId is repaired or cleared, since per-spool attribution
+   *     can't survive a filamentId rewrite without spool syncIds.
+   *
+   * Does NOT bump updatedAt — same rationale as the other repair passes.
+   */
+  private async repairPrinterAmsSlots(
+    localDb: ReturnType<MongoClient["db"]>,
+    remoteDb: ReturnType<MongoClient["db"]>,
+    localFilamentBySyncId: Map<string, ObjectId>,
+    remoteFilamentBySyncId: Map<string, ObjectId>,
+  ): Promise<void> {
+    const localFilIds = new Set(Array.from(localFilamentBySyncId.values()).map((id) => id.toString()));
+    const remoteFilIds = new Set(Array.from(remoteFilamentBySyncId.values()).map((id) => id.toString()));
+
+    const localFilIdToSyncId = new Map<string, string>();
+    for (const [syncId, id] of localFilamentBySyncId) localFilIdToSyncId.set(id.toString(), syncId);
+    const remoteFilIdToSyncId = new Map<string, string>();
+    for (const [syncId, id] of remoteFilamentBySyncId) remoteFilIdToSyncId.set(id.toString(), syncId);
+
+    await this.repairSidePrinterAmsSlots(localDb, localFilIds, localFilamentBySyncId, remoteFilIdToSyncId, "local");
+    await this.repairSidePrinterAmsSlots(remoteDb, remoteFilIds, remoteFilamentBySyncId, localFilIdToSyncId, "remote");
+  }
+
+  private async repairSidePrinterAmsSlots(
+    db: ReturnType<MongoClient["db"]>,
+    sideValidFilIds: Set<string>,
+    sideFilSyncIdToId: Map<string, ObjectId>,
+    otherSideFilIdToSyncId: Map<string, string>,
+    sideLabel: "local" | "remote",
+  ): Promise<void> {
+    // Use $elemMatch — the naive "amsSlots.filamentId": { $ne: null } would
+    // exclude any printer that has *any* slot with filamentId === null, even
+    // if a sibling slot is set (Mongo's array-positional matching makes
+    // negated equality match on whole-array, not per-element).
+    const printers = await db
+      .collection("printers")
+      .find({
+        _deletedAt: null,
+        amsSlots: { $elemMatch: { filamentId: { $ne: null } } },
+      })
+      .toArray();
+
+    let repaired = 0;
+    for (const p of printers) {
+      const slots: Document[] = Array.isArray(p.amsSlots) ? p.amsSlots : [];
+      let changed = false;
+      const newSlots = slots.map((slot) => {
+        if (!slot.filamentId) return slot;
+        const idStr = slot.filamentId.toString();
+        if (sideValidFilIds.has(idStr)) return slot; // already valid
+
+        const syncId = otherSideFilIdToSyncId.get(idStr);
+        const correctId = syncId ? sideFilSyncIdToId.get(syncId) : null;
+        if (!correctId) {
+          changed = true;
+          return { ...slot, filamentId: null, spoolId: null };
+        }
+        if (correctId.toString() === idStr) return slot;
+        changed = true;
+        // Filament repaired but spool can't be reliably mapped — clear it.
+        return { ...slot, filamentId: correctId, spoolId: null };
+      });
+      if (changed) {
+        await db.collection("printers").updateOne(
+          { _id: p._id },
+          { $set: { amsSlots: newSlots } },
+        );
+        repaired++;
+      }
+    }
+    if (repaired > 0) {
+      console.log(`repairPrinterAmsSlots: fixed ${repaired} ${sideLabel} printer(s)`);
+    }
   }
 
   destroy() {

--- a/src/app/api/print-history/[id]/route.ts
+++ b/src/app/api/print-history/[id]/route.ts
@@ -66,7 +66,15 @@ export async function DELETE(
       await filament.save();
     }
 
-    await PrintHistory.deleteOne({ _id: id });
+    // Soft-delete by setting _deletedAt. Hard `deleteOne` would let a peer
+    // sync resurrect the row from the other DB on the next cycle —
+    // syncCollection treats "missing on one side" as pull/push, not delete,
+    // and only propagates deletes via the _deletedAt tombstone. Same model
+    // the rest of the synced collections already use.
+    await PrintHistory.updateOne(
+      { _id: id },
+      { $set: { _deletedAt: new Date() } },
+    );
     return NextResponse.json({ message: "Deleted and refunded" });
   } catch (err) {
     return errorResponse("Failed to delete print history", 500, getErrorMessage(err));

--- a/src/app/api/print-history/[id]/route.ts
+++ b/src/app/api/print-history/[id]/route.ts
@@ -19,7 +19,11 @@ export async function DELETE(
   try {
     await dbConnect();
     const { id } = await params;
-    const entry = await PrintHistory.findById(id);
+    // Filter on _deletedAt: null so a retry / double-click / client-retry
+    // after a timeout doesn't re-run the refund loop on an already
+    // tombstoned entry. Without this, each repeat call would refund the
+    // spool weight again and inflate inventory totals.
+    const entry = await PrintHistory.findOne({ _id: id, _deletedAt: null });
     if (!entry) {
       return errorResponse("Not found", 404);
     }

--- a/src/app/api/share/[slug]/route.ts
+++ b/src/app/api/share/[slug]/route.ts
@@ -21,8 +21,10 @@ export async function GET(
     // save) races under concurrent viewers: each reader sees the same count
     // and increments it by one, so simultaneous hits silently drop updates.
     // findOneAndUpdate with $inc is one round-trip and collision-safe.
+    // Filter on _deletedAt: null so an unpublished (soft-deleted) slug
+    // returns 404 rather than 200.
     const catalog = await SharedCatalog.findOneAndUpdate(
-      { slug },
+      { slug, _deletedAt: null },
       { $inc: { viewCount: 1 } },
       { returnDocument: "after" },
     );
@@ -60,8 +62,16 @@ export async function DELETE(
   try {
     await dbConnect();
     const { slug } = await params;
-    const res = await SharedCatalog.deleteOne({ slug });
-    if (res.deletedCount === 0) {
+    // Soft-delete instead of hard `deleteOne` so the unpublish actually
+    // sticks across peers. syncCollection treats a missing row as
+    // "pull/push back" rather than "propagate the delete" — without a
+    // _deletedAt tombstone the next sync from the other peer would
+    // resurrect the catalog and re-expose the link the user took down.
+    const res = await SharedCatalog.updateOne(
+      { slug, _deletedAt: null },
+      { $set: { _deletedAt: new Date() } },
+    );
+    if (res.matchedCount === 0) {
       return errorResponse("Shared catalog not found", 404);
     }
     return NextResponse.json({ message: "Unpublished" });

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -13,7 +13,7 @@ import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
 export async function GET() {
   try {
     await dbConnect();
-    const catalogs = await SharedCatalog.find({})
+    const catalogs = await SharedCatalog.find({ _deletedAt: null })
       .select("slug title description expiresAt viewCount createdAt updatedAt")
       .sort({ createdAt: -1 })
       .lean();

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -54,7 +54,7 @@ export default async function dbConnect() {
 
   cached.conn = await cached.promise;
 
-  // One-time migration: backfill instanceId for existing filaments
+  // One-time migrations on first connect after process start.
   if (!cached.migrated) {
     try {
       const { backfillInstanceIds } = await import("@/models/Filament");
@@ -62,10 +62,29 @@ export default async function dbConnect() {
       if (count > 0) {
         console.log(`[migration] Backfilled instanceId for ${count} filament(s)`);
       }
-      cached.migrated = true;
     } catch (err) {
       console.error("[migration] Failed to backfill instanceIds:", err);
     }
+
+    // SharedCatalog's slug index changed from a plain unique index to
+    // a partial-unique-on-_deletedAt-null index when soft-delete landed.
+    // MongoDB won't mutate existing index options in-place, so on
+    // existing installs the old `slug_1` index keeps enforcing global
+    // uniqueness (including over tombstoned rows). syncIndexes() drops
+    // indexes that don't match the current schema and recreates them
+    // with the new options — idempotent on fresh databases (the indexes
+    // already match), corrective on upgraded ones.
+    try {
+      const SharedCatalog = (await import("@/models/SharedCatalog")).default;
+      const dropped = await SharedCatalog.syncIndexes();
+      if (dropped.length > 0) {
+        console.log(`[migration] Rebuilt SharedCatalog indexes (dropped: ${dropped.join(", ")})`);
+      }
+    } catch (err) {
+      console.error("[migration] Failed to sync SharedCatalog indexes:", err);
+    }
+
+    cached.migrated = true;
   }
 
   return cached.conn;

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -4,7 +4,14 @@ interface MongooseCache {
   conn: typeof mongoose | null;
   promise: Promise<typeof mongoose> | null;
   uri: string | null;
-  migrated: boolean;
+  /** Per-migration completion flags. Each migration only runs until it
+   * succeeds — a transient failure (network blip, MongoDB busy) won't
+   * permanently mark the migration done, so the next request will retry
+   * instead of leaving the install stuck on stale data/index state. */
+  migrations: {
+    instanceIds: boolean;
+    sharedCatalogIndexes: boolean;
+  };
 }
 
 declare global {
@@ -24,67 +31,82 @@ export default async function dbConnect() {
     conn: null,
     promise: null,
     uri: null,
-    migrated: false,
+    migrations: { instanceIds: false, sharedCatalogIndexes: false },
   };
 
   if (!global.mongoose) {
     global.mongoose = cached;
   }
 
-  // If URI changed (e.g., switched from local to Atlas), reconnect
+  // If URI changed (e.g., switched from local to Atlas), reconnect — and
+  // re-run migrations against the new database.
   if (cached.conn && cached.uri !== MONGODB_URI) {
     await mongoose.disconnect();
     cached.conn = null;
     cached.promise = null;
     cached.uri = null;
-    cached.migrated = false;
+    cached.migrations = { instanceIds: false, sharedCatalogIndexes: false };
   }
 
-  if (cached.conn) {
+  // Short-circuit only when both the connection AND all migrations are
+  // settled. Without checking migrations, a transient failure on first
+  // connect would never get retried — the next call would hit this
+  // early return and skip the migration block entirely.
+  if (
+    cached.conn &&
+    cached.migrations.instanceIds &&
+    cached.migrations.sharedCatalogIndexes
+  ) {
     return cached.conn;
   }
 
-  if (!cached.promise) {
-    cached.uri = MONGODB_URI;
-    cached.promise = mongoose.connect(MONGODB_URI).catch((err) => {
-      cached.promise = null;
-      throw err;
-    });
+  if (!cached.conn) {
+    if (!cached.promise) {
+      cached.uri = MONGODB_URI;
+      cached.promise = mongoose.connect(MONGODB_URI).catch((err) => {
+        cached.promise = null;
+        throw err;
+      });
+    }
+    cached.conn = await cached.promise;
   }
 
-  cached.conn = await cached.promise;
-
-  // One-time migrations on first connect after process start.
-  if (!cached.migrated) {
+  // One-time migrations on first connect after process start. Each
+  // migration tracks its own success flag — a transient failure on one
+  // doesn't poison the cache for the rest, and the next request retries
+  // any that didn't complete instead of skipping the whole block.
+  if (!cached.migrations.instanceIds) {
     try {
       const { backfillInstanceIds } = await import("@/models/Filament");
       const count = await backfillInstanceIds();
       if (count > 0) {
         console.log(`[migration] Backfilled instanceId for ${count} filament(s)`);
       }
+      cached.migrations.instanceIds = true;
     } catch (err) {
-      console.error("[migration] Failed to backfill instanceIds:", err);
+      console.error("[migration] Failed to backfill instanceIds (will retry on next connect):", err);
     }
+  }
 
-    // SharedCatalog's slug index changed from a plain unique index to
-    // a partial-unique-on-_deletedAt-null index when soft-delete landed.
-    // MongoDB won't mutate existing index options in-place, so on
-    // existing installs the old `slug_1` index keeps enforcing global
-    // uniqueness (including over tombstoned rows). syncIndexes() drops
-    // indexes that don't match the current schema and recreates them
-    // with the new options — idempotent on fresh databases (the indexes
-    // already match), corrective on upgraded ones.
+  // SharedCatalog's slug index changed from a plain unique index to
+  // a partial-unique-on-_deletedAt-null index when soft-delete landed.
+  // MongoDB won't mutate existing index options in-place, so on
+  // existing installs the old `slug_1` index keeps enforcing global
+  // uniqueness (including over tombstoned rows). syncIndexes() drops
+  // indexes that don't match the current schema and recreates them
+  // with the new options — idempotent on fresh databases (the indexes
+  // already match), corrective on upgraded ones.
+  if (!cached.migrations.sharedCatalogIndexes) {
     try {
       const SharedCatalog = (await import("@/models/SharedCatalog")).default;
       const dropped = await SharedCatalog.syncIndexes();
       if (dropped.length > 0) {
         console.log(`[migration] Rebuilt SharedCatalog indexes (dropped: ${dropped.join(", ")})`);
       }
+      cached.migrations.sharedCatalogIndexes = true;
     } catch (err) {
-      console.error("[migration] Failed to sync SharedCatalog indexes:", err);
+      console.error("[migration] Failed to sync SharedCatalog indexes (will retry on next connect):", err);
     }
-
-    cached.migrated = true;
   }
 
   return cached.conn;

--- a/src/models/SharedCatalog.ts
+++ b/src/models/SharedCatalog.ts
@@ -13,6 +13,7 @@ import mongoose, { Schema, Document, Model } from "mongoose";
 export interface ISharedCatalog extends Document {
   /** Short URL-safe identifier used in the share link. */
   slug: string;
+  syncId: string | null;
   /** Human-readable title shown on the share page. */
   title: string;
   /** Optional description shown on the share page. */
@@ -30,6 +31,9 @@ export interface ISharedCatalog extends Document {
   };
   expiresAt: Date | null;
   viewCount: number;
+  /** Soft-delete tombstone so a hard-delete on one peer doesn't get
+   * resurrected by the next sync cycle from the other peer. */
+  _deletedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -42,14 +46,27 @@ function generateSlug(): string {
 
 const SharedCatalogSchema = new Schema<ISharedCatalog>(
   {
-    slug: { type: String, required: true, unique: true, index: true, default: generateSlug },
+    // Slug is unique only among non-deleted rows so a soft-deleted slug
+    // can be reused if the random-base64url generator ever collides on
+    // a republish. Same partial-unique pattern Location and BedType use.
+    // Field-level `index: true` is intentionally omitted — the
+    // schema.index() call below owns the index and adding another would
+    // create a duplicate-name collision.
+    slug: { type: String, required: true, default: generateSlug },
+    syncId: { type: String, unique: true, sparse: true, index: true },
     title: { type: String, required: true },
     description: { type: String, default: "" },
     payload: { type: Schema.Types.Mixed, required: true },
     expiresAt: { type: Date, default: null, index: true },
     viewCount: { type: Number, default: 0, min: 0 },
+    _deletedAt: { type: Date, default: null },
   },
   { timestamps: true }
+);
+
+SharedCatalogSchema.index(
+  { slug: 1 },
+  { unique: true, partialFilterExpression: { _deletedAt: null } }
 );
 
 const SharedCatalog: Model<ISharedCatalog> =

--- a/tests/SharedCatalog.test.ts
+++ b/tests/SharedCatalog.test.ts
@@ -53,4 +53,47 @@ describe("SharedCatalog Model", () => {
   it("requires title and payload", async () => {
     await expect(SharedCatalog.create({})).rejects.toThrow();
   });
+
+  it("syncIndexes() upgrades a legacy non-partial slug index to the partial-on-_deletedAt one", async () => {
+    // Codex round-3 P2: existing installs already have the prior plain
+    // unique-on-slug index from earlier schema versions; createIndex()
+    // won't mutate options in-place, so the soft-delete republish flow
+    // would still trip on the old global-uniqueness rule. The migration
+    // in src/lib/mongodb.ts calls SharedCatalog.syncIndexes() to drop
+    // any incompatible existing index and recreate. Simulate the
+    // upgrade scenario: drop the model's index, install the legacy one
+    // by hand, then re-run syncIndexes and assert the result.
+    const col = SharedCatalog.collection;
+    await col.dropIndex("slug_1").catch(() => {});
+    await col.createIndex({ slug: 1 }, { unique: true, name: "slug_1" });
+
+    const before = await col.indexes();
+    const beforeSlug = before.find((i: { name?: string }) => i.name === "slug_1");
+    expect(beforeSlug).toBeDefined();
+    expect(beforeSlug?.partialFilterExpression).toBeUndefined();
+
+    const dropped = await SharedCatalog.syncIndexes();
+    expect(dropped).toContain("slug_1");
+
+    const after = await col.indexes();
+    const afterSlug = after.find((i: { name?: string }) => i.name === "slug_1");
+    expect(afterSlug).toBeDefined();
+    expect(afterSlug?.partialFilterExpression).toEqual({ _deletedAt: null });
+
+    // Republish-after-unpublish now works: a slug used by a tombstoned
+    // row can be re-minted without tripping the unique index.
+    const seed = await SharedCatalog.create({
+      slug: "reused",
+      title: "Original",
+      payload: { version: 1, createdAt: "", filaments: [], nozzles: [], printers: [], bedTypes: [] },
+    });
+    await SharedCatalog.updateOne({ _id: seed._id }, { $set: { _deletedAt: new Date() } });
+    await expect(
+      SharedCatalog.create({
+        slug: "reused",
+        title: "Re-published",
+        payload: { version: 1, createdAt: "", filaments: [], nozzles: [], printers: [], bedTypes: [] },
+      }),
+    ).resolves.toBeDefined();
+  });
 });

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -42,6 +42,8 @@ describe("dbConnect", () => {
     (global as Record<string, unknown>).mongoose = {
       conn: null,
       promise: connectPromise,
+      uri: process.env.MONGODB_URI,
+      migrations: { instanceIds: false, sharedCatalogIndexes: false },
     };
 
     const result = await dbConnect();
@@ -71,7 +73,7 @@ describe("dbConnect", () => {
 
     // Reset cache to force migration to run again
     const cached = (global as Record<string, unknown>).mongoose as Record<string, unknown>;
-    cached.migrated = false;
+    cached.migrations = { instanceIds: false, sharedCatalogIndexes: false };
     cached.conn = null;
     cached.promise = null;
 
@@ -103,26 +105,61 @@ describe("dbConnect", () => {
     expect(result).toBeDefined();
   });
 
-  it("runs migration on first connect", async () => {
-    // Reset cache to force fresh connection
+  it("marks each migration complete on first successful connect", async () => {
     (global as Record<string, unknown>).mongoose = undefined;
 
     const result = await dbConnect();
     expect(result).toBeDefined();
-    // Migration should have run (cached.migrated = true)
-    const cached = (global as Record<string, unknown>).mongoose as Record<string, unknown>;
-    expect(cached.migrated).toBe(true);
+    const cached = (global as Record<string, unknown>).mongoose as {
+      migrations: { instanceIds: boolean; sharedCatalogIndexes: boolean };
+    };
+    expect(cached.migrations.instanceIds).toBe(true);
+    expect(cached.migrations.sharedCatalogIndexes).toBe(true);
   });
 
-  it("skips migration on subsequent connects", async () => {
+  it("skips migrations on subsequent connects once they've succeeded", async () => {
     (global as Record<string, unknown>).mongoose = undefined;
     await dbConnect();
 
-    // Second call should skip migration
-    const cached = (global as Record<string, unknown>).mongoose as Record<string, unknown>;
-    expect(cached.migrated).toBe(true);
+    const cached = (global as Record<string, unknown>).mongoose as {
+      migrations: { instanceIds: boolean; sharedCatalogIndexes: boolean };
+    };
+    expect(cached.migrations.instanceIds).toBe(true);
+    expect(cached.migrations.sharedCatalogIndexes).toBe(true);
 
     const result = await dbConnect();
     expect(result).toBeDefined();
+  });
+
+  it("retries a failed migration on the next connect (doesn't poison the cache)", async () => {
+    // Codex round-4 P2: a transient failure on backfillInstanceIds or
+    // syncIndexes used to set the single `migrated` flag and skip both
+    // migrations forever after. With per-migration flags, only the
+    // succeeded migration sticks; a failed one retries on the next call.
+    (global as Record<string, unknown>).mongoose = undefined;
+
+    // Force the SharedCatalog migration to throw on its first attempt.
+    const sharedCatalogMod = await import("@/models/SharedCatalog");
+    const SharedCatalog = sharedCatalogMod.default;
+    const syncIndexesSpy = vi
+      .spyOn(SharedCatalog, "syncIndexes")
+      .mockRejectedValueOnce(new Error("transient failure"));
+
+    try {
+      await dbConnect();
+      const cached = (global as Record<string, unknown>).mongoose as {
+        migrations: { instanceIds: boolean; sharedCatalogIndexes: boolean };
+      };
+      // The instanceIds backfill succeeded; the sharedCatalog migration didn't.
+      expect(cached.migrations.instanceIds).toBe(true);
+      expect(cached.migrations.sharedCatalogIndexes).toBe(false);
+
+      // Next call should retry the failed one — and now succeed.
+      await dbConnect();
+      expect(syncIndexesSpy).toHaveBeenCalledTimes(2);
+      expect(cached.migrations.sharedCatalogIndexes).toBe(true);
+    } finally {
+      syncIndexesSpy.mockRestore();
+    }
   });
 });

--- a/tests/print-history.test.ts
+++ b/tests/print-history.test.ts
@@ -416,6 +416,35 @@ describe("print-history DELETE (undo)", () => {
     expect(res.status).toBe(404);
   });
 
+  it("is idempotent — a repeat DELETE on a tombstoned entry returns 404 and doesn't double-refund", async () => {
+    // Codex round-2 P1: switching to soft-delete left the door open for
+    // a retry / double-click / client retry after timeout to re-run the
+    // refund loop. Each repeat would add u.grams back to the spool,
+    // inflating inventory. The handler now filters findOne on
+    // _deletedAt: null so the second call short-circuits to 404.
+    const f = await Filament.create({
+      name: "Idempotent",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    const job = await postJob(f, "double-click", 100);
+
+    const first = await deletePrintHistory(delReq(job._id), { params: Promise.resolve({ id: job._id }) });
+    expect(first.status).toBe(200);
+    const afterFirst = await Filament.findById(f._id);
+    expect(afterFirst.spools[0].totalWeight).toBe(1000); // refunded once
+
+    const second = await deletePrintHistory(delReq(job._id), { params: Promise.resolve({ id: job._id }) });
+    expect(second.status).toBe(404);
+    const afterSecond = await Filament.findById(f._id);
+    // Critical: weight unchanged after the second call. Without the
+    // _deletedAt filter this would be 1100 (refund applied twice).
+    expect(afterSecond.spools[0].totalWeight).toBe(1000);
+  });
+
   it("soft-deletes the PrintHistory row (sets _deletedAt) so peer sync can propagate", async () => {
     // Hard delete would let syncCollection resurrect the row from the
     // other DB on the next cycle (it treats missing rows as

--- a/tests/print-history.test.ts
+++ b/tests/print-history.test.ts
@@ -415,6 +415,32 @@ describe("print-history DELETE (undo)", () => {
     const res = await deletePrintHistory(delReq(fakeId), { params: Promise.resolve({ id: fakeId }) });
     expect(res.status).toBe(404);
   });
+
+  it("soft-deletes the PrintHistory row (sets _deletedAt) so peer sync can propagate", async () => {
+    // Hard delete would let syncCollection resurrect the row from the
+    // other DB on the next cycle (it treats missing rows as
+    // pull-or-push, only respecting deletes via the _deletedAt
+    // tombstone). Refund still happens; only the row stays.
+    const f = await Filament.create({
+      name: "Soft Delete Check",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    const job = await postJob(f, "soft", 100);
+
+    const delRes = await deletePrintHistory(delReq(job._id), { params: Promise.resolve({ id: job._id }) });
+    expect(delRes.status).toBe(200);
+
+    const tombstone = await PrintHistory.findById(job._id);
+    expect(tombstone).not.toBeNull();
+    expect(tombstone._deletedAt).toBeInstanceOf(Date);
+    // Refund still happened
+    const refunded = await Filament.findById(f._id);
+    expect(refunded.spools[0].totalWeight).toBe(1000);
+  });
 });
 
 describe("analytics GET — double-counting regression", () => {

--- a/tests/share-route.test.ts
+++ b/tests/share-route.test.ts
@@ -284,7 +284,7 @@ describe("/api/share", () => {
   });
 
   describe("DELETE /api/share/[slug]", () => {
-    it("unpublishes a catalog", async () => {
+    it("unpublishes a catalog (soft-delete sets _deletedAt)", async () => {
       const catalog = await SharedCatalog.create({
         title: "Doomed",
         payload: {
@@ -301,8 +301,41 @@ describe("/api/share", () => {
         { params: Promise.resolve({ slug: catalog.slug }) },
       );
       expect(res.status).toBe(200);
-      const check = await SharedCatalog.findOne({ slug: catalog.slug });
-      expect(check).toBeNull();
+      // Soft-delete: row stays in collection so peer sync can propagate
+      // the unpublish via _deletedAt rather than resurrecting on the
+      // next pull. The slug-active query (used by the public GET) must
+      // miss it so the link returns 404.
+      const active = await SharedCatalog.findOne({ slug: catalog.slug, _deletedAt: null });
+      expect(active).toBeNull();
+      const tombstone = await SharedCatalog.findOne({ slug: catalog.slug });
+      expect(tombstone).not.toBeNull();
+      expect(tombstone?._deletedAt).toBeInstanceOf(Date);
+    });
+
+    it("returns 404 when deleting an already-soft-deleted catalog", async () => {
+      const catalog = await SharedCatalog.create({
+        title: "Already gone",
+        payload: { version: 1, createdAt: new Date().toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
+        _deletedAt: new Date(),
+      });
+      const res = await deleteShare(
+        new NextRequest(`http://localhost/api/share/${catalog.slug}`),
+        { params: Promise.resolve({ slug: catalog.slug }) },
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("public GET hides a soft-deleted catalog", async () => {
+      const catalog = await SharedCatalog.create({
+        title: "Hidden",
+        payload: { version: 1, createdAt: new Date().toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
+        _deletedAt: new Date(),
+      });
+      const res = await getShare(
+        new NextRequest(`http://localhost/api/share/${catalog.slug}`),
+        { params: Promise.resolve({ slug: catalog.slug }) },
+      );
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1,0 +1,385 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, ObjectId } from "mongodb";
+import { SyncService } from "../electron/sync-service";
+
+/**
+ * Coverage for the v1.12 sync expansion (P1 audit follow-up):
+ *
+ *   - Sync now covers bedtypes, printhistories, sharedcatalogs.
+ *   - Filament transform remaps calibrations[].bedType.
+ *   - Printer.amsSlots[].filamentId is repaired post-filament-sync.
+ *   - Spool subdocument refs (amsSlots[].spoolId, usage[].spoolId) are
+ *     cleared on cross-side remap because no spool syncIds exist yet.
+ *
+ * Each test reaches into the raw MongoDB driver to seed minimal docs and
+ * then asserts the post-sync state on the opposite side.
+ */
+describe("SyncService — v1.12 sync expansion", () => {
+  let localServer: MongoMemoryServer;
+  let remoteServer: MongoMemoryServer;
+  let localClient: MongoClient;
+  let remoteClient: MongoClient;
+  let sync: SyncService | null = null;
+
+  beforeAll(async () => {
+    [localServer, remoteServer] = await Promise.all([
+      MongoMemoryServer.create(),
+      MongoMemoryServer.create(),
+    ]);
+    localClient = await new MongoClient(localServer.getUri()).connect();
+    remoteClient = await new MongoClient(remoteServer.getUri()).connect();
+  }, 120_000);
+
+  afterAll(async () => {
+    await Promise.all([
+      localClient?.close().catch(() => {}),
+      remoteClient?.close().catch(() => {}),
+    ]);
+    await Promise.all([
+      localServer?.stop().catch(() => {}),
+      remoteServer?.stop().catch(() => {}),
+    ]);
+  });
+
+  beforeAll(async () => {
+    // Mirror the partial-unique name indexes Mongoose creates for
+    // bedtypes and locations so name-reconciliation tests actually
+    // hit the duplicate-key constraint.
+    for (const db of [localClient.db("filament-db"), remoteClient.db("filament-db")]) {
+      await db.collection("bedtypes").createIndex(
+        { name: 1 },
+        { unique: true, partialFilterExpression: { _deletedAt: null } },
+      ).catch(() => {});
+      await db.collection("locations").createIndex(
+        { name: 1 },
+        { unique: true, partialFilterExpression: { _deletedAt: null } },
+      ).catch(() => {});
+      await db.collection("sharedcatalogs").createIndex(
+        { slug: 1 },
+        { unique: true },
+      ).catch(() => {});
+    }
+  }, 120_000);
+
+  afterEach(async () => {
+    const localDb = localClient.db("filament-db");
+    const remoteDb = remoteClient.db("filament-db");
+    for (const col of ["bedtypes", "filaments", "locations", "nozzles", "printers", "printhistories", "sharedcatalogs"]) {
+      await localDb.collection(col).deleteMany({}).catch(() => {});
+      await remoteDb.collection(col).deleteMany({}).catch(() => {});
+    }
+    sync?.destroy();
+    sync = null;
+  });
+
+  function makeSync() {
+    return new SyncService(localServer.getUri(), remoteServer.getUri());
+  }
+
+  // ── bedtypes ──────────────────────────────────────────────────────────
+
+  describe("bedtypes", () => {
+    it("pushes a local-only bedtype to remote", async () => {
+      await localClient.db("filament-db").collection("bedtypes").insertOne({
+        name: "Textured PEI",
+        material: "PEI",
+        notes: "",
+        _deletedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+      const bedTypeResult = results.find((r) => r.collection === "bedtypes");
+      expect(bedTypeResult?.pushed).toBe(1);
+
+      const remote = await remoteClient.db("filament-db").collection("bedtypes").findOne({ name: "Textured PEI" });
+      expect(remote?.material).toBe("PEI");
+      expect(remote?.syncId).toBeTruthy();
+    });
+
+    it("reconciles same-name bedtypes across DBs without tripping the unique-name index", async () => {
+      // Both sides independently created the same bedtype with their own syncIds —
+      // the very shape that would E11000 on first sync without reconcileByName.
+      await localClient.db("filament-db").collection("bedtypes").insertOne({
+        name: "Cool Plate", material: "PEI", notes: "local", syncId: "local-uuid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+      await remoteClient.db("filament-db").collection("bedtypes").insertOne({
+        name: "Cool Plate", material: "PEI", notes: "remote", syncId: "remote-uuid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+      expect(results.find((r) => r.collection === "bedtypes")).toBeDefined();
+
+      // Each side still has exactly one row for the name (no E11000).
+      const localCount = await localClient.db("filament-db").collection("bedtypes").countDocuments({ name: "Cool Plate", _deletedAt: null });
+      const remoteCount = await remoteClient.db("filament-db").collection("bedtypes").countDocuments({ name: "Cool Plate", _deletedAt: null });
+      expect(localCount).toBe(1);
+      expect(remoteCount).toBe(1);
+
+      // syncIds unified — local wins per the tie-break rule.
+      const localRow = await localClient.db("filament-db").collection("bedtypes").findOne({ name: "Cool Plate" });
+      const remoteRow = await remoteClient.db("filament-db").collection("bedtypes").findOne({ name: "Cool Plate" });
+      expect(localRow?.syncId).toBe("local-uuid");
+      expect(remoteRow?.syncId).toBe("local-uuid");
+    });
+  });
+
+  // ── filament calibrations[].bedType remap ─────────────────────────────
+
+  describe("filament calibrations.bedType remap", () => {
+    it("translates calibrations[].bedType ObjectId across DBs via syncId", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      // Seed: a nozzle (referenced by calibration) and a bedtype on local.
+      const localNozzleId = new ObjectId();
+      await localDb.collection("nozzles").insertOne({
+        _id: localNozzleId, name: "0.4 brass", diameter: 0.4, type: "brass",
+        highFlow: false, syncId: "n-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+      const localBedTypeId = new ObjectId();
+      await localDb.collection("bedtypes").insertOne({
+        _id: localBedTypeId, name: "Textured PEI", material: "PEI", notes: "",
+        syncId: "bt-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+      // Same nozzle/bedtype identities pre-existing on remote so the calibration
+      // entry has a target. (In real sync, these would propagate via the
+      // collection sync that runs first; pre-seeding keeps this test focused.)
+      const remoteNozzleId = new ObjectId();
+      await remoteDb.collection("nozzles").insertOne({
+        _id: remoteNozzleId, name: "0.4 brass", diameter: 0.4, type: "brass",
+        highFlow: false, syncId: "n-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+      const remoteBedTypeId = new ObjectId();
+      await remoteDb.collection("bedtypes").insertOne({
+        _id: remoteBedTypeId, name: "Textured PEI", material: "PEI", notes: "",
+        syncId: "bt-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+
+      // Filament with a calibration referencing local nozzle + bedtype.
+      await localDb.collection("filaments").insertOne({
+        name: "Test PLA", vendor: "Test", type: "PLA", color: "#ffffff",
+        diameter: 1.75, temperatures: {}, bedTypeTemps: [],
+        compatibleNozzles: [],
+        calibrations: [
+          { nozzle: localNozzleId, bedType: localBedTypeId, extrusionMultiplier: 0.97 },
+        ],
+        spools: [], optTags: [], settings: {},
+        syncId: "f-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      // The pushed filament's calibration.bedType should now point at the
+      // remote-side bedtype id, not local's.
+      const remoteFilament = await remoteDb.collection("filaments").findOne({ name: "Test PLA" });
+      expect(remoteFilament).not.toBeNull();
+      expect(remoteFilament?.calibrations).toHaveLength(1);
+      const cal = remoteFilament?.calibrations?.[0];
+      expect(cal.bedType.toString()).toBe(remoteBedTypeId.toString());
+      expect(cal.bedType.toString()).not.toBe(localBedTypeId.toString());
+    });
+  });
+
+  // ── printer.amsSlots[].filamentId repair ──────────────────────────────
+
+  describe("printer amsSlots.filamentId repair", () => {
+    it("rewrites a stale amsSlots.filamentId to point at the right side's filament id", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      // Filament present on both sides with the same syncId but different _id.
+      const localFilId = new ObjectId();
+      const remoteFilId = new ObjectId();
+      const filDoc = {
+        name: "AMS PLA", vendor: "Test", type: "PLA", color: "#000",
+        diameter: 1.75, temperatures: {}, bedTypeTemps: [],
+        compatibleNozzles: [], calibrations: [], spools: [], optTags: [], settings: {},
+        syncId: "ams-fil",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      };
+      await localDb.collection("filaments").insertOne({ ...filDoc, _id: localFilId });
+      await remoteDb.collection("filaments").insertOne({ ...filDoc, _id: remoteFilId });
+
+      // Printer on local with amsSlots pointing at the LOCAL filament id.
+      // After sync to remote, the value would be a stale local-side id
+      // unless the amsSlots repair pass rewrites it to remoteFilId.
+      await localDb.collection("printers").insertOne({
+        name: "X1C", manufacturer: "Bambu", printerModel: "X1C",
+        installedNozzles: [], notes: "", buildVolume: { x: null, y: null, z: null },
+        maxFlow: null, maxSpeed: null, enclosed: false, autoBedLevel: false,
+        amsSlots: [
+          { slotName: "A", filamentId: localFilId, spoolId: new ObjectId() },
+          { slotName: "B", filamentId: null, spoolId: null },
+        ],
+        syncId: "p-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      const remotePrinter = await remoteDb.collection("printers").findOne({ name: "X1C" });
+      expect(remotePrinter).not.toBeNull();
+      const slotA = remotePrinter?.amsSlots?.find((s: { slotName: string }) => s.slotName === "A");
+      expect(slotA.filamentId.toString()).toBe(remoteFilId.toString());
+      // spoolId cleared on remap because no spool syncIds yet.
+      expect(slotA.spoolId).toBeNull();
+
+      const slotB = remotePrinter?.amsSlots?.find((s: { slotName: string }) => s.slotName === "B");
+      // Empty slot stays empty.
+      expect(slotB.filamentId).toBeNull();
+      expect(slotB.spoolId).toBeNull();
+    });
+
+    it("clears amsSlots.filamentId when the filament doesn't exist on either side", async () => {
+      const localDb = localClient.db("filament-db");
+
+      // Printer with amsSlots.filamentId pointing at a filament that exists on
+      // neither side — orphan. The repair pass should null it out.
+      await localDb.collection("printers").insertOne({
+        name: "Orphan",  manufacturer: "Test", printerModel: "X",
+        installedNozzles: [], notes: "", buildVolume: { x: null, y: null, z: null },
+        maxFlow: null, maxSpeed: null, enclosed: false, autoBedLevel: false,
+        amsSlots: [{ slotName: "A", filamentId: new ObjectId(), spoolId: new ObjectId() }],
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      // Local printer's stale slot should be cleared.
+      const localPrinter = await localDb.collection("printers").findOne({ name: "Orphan" });
+      expect(localPrinter?.amsSlots?.[0].filamentId).toBeNull();
+      expect(localPrinter?.amsSlots?.[0].spoolId).toBeNull();
+    });
+  });
+
+  // ── printhistories ────────────────────────────────────────────────────
+
+  describe("printhistories", () => {
+    it("syncs print history records, remapping printerId + usage.filamentId and clearing usage.spoolId", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      // Pre-seed matching printer + filament on both sides via syncId.
+      const localPrinterId = new ObjectId();
+      const remotePrinterId = new ObjectId();
+      const printerDoc = {
+        name: "Prusa", manufacturer: "Prusa", printerModel: "Mk3",
+        installedNozzles: [], notes: "", buildVolume: { x: null, y: null, z: null },
+        maxFlow: null, maxSpeed: null, enclosed: false, autoBedLevel: false,
+        amsSlots: [],
+        syncId: "p-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      };
+      await localDb.collection("printers").insertOne({ ...printerDoc, _id: localPrinterId });
+      await remoteDb.collection("printers").insertOne({ ...printerDoc, _id: remotePrinterId });
+
+      const localFilId = new ObjectId();
+      const remoteFilId = new ObjectId();
+      const filDoc = {
+        name: "Used PLA", vendor: "Test", type: "PLA", color: "#fff",
+        diameter: 1.75, temperatures: {}, bedTypeTemps: [],
+        compatibleNozzles: [], calibrations: [], spools: [], optTags: [], settings: {},
+        syncId: "f-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      };
+      await localDb.collection("filaments").insertOne({ ...filDoc, _id: localFilId });
+      await remoteDb.collection("filaments").insertOne({ ...filDoc, _id: remoteFilId });
+
+      // Local-only print history record.
+      await localDb.collection("printhistories").insertOne({
+        jobLabel: "calibration_cube.3mf",
+        printerId: localPrinterId,
+        usage: [
+          { filamentId: localFilId, spoolId: new ObjectId(), grams: 12.3 },
+        ],
+        startedAt: new Date(),
+        source: "manual",
+        notes: "",
+        _deletedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+      expect(results.find((r) => r.collection === "printhistories")?.pushed).toBe(1);
+
+      const remoteHistory = await remoteDb.collection("printhistories").findOne({ jobLabel: "calibration_cube.3mf" });
+      expect(remoteHistory).not.toBeNull();
+      expect(remoteHistory?.printerId.toString()).toBe(remotePrinterId.toString());
+      expect(remoteHistory?.usage).toHaveLength(1);
+      expect(remoteHistory?.usage?.[0].filamentId.toString()).toBe(remoteFilId.toString());
+      expect(remoteHistory?.usage?.[0].spoolId).toBeNull(); // cleared per the comment
+      expect(remoteHistory?.usage?.[0].grams).toBe(12.3);
+    });
+
+    it("drops usage entries whose filament can't be resolved on the target side", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      // Print history with a filamentId that has no match on the other side.
+      await localDb.collection("printhistories").insertOne({
+        jobLabel: "ghost.gcode",
+        printerId: null,
+        usage: [{ filamentId: new ObjectId(), spoolId: null, grams: 5 }],
+        startedAt: new Date(),
+        source: "manual",
+        notes: "",
+        _deletedAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      const remoteHistory = await remoteDb.collection("printhistories").findOne({ jobLabel: "ghost.gcode" });
+      expect(remoteHistory).not.toBeNull();
+      // The unresolvable usage entry was dropped — better than persisting a
+      // dangling pointer; the job ledger entry survives so the user still sees
+      // the job ran.
+      expect(remoteHistory?.usage).toHaveLength(0);
+    });
+  });
+
+  // ── sharedcatalogs ────────────────────────────────────────────────────
+
+  describe("sharedcatalogs", () => {
+    it("pushes a local-only shared catalog to remote", async () => {
+      await localClient.db("filament-db").collection("sharedcatalogs").insertOne({
+        slug: "abcdefghijkl",
+        title: "My picks",
+        description: "Tuned profiles",
+        payload: { version: 1, createdAt: new Date().toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
+        expiresAt: null,
+        viewCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+      const sharedResult = results.find((r) => r.collection === "sharedcatalogs");
+      expect(sharedResult?.pushed).toBe(1);
+
+      const remote = await remoteClient.db("filament-db").collection("sharedcatalogs").findOne({ slug: "abcdefghijkl" });
+      expect(remote?.title).toBe("My picks");
+      expect(remote?.syncId).toBeTruthy();
+    });
+  });
+});

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -355,6 +355,54 @@ describe("SyncService — v1.12 sync expansion", () => {
       // the job ran.
       expect(remoteHistory?.usage).toHaveLength(0);
     });
+
+    it("propagates a soft-deleted print history (tombstone) to the other side", async () => {
+      // Hard-delete on one peer would let the other peer push the row
+      // back on the next sync. The DELETE route now soft-deletes via
+      // _deletedAt so syncCollection's tombstone path can carry the
+      // deletion across.
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      const sharedSyncId = "ph-shared-syncid";
+      const startedAt = new Date("2026-04-30T12:00:00Z");
+      // Both sides have the row (state after a prior sync). The user
+      // then unpublishes on local — soft-delete sets _deletedAt to a
+      // value newer than the remote's updatedAt.
+      await localDb.collection("printhistories").insertOne({
+        jobLabel: "to-be-deleted",
+        printerId: null,
+        usage: [],
+        startedAt,
+        source: "manual",
+        notes: "",
+        syncId: sharedSyncId,
+        _deletedAt: new Date(Date.now() + 1000), // newer than remote's updatedAt
+        createdAt: startedAt,
+        updatedAt: startedAt,
+      });
+      await remoteDb.collection("printhistories").insertOne({
+        jobLabel: "to-be-deleted",
+        printerId: null,
+        usage: [],
+        startedAt,
+        source: "manual",
+        notes: "",
+        syncId: sharedSyncId,
+        _deletedAt: null,
+        createdAt: startedAt,
+        updatedAt: startedAt,
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      const remoteRow = await remoteDb.collection("printhistories").findOne({ syncId: sharedSyncId });
+      expect(remoteRow).not.toBeNull();
+      // The tombstone propagated to the remote side instead of remote
+      // pushing its still-active copy back over local.
+      expect(remoteRow?._deletedAt).not.toBeNull();
+    });
   });
 
   // ── sharedcatalogs ────────────────────────────────────────────────────
@@ -368,6 +416,7 @@ describe("SyncService — v1.12 sync expansion", () => {
         payload: { version: 1, createdAt: new Date().toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
         expiresAt: null,
         viewCount: 0,
+        _deletedAt: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -380,6 +429,48 @@ describe("SyncService — v1.12 sync expansion", () => {
       const remote = await remoteClient.db("filament-db").collection("sharedcatalogs").findOne({ slug: "abcdefghijkl" });
       expect(remote?.title).toBe("My picks");
       expect(remote?.syncId).toBeTruthy();
+    });
+
+    it("propagates a soft-deleted (unpublished) shared catalog tombstone", async () => {
+      // Same model as print-history above: the share unpublish route
+      // now soft-deletes so peer sync stops resurrecting unpublished
+      // links. Without _deletedAt, syncCollection would push the
+      // still-active remote row back over local's tombstone-attempt.
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      const sharedSyncId = "sc-shared-syncid";
+      const t0 = new Date("2026-04-30T12:00:00Z");
+      await localDb.collection("sharedcatalogs").insertOne({
+        slug: "shared-link",
+        title: "Hidden",
+        description: "",
+        payload: { version: 1, createdAt: t0.toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
+        expiresAt: null,
+        viewCount: 0,
+        syncId: sharedSyncId,
+        _deletedAt: new Date(Date.now() + 1000),
+        createdAt: t0,
+        updatedAt: t0,
+      });
+      await remoteDb.collection("sharedcatalogs").insertOne({
+        slug: "shared-link",
+        title: "Hidden",
+        description: "",
+        payload: { version: 1, createdAt: t0.toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
+        expiresAt: null,
+        viewCount: 0,
+        syncId: sharedSyncId,
+        _deletedAt: null,
+        createdAt: t0,
+        updatedAt: t0,
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      const remoteRow = await remoteDb.collection("sharedcatalogs").findOne({ syncId: sharedSyncId });
+      expect(remoteRow?._deletedAt).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
P1 audit follow-up. Closes the v1.11 sync gap where `bedtypes`, `printhistories`, and `sharedcatalogs` were never synced, plus two newer references the existing transforms didn't cover (`calibrations[].bedType`, `printer.amsSlots[].filamentId`).

## Changes

### Sync order
Now: nozzles → printers → locations → bedtypes → filaments → printhistories → sharedcatalogs.

- **bedtypes** sync runs **before** filaments so the filament transform can remap `calibrations[].bedType`. Reuses the same `reconcileByName` pre-pass used for locations (BedType has the same partial-unique-name index that would E11000 the very first sync if both desktops created the same name independently). I factored the reconciliation out of `reconcileLocationsByName` into a generic `reconcileByName(collectionName)` and now both call into it.
- **printers** still sync **before** filaments to break the `calibrations.printer` ↔ `amsSlots.filamentId` reference cycle. After filament sync settles, a new **`repairPrinterAmsSlots`** pass projects the correct filament id via the freshly-built syncId maps. Same pattern as `repairFilamentParentIds` / `repairDanglingSpoolLocations`. Doesn't bump `updatedAt`.
- **printhistories** sync runs after filaments. New `buildPrintHistoryTransform` remaps `printerId` + `usage[].filamentId` via syncId; `usage[].spoolId` is cleared on insert/update because spool subdocuments don't have stable cross-side ids. Usage entries whose filament can't be resolved on the target side are dropped (better than persisting a dangling pointer; the job ledger entry survives).
- **sharedcatalogs** sync runs last. Straight last-write-wins on the syncId/slug — no refs to remap because the payload is denormalised at publish time.

### Filament transform
- Added `bedType` remap in `buildFilamentRefsTransform` alongside the existing nozzle/printer remap. Unknown bedType on the target clears to null (same model as printer/location), keeping the calibration entry rather than dropping it.

### Spool-id limitation (documented in class header + inline)
Spool subdocuments inside Filament don't have stable cross-side identifiers. Anything that references a spool by id — `printer.amsSlots[].spoolId`, `printhistory.usage[].spoolId` — clears that id during cross-side remap. Per-filament gram totals still reconcile; per-spool attribution is dropped pending a spool-syncId migration (a separate, larger change).

### Subtle MongoDB query gotcha
The naive `{ "amsSlots.filamentId": { $ne: null } }` excludes any printer with *any* slot whose `filamentId === null`, even if a sibling slot is set — Mongo's array-positional negated-equality matches at the whole-array level. Used `{ amsSlots: { $elemMatch: { filamentId: { $ne: null } } } }` instead. Discovered via the test feedback loop on the amsSlots repair test, which is the only reason the bug isn't shipping.

## Test plan
- [x] 8 new tests in `tests/sync-service-expansion.test.ts` — bedtype push, bedtype name reconciliation, calibrations[].bedType remap across sides, amsSlots[].filamentId rewrite (with spoolId clear), amsSlots cleared for orphan filament, printhistory printerId + filamentId remap (with spoolId clear), printhistory usage entries dropped when filament unresolvable, sharedcatalog push.
- [x] Existing `tests/sync-service.test.ts` (12) + `tests/sync-service-locations.test.ts` (9) still pass — the location reconciliation now goes through `reconcileByName` but the behavior is identical.
- [x] Full `npm test` — 825/825 pass.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)