### PR TITLE
Fix #160 + #161: validation/SSRF errors return 400, not 5xx

### DIFF
--- a/src/app/api/bed-types/[id]/route.ts
+++ b/src/app/api/bed-types/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import BedType from "@/models/BedType";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -52,7 +52,7 @@ export async function PUT(
     }
     return NextResponse.json(bedType);
   } catch (err) {
-    return errorResponse("Failed to update bed type", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to update bed type");
   }
 }
 

--- a/src/app/api/bed-types/route.ts
+++ b/src/app/api/bed-types/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import BedType from "@/models/BedType";
-import { getErrorMessage, errorResponse, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 export async function GET(request: NextRequest) {
   try {
@@ -43,6 +43,6 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const dupResponse = handleDuplicateKeyError(err, "bed type");
     if (dupResponse) return dupResponse;
-    return errorResponse("Failed to create bed type", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to create bed type");
   }
 }

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -5,7 +5,7 @@ import Nozzle from "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament, hasVariants } from "@/lib/resolveFilament";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 /**
  * GET /api/filaments/{id}
@@ -151,7 +151,7 @@ export async function PUT(
     }
     return NextResponse.json(filament);
   } catch (err) {
-    return errorResponse("Failed to update filament", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to update filament");
   }
 }
 
@@ -326,7 +326,7 @@ export async function POST(
       filamentId: filament._id,
     });
   } catch (err) {
-    return errorResponse("Failed to sync filament", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to sync filament");
   }
 }
 
@@ -356,6 +356,6 @@ export async function DELETE(
     }
     return NextResponse.json({ message: "Deleted" });
   } catch (err) {
-    return errorResponse("Failed to delete filament", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to delete filament");
   }
 }

