### PR TITLE
Fix #176: ASAR-bundle standalone server + window-show safety net

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,7 +9,20 @@ directories:
 
 icon: assets/icon.png
 
-asar: false
+# Bundle the standalone Next.js server + node_modules into an ASAR archive.
+# The standalone bundle is thousands of small JS files; without ASAR the
+# NSIS installer extracts each one individually and Windows Defender real-
+# time-scans every file, producing the multi-minute install stall users
+# reported in GH #176. ASAR collapses them into one opaque archive that
+# copies in a single I/O burst and is opaque to per-file AV scanning.
+#
+# .node native binaries cannot be loaded from inside an ASAR archive — they
+# must live on disk so dlopen()/LoadLibrary() can mmap them. Unpack them
+# explicitly so Electron's asar shim transparently rewrites paths to the
+# unpacked copy at runtime.
+asar: true
+asarUnpack:
+  - "**/*.node"
 npmRebuild: false
 
 files:

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,11 +1,34 @@
 import { app, BrowserWindow, Menu, ipcMain, dialog, utilityProcess, UtilityProcess, shell, session } from "electron";
 import path from "path";
+import fs from "fs";
 import Store from "electron-store";
 import http from "http";
 import { NfcService } from "./nfc-service";
 import { startLocalMongo, stopLocalMongo } from "./local-mongo";
 import { SyncService, SyncStatus, getDbNameFromUri } from "./sync-service";
 import { initAutoUpdater } from "./auto-updater";
+
+// ── Diagnostic log ──
+// Writes lifecycle and crash events to a file in userData so users on
+// machines where the window never appears (GH #176) can attach a log
+// instead of guessing at console output they can't see. Best-effort only —
+// never throws, never blocks startup. Entries are also mirrored to
+// console.log for the dev workflow.
+const LOG_PATH = path.join(app.getPath("userData"), "logs", "main.log");
+let logStream: fs.WriteStream | null = null;
+function diag(message: string) {
+  console.log(`[diag] ${message}`);
+  try {
+    if (!logStream) {
+      fs.mkdirSync(path.dirname(LOG_PATH), { recursive: true });
+      logStream = fs.createWriteStream(LOG_PATH, { flags: "a" });
+    }
+    logStream.write(`[${new Date().toISOString()}] ${message}\n`);
+  } catch {
+    // best-effort; the logger must never become a startup blocker
+  }
+}
+diag(`startup: pid=${process.pid} platform=${process.platform} version=${app.getVersion()} packaged=${app.isPackaged}`);
 
 export type ConnectionMode = "atlas" | "offline" | "hybrid";
 
@@ -44,6 +67,7 @@ const PORT = parseInt(process.env.PORT || "3456", 10);
 // before quitting so the user knows why nothing appeared.
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
+  diag("single-instance lock denied — another instance owns it; quitting");
   // showErrorBox is synchronous and works before app.whenReady, unlike
   // the regular dialog.show APIs. Keep the message short — the user
   // hasn't even seen a window yet.
