### PR TITLE
Fix #166: surface retired-spool count on dashboard tile

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -127,6 +127,11 @@ export async function GET() {
         bedTypes: bedTypeCount,
         spools: spoolCount,
         retiredSpools,
+        // Active + retired. The "Active Spools" tile renders `spools`; the
+        // "(N retired)" hint renders when `retiredSpools > 0`. Surfacing
+        // the total here means a future tooltip / breakdown can show it
+        // without re-deriving the sum on the client (GH #166).
+        totalSpools: spoolCount + retiredSpools,
       },
       totalGrams,
       lowStock,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ interface DashboardData {
     bedTypes: number;
     spools: number;
     retiredSpools: number;
+    totalSpools: number;
   };
   totalGrams: number;
   lowStock: {
@@ -95,7 +96,15 @@ export default function DashboardPage() {
       {/* Top metrics */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
         <Metric label={t("dashboard.filaments")} value={data.counts.filaments} href="/" />
-        <Metric label={t("dashboard.spools")} value={data.counts.spools} />
+        <Metric
+          label={t("dashboard.spools")}
+          value={data.counts.spools}
+          hint={
+            data.counts.retiredSpools > 0
+              ? t("dashboard.spools.retiredHint", { count: data.counts.retiredSpools })
+              : undefined
+          }
+        />
         <Metric label={t("dashboard.totalWeight")} value={`${kg} kg`} />
         <Metric label={t("dashboard.printers")} value={data.counts.printers} href="/printers" />
         <Metric label={t("dashboard.nozzles")} value={data.counts.nozzles} href="/nozzles" />
@@ -213,10 +222,12 @@ function Metric({
   label,
   value,
   href,
+  hint,
 }: {
   label: string;
   value: number | string;
   href?: string;
+  hint?: string;
 }) {
   const content = (
     <div className="border border-gray-200 dark:border-gray-700 rounded px-3 py-2 bg-white dark:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600 transition-colors h-full">
@@ -224,6 +235,9 @@ function Metric({
       <div className="text-xl font-semibold text-gray-900 dark:text-gray-100 mt-0.5">
         {value}
       </div>
+      {hint ? (
+        <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">{hint}</div>
+      ) : null}
     </div>
   );
   return href ? <Link href={href}>{content}</Link> : content;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -94,6 +94,7 @@
   "dashboard.backToFilaments": "Zurück zu Filamenten",
   "dashboard.filaments": "Filamente",
   "dashboard.spools": "Aktive Spulen",
+  "dashboard.spools.retiredHint": "+{count} ausgemustert",
   "dashboard.totalWeight": "Gesamt verbleibend",
   "dashboard.printers": "Drucker",
   "dashboard.nozzles": "Düsen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -94,6 +94,7 @@
   "dashboard.backToFilaments": "Back to filaments",
   "dashboard.filaments": "Filaments",
   "dashboard.spools": "Active Spools",
+  "dashboard.spools.retiredHint": "+{count} retired",
   "dashboard.totalWeight": "Total Remaining",
   "dashboard.printers": "Printers",
   "dashboard.nozzles": "Nozzles",

--- a/tests/dashboard-route.test.ts
+++ b/tests/dashboard-route.test.ts
@@ -119,3 +119,73 @@ describe("/api/dashboard — dry-cycle inheritance", () => {
     expect(ids).not.toContain(String(variant._id));
   });
 });
+
+/**
+ * GH #166 regression guard.
+ *
+ * The "ACTIVE SPOOLS" tile renders `data.counts.spools` against a label
+ * that says "Active". If `counts.spools` doesn't match the dashboard's
+ * own definition of "active" (i.e. excludes retired), the tile lies the
+ * moment any spool is retired. The fix returns both the active count
+ * and a separate `totalSpools` so the API surface is unambiguous and a
+ * future tile / tooltip can render the breakdown.
+ */
+describe("/api/dashboard — counts.spools is active-only (excludes retired)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  it("excludes retired spools from counts.spools and surfaces them in counts.retiredSpools", async () => {
+    await Filament.create({
+      name: "PLA Active",
+      vendor: "Test",
+      type: "PLA",
+      spools: [
+        { label: "A1", totalWeight: 1000 },
+        { label: "A2", totalWeight: 1000 },
+      ],
+    });
+    await Filament.create({
+      name: "PLA Mixed",
+      vendor: "Test",
+      type: "PLA",
+      spools: [
+        { label: "B1", totalWeight: 1000 },
+        { label: "B2-retired", totalWeight: 50, retired: true },
+      ],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+
+    expect(body.counts.spools).toBe(3);          // A1, A2, B1
+    expect(body.counts.retiredSpools).toBe(1);   // B2-retired
+    expect(body.counts.totalSpools).toBe(4);     // breakdown for tooltips / future tiles
+  });
+
+  it("counts.spools is 0 when every spool is retired", async () => {
+    await Filament.create({
+      name: "All Retired PLA",
+      vendor: "Test",
+      type: "PLA",
+      spools: [
+        { label: "old1", totalWeight: 0, retired: true },
+        { label: "old2", totalWeight: 0, retired: true },
+      ],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+
+    expect(body.counts.spools).toBe(0);
+    expect(body.counts.retiredSpools).toBe(2);
+    expect(body.counts.totalSpools).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- The Active Spools tile already rendered the active-only count (the API loop in [dashboard/route.ts](src/app/api/dashboard/route.ts) excluded retired spools from `counts.spools`), but the breakdown was invisible. Once any spool was retired the user had no way to verify which spools were counted — and so the issue reporter (correctly!) flagged it as misleading.
- Add `counts.totalSpools` (active + retired) to the dashboard payload.
- Render `+N retired` underneath the value when `retiredSpools > 0`.
- Tile label stays "Active Spools"; the new hint resolves the ambiguity without needing a second tile or a tooltip.
- New i18n key `dashboard.spools.retiredHint` (EN + DE).

## Test plan
- [x] `npx vitest run tests/dashboard-route.test.ts` — 6 passed (two new GH #166 regression cases: mixed library + all-retired library)
- [x] `npm run lint` — clean
- [ ] Manual: dashboard with no retired spools — tile shows "ACTIVE SPOOLS / N" (no hint, baseline behavior)
- [ ] Manual: retire one spool — tile shows "ACTIVE SPOOLS / (N-1) / +1 retired"

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)