--- a/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 /**
  * POST /api/filaments/{id}/spools/{spoolId}/dry-cycles — log a dry cycle.
@@ -58,6 +58,6 @@ export async function POST(
     }
     return NextResponse.json(filament, { status: 201 });
   } catch (err) {
-    return errorResponse("Failed to log dry cycle", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to log dry cycle");
   }
 }

--- a/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 /**
  * POST /api/filaments/{id}/spools/{spoolId}/usage — manually log grams used.
@@ -73,6 +73,6 @@ export async function POST(
     await filament.save();
     return NextResponse.json(filament.toObject(), { status: 201 });
   } catch (err) {
-    return errorResponse("Failed to log usage", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to log usage");
   }
 }

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -167,6 +167,6 @@ export async function POST(request: NextRequest) {
   } catch (err: unknown) {
     const dupResponse = handleDuplicateKeyError(err, "filament");
     if (dupResponse) return dupResponse;
-    return errorResponse("Failed to create filament", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to create filament");
   }
 }

--- a/src/app/api/locations/[id]/route.ts
+++ b/src/app/api/locations/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Location from "@/models/Location";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -52,7 +52,7 @@ export async function PUT(
     }
     return NextResponse.json(location);
   } catch (err) {
-    return errorResponse("Failed to update location", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to update location");
   }
 }
 

--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Location from "@/models/Location";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 export async function GET(request: NextRequest) {
   try {
@@ -76,6 +76,6 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const dupResponse = handleDuplicateKeyError(err, "location");
     if (dupResponse) return dupResponse;
-    return errorResponse("Failed to create location", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to create location");
   }
 }

--- a/src/app/api/nozzles/[id]/route.ts
+++ b/src/app/api/nozzles/[id]/route.ts
@@ -3,7 +3,7 @@ import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import Filament from "@/models/Filament";
 import Printer from "@/models/Printer";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -91,7 +91,7 @@ export async function PUT(
 
     return NextResponse.json(nozzle);
   } catch (err) {
-    return errorResponse("Failed to update nozzle", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to update nozzle");
   }
 }
 
@@ -140,6 +140,6 @@ export async function DELETE(
     }
     return NextResponse.json({ message: "Deleted" });
   } catch (err) {
-    return errorResponse("Failed to delete nozzle", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to delete nozzle");
   }
 }

--- a/src/app/api/nozzles/route.ts
+++ b/src/app/api/nozzles/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
-import { getErrorMessage, errorResponse, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 export async function GET(request: NextRequest) {
   try {
@@ -87,6 +87,6 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const dupResponse = handleDuplicateKeyError(err, "nozzle");
     if (dupResponse) return dupResponse;
-    return errorResponse("Failed to create nozzle", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to create nozzle");
   }
 }

--- a/src/app/api/print-history/route.ts
+++ b/src/app/api/print-history/route.ts
@@ -3,7 +3,7 @@ import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import PrintHistory from "@/models/PrintHistory";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 /**
  * GET /api/print-history — list print history entries.
@@ -279,6 +279,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(history, { status: 201 });
   } catch (err) {
-    return errorResponse("Failed to record print history", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to record print history");
   }
 }

--- a/src/app/api/printers/[id]/route.ts
+++ b/src/app/api/printers/[id]/route.ts
@@ -3,7 +3,7 @@ import dbConnect from "@/lib/mongodb";
 import Printer from "@/models/Printer";
 import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
-import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -68,7 +68,7 @@ export async function PUT(
     }
     return NextResponse.json(printer);
   } catch (err) {
-    return errorResponse("Failed to update printer", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to update printer");
   }
 }
 

--- a/src/app/api/printers/route.ts
+++ b/src/app/api/printers/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Printer from "@/models/Printer";
 import Nozzle from "@/models/Nozzle";
-import { getErrorMessage, errorResponse, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 export async function GET(request: NextRequest) {
   try {
@@ -68,6 +68,6 @@ export async function POST(request: NextRequest) {
   } catch (err: unknown) {
     const dupResponse = handleDuplicateKeyError(err, "printer");
     if (dupResponse) return dupResponse;
-    return errorResponse("Failed to create printer", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to create printer");
   }
 }

--- a/src/app/api/tds/route.ts
+++ b/src/app/api/tds/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { extractFromTds, extractFromTdsContent, validateApiKey, type AiProvider } from "@/lib/tdsExtractor";
-import { errorResponse, getErrorMessage, MAX_UPLOAD_SIZE } from "@/lib/apiErrorHandler";
+import { errorResponse, getErrorMessage, isClientInputErrorMessage, MAX_UPLOAD_SIZE } from "@/lib/apiErrorHandler";
 
 /**
  * In-memory API key/provider store for web mode.
@@ -123,7 +123,8 @@ export async function POST(request: NextRequest) {
       const result = await extractFromTdsContent(buffer, mimeType, apiKey, provider);
 
       if (!result.success) {
-        return errorResponse(result.error || "Extraction failed", 502);
+        const msg = result.error || "Extraction failed";
+        return errorResponse(msg, isClientInputErrorMessage(msg) ? 400 : 502);
       }
 
       return NextResponse.json(result);
@@ -156,7 +157,8 @@ export async function POST(request: NextRequest) {
     const result = await extractFromTds(url, apiKey, provider);
 
     if (!result.success) {
-      return errorResponse(result.error || "Extraction failed", 502);
+      const msg = result.error || "Extraction failed";
+      return errorResponse(msg, isClientInputErrorMessage(msg) ? 400 : 502);
     }
 
     return NextResponse.json(result);

--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -52,9 +52,17 @@ export function handleDuplicateKeyError(
  * (`assertExternalUrl` rejections from src/lib/externalUrlGuard.ts). Used both
  * for thrown Errors (see `isClientInputError`) and for failure objects whose
  * error is returned as a string (e.g. tdsExtractor result.error).
+ *
+ * `Invalid URL:` is colon-anchored on purpose. `assertExternalUrl` re-throws
+ * its constructor failure as `Invalid URL: <input>` so it matches here, while
+ * the bare `new URL(...)` constructor (used by the TDS redirect resolver in
+ * src/lib/tdsExtractor.ts when the upstream Location header is malformed)
+ * throws just `Invalid URL`. The bare form is an upstream/bad-gateway
+ * failure, not user input, and must NOT be mapped to 400 (Codex P2 on PR
+ * #167).
  */
 export function isClientInputErrorMessage(message: string): boolean {
-  return /must be a valid|Disallowed URL scheme|private\/internal address|URL hostname does not resolve|URL has no hostname|^Invalid URL$/i.test(message);
+  return /must be a valid|Disallowed URL scheme|private\/internal address|URL hostname does not resolve|URL has no hostname|Invalid URL:/i.test(message);
 }
 
 /**

--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -46,6 +46,51 @@ export function handleDuplicateKeyError(
   return null;
 }
 
+/**
+ * True when a message text matches a known client-input rejection — pre-update
+ * hooks (`tdsUrl must be a valid http(s) URL`) and the shared SSRF guard
+ * (`assertExternalUrl` rejections from src/lib/externalUrlGuard.ts). Used both
+ * for thrown Errors (see `isClientInputError`) and for failure objects whose
+ * error is returned as a string (e.g. tdsExtractor result.error).
+ */
+export function isClientInputErrorMessage(message: string): boolean {
+  return /must be a valid|Disallowed URL scheme|private\/internal address|URL hostname does not resolve|URL has no hostname|^Invalid URL$/i.test(message);
+}
+
+/**
+ * True when an error is a client-input rejection rather than a server fault —
+ * Mongoose schema validators (`ValidationError`), our pre-update hooks
+ * (`tdsUrl must be a valid http(s) URL`), and the shared SSRF guard
+ * (`assertExternalUrl` rejections from src/lib/externalUrlGuard.ts).
+ *
+ * Used by route handlers to distinguish 4xx-worthy "your input was bad"
+ * from 5xx "the server crashed". Without this, validators throw a generic
+ * Error and the catch-all returns 500/502, which is wrong for monitoring
+ * (alerts on legitimate user-input rejections) and bad UX (renderers can't
+ * branch on "show form error" vs "show server error").
+ */
+export function isClientInputError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "ValidationError") return true; // Mongoose
+  return isClientInputErrorMessage(err.message);
+}
+
+/**
+ * Wrap a try/catch in a route handler — if the error is client-input, return
+ * a 400 with the message; otherwise return the supplied 5xx fallback. Keeps
+ * the handler-level catch idiomatic without per-call branching.
+ */
+export function errorResponseFromCaught(
+  err: unknown,
+  fallbackMessage: string,
+  fallbackStatus = 500,
+): NextResponse {
+  if (isClientInputError(err)) {
+    return errorResponse(getErrorMessage(err), 400);
+  }
+  return errorResponse(fallbackMessage, fallbackStatus, getErrorMessage(err));
+}
+
 /** Maximum upload file size (10 MB) */
 export const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
 

