### PR TITLE
Fix #154: idempotent auto-updater + skip broken mac auto-download

### DIFF
--- a/electron/auto-updater.ts
+++ b/electron/auto-updater.ts
@@ -30,6 +30,14 @@ interface UpdateInfo {
 
 let mainWindow: BrowserWindow | null = null;
 let currentState: UpdateInfo = { state: "idle" };
+/** Tracks whether initAutoUpdater has done its one-time setup (IPC handlers,
+ * autoUpdater listeners, periodic-check timers) for this process. The
+ * function is called from `createWindow()` in electron/main.ts, which on
+ * macOS runs every time the user clicks the dock icon after closing the
+ * window. Without this guard the second call hits
+ * `Error: Attempted to register a second handler for 'update-get-status'`
+ * and crashes the app on reopen (GH #154). */
+let initialized = false;
 
 function emit(update: Partial<UpdateInfo>) {
   currentState = { ...currentState, ...update };
@@ -37,7 +45,19 @@ function emit(update: Partial<UpdateInfo>) {
 }
 
 export function initAutoUpdater(win: BrowserWindow) {
+  // Always refresh the window reference — the previous window may have
+  // been closed and the renderer for the new window needs to receive
+  // future status events.
   mainWindow = win;
+
+  if (initialized) {
+    // Re-emit the current state into the new window so the renderer's
+    // initial getSyncStatus() / status listener attaches to a fresh value
+    // instead of waiting for the next tick.
+    emit({});
+    return;
+  }
+  initialized = true;
 
   // IPC surface is registered unconditionally so the dev-mode renderer can
   // still call update-get-status (and friends) without crashing with

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -21,6 +21,13 @@ export default function UpdateBanner() {
   const [status, setStatus] = useState<UpdateStatus>({ state: "idle" });
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
   const isElectron = typeof window !== "undefined" && !!window.electronAPI;
+  // macOS Gatekeeper blocks unsigned auto-installs. Even the download path
+  // currently fails ("ZIP file not provided") because we don't ship mac
+  // .zip artifacts and the per-arch yml lookup picks the wrong installer
+  // on Apple Silicon (GH #154). Until those ship, route mac users straight
+  // to the GitHub release page where they can grab the right .dmg manually.
+  const isMac =
+    typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   useEffect(() => {
     if (!isElectron) return;
@@ -62,15 +69,21 @@ export default function UpdateBanner() {
     body = (
       <>
         <span>{t("update.available", { version: status.version ?? "" })}</span>
-        <button
-          onClick={handleDownload}
-          className="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-xs"
-        >
-          {t("update.download")}
-        </button>
+        {!isMac && (
+          <button
+            onClick={handleDownload}
+            className="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-xs"
+          >
+            {t("update.download")}
+          </button>
+        )}
         <button
           onClick={handleOpenPage}
-          className="text-xs underline opacity-80 hover:opacity-100"
+          className={
+            isMac
+              ? "px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-xs"
+              : "text-xs underline opacity-80 hover:opacity-100"
+          }
         >
           {t("update.viewRelease")}
         </button>

--- a/tests/auto-updater.test.ts
+++ b/tests/auto-updater.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * GH #154 regression guard. `initAutoUpdater()` is invoked from
+ * `createWindow()` in electron/main.ts. On macOS, closing the window sets
+ * `mainWindow = null` but the app stays running; clicking the dock icon
+ * fires `app.on("activate")` → `createWindow()` → `initAutoUpdater()`
+ * AGAIN. Before the fix, the second call hit
+ *   Error: Attempted to register a second handler for 'update-get-status'
+ * and crashed the app on every reopen.
+ */
+
+// Stub out the electron + electron-updater modules at the module-graph
+// level — they don't load in a Node test env. Vitest hoists vi.mock so
+// these run before the auto-updater import below.
+const handleSpy = vi.fn();
+const sendSpy = vi.fn();
+const onSpy = vi.fn();
+
+vi.mock("electron", () => ({
+  app: { isPackaged: false },
+  BrowserWindow: class {},
+  dialog: { showMessageBox: vi.fn() },
+  ipcMain: {
+    handle: handleSpy,
+  },
+  shell: { openExternal: vi.fn() },
+}));
+
+vi.mock("electron-updater", () => ({
+  autoUpdater: {
+    autoDownload: false,
+    autoInstallOnAppQuit: true,
+    on: onSpy,
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+  },
+}));
+
+interface FakeWindow {
+  webContents: { send: typeof sendSpy };
+}
+function makeWin(): FakeWindow {
+  return { webContents: { send: sendSpy } };
+}
+
+describe("initAutoUpdater — idempotency", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let initAutoUpdater: (win: any) => void;
+
+  beforeEach(async () => {
+    // Reset module cache so the `initialized` flag inside the module
+    // starts false for each test. Without this, the first test's
+    // initialized=true bleeds into the next test.
+    vi.resetModules();
+    handleSpy.mockClear();
+    sendSpy.mockClear();
+    onSpy.mockClear();
+    initAutoUpdater = (await import("../electron/auto-updater")).initAutoUpdater;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers each IPC handler exactly once across multiple calls", () => {
+    const win1 = makeWin();
+    const win2 = makeWin();
+    const win3 = makeWin();
+
+    initAutoUpdater(win1);
+    initAutoUpdater(win2);
+    initAutoUpdater(win3);
+
+    // 4 distinct ipcMain.handle channels: get-status, check, download,
+    // install, open-release-page → 5 total. Each must be registered once.
+    const channels = handleSpy.mock.calls.map((c) => c[0]);
+    expect(channels).toEqual([
+      "update-get-status",
+      "update-check",
+      "update-download",
+      "update-install",
+      "update-open-release-page",
+    ]);
+    // Exactly one registration per channel — no duplicate.
+    expect(handleSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it("refreshes the window reference on subsequent calls so future emits target the new window", () => {
+    const win1 = makeWin();
+    const win2 = makeWin();
+
+    initAutoUpdater(win1);
+    initAutoUpdater(win2);
+
+    // The re-init path should immediately re-emit the current state into
+    // the new window so the renderer sees a value without waiting for the
+    // next status change.
+    expect(win2.webContents.send).toHaveBeenCalledWith(
+      "update-status",
+      expect.objectContaining({ state: "idle" }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #154.

Two bugs surfaced by the v1.13.0 upgrade prompt for an Apple Silicon user.

## 1. Crash on app reopen (the hard bug)

`initAutoUpdater()` was invoked from `createWindow()` in `electron/main.ts`. On macOS, closing the window nulls \`mainWindow\` but the app keeps running; clicking the dock icon fires \`app.on(\"activate\")\` → \`createWindow()\` → \`initAutoUpdater()\` AGAIN. The second call hits:

\`\`\`
Error: Attempted to register a second handler for 'update-get-status'
\`\`\`

…and crashes the app on every reopen.

**Fix**: track an \`initialized\` flag at module scope. Subsequent calls just refresh the \`mainWindow\` reference (so future status emits target the newly-opened window) and re-emit the current state immediately so the renderer doesn't need to wait for the next tick.

## 2. Cryptic "ZIP file not provided" on macOS download (the soft bug)

The release workflow runs separate matrix jobs for arm64 and x64 mac builds; each produces a \`latest-mac.yml\` and they clobber each other in the GitHub Release upload step. Combined with the fact that we don't publish mac \`.zip\` artifacts (only dmg, but electron-updater needs zip for auto-install), Apple Silicon users got pointed at the wrong installer URL and saw an opaque ZIP error.

Properly fixing macOS auto-update needs zip publishing + per-arch yml + signing — out of scope for this hotfix. **Workaround**: hide the **Download** button on macOS in \`UpdateBanner\` and surface only **View release** (promoted from a small underline link to a full button so it visually replaces Download). The original intent in \`auto-updater.ts\` has always been "macOS users open the release page and grab the dmg manually"; this just makes the UI match the intent.

The proper mac auto-update work is noted in an inline comment on \`UpdateBanner\` for a future change.

## Test plan

- [x] New \`tests/auto-updater.test.ts\` mocks electron + electron-updater; asserts each \`ipcMain.handle\` channel is registered exactly once across three \`initAutoUpdater(win)\` calls, and that the new window receives the re-emitted status on reinit.
- [x] Full \`npm test\` — 870/870 pass.
- [x] \`npm run lint\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)