### PR TITLE
Feat #156: move version + sync + NFC pills to common app header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,6 @@ import { useToast } from "@/components/Toast";
 import ImportAtlasDialog from "@/components/ImportAtlasDialog";
 import PrusamentImportDialog from "@/components/PrusamentImportDialog";
 import SpoolCsvImportDialog from "@/components/SpoolCsvImportDialog";
-import SyncStatusIndicator from "@/components/SyncStatusIndicator";
-import NfcStatus from "@/components/NfcStatus";
 import QuickFilterChips, { type QuickFilter } from "@/components/QuickFilterChips";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useTranslation } from "@/i18n/TranslationProvider";
@@ -693,9 +691,6 @@ export default function Home() {
         <div className="min-w-0">
           <div className="flex items-center gap-3 flex-wrap">
             <h1 className="text-3xl font-bold whitespace-nowrap">{t("filaments.title")}</h1>
-            <span className="text-sm text-gray-500 font-mono self-end mb-0.5">v{process.env.APP_VERSION}</span>
-            <SyncStatusIndicator />
-            <NfcStatus />
           </div>
         </div>
         <div className="flex gap-2 shrink-0">

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "@/i18n/TranslationProvider";
+import SyncStatusIndicator from "@/components/SyncStatusIndicator";
+import NfcStatus from "@/components/NfcStatus";
 
 const LINKS: { href: string; labelKey: string; exact?: boolean }[] = [
   { href: "/", labelKey: "common.filaments", exact: true },
@@ -49,23 +51,38 @@ export default function AppHeader() {
       <div className="max-w-7xl mx-auto px-4 h-12 flex items-center justify-between gap-3">
         <Link
           href="/"
-          className="font-semibold text-base sm:text-lg whitespace-nowrap text-gray-900 dark:text-gray-100 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+          className="flex items-baseline gap-2 whitespace-nowrap text-gray-900 dark:text-gray-100 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
         >
-          {t("filaments.title")}
+          <span className="font-semibold text-base sm:text-lg">{t("filaments.title")}</span>
+          {/* Version pill — moved out of /filaments header (GH #156) so the
+              user can see the running version on every page. APP_VERSION is
+              injected by next.config at build time from package.json. */}
+          <span className="hidden sm:inline text-[10px] font-mono text-gray-400 dark:text-gray-500">
+            v{process.env.APP_VERSION}
+          </span>
         </Link>
-        {/* Desktop nav — hidden on mobile */}
-        <nav className="hidden md:flex items-center gap-1" aria-label="Primary">
-          {LINKS.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              aria-current={isActive(link) ? "page" : undefined}
-              className={`${baseClass} ${isActive(link) ? activeClass : inactiveClass}`}
-            >
-              {t(link.labelKey)}
-            </Link>
-          ))}
-        </nav>
+        {/* Right cluster: status pills + primary nav. Status pills (Sync,
+            NFC) used to live on the /filaments page header only; moving them
+            here makes them visible on every page (GH #156). Both render to
+            null when not in Electron / not relevant. */}
+        <div className="hidden md:flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <SyncStatusIndicator />
+            <NfcStatus />
+          </div>
+          <nav className="flex items-center gap-1" aria-label="Primary">
+            {LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-current={isActive(link) ? "page" : undefined}
+                className={`${baseClass} ${isActive(link) ? activeClass : inactiveClass}`}
+              >
+                {t(link.labelKey)}
+              </Link>
+            ))}
+          </nav>
+        </div>
         {/* Mobile hamburger — hidden on ≥md */}
         <button
           type="button"


### PR DESCRIPTION
## Summary
The version label, sync-status indicator (Atlas / embedded / hybrid + last-sync timing), and NFC reader status used to live only on the `/filaments` page header. Every other page (dashboard, compare, analytics, share, settings, `/openprinttag`, `/filaments/{id}`, etc.) had no version visible at a glance and no live sync/NFC pulse — the user had to navigate back to `/` to check.

Move all three into [AppHeader](src/components/AppHeader.tsx), the persistent app shell rendered by the root layout. They render on every page now. Both status pills self-render to null when not in Electron / not relevant, so the web build is unaffected.

## Layout
- Brand link picks up an inline `v<APP_VERSION>` next to "Filament DB" (`sm:inline` so the mobile drawer brand doesn't bloat).
- Right cluster groups status pills + primary nav so they're visually paired and the nav still anchors the right edge.
- Mobile drawer behavior unchanged (status pills are `hidden md:flex`, matching the existing nav-on-mobile-is-drawer pattern).

## Verified manually against dev server (1280×600)
- `/` → page header reads only "Filament DB"; `v1.13.1` pill + `Connected` sync badge appear once in the app shell.
- `/dashboard` → same app-shell badges visible at the top.
- Page header on home no longer renders SyncStatusIndicator/NfcStatus (verified by DOM query — body has zero `v1.13` occurrences outside the AppHeader).

## Test plan
- [x] `npm run lint` — clean
- [x] Manual: home page no longer shows duplicates
- [x] Manual: dashboard / other pages now show version + sync badges

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)