### PR TITLE
Fix #158: include SharedCatalog in snapshot/restore

### DIFF
--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -7,6 +7,7 @@ import Printer from "@/models/Printer";
 import BedType from "@/models/BedType";
 import Location from "@/models/Location";
 import PrintHistory from "@/models/PrintHistory";
+import SharedCatalog from "@/models/SharedCatalog";
 
 // Simple in-memory mutex to prevent concurrent restore operations.
 // Limitation: this only guards within a single Node.js process. In a
@@ -75,29 +76,50 @@ function restoreTypes(doc: Record<string, unknown>): Record<string, unknown> {
  * GET /api/snapshot — Export snapshot-scoped app data as JSON.
  *
  * The snapshot includes all documents (including soft-deleted) from
- * filaments, nozzles, printers, bed types, locations, and print history.
- * Timestamps, _ids, and references are preserved so the snapshot can be
- * restored as-is. Shared catalogs are deliberately excluded from backup /
- * restore; the danger-zone delete endpoint clears them separately.
+ * filaments, nozzles, printers, bed types, locations, print history,
+ * and shared catalogs. Timestamps, _ids, and references are preserved
+ * so the snapshot can be restored as-is.
+ *
+ * Note on JSON keys: `bedTypes`, `printHistory`, and `sharedCatalogs`
+ * are camelCase keys in the JSON shape, but the restore writes go
+ * through the corresponding Mongoose models (BedType, PrintHistory,
+ * SharedCatalog) — the keys never reach Mongo, so there's no
+ * collection-name mismatch. The keys are kept stable so older
+ * snapshots round-trip on the same shape.
  */
 export async function GET() {
   await dbConnect();
 
-  const [filaments, nozzles, printers, bedTypes, locations, printHistory] =
-    await Promise.all([
-      Filament.find({}).lean(),
-      Nozzle.find({}).lean(),
-      Printer.find({}).lean(),
-      BedType.find({}).lean(),
-      Location.find({}).lean(),
-      PrintHistory.find({}).lean(),
-    ]);
+  const [
+    filaments,
+    nozzles,
+    printers,
+    bedTypes,
+    locations,
+    printHistory,
+    sharedCatalogs,
+  ] = await Promise.all([
+    Filament.find({}).lean(),
+    Nozzle.find({}).lean(),
+    Printer.find({}).lean(),
+    BedType.find({}).lean(),
+    Location.find({}).lean(),
+    PrintHistory.find({}).lean(),
+    SharedCatalog.find({}).lean(),
+  ]);
 
-  // Snapshot version 3 adds locations + printHistory. v2 snapshots (with
-  // bedTypes but no locations/printHistory) still restore cleanly. v1
-  // snapshots (without bedTypes either) also still restore.
+  // Snapshot version history:
+  //   v1 — filaments, nozzles, printers
+  //   v2 — adds bedTypes
+  //   v3 — adds locations + printHistory
+  //   v4 — adds sharedCatalogs (GH #158: previously dropped on every
+  //        snapshot/restore round-trip, silently losing every published
+  //        share link; now symmetric with /api/snapshot/delete which
+  //        always cleared SharedCatalog)
+  // Older snapshots still restore cleanly because POST destructures
+  // missing collections to `[]`.
   const snapshot = {
-    version: 3,
+    version: 4,
     createdAt: new Date().toISOString(),
     collections: {
       filaments,
@@ -106,6 +128,7 @@ export async function GET() {
       bedTypes,
       locations,
       printHistory,
+      sharedCatalogs,
     },
   };
 
@@ -159,6 +182,7 @@ async function restoreSnapshot(request: NextRequest) {
       bedTypes?: unknown[];
       locations?: unknown[];
       printHistory?: unknown[];
+      sharedCatalogs?: unknown[];
     };
   };
 
@@ -211,6 +235,7 @@ async function restoreSnapshot(request: NextRequest) {
     bedTypes = [],
     locations = [],
     printHistory = [],
+    sharedCatalogs = [],
   } = snapshot.collections;
 
   // --- Safety: snapshot the current DB so we can roll back on failure ---
@@ -221,6 +246,7 @@ async function restoreSnapshot(request: NextRequest) {
     backupBedTypes,
     backupLocations,
     backupPrintHistory,
+    backupSharedCatalogs,
   ] = await Promise.all([
     Filament.find({}).lean(),
     Nozzle.find({}).lean(),
@@ -228,6 +254,7 @@ async function restoreSnapshot(request: NextRequest) {
     BedType.find({}).lean(),
     Location.find({}).lean(),
     PrintHistory.find({}).lean(),
+    SharedCatalog.find({}).lean(),
   ]);
 
   try {
@@ -239,6 +266,7 @@ async function restoreSnapshot(request: NextRequest) {
       BedType.deleteMany({}),
       Location.deleteMany({}),
       PrintHistory.deleteMany({}),
+      SharedCatalog.deleteMany({}),
     ]);
 
     // Insert snapshot data (order matters: reference targets before referrers
@@ -251,6 +279,7 @@ async function restoreSnapshot(request: NextRequest) {
       bedTypes: 0,
       locations: 0,
       printHistory: 0,
+      sharedCatalogs: 0,
     };
 
     if (nozzles.length > 0) {
@@ -289,6 +318,12 @@ async function restoreSnapshot(request: NextRequest) {
       results.printHistory = printHistory.length;
     }
 
+    if (sharedCatalogs.length > 0) {
+      const docs = (sharedCatalogs as Record<string, unknown>[]).map(restoreTypes);
+      await SharedCatalog.insertMany(docs, { lean: true, ordered: false });
+      results.sharedCatalogs = sharedCatalogs.length;
+    }
+
     return NextResponse.json({
       message: "Snapshot restored successfully",
       restored: results,
@@ -303,6 +338,7 @@ async function restoreSnapshot(request: NextRequest) {
         BedType.deleteMany({}),
         Location.deleteMany({}),
         PrintHistory.deleteMany({}),
+        SharedCatalog.deleteMany({}),
       ]);
       if (backupNozzles.length > 0) await Nozzle.insertMany(backupNozzles, { ordered: false });
       if (backupPrinters.length > 0) await Printer.insertMany(backupPrinters, { ordered: false });
@@ -310,6 +346,7 @@ async function restoreSnapshot(request: NextRequest) {
       if (backupLocations.length > 0) await Location.insertMany(backupLocations, { ordered: false });
       if (backupFilaments.length > 0) await Filament.insertMany(backupFilaments, { ordered: false });
       if (backupPrintHistory.length > 0) await PrintHistory.insertMany(backupPrintHistory, { ordered: false });
+      if (backupSharedCatalogs.length > 0) await SharedCatalog.insertMany(backupSharedCatalogs, { ordered: false });
     } catch (rollbackErr) {
       // Rollback itself failed — report it so the user knows data may be lost
       const detail = err instanceof Error ? err.message : String(err);

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -160,7 +160,8 @@ describe("snapshot route — bedTypes round-trip", () => {
     expect(body.restored.sharedCatalogs).toBe(1);
 
     const restored = await SharedCatalog.findOne({ slug: "test-share-abc123" }).lean();
-    expect(restored).toBeTruthy();
+    expect(restored).not.toBeNull();
+    if (!restored) throw new Error("unreachable — guarded by expect above");
     expect(restored.title).toBe("Shareable PLA");
     expect(restored.viewCount).toBe(7);
     expect(String(restored._id)).toBe(String(seed._id));

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -113,6 +113,91 @@ describe("snapshot route — bedTypes round-trip", () => {
     expect(bedTypes).toHaveLength(0);
   });
 
+  /**
+   * GH #158 regression guard.
+   *
+   * Pre-fix the snapshot payload deliberately excluded SharedCatalog —
+   * but /api/snapshot/delete (the danger-zone wipe) DID clear it. So a
+   * snapshot → delete-all → restore round-trip silently dropped every
+   * published share link. The fix makes the snapshot symmetric with
+   * the delete: SharedCatalog is now part of the export and restore.
+   */
+  it("snapshot/restore round-trip preserves SharedCatalog (GH #158)", async () => {
+    // Re-register SharedCatalog model after the per-test wipe.
+    delete mongoose.models.SharedCatalog;
+    const SharedCatalog = (await import("@/models/SharedCatalog")).default;
+
+    // Seed a published catalog
+    const seed = await SharedCatalog.create({
+      slug: "test-share-abc123",
+      title: "Shareable PLA",
+      description: "A test share",
+      payload: { version: 1, createdAt: new Date().toISOString(), filaments: [{ name: "X" }], nozzles: [], printers: [], bedTypes: [] },
+      viewCount: 7,
+    });
+
+    // Export
+    const exportRes = await GET();
+    const snapshot = JSON.parse(await exportRes.text());
+    expect(snapshot.version).toBeGreaterThanOrEqual(4);
+    expect(Array.isArray(snapshot.collections.sharedCatalogs)).toBe(true);
+    expect(snapshot.collections.sharedCatalogs).toHaveLength(1);
+    expect(snapshot.collections.sharedCatalogs[0].slug).toBe("test-share-abc123");
+    expect(snapshot.collections.sharedCatalogs[0].viewCount).toBe(7);
+
+    // Wipe and restore
+    await SharedCatalog.deleteMany({});
+    expect(await SharedCatalog.countDocuments({})).toBe(0);
+
+    const req = new NextRequest("http://localhost/api/snapshot", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(snapshot),
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.restored.sharedCatalogs).toBe(1);
+
+    const restored = await SharedCatalog.findOne({ slug: "test-share-abc123" }).lean();
+    expect(restored).toBeTruthy();
+    expect(restored.title).toBe("Shareable PLA");
+    expect(restored.viewCount).toBe(7);
+    expect(String(restored._id)).toBe(String(seed._id));
+  });
+
+  it("POST restore of a snapshot without sharedCatalogs (v3 shape) leaves the collection empty (no crash)", async () => {
+    delete mongoose.models.SharedCatalog;
+    const SharedCatalog = (await import("@/models/SharedCatalog")).default;
+    await SharedCatalog.create({
+      slug: "pre-restore-share",
+      title: "Pre-restore",
+      description: "",
+      payload: { version: 1, createdAt: new Date().toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
+    });
+
+    // v3 shape — no sharedCatalogs key
+    const snapshot = {
+      version: 3,
+      createdAt: new Date().toISOString(),
+      collections: { filaments: [], nozzles: [], printers: [], bedTypes: [], locations: [], printHistory: [] },
+    };
+
+    const req = new NextRequest("http://localhost/api/snapshot", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(snapshot),
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    // No sharedCatalogs in the snapshot → collection wiped (because POST
+    // always wipes everything before restoring), and the count comes back
+    // 0 — not undefined.
+    expect(body.restored.sharedCatalogs).toBe(0);
+    expect(await SharedCatalog.countDocuments({})).toBe(0);
+  });
+
   it("POST restore preserves calibration.bedType references through ObjectId rehydration", async () => {
     // End-to-end: export a filament whose calibration references a BedType,
     // restore the snapshot, and verify the reference still resolves.


### PR DESCRIPTION
## Summary
[GET /api/snapshot](src/app/api/snapshot/route.ts) deliberately excluded SharedCatalog. But [DELETE /api/snapshot/delete](src/app/api/snapshot/delete/route.ts) (the danger-zone wipe) DID clear it. A snapshot → delete-all → restore round-trip silently dropped every published share link, with no warning.

Make snapshot symmetric with delete: SharedCatalog joins the export, restore path, rollback path, and per-collection restored counts. Bump the snapshot schema version 3 → 4 as a documentation marker — older snapshots still restore cleanly because POST destructures missing collections to `[]`.

## Camel-case key concern (non-issue, but documented)
The issue body raised a concern that `bedTypes` / `printHistory` keys (camelCase) might cause restored docs to land in parallel collections. They don't — the JSON keys are only used to look up arrays in the payload, then handed to the corresponding Mongoose model (`BedType`, `PrintHistory`, `SharedCatalog`), which maps to its real Mongo collection name (lowercase plural). The keys never reach Mongo. Added a comment in the GET handler so the next reader doesn't re-raise this.

## Test plan
- [x] `npx vitest run tests/snapshot.test.ts` — 6 passed (4 prior + 2 new GH #158 cases)
- [x] `npm run lint` — clean
- [x] New cases: round-trip preserves SharedCatalog (slug, viewCount, _id) + v3 snapshot without `sharedCatalogs` key still restores cleanly (count = 0, no crash)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)