@@ -55,6 +79,7 @@ if (!gotTheLock) {
   );
   app.quit();
 } else {
+  diag("single-instance lock acquired");
 
 app.on("second-instance", () => {
   if (mainWindow) {
@@ -73,7 +98,18 @@ function getAppURL(urlPath = "/") {
   return `http://localhost:${PORT}${urlPath}`;
 }
 
+/** Hard cap on how long we'll wait for `ready-to-show` before forcing the
+ * window visible. The point of the safety net is GH #176: users on Windows
+ * with KB5083631 / strict Defender / SAC report the process running with
+ * no visible window. If the renderer hangs (load blocked, GPU process
+ * crashed mid-paint, server slow to respond), we'd rather show a blank
+ * window the user can interact with than leave a phantom background
+ * process. Must be longer than the realistic startup time on a cold
+ * Windows install with Defender scanning every file. */
+const WINDOW_SHOW_TIMEOUT_MS = 20_000;
+
 function createWindow(urlPath = "/") {
+  diag(`createWindow: urlPath=${urlPath}`);
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -81,11 +117,45 @@ function createWindow(urlPath = "/") {
     minHeight: 600,
     title: "Filament DB",
     icon: path.join(__dirname, "..", "assets", "icon.png"),
+    // Defer paint until the renderer reports ready-to-show (or the
+    // safety-net timeout fires). Without this, a window flash of unstyled
+    // content can occur on slow first loads, AND — more importantly for
+    // GH #176 — there's no path to recover if the renderer never reaches
+    // a visible state on its own.
+    show: false,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
     },
+  });
+
+  mainWindow.once("ready-to-show", () => {
+    diag("ready-to-show — showing window");
+    mainWindow?.show();
+  });
+
+  // Safety-net: if ready-to-show never fires (renderer hung, did-fail-load,
+  // GPU crash mid-paint), force the window visible so the user can at
+  // least see and report the failure instead of seeing nothing. GH #176.
+  setTimeout(() => {
+    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+      diag(`window-show timeout (${WINDOW_SHOW_TIMEOUT_MS}ms) — forcing show`);
+      mainWindow.show();
+    }
+  }, WINDOW_SHOW_TIMEOUT_MS);
+
+  // Surface renderer / load failures into the diagnostic log. Without
+  // these, a renderer that crashes during navigation leaves a process in
+  // Task Manager with no UI and no console anyone can read.
+  mainWindow.webContents.on("did-fail-load", (_evt, errorCode, errorDescription, validatedURL) => {
+    diag(`did-fail-load url=${validatedURL} code=${errorCode} desc=${errorDescription}`);
+  });
+  mainWindow.webContents.on("render-process-gone", (_evt, details) => {
+    diag(`render-process-gone reason=${details.reason} exitCode=${details.exitCode}`);
+  });
+  mainWindow.webContents.on("unresponsive", () => {
+    diag("renderer unresponsive");
   });
 
   mainWindow.loadURL(getAppURL(urlPath));
@@ -659,7 +729,16 @@ ipcMain.handle("nfc-format-tag", async () => {
 
 // ── App lifecycle ──
 
+// `child-process-gone` covers GPU, utility, and any other Chromium child
+// processes — useful when the new Windows graphics stack (KB5083631 era)
+// kills the GPU process and the renderer is left half-painted. Logging
+// it gives users on GH #176 something concrete to attach.
+app.on("child-process-gone", (_evt, details) => {
+  diag(`child-process-gone type=${details.type} reason=${details.reason} exitCode=${details.exitCode}`);
+});
+
 app.whenReady().then(async () => {
+  diag("app ready");
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
     callback({
       responseHeaders: {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,16 +16,35 @@ import { initAutoUpdater } from "./auto-updater";
 // console.log for the dev workflow.
 const LOG_PATH = path.join(app.getPath("userData"), "logs", "main.log");
 let logStream: fs.WriteStream | null = null;
+let loggerDisabled = false;
+function disableLogger() {
+  loggerDisabled = true;
+  if (logStream) {
+    logStream.removeAllListeners("error");
+    logStream.end();
+    logStream = null;
+  }
+}
 function diag(message: string) {
   console.log(`[diag] ${message}`);
+  if (loggerDisabled) return;
   try {
     if (!logStream) {
       fs.mkdirSync(path.dirname(LOG_PATH), { recursive: true });
-      logStream = fs.createWriteStream(LOG_PATH, { flags: "a" });
+      const stream = fs.createWriteStream(LOG_PATH, { flags: "a" });
+      // WriteStream errors (perm-denied on roaming profile, AV file lock,
+      // disk-full mid-write) emit asynchronously on the stream; without a
+      // listener Node treats them as uncaught and would kill the main
+      // process — exactly the failure mode the logger is supposed to
+      // help debug, not cause. Absorb and disable further writes.
+      stream.on("error", disableLogger);
+      logStream = stream;
     }
     logStream.write(`[${new Date().toISOString()}] ${message}\n`);
   } catch {
-    // best-effort; the logger must never become a startup blocker
+    // Sync errors (mkdirSync, createWriteStream throwing on bad path,
+    // write() back-pressure rejection) — same policy: stop trying.
+    disableLogger();
   }
 }
 diag(`startup: pid=${process.pid} platform=${process.platform} version=${app.getVersion()} packaged=${app.isPackaged}`);


### PR DESCRIPTION
## Summary

Two-pronged fix for [#176](https://github.com/hyiger/filament-db/issues/176) — slow Windows install AND "process runs but no window appears" — based on the user reports from @tonysurma and @GLAFEBE6.

### 1. `asar: true` + `asarUnpack: ["**/*.node"]` (`electron-builder.yml`)

Tony correctly diagnosed the slow-install root cause: "many, many little js files." The standalone Next.js bundle has thousands of tiny JS files; with `asar: false`, NSIS extracts each one individually and Windows Defender real-time-scans every file as it lands. ASAR collapses them into one archive that copies in a single I/O burst and is opaque to per-file AV scanning. `.node` binaries are unpacked because `dlopen()`/`LoadLibrary()` can't mmap from inside an ASAR archive — electron's asar shim transparently rewrites paths to the unpacked copy at runtime.

### 2. Window-show safety net + diagnostic log (`electron/main.ts`)

Today the window is created with default `show: true` and `loadURL` fires immediately. If the renderer hangs (KB5083631 GPU driver regression, Defender holding files, server slow to respond), there's no recovery — the user sees a phantom background process. New behavior:

- `show: false` + `ready-to-show` — paints when the renderer says it's ready (also kills FOUC).
- 20s safety-net timeout that forces the window visible even if `ready-to-show` never fires. A blank window the user can interact with beats nothing.
- Diagnostic log at `userData/logs/main.log` capturing: startup info, lock acquire/deny, `createWindow` entry, `did-fail-load`, `render-process-gone`, `unresponsive`, `child-process-gone` (covers GPU + utility process crashes). Best-effort writer that never throws — gives us real data when the next user reports this instead of "what does Task Manager show".

## Out of scope

Code signing the Windows binary was the medium-term recommendation in the issue analysis but is **not** part of this PR (per maintainer decision — paid certs aren't on the table). The diagnostic log will tell us whether SAC / Defender suspension is actually what's hitting users post-KB5083631; if so, free options like SignPath OSS sponsorship or self-signed-with-SmartScreen-rep-building can be revisited later.

## Test plan

- [x] `npm run lint` — passes (5 pre-existing warnings, none from changed files)
- [x] `npm test` — 994/994 passing (51 files)
- [x] `npm run electron:compile` — clean
- [x] `npm run build` — Next.js production build clean
- [ ] **Smoke test on Windows after CI builds the installer:**
  - [ ] Verify install time vs. v1.14.1 on a clean Windows 11 VM with Defender enabled
  - [ ] Verify NFC reader still works (ensures `asarUnpack` correctly exposed `pcsclite.node`)
  - [ ] Verify `userData\logs\main.log` is written and contains lifecycle entries
  - [ ] Verify window appears within ~20s on cold first run

If `asarUnpack: ["**/*.node"]` turns out to need a more specific glob for `mongodb-memory-server-core`'s downloaded mongod binary, that's a fast follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)