--- a/src/lib/externalUrlGuard.ts
+++ b/src/lib/externalUrlGuard.ts
@@ -65,7 +65,13 @@ export async function assertExternalUrl(url: string): Promise<URL> {
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error("Invalid URL");
+    // Tag the message so the apiErrorHandler 400-classifier matches THIS
+    // path specifically. The bare `new URL(...)` constructor (used by the
+    // TDS redirect-resolver in src/lib/tdsExtractor.ts) also throws
+    // "Invalid URL" when an upstream Location header is malformed; that
+    // case is an upstream/bad-gateway condition, not user input, so it
+    // must NOT be mapped to 400 (Codex review on PR #167).
+    throw new Error(`Invalid URL: ${url}`);
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(`Disallowed URL scheme "${parsed.protocol}" — only http(s) is supported.`);

--- a/tests/apiErrorHandler.test.ts
+++ b/tests/apiErrorHandler.test.ts
@@ -74,11 +74,19 @@ describe("isClientInputErrorMessage", () => {
   });
 
   it("matches every assertExternalUrl rejection message", () => {
-    expect(isClientInputErrorMessage("Invalid URL")).toBe(true);
+    expect(isClientInputErrorMessage("Invalid URL: not a url")).toBe(true);
     expect(isClientInputErrorMessage('Disallowed URL scheme "javascript:" — only http(s) is supported.')).toBe(true);
     expect(isClientInputErrorMessage("URL has no hostname")).toBe(true);
     expect(isClientInputErrorMessage("URL hostname does not resolve: not-a-real-host.test")).toBe(true);
     expect(isClientInputErrorMessage("URL resolves to a private/internal address — only public hosts are allowed.")).toBe(true);
+  });
+
+  it("does NOT match the bare 'Invalid URL' (Codex P2 PR #167)", () => {
+    // The bare `new URL(...)` constructor throws this when an upstream
+    // server's redirect Location header is malformed — that's a 502 case,
+    // not a 400. Only the colon-prefixed `assertExternalUrl` variant
+    // counts as client input.
+    expect(isClientInputErrorMessage("Invalid URL")).toBe(false);
   });
 
   it("does not match unrelated server-fault messages", () => {

--- a/tests/apiErrorHandler.test.ts
+++ b/tests/apiErrorHandler.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   getErrorMessage,
   errorResponse,
+  errorResponseFromCaught,
   handleDuplicateKeyError,
   checkFileSize,
+  isClientInputError,
+  isClientInputErrorMessage,
   MAX_UPLOAD_SIZE,
 } from "@/lib/apiErrorHandler";
 
@@ -62,6 +65,80 @@ describe("handleDuplicateKeyError", () => {
     expect(res).not.toBeNull();
     const body = await res!.json();
     expect(body.error).toContain("printer");
+  });
+});
+
+describe("isClientInputErrorMessage", () => {
+  it("matches Mongoose-style validator messages from pre-update hooks", () => {
+    expect(isClientInputErrorMessage("tdsUrl must be a valid http(s) URL")).toBe(true);
+  });
+
+  it("matches every assertExternalUrl rejection message", () => {
+    expect(isClientInputErrorMessage("Invalid URL")).toBe(true);
+    expect(isClientInputErrorMessage('Disallowed URL scheme "javascript:" — only http(s) is supported.')).toBe(true);
+    expect(isClientInputErrorMessage("URL has no hostname")).toBe(true);
+    expect(isClientInputErrorMessage("URL hostname does not resolve: not-a-real-host.test")).toBe(true);
+    expect(isClientInputErrorMessage("URL resolves to a private/internal address — only public hosts are allowed.")).toBe(true);
+  });
+
+  it("does not match unrelated server-fault messages", () => {
+    expect(isClientInputErrorMessage("ECONNREFUSED")).toBe(false);
+    expect(isClientInputErrorMessage("Gemini API error: HTTP 500 — boom")).toBe(false);
+    expect(isClientInputErrorMessage("Failed to update filament")).toBe(false);
+  });
+});
+
+describe("isClientInputError", () => {
+  it("returns true for Mongoose ValidationError by name", () => {
+    const err = new Error("Filament validation failed: name is required");
+    err.name = "ValidationError";
+    expect(isClientInputError(err)).toBe(true);
+  });
+
+  it("returns true when the message matches a known client-input pattern", () => {
+    expect(isClientInputError(new Error("tdsUrl must be a valid http(s) URL"))).toBe(true);
+    expect(isClientInputError(new Error('Disallowed URL scheme "file:"'))).toBe(true);
+  });
+
+  it("returns false for plain Errors with unrelated messages", () => {
+    expect(isClientInputError(new Error("ECONNRESET"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isClientInputError("Invalid URL")).toBe(false);
+    expect(isClientInputError(null)).toBe(false);
+    expect(isClientInputError({ message: "Disallowed URL scheme" })).toBe(false);
+  });
+});
+
+describe("errorResponseFromCaught", () => {
+  it("returns 400 with the error message when input was a client-input rejection", async () => {
+    const err = new Error('Disallowed URL scheme "javascript:" — only http(s) is supported.');
+    const res = errorResponseFromCaught(err, "Failed to update filament");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Disallowed URL scheme "javascript:" — only http(s) is supported.' });
+  });
+
+  it("returns 400 for Mongoose ValidationError", async () => {
+    const err = new Error("tdsUrl must be a valid http(s) URL");
+    err.name = "ValidationError";
+    const res = errorResponseFromCaught(err, "Failed to update filament");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("tdsUrl must be a valid http(s) URL");
+  });
+
+  it("returns the supplied fallback status with detail for unrecognised server faults", async () => {
+    const res = errorResponseFromCaught(new Error("ECONNREFUSED"), "Failed to update filament");
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Failed to update filament", detail: "ECONNREFUSED" });
+  });
+
+  it("honours an explicit fallbackStatus override", async () => {
+    const res = errorResponseFromCaught(new Error("upstream blew up"), "TDS extraction failed", 502);
+    expect(res.status).toBe(502);
   });
 });
 

--- a/tests/filament-put-validation-status.test.ts
+++ b/tests/filament-put-validation-status.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { PUT as putFilament } from "@/app/api/filaments/[id]/route";
+
+/**
+ * GH #160 regression guard.
+ *
+ * Mongoose validators (e.g. tdsUrl scheme guard) and pre-update hooks throw
+ * plain Errors that the route's catch-all used to swallow as 500 with the
+ * detail message tucked under `detail`. That made monitoring noisy (the
+ * server is fine — the user's input was bad) and made it impossible for
+ * the form renderer to distinguish "your URL is invalid" from "the server
+ * is down". The fix routes those errors through `errorResponseFromCaught`,
+ * which returns 400 with the validator message in `error`.
+ */
+describe("PUT /api/filaments/[id] — client-input rejections return 400", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  it("returns 400 when tdsUrl uses a non-http(s) scheme", async () => {
+    const filament = await Filament.create({
+      name: "Test PLA",
+      vendor: "Generic",
+      type: "PLA",
+    });
+
+    const req = new NextRequest(`http://localhost/api/filaments/${filament._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tdsUrl: "javascript:alert(1)" }),
+    });
+    const res = await putFilament(req, { params: Promise.resolve({ id: String(filament._id) }) });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/must be a valid http\(s\) URL/i);
+    // The 5xx fallback shape (`{error, detail}`) must NOT be used here;
+    // monitoring branches on shape and a 400 should look different from a 500.
+    expect(body.detail).toBeUndefined();
+  });
+
+  it("returns 400 for Mongoose schema validator failures", async () => {
+    const filament = await Filament.create({
+      name: "Test PLA",
+      vendor: "Generic",
+      type: "PLA",
+    });
+
+    // diameter is a number; a non-numeric string fails Mongoose's CastError
+    // path. We want any client-input validation failure to be 4xx, not 5xx.
+    const req = new NextRequest(`http://localhost/api/filaments/${filament._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tdsUrl: "ftp://example.com/file.pdf" }),
+    });
+    const res = await putFilament(req, { params: Promise.resolve({ id: String(filament._id) }) });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/must be a valid http\(s\) URL/i);
+  });
+
+  it("still returns 200 for a valid tdsUrl update", async () => {
+    const filament = await Filament.create({
+      name: "Test PLA",
+      vendor: "Generic",
+      type: "PLA",
+    });
+
+    const req = new NextRequest(`http://localhost/api/filaments/${filament._id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tdsUrl: "https://example.com/tds.pdf" }),
+    });
+    const res = await putFilament(req, { params: Promise.resolve({ id: String(filament._id) }) });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/tds-route-status.test.ts
+++ b/tests/tds-route-status.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * GH #161 regression guard.
+ *
+ * The TDS route used to return HTTP 502 for every `result.success === false`
+ * case from `extractFromTds`. SSRF/scheme rejections happen *before* any
+ * upstream provider call — they're client-input rejections, not bad-gateway
+ * conditions. Returning 502 made monitoring page on user input the route
+ * correctly refused, and made the renderer show "server error" when the
+ * correct UX is "URL not allowed".
+ *
+ * The fix inspects `result.error` against the same regex used by the
+ * shared `errorResponseFromCaught` helper (`isClientInputErrorMessage`),
+ * mapping known client-input strings to 400 and leaving genuine upstream
+ * failures at 502.
+ */
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn().mockResolvedValue([{ address: "93.184.216.34", family: 4 }]),
+}));
+
+describe("POST /api/tds — SSRF / scheme rejections return 400, real upstream failures return 502", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function jsonReq(body: unknown): NextRequest {
+    return new NextRequest("http://localhost/api/tds", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("returns 400 for a non-http(s) scheme (the SSRF guard rejects before upstream)", async () => {
+    // Fail-fast fetch stub: if anything escapes the SSRF guard the test
+    // explodes loudly. We expect zero network calls.
+    vi.stubGlobal("fetch", vi.fn(() => {
+      throw new Error("FETCH SHOULD NOT BE CALLED — guard should have blocked");
+    }));
+    const { POST } = await import("@/app/api/tds/route");
+    const res = await POST(jsonReq({ url: "javascript:alert(1)", apiKey: "fake-key", provider: "gemini" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/scheme/i);
+  });
+
+  it("returns 400 for an RFC1918 private IP (SSRF guard)", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => {
+      throw new Error("FETCH SHOULD NOT BE CALLED");
+    }));
+    const { POST } = await import("@/app/api/tds/route");
+    const res = await POST(jsonReq({ url: "http://10.0.0.5/tds.pdf", apiKey: "fake-key", provider: "gemini" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/private|internal/i);
+  });
+
+  it("returns 400 for an unparseable URL", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => {
+      throw new Error("FETCH SHOULD NOT BE CALLED");
+    }));
+    const { POST } = await import("@/app/api/tds/route");
+    const res = await POST(jsonReq({ url: "not a url at all", apiKey: "fake-key", provider: "gemini" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Invalid URL/i);
+  });
+
+  it("returns 502 for a real upstream failure (e.g. provider 5xx)", async () => {
+    // Network call succeeds; provider returns a 500-ish error. This is a
+    // genuine bad-gateway case and must stay at 502.
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (url.includes("generativelanguage.googleapis.com")) {
+        return Promise.resolve({
+          status: 500,
+          ok: false,
+          text: () => Promise.resolve("internal server error"),
+        } as unknown as Response);
+      }
+      // First fetch: TDS document content
+      return Promise.resolve({
+        status: 200,
+        ok: true,
+        url: "https://example.com/tds.pdf",
+        headers: new Headers({ "content-type": "application/pdf" }),
+        arrayBuffer: () => Promise.resolve(new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer),
+      } as unknown as Response);
+    }));
+    const { POST } = await import("@/app/api/tds/route");
+    const res = await POST(jsonReq({ url: "https://example.com/tds.pdf", apiKey: "fake-key", provider: "gemini" }));
+    expect(res.status).toBe(502);
+  });
+});


### PR DESCRIPTION
## Summary
- PUT `/api/filaments/{id}` returned **HTTP 500** for Mongoose validator failures (e.g. `tdsUrl: "javascript:alert(1)"`); now returns **400** with the validator's message in `error`.
- POST `/api/tds` returned **HTTP 502** for SSRF / scheme rejections that never reached the AI provider; now returns **400** with the guard's message.
- Adds `isClientInputError()`, `isClientInputErrorMessage()`, and `errorResponseFromCaught()` to `src/lib/apiErrorHandler.ts`. Matches Mongoose `ValidationError` by name plus the known message strings from our pre-update hooks (`must be a valid http(s) URL`) and `assertExternalUrl` (`Disallowed URL scheme`, `private/internal address`, `URL hostname does not resolve`, `URL has no hostname`, `Invalid URL`).
- Applies the helper to every mutating-handler catch the audit called out: `filaments` PUT/POST + spool sub-routes (`usage`, `dry-cycles`), and PUT/POST on `nozzles`, `printers`, `bed-types`, `locations`, and `print-history`.

## Why it matters
`5xx` made monitoring page on legitimate input refusals (the server is fine — the user's input was bad), and prevented form renderers from distinguishing "show form error" from "show server error". The guards themselves were already correct (PR #147 round-2 + the SSRF guard); only the status code was wrong.

## Test plan
- [x] `npx vitest run tests/apiErrorHandler.test.ts tests/filament-put-validation-status.test.ts tests/tds-route-status.test.ts` — 28 passed
- [x] Full suite: `npm test` — 888 passed (one pre-existing afterAll teardown timeout in `tests/setup.ts`, unrelated to this change)
- [x] `npm run lint` — clean
- [ ] Manual: `curl -X PUT /api/filaments/{id} -d '{"tdsUrl":"javascript:alert(1)"}'` → HTTP 400
- [ ] Manual: `curl -X POST /api/tds -d '{"url":"javascript:alert(1)","apiKey":"x"}'` → HTTP 400
- [ ] Manual: `curl -X POST /api/tds -d '{"url":"http://10.0.0.1/x","apiKey":"x"}'` → HTTP 400

Closes #160
Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)