### PR TITLE
Fix #164: Clone form submit reads 'Create Filament', not 'Update'

### DIFF
--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -733,9 +733,18 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
 
   // Single source of truth for the submit button label so the duplicate at
   // the top of the form can't drift from the bottom one.
+  //
+  // Edit mode is identified by the presence of `_id` on initialData — only
+  // /filaments/{id}/edit fetches a real doc with that field; the populate-from
+  // flows on /filaments/new (clone, NFC, Prusament, INI, TDS, parent) all
+  // synthesise an initialData object without an _id. Branching on the bare
+  // truthiness of initialData (the prior behaviour) made every populate-from
+  // flow show "Update Filament" on what is in fact a create — confusing on a
+  // destructive-feeling action like Clone (GH #164).
+  const isEdit = Boolean(initialData?._id);
   const submitLabel = saving
     ? t("form.saving")
-    : initialData
+    : isEdit
       ? t("form.updateFilament")
       : t("form.createFilament");
 


### PR DESCRIPTION
## Summary
The submit-button label branched on `Boolean(initialData)`. Edit mode set it (with a real `_id`), but every **populate-from** flow on [filaments/new/page.tsx](src/app/filaments/new/page.tsx) (NFC, Prusament, INI, TDS, parent, **clone**) also synthesises an initialData object — without an `_id`. So Clone landed on a page that read "Clone Filament" at the top and "Update Filament" on the submit, which is exactly the wrong reassurance on a destructive-feeling action.

Branch on `initialData?._id` instead — only `/filaments/{id}/edit` fetches a real doc with that field.

## Verified manually against the dev server

| Route | Heading | Submit |
|---|---|---|
| `/filaments/new` | Add New Filament | Create Filament |
| `/filaments/new?cloneId=…` | Clone Filament | **Create Filament** *(was "Update Filament")* |
| `/filaments/{id}/edit` | Edit Filament | Update Filament *(unchanged)* |

## Test plan
- [x] Manual: clone flow now shows "Create Filament" submit
- [x] Manual: edit flow still shows "Update Filament" submit
- [x] Manual: fresh /filaments/new still shows "Create Filament" submit
- [x] `npm run lint` — clean

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)