### PR TITLE
Fix #162: project _parent to inheritable display fields in raw mode

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -42,19 +42,37 @@ export async function GET(
       return errorResponse("Not found", 404);
     }
 
-    // Resolve inheritance when displaying; skip when editing so the form
-    // only sees the variant's own overrides.
+    // Two parent-fetch shapes:
+    //
+    //   raw=true  → variant edit form. Skip resolveFilament (the form must
+    //               see only the variant's own overrides — GH #106) and
+    //               attach a slim parent-summary projected to the inheritable
+    //               display values FilamentForm consumes for hint placeholders.
+    //               Dropping settings/presets/populated nozzles/sync metadata
+    //               (__v, syncId, instanceId) cuts ~2KB/request and stops
+    //               leaking sync internals to the renderer (GH #162).
+    //
+    //   raw=false → variant detail page. Run resolveFilament on the populated
+    //               parent so inherited fields render correctly, then attach
+    //               only `{ _id, name }` for the "Up to <parent>" link.
     let resolved: IFilament | ReturnType<typeof resolveFilament> = filament;
-    let parentDoc: IFilament | null = null;
+    let parentSummary: { _id: unknown; name?: string; vendor?: string; type?: string; color?: string; cost?: number | null; density?: number | null; diameter?: number | null } | null = null;
     if (filament.parentId) {
-      parentDoc = (await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
-        .populate("compatibleNozzles")
-        .populate("calibrations.nozzle")
-        .populate("calibrations.printer")
-        .populate("calibrations.bedType")
-        .lean()) as IFilament | null;
-      if (!raw && parentDoc) {
-        resolved = resolveFilament(filament, parentDoc);
+      if (raw) {
+        parentSummary = (await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
+          .select("_id name vendor type color cost density diameter")
+          .lean()) as typeof parentSummary;
+      } else {
+        const parentDoc = (await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
+          .populate("compatibleNozzles")
+          .populate("calibrations.nozzle")
+          .populate("calibrations.printer")
+          .populate("calibrations.bedType")
+          .lean()) as IFilament | null;
+        if (parentDoc) {
+          resolved = resolveFilament(filament, parentDoc);
+          parentSummary = { _id: parentDoc._id, name: parentDoc.name };
+        }
       }
     }
 
@@ -64,24 +82,11 @@ export async function GET(
       .sort({ name: 1 })
       .lean();
 
-    // In raw mode, attach the full parent doc alongside so the edit UI can
-    // show "inherited from parent" placeholders for any field the variant
-    // left blank, without a second round-trip. In non-raw mode, attach a
-    // light parent-summary (just _id + name) so the variant detail page
-    // can render a clickable "Up to <parent name>" link without a second
-    // request (GH #127).
-    if (raw && parentDoc) {
+    if (parentSummary) {
       return NextResponse.json({
         ...resolved,
         _variants: variants,
-        _parent: parentDoc,
-      });
-    }
-    if (parentDoc) {
-      return NextResponse.json({
-        ...resolved,
-        _variants: variants,
-        _parent: { _id: parentDoc._id, name: parentDoc.name },
+        _parent: parentSummary,
       });
     }
 

--- a/tests/variant-edit-preserves-inheritance.test.ts
+++ b/tests/variant-edit-preserves-inheritance.test.ts
@@ -138,6 +138,57 @@ describe("variant edit round-trip preserves inheritance", () => {
     expect(resolved._inherited).toContain("temperatures.nozzle");
   });
 
+  it("GH #162: ?raw=true returns a slim _parent (no settings, no populated nozzles, no sync metadata)", async () => {
+    const parent = await Filament.create({
+      name: "Parent with internals",
+      vendor: "Vendor",
+      type: "PLA",
+      cost: 35,
+      density: 1.24,
+      diameter: 1.75,
+      color: "#222222",
+      // Stuff the parent with the kinds of fields the audit complained about
+      // leaking through the raw _parent payload.
+      settings: {
+        filament_notes: "private vendor data",
+        chamber_temperature: "55",
+        cooling_overrides: "complex",
+      },
+    });
+    const variant = await Filament.create({
+      name: "Variant",
+      vendor: "Vendor",
+      type: "PLA",
+      parentId: parent._id,
+    });
+
+    const req = new NextRequest(`http://localhost/api/filaments/${variant._id}?raw=true`);
+    const res = await getFilament(req, { params: Promise.resolve({ id: String(variant._id) }) });
+    const body = await res.json();
+
+    expect(body._parent).toBeDefined();
+    // Inheritable display values that FilamentForm would render as hint text.
+    expect(body._parent.name).toBe("Parent with internals");
+    expect(body._parent.color).toBe("#222222");
+    expect(body._parent.cost).toBe(35);
+    expect(body._parent.density).toBe(1.24);
+    // Mongoose / sync internals must NOT be on the wire.
+    expect(body._parent.__v).toBeUndefined();
+    expect(body._parent.syncId).toBeUndefined();
+    expect(body._parent.instanceId).toBeUndefined();
+    // PrusaSlicer settings bag must NOT be on the wire (~2KB of irrelevant
+    // keys per request).
+    expect(body._parent.settings).toBeUndefined();
+    // Populated nozzle/calibration arrays must NOT be on the wire.
+    expect(body._parent.compatibleNozzles).toBeUndefined();
+    expect(body._parent.calibrations).toBeUndefined();
+    // Spool subdocs would be even bigger — must NOT be on the wire.
+    expect(body._parent.spools).toBeUndefined();
+    // createdAt/updatedAt are noise on a derived link target.
+    expect(body._parent.createdAt).toBeUndefined();
+    expect(body._parent.updatedAt).toBeUndefined();
+  });
+
   it("explicit overrides on the variant are preserved across the round-trip", async () => {
     const { parent, variant } = await seed();
 


### PR DESCRIPTION
## Summary
`GET /api/filaments/{variantId}?raw=true` (variant edit form) attached the entire populated parent doc — Mongoose internals (`__v`, `syncId`, `instanceId`, timestamps), the full PrusaSlicer `settings` bag (~2KB), populated `compatibleNozzles[]` + `calibrations[]` (each carrying their own `__v`/`syncId`), and spool subdocs.

[FilamentForm](src/app/filaments/FilamentForm.tsx) only reads `_parent.name` (variant banner). The CLAUDE.md intent was to expose inheritable display values for form-hint placeholders, so project to that documented shape — `{ _id, name, vendor, type, color, cost, density, diameter }` — and drop the rest.

Restructure the GET handler in [route.ts](src/app/api/filaments/[id]/route.ts) so the two modes use different parent fetches:

- **raw=true** — single `.findOne().select(...).lean()` with no populates (resolveFilament doesn't run in raw mode).
- **raw=false** — `.findOne().populate(...).lean()` as before (resolveFilament needs the populated nozzles/printers/bed-types), then attach the slim `{ _id, name }` summary the detail page already used.

## Verified manually against dev server
- `?raw=true`  → `_parent` keys exactly `[_id, name, vendor, type, color, cost, density, diameter]`; `__v`/`syncId`/`instanceId`/`settings`/`compatibleNozzles`/`calibrations`/`spools`/`createdAt`/`updatedAt` all undefined.
- `?raw=false` → `_parent` keys exactly `[_id, name]` (unchanged); inherited `temperatures.nozzle = 285` resolved correctly; `_inherited` count = 2.
- Variant edit page renders with the variant banner intact ("This is a variant of \"PC Blend CoreOne\"").

## Test plan
- [x] `npx vitest run tests/variant-edit-preserves-inheritance.test.ts` — 11 passed (10 prior GH #106 cases + 1 new GH #162 case asserting the projection)
- [x] `npm run lint` — clean
- [x] Manual: variant edit page still functional, parent banner shows parent name correctly

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)