### PR TITLE
GH #89: widen type-stats label to fit "PLA Tough"

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,7 +80,10 @@ function FilamentStats({ filaments }: { filaments: Filament[] }) {
         <div className="space-y-1.5">
           {byType.map(([type, count]) => (
             <div key={type} className="flex items-center gap-2 text-sm">
-              <span className="w-16 truncate text-gray-600 dark:text-gray-300 font-medium">{type}</span>
+              {/* w-24 matches the vendor row below (was w-16, which clipped
+                  "PLA Tough" to "PLA TO…" — GH #89). title= is the
+                  fallback for any type name that still exceeds 96px. */}
+              <span title={type} className="w-24 truncate text-gray-600 dark:text-gray-300 font-medium">{type}</span>
               <div className="flex-1 bg-gray-200 dark:bg-gray-800 rounded-full h-3">
                 <div
                   className="h-3 rounded-full bg-blue-500"
@@ -99,7 +102,7 @@ function FilamentStats({ filaments }: { filaments: Filament[] }) {
         <div className="space-y-1.5">
           {byVendor.map(([vendor, count]) => (
             <div key={vendor} className="flex items-center gap-2 text-sm">
-              <span className="w-24 truncate text-gray-600 dark:text-gray-300 font-medium">{vendor}</span>
+              <span title={vendor} className="w-24 truncate text-gray-600 dark:text-gray-300 font-medium">{vendor}</span>
               <div className="flex-1 bg-gray-200 dark:bg-gray-800 rounded-full h-3">
                 <div
                   className="h-3 rounded-full bg-amber-500"


### PR DESCRIPTION
## Summary

The April fixes for [#89](https://github.com/hyiger/filament-db/issues/89) (v1.9.1, v1.10.1) widened the **table** name column, but @jandslay's screenshots throughout the thread have actually been showing the **stats panel** above the table — specifically the by-type bar chart. \"PLA Tough\" was clipping to \"PLA TO…\" because the type label is `w-16` (64px) with `truncate`.

## Change

[src/app/page.tsx:83](src/app/page.tsx#L83) — bump `w-16` → `w-24` to match the vendor row below it (which renders \"Material4Print\" without issue) and add `title={type}` so any future type name longer than 96px still hover-reveals. Same `title=` treatment added to the vendor row below for consistency.

Two-line presentational change. No tests affected.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 994/994 passing
- [ ] Visual: stats panel renders \"PLA Tough\" without truncation, vendor row hover reveals long names
- [ ] @jandslay confirms before this issue is closed

Issue intentionally referenced as `GH #89` (not `Fix #89`) so it stays open until @jandslay confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)