### PR TITLE
Fix #159: dedup spool CSV import by spoolId so re-import is idempotent

### DIFF
--- a/src/app/api/spools/import/route.ts
+++ b/src/app/api/spools/import/route.ts
@@ -165,7 +165,9 @@ export async function POST(request: NextRequest) {
       const purchaseDate = r.purchaseDate ? new Date(r.purchaseDate) : null;
       const openedDate = r.openedDate ? new Date(r.openedDate) : null;
 
-      const spoolFields = {
+      // Build the field set for a NEW spool — defaults fill in for any
+      // optional column the user didn't include.
+      const newSpoolFields = {
         label: unsanitizeCsvCell(r.label || ""),
         totalWeight: weight,
         lotNumber: r.lotNumber ? unsanitizeCsvCell(r.lotNumber) : null,
@@ -179,6 +181,13 @@ export async function POST(request: NextRequest) {
       // update the existing entry instead of appending a duplicate.
       // Without this, exporting and re-importing the same CSV silently
       // doubles the library's spool count (GH #159).
+      //
+      // For the UPDATE path, only assign the columns that were actually
+      // present in the CSV header — missing columns must leave existing
+      // metadata untouched. Otherwise a partial-column re-import (e.g.
+      // `filament,totalWeight,spoolId` to bulk-update weights) would
+      // silently null label / lotNumber / dates / location on every
+      // matched spool. Codex P1 on PR #172.
       const incomingSpoolId = (r.spoolId || "").trim();
       let action: "created" | "updated" = "created";
       if (incomingSpoolId) {
@@ -187,7 +196,19 @@ export async function POST(request: NextRequest) {
         // fields, the same workaround the push path below uses.
         const existing = (filament.spools as unknown as { id(id: string): Record<string, unknown> | null }).id(incomingSpoolId);
         if (existing) {
-          Object.assign(existing, spoolFields);
+          // totalWeight is required so it always counts as "present" — its
+          // empty-cell-means-null semantics are still honoured by `weight`.
+          const partialUpdate: Record<string, unknown> = { totalWeight: weight };
+          if ("label" in r) partialUpdate.label = unsanitizeCsvCell(r.label || "");
+          if ("lotNumber" in r) partialUpdate.lotNumber = r.lotNumber ? unsanitizeCsvCell(r.lotNumber) : null;
+          if ("purchaseDate" in r) {
+            partialUpdate.purchaseDate = purchaseDate && !isNaN(+purchaseDate) ? purchaseDate : null;
+          }
+          if ("openedDate" in r) {
+            partialUpdate.openedDate = openedDate && !isNaN(+openedDate) ? openedDate : null;
+          }
+          if ("location" in r) partialUpdate.locationId = locationId || null;
+          Object.assign(existing, partialUpdate);
           action = "updated";
         }
       }
@@ -196,7 +217,7 @@ export async function POST(request: NextRequest) {
         // the outer Filament schema is re-inferred — cast to unknown first
         // to avoid the direct `any` eslint rule while still satisfying the
         // push signature.
-        filament.spools.push(spoolFields as unknown as Parameters<typeof filament.spools.push>[0]);
+        filament.spools.push(newSpoolFields as unknown as Parameters<typeof filament.spools.push>[0]);
       }
       await filament.save();
       results.push({ row: i + 2, ok: true, action, filament: filament.name });

--- a/src/app/api/spools/import/route.ts
+++ b/src/app/api/spools/import/route.ts
@@ -7,7 +7,7 @@ import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
 import { unsanitizeCsvCell } from "@/lib/csvWriter";
 
 /**
- * POST /api/spools/import — bulk-create spools from CSV.
+ * POST /api/spools/import — bulk-create OR upsert spools from CSV.
  *
  * Accepts either:
  *   - Content-Type: text/csv with the CSV as the raw request body
@@ -23,11 +23,16 @@ import { unsanitizeCsvCell } from "@/lib/csvWriter";
  *
  * Optional columns:
  *   vendor, label, lotNumber, purchaseDate (ISO date), openedDate,
- *   location (name — will create the Location if it doesn't exist)
+ *   location (name — will create the Location if it doesn't exist),
+ *   spoolId — when present and the matching filament already has a spool
+ *     with that subdoc _id, the existing spool's mutable fields are
+ *     updated instead of appending a new one. This makes the export →
+ *     re-import round-trip idempotent (GH #159 — pre-fix re-importing
+ *     an export silently doubled inventory).
  *
- * Returns a per-row result so the client can show granular success/failure.
- * Does not transactionally roll back on partial failure — this is a user
- * bulk-paste, not a critical path.
+ * Returns a per-row result tagged `created | updated` so the client can
+ * show granular success/failure. Does not transactionally roll back on
+ * partial failure — this is a user bulk-paste, not a critical path.
  */
 export async function POST(request: NextRequest) {
   let csvText: string;
@@ -96,6 +101,7 @@ export async function POST(request: NextRequest) {
     const results: Array<{
       row: number;
       ok: boolean;
+      action?: "created" | "updated";
       error?: string;
       filament?: string;
     }> = [];
@@ -159,25 +165,52 @@ export async function POST(request: NextRequest) {
       const purchaseDate = r.purchaseDate ? new Date(r.purchaseDate) : null;
       const openedDate = r.openedDate ? new Date(r.openedDate) : null;
 
-      // Mongoose's subdocument type doesn't include our added fields until
-      // the outer Filament schema is re-inferred — cast to unknown first
-      // to avoid the direct `any` eslint rule while still satisfying the
-      // push signature.
-      filament.spools.push({
+      const spoolFields = {
         label: unsanitizeCsvCell(r.label || ""),
         totalWeight: weight,
         lotNumber: r.lotNumber ? unsanitizeCsvCell(r.lotNumber) : null,
         purchaseDate: purchaseDate && !isNaN(+purchaseDate) ? purchaseDate : null,
         openedDate: openedDate && !isNaN(+openedDate) ? openedDate : null,
         locationId: locationId || null,
-      } as unknown as Parameters<typeof filament.spools.push>[0]);
+      };
+
+      // Round-trip dedup: when the CSV row carries a `spoolId` and the
+      // matching filament already has a spool with that subdoc _id,
+      // update the existing entry instead of appending a duplicate.
+      // Without this, exporting and re-importing the same CSV silently
+      // doubles the library's spool count (GH #159).
+      const incomingSpoolId = (r.spoolId || "").trim();
+      let action: "created" | "updated" = "created";
+      if (incomingSpoolId) {
+        // .id() returns the matching subdoc or null. Cast through unknown
+        // because the inferred subdoc type doesn't expose our extended
+        // fields, the same workaround the push path below uses.
+        const existing = (filament.spools as unknown as { id(id: string): Record<string, unknown> | null }).id(incomingSpoolId);
+        if (existing) {
+          Object.assign(existing, spoolFields);
+          action = "updated";
+        }
+      }
+      if (action === "created") {
+        // Mongoose's subdocument type doesn't include our added fields until
+        // the outer Filament schema is re-inferred — cast to unknown first
+        // to avoid the direct `any` eslint rule while still satisfying the
+        // push signature.
+        filament.spools.push(spoolFields as unknown as Parameters<typeof filament.spools.push>[0]);
+      }
       await filament.save();
-      results.push({ row: i + 2, ok: true, filament: filament.name });
+      results.push({ row: i + 2, ok: true, action, filament: filament.name });
     }
 
     const ok = results.filter((r) => r.ok).length;
+    const created = results.filter((r) => r.ok && r.action === "created").length;
+    const updated = results.filter((r) => r.ok && r.action === "updated").length;
     const failed = results.length - ok;
-    return NextResponse.json({ imported: ok, failed, results });
+    // `imported` is preserved for backwards compatibility with any client
+    // that already reads it; `created`/`updated` are the new breakdown so
+    // a re-import can be reported as "updated 6" rather than misleadingly
+    // "imported 6" (which would imply doubling).
+    return NextResponse.json({ imported: ok, created, updated, failed, results });
   } catch (err) {
     return errorResponse("Failed to import spools", 500, getErrorMessage(err));
   }

--- a/tests/spools-import-route.test.ts
+++ b/tests/spools-import-route.test.ts
@@ -335,6 +335,68 @@ describe("/api/spools/import", () => {
       expect(fresh.spools[1].totalWeight).toBe(1000);
     });
 
+    it("partial-column update preserves existing metadata (Codex P1 PR #172)", async () => {
+      // Seed a spool with full metadata. A re-import that only includes
+      // filament/totalWeight/spoolId (e.g. bulk weight tweak) must NOT
+      // null out label/lotNumber/dates/location on the matched spool.
+      const f = await Filament.create({
+        name: "PETG Yellow",
+        vendor: "Test",
+        type: "PETG",
+        spools: [
+          {
+            label: "Yellow shelf #2",
+            totalWeight: 950,
+            lotNumber: "LOT-007",
+            purchaseDate: new Date("2025-01-15"),
+            openedDate: new Date("2025-02-01"),
+          },
+        ],
+      });
+      const spoolId = String(f.spools[0]._id);
+
+      const csv =
+        "filament,totalWeight,spoolId\n" +
+        `PETG Yellow,825,${spoolId}\n`;
+      const res = await importSpools(csvRequest(csv));
+      const body = await res.json();
+      expect(body.imported).toBe(1);
+      expect(body.updated).toBe(1);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools).toHaveLength(1);
+      const updated = fresh.spools[0];
+      expect(updated.totalWeight).toBe(825);                // updated
+      expect(updated.label).toBe("Yellow shelf #2");        // preserved
+      expect(updated.lotNumber).toBe("LOT-007");            // preserved
+      expect(updated.purchaseDate?.toISOString().slice(0, 10)).toBe("2025-01-15"); // preserved
+      expect(updated.openedDate?.toISOString().slice(0, 10)).toBe("2025-02-01");   // preserved
+    });
+
+    it("explicit empty cell on update path clears the field (round-trip with full export)", async () => {
+      // Distinguishing "column absent" from "column present + empty" is
+      // the round-trip contract: an exported CSV that includes label as
+      // an empty cell means the spool genuinely has no label, and the
+      // re-import should respect that.
+      const f = await Filament.create({
+        name: "TPU Pink",
+        vendor: "Test",
+        type: "TPU",
+        spools: [{ label: "Old label", totalWeight: 800 }],
+      });
+      const spoolId = String(f.spools[0]._id);
+
+      const csv =
+        "filament,totalWeight,label,spoolId\n" +
+        `TPU Pink,800,,${spoolId}\n`;
+      const res = await importSpools(csvRequest(csv));
+      const body = await res.json();
+      expect(body.updated).toBe(1);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools[0].label).toBe(""); // explicitly cleared
+    });
+
     it("mixed CSV with one update and one create reports both counts correctly", async () => {
       const f = await Filament.create({
         name: "ASA Grey",

--- a/tests/spools-import-route.test.ts
+++ b/tests/spools-import-route.test.ts
@@ -255,4 +255,109 @@ describe("/api/spools/import", () => {
     // finds the seeded row.
     expect(body.imported).toBe(1);
   });
+
+  describe("GH #159: round-trip dedup via spoolId", () => {
+    it("re-importing an exported CSV updates existing spools instead of duplicating", async () => {
+      // Seed a filament with a single spool so we can capture the spoolId
+      // the exporter would emit and feed it back through the importer.
+      const f = await Filament.create({
+        name: "PLA Black",
+        vendor: "Test",
+        type: "PLA",
+        spools: [{ label: "Original", totalWeight: 1000 }],
+      });
+      const seededSpoolId = String(f.spools[0]._id);
+
+      // Re-import the exact row the exporter would produce, including the
+      // spoolId column. Pre-fix this would push a NEW spool (doubling
+      // the count). Post-fix it should update the existing one.
+      const csv =
+        "filament,totalWeight,label,spoolId\n" +
+        `PLA Black,950,Original,${seededSpoolId}\n`;
+      const res = await importSpools(csvRequest(csv));
+      const body = await res.json();
+      expect(body.imported).toBe(1);
+      expect(body.created).toBe(0);
+      expect(body.updated).toBe(1);
+      expect(body.results[0].action).toBe("updated");
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools).toHaveLength(1); // NOT 2
+      expect(String(fresh.spools[0]._id)).toBe(seededSpoolId);
+      expect(fresh.spools[0].totalWeight).toBe(950); // updated value persisted
+    });
+
+    it("a row whose spoolId doesn't match falls through to create (so foreign exports still work)", async () => {
+      const f = await Filament.create({
+        name: "PETG Blue",
+        vendor: "Test",
+        type: "PETG",
+      });
+
+      // spoolId from a different DB / filament — exporter from another
+      // instance would carry an _id this DB has never seen. The current
+      // filament has no spools, so .id() returns null and the row creates.
+      const foreignSpoolId = new mongoose.Types.ObjectId().toString();
+      const csv =
+        "filament,totalWeight,spoolId\n" +
+        `PETG Blue,850,${foreignSpoolId}\n`;
+      const res = await importSpools(csvRequest(csv));
+      const body = await res.json();
+      expect(body.imported).toBe(1);
+      expect(body.created).toBe(1);
+      expect(body.updated).toBe(0);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools).toHaveLength(1);
+      expect(fresh.spools[0].totalWeight).toBe(850);
+    });
+
+    it("a row with no spoolId column behaves exactly like the legacy create path", async () => {
+      const f = await Filament.create({
+        name: "TPU Red",
+        vendor: "Test",
+        type: "TPU",
+        spools: [{ label: "Existing", totalWeight: 500 }],
+      });
+
+      const csv =
+        "filament,totalWeight,label\n" +
+        `TPU Red,1000,Newly added\n`;
+      const res = await importSpools(csvRequest(csv));
+      const body = await res.json();
+      expect(body.imported).toBe(1);
+      expect(body.created).toBe(1);
+      expect(body.updated).toBe(0);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools).toHaveLength(2); // existing + newly created
+      expect(fresh.spools[1].label).toBe("Newly added");
+      expect(fresh.spools[1].totalWeight).toBe(1000);
+    });
+
+    it("mixed CSV with one update and one create reports both counts correctly", async () => {
+      const f = await Filament.create({
+        name: "ASA Grey",
+        vendor: "Test",
+        type: "ASA",
+        spools: [{ label: "First", totalWeight: 1000 }],
+      });
+      const existingId = String(f.spools[0]._id);
+
+      const csv =
+        "filament,totalWeight,label,spoolId\n" +
+        `ASA Grey,800,First,${existingId}\n` +     // updates existing
+        `ASA Grey,1000,Second,\n`;                   // creates new
+      const res = await importSpools(csvRequest(csv));
+      const body = await res.json();
+      expect(body.imported).toBe(2);
+      expect(body.created).toBe(1);
+      expect(body.updated).toBe(1);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools).toHaveLength(2);
+      const byId = new Map(fresh.spools.map((s: { _id: { toString(): string }; totalWeight: number; label: string }) => [String(s._id), s]));
+      expect(byId.get(existingId)?.totalWeight).toBe(800);
+    });
+  });
 });

--- a/tests/spools-import-route.test.ts
+++ b/tests/spools-import-route.test.ts
@@ -356,8 +356,11 @@ describe("/api/spools/import", () => {
 
       const fresh = await Filament.findById(f._id);
       expect(fresh.spools).toHaveLength(2);
-      const byId = new Map(fresh.spools.map((s: { _id: { toString(): string }; totalWeight: number; label: string }) => [String(s._id), s]));
-      expect(byId.get(existingId)?.totalWeight).toBe(800);
+      const updatedSpool = fresh.spools.find(
+        (s: { _id: { toString(): string }; totalWeight: number }) =>
+          String(s._id) === existingId,
+      );
+      expect(updatedSpool?.totalWeight).toBe(800);
     });
   });
 });


### PR DESCRIPTION
## Summary
The exported CSV from `/api/spools/export-csv` includes a `spoolId` column (subdoc `_id`) but [the importer](src/app/api/spools/import/route.ts) ignored it. So the most common round-trip pattern — export → edit somewhere → re-import — silently doubled the library's spool count, with no warning.

When a row carries `spoolId` and the matching filament already has a spool with that subdoc `_id`, the importer now **updates** the existing entry's mutable fields (label, totalWeight, lotNumber, purchaseDate, openedDate, locationId) instead of pushing a duplicate. Rows without a spoolId, or whose spoolId doesn't match anything in the target filament, fall through to the legacy create path — so a CSV from another instance still imports cleanly.

Response gains a created/updated breakdown so a re-import reads "updated 6, created 0" rather than the misleading "imported 6":
```json
{ "imported": 6, "created": 0, "updated": 6, "failed": 0, "results": [...] }
```
`imported` is preserved for backwards compat with any client already reading it. Per-row results gain an `action: "created" | "updated"` tag.

## Test plan
- [x] `npx vitest run tests/spools-import-route.test.ts` — 17 passed (13 prior + 4 new GH #159 cases)
- [x] `npm run lint` — clean
- [x] New test cases:
  - Round-trip: re-importing an exported CSV updates instead of duplicating (asserts `spools.length === 1`, not 2)
  - Foreign spoolId (from another instance) falls through to create
  - CSV without a `spoolId` column behaves exactly like the legacy create path
  - Mixed update + create CSV reports both counts correctly

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)