### PR TITLE
Fix #165: regression test for symmetric column sort behavior

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { useCurrency } from "@/hooks/useCurrency";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import type { FilamentSummary } from "@/types/filament";
 import { getRemainingGrams, getRemainingPct, getSpoolCount } from "@/lib/inventoryStats";
+import { compareFilaments, nextSortState, type SortKey, type SortDir } from "@/lib/sortFilamentList";
 
 type Filament = FilamentSummary;
 
@@ -21,28 +22,6 @@ function isLowStock(f: Filament): boolean {
   if (!threshold || threshold <= 0) return false;
   const remaining = getRemainingGrams(f);
   return remaining !== null && remaining < threshold;
-}
-
-type SortKey = "name" | "vendor" | "type" | "nozzle" | "bed" | "cost" | "remaining";
-type SortDir = "asc" | "desc";
-
-function getSortValue(f: Filament, key: SortKey): string | number {
-  switch (key) {
-    case "name":
-      return f.name.toLowerCase();
-    case "vendor":
-      return f.vendor.toLowerCase();
-    case "type":
-      return f.type.toLowerCase();
-    case "nozzle":
-      return f.temperatures.nozzle ?? -1;
-    case "bed":
-      return f.temperatures.bed ?? -1;
-    case "cost":
-      return f.cost ?? -1;
-    case "remaining":
-      return getRemainingPct(f) ?? -1;
-  }
 }
 
 function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: SortKey; sortDir: SortDir }) {
@@ -363,14 +342,11 @@ export default function Home() {
       ...standalone.map((f) => f),
     ];
 
+    const cmp = compareFilaments(sortKey, sortDir);
     all.sort((a, b) => {
       const fa = "parent" in a ? a.parent : a;
       const fb = "parent" in b ? b.parent : b;
-      const aVal = getSortValue(fa, sortKey);
-      const bVal = getSortValue(fb, sortKey);
-      if (aVal < bVal) return sortDir === "asc" ? -1 : 1;
-      if (aVal > bVal) return sortDir === "asc" ? 1 : -1;
-      return 0;
+      return cmp(fa, fb);
     });
 
     return all;
@@ -386,12 +362,9 @@ export default function Home() {
   };
 
   const handleSort = (key: SortKey) => {
-    if (sortKey === key) {
-      setSortDir(sortDir === "asc" ? "desc" : "asc");
-    } else {
-      setSortKey(key);
-      setSortDir("asc");
-    }
+    const next = nextSortState({ sortKey, sortDir }, key);
+    setSortKey(next.sortKey);
+    setSortDir(next.sortDir);
   };
 
   const allFilamentIds = useMemo(() => filaments.map((f) => f._id), [filaments]);

--- a/src/lib/sortFilamentList.ts
+++ b/src/lib/sortFilamentList.ts
@@ -1,0 +1,79 @@
+/**
+ * Sorting helpers for the home filament list.
+ *
+ * Extracted from src/app/page.tsx so the comparator + handleSort
+ * contract can be unit-tested without mounting the React component.
+ * GH #165 reported a (non-reproducible) "Cost column sorts desc on
+ * first click" bug; this module exists so any future refactor that
+ * accidentally introduces a per-column polarity bias gets caught
+ * by tests/sortFilamentList.test.ts.
+ *
+ * Behaviour locked in here:
+ *   - Clicking a *new* column always sets sortDir = "asc" (no
+ *     per-column override — same rule for every column).
+ *   - Clicking the *same* column toggles asc ↔ desc.
+ *   - getSortValue uses -1 as the sentinel for null on numeric
+ *     columns, so nulls sort *first* in asc and *last* in desc.
+ */
+
+import type { FilamentSummary } from "@/types/filament";
+import { getRemainingPct, type InventoryFilament } from "@/lib/inventoryStats";
+
+export type SortKey = "name" | "vendor" | "type" | "nozzle" | "bed" | "cost" | "remaining";
+export type SortDir = "asc" | "desc";
+
+/** Subset of FilamentSummary the comparator actually reads. Keeps tests
+ * lightweight without forcing every fixture to spell out unrelated fields
+ * (spools, color, etc). */
+export type SortableFilament = Pick<
+  FilamentSummary,
+  "name" | "vendor" | "type" | "cost" | "temperatures" | "spools" | "spoolWeight" | "netFilamentWeight" | "totalWeight"
+>;
+
+export function getSortValue(f: SortableFilament, key: SortKey): string | number {
+  switch (key) {
+    case "name":
+      return f.name.toLowerCase();
+    case "vendor":
+      return f.vendor.toLowerCase();
+    case "type":
+      return f.type.toLowerCase();
+    case "nozzle":
+      return f.temperatures.nozzle ?? -1;
+    case "bed":
+      return f.temperatures.bed ?? -1;
+    case "cost":
+      return f.cost ?? -1;
+    case "remaining":
+      return getRemainingPct(f as unknown as InventoryFilament) ?? -1;
+  }
+}
+
+/**
+ * Comparator factory. Returns a `(a, b) => number` that sorts
+ * filaments by `key` in `dir` direction. Symmetric across every key
+ * so the user gets the same first-click behaviour everywhere.
+ */
+export function compareFilaments(key: SortKey, dir: SortDir) {
+  return (a: SortableFilament, b: SortableFilament): number => {
+    const aVal = getSortValue(a, key);
+    const bVal = getSortValue(b, key);
+    if (aVal < bVal) return dir === "asc" ? -1 : 1;
+    if (aVal > bVal) return dir === "asc" ? 1 : -1;
+    return 0;
+  };
+}
+
+/**
+ * Compute the next sort state when the user clicks a column header.
+ * Same column → toggle direction. Different column → reset to asc.
+ */
+export function nextSortState(
+  prev: { sortKey: SortKey; sortDir: SortDir },
+  clicked: SortKey,
+): { sortKey: SortKey; sortDir: SortDir } {
+  if (prev.sortKey === clicked) {
+    return { sortKey: clicked, sortDir: prev.sortDir === "asc" ? "desc" : "asc" };
+  }
+  return { sortKey: clicked, sortDir: "asc" };
+}

--- a/tests/sortFilamentList.test.ts
+++ b/tests/sortFilamentList.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareFilaments,
+  getSortValue,
+  nextSortState,
+  type SortKey,
+  type SortableFilament,
+} from "@/lib/sortFilamentList";
+
+/**
+ * GH #165 regression guard.
+ *
+ * Issue #165 reported the Cost column header sorted desc on first click
+ * while every other column sorted asc. An empirical UI test against
+ * v1.13.1 (and current main) showed all six numeric/text columns behave
+ * identically: a fresh click on a column the user wasn't already
+ * sorting by sets sortDir = "asc". The "Cost = desc" observation was a
+ * misread (likely after an intermediate click had already toggled the
+ * direction).
+ *
+ * The comparator + sort-state logic was extracted from src/app/page.tsx
+ * into src/lib/sortFilamentList.ts so this file can lock the symmetric
+ * behaviour into the test suite. Any future refactor that introduces a
+ * per-column polarity bias will fail the cross-product test below.
+ */
+
+function f(overrides: Partial<SortableFilament>): SortableFilament {
+  return {
+    name: "Filament",
+    vendor: "Vendor",
+    type: "PLA",
+    cost: null,
+    temperatures: { nozzle: null, bed: null },
+    spools: [],
+    spoolWeight: null,
+    netFilamentWeight: null,
+    totalWeight: null,
+    ...overrides,
+  };
+}
+
+const fixtures: SortableFilament[] = [
+  f({ name: "Aardvark", vendor: "Acme", type: "PLA", cost: 10, temperatures: { nozzle: 200, bed: 60 } }),
+  f({ name: "Zebra", vendor: "Zoo", type: "ABS", cost: 82, temperatures: { nozzle: 250, bed: 90 } }),
+  f({ name: "Mango", vendor: "Mango Co", type: "PETG", cost: null, temperatures: { nozzle: null, bed: null } }),
+  f({ name: "Bear", vendor: "BearCorp", type: "TPU", cost: 22, temperatures: { nozzle: 220, bed: 50 } }),
+];
+
+describe("getSortValue — null-safe sentinel for numeric columns", () => {
+  it("returns -1 for null cost so nulls sort first in asc", () => {
+    expect(getSortValue(f({ cost: null }), "cost")).toBe(-1);
+  });
+
+  it("returns -1 for null nozzle/bed temperatures (same shape as cost)", () => {
+    expect(getSortValue(f({ temperatures: { nozzle: null, bed: null } }), "nozzle")).toBe(-1);
+    expect(getSortValue(f({ temperatures: { nozzle: null, bed: null } }), "bed")).toBe(-1);
+  });
+
+  it("lowercases text columns for case-insensitive sort", () => {
+    expect(getSortValue(f({ name: "Zebra" }), "name")).toBe("zebra");
+    expect(getSortValue(f({ vendor: "ACME" }), "vendor")).toBe("acme");
+  });
+});
+
+describe("compareFilaments — Cost behaves identically to other numeric columns (GH #165)", () => {
+  it("Cost asc: nulls first (-1), then ascending price", () => {
+    const sorted = [...fixtures].sort(compareFilaments("cost", "asc"));
+    expect(sorted.map((x) => x.cost)).toEqual([null, 10, 22, 82]);
+  });
+
+  it("Cost desc: highest price first, nulls last", () => {
+    const sorted = [...fixtures].sort(compareFilaments("cost", "desc"));
+    expect(sorted.map((x) => x.cost)).toEqual([82, 22, 10, null]);
+  });
+
+  it("Nozzle asc behaves identically to Cost asc (nulls first)", () => {
+    const sorted = [...fixtures].sort(compareFilaments("nozzle", "asc"));
+    expect(sorted.map((x) => x.temperatures.nozzle)).toEqual([null, 200, 220, 250]);
+  });
+
+  it("Bed asc behaves identically to Cost asc (nulls first)", () => {
+    const sorted = [...fixtures].sort(compareFilaments("bed", "asc"));
+    expect(sorted.map((x) => x.temperatures.bed)).toEqual([null, 50, 60, 90]);
+  });
+
+  it("Name asc sorts case-insensitively", () => {
+    const sorted = [...fixtures].sort(compareFilaments("name", "asc"));
+    expect(sorted.map((x) => x.name)).toEqual(["Aardvark", "Bear", "Mango", "Zebra"]);
+  });
+});
+
+describe("nextSortState — clicking a different column always resets to asc (GH #165)", () => {
+  // Symmetric cross-product: from every prior column, clicking each other
+  // column must reset to asc, regardless of the prior direction. Locks in
+  // the behavior across all combinations so a per-column override (the
+  // bug the issue suspected) gets caught.
+  const cols: SortKey[] = ["name", "vendor", "type", "nozzle", "bed", "cost", "remaining"];
+
+  for (const prev of cols) {
+    for (const next of cols) {
+      if (prev === next) continue;
+      it(`from ${prev}/asc → click ${next} → ${next}/asc`, () => {
+        expect(nextSortState({ sortKey: prev, sortDir: "asc" }, next)).toEqual({ sortKey: next, sortDir: "asc" });
+      });
+      it(`from ${prev}/desc → click ${next} → ${next}/asc (does not inherit prior dir)`, () => {
+        expect(nextSortState({ sortKey: prev, sortDir: "desc" }, next)).toEqual({ sortKey: next, sortDir: "asc" });
+      });
+    }
+  }
+
+  it("clicking the same column toggles asc → desc", () => {
+    expect(nextSortState({ sortKey: "cost", sortDir: "asc" }, "cost")).toEqual({ sortKey: "cost", sortDir: "desc" });
+  });
+
+  it("clicking the same column toggles desc → asc", () => {
+    expect(nextSortState({ sortKey: "cost", sortDir: "desc" }, "cost")).toEqual({ sortKey: "cost", sortDir: "asc" });
+  });
+});


### PR DESCRIPTION
## Summary
The reported bug — Cost column sorts desc on first click while every other column sorts asc — does **not reproduce** against v1.13.1 or current main. Empirical UI test (clicking each header in turn from the initial state) shows Cost behaves identically to Nozzle/Bed: asc, with `—` (null) at the top.

Rather than close as no-op, extract the comparator and sort-toggle logic from [page.tsx](src/app/page.tsx) into [sortFilamentList.ts](src/lib/sortFilamentList.ts) so the symmetric behavior can be locked into the test suite. The new cross-product test covers every (prev → next) column pair and asserts that switching columns always resets `sortDir = "asc"`, regardless of the prior direction — exactly the contract the issue suspected was broken.

## Test plan
- [x] `npx vitest run tests/sortFilamentList.test.ts` — 94 passed (cross-product asc/desc transitions for all 7 columns + null sentinel + case-insensitive text sort)
- [x] `npm run lint` — clean
- [x] Manual: home page renders, header clicks cycle Name(toggle)→Vendor→Type→Nozzle→Bed→Cost — every fresh column lands in asc, identical to before the refactor.

## Empirical evidence
Clicking each column header once in turn from the initial state (sortKey=name, sortDir=asc):

| Column | aria-sort after click | First row |
|---|---|---|
| Name | descending | "Yousu PP" (toggle) |
| Vendor | ascending | "3D Fuel" |
| Type | ascending | "ASA" |
| Nozzle | ascending | "—" |
| Bed | ascending | "—" |
| Cost | ascending | "—" |

Cost behaves identically to other numeric columns. The original observation in the smoke test was likely captured after an intermediate click had already toggled the direction.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)