### PR TITLE
v1.14.3 hotfix: revert asar — broke embedded server in v1.14.2

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,20 +9,17 @@ directories:
 
 icon: assets/icon.png
 
-# Bundle the standalone Next.js server + node_modules into an ASAR archive.
-# The standalone bundle is thousands of small JS files; without ASAR the
-# NSIS installer extracts each one individually and Windows Defender real-
-# time-scans every file, producing the multi-minute install stall users
-# reported in GH #176. ASAR collapses them into one opaque archive that
-# copies in a single I/O burst and is opaque to per-file AV scanning.
-#
-# .node native binaries cannot be loaded from inside an ASAR archive — they
-# must live on disk so dlopen()/LoadLibrary() can mmap them. Unpack them
-# explicitly so Electron's asar shim transparently rewrites paths to the
-# unpacked copy at runtime.
-asar: true
-asarUnpack:
-  - "**/*.node"
+# asar disabled — v1.14.2 attempted asar:true to fix the slow Windows
+# install (GH #176 install stall) but the embedded server's utility
+# process exited with code 1 during module load. Likely cause: sharp's
+# bundled .node binary, built for Node's ABI by `npm install`, fails to
+# load in Electron's Node runtime when paired with `npmRebuild: false`,
+# OR a path-resolution lookup escapes the asar shim. Either way, asar
+# needs more investigation before we attempt it again — the server
+# stdio capture added in electron/main.ts will log the actual exception
+# next time. Slow install returns until we have a working asar config;
+# that's preferable to an app that doesn't start.
+asar: false
 npmRebuild: false
 
 files:

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -373,20 +373,34 @@ async function startProductionServer(mongoUri?: string): Promise<void> {
       serviceName: "next-server",
     });
 
+    // Mirror server output into the diag log too — when the utility
+    // process dies during module load (as it did under v1.14.2's asar
+    // packaging), the stack trace lands on stderr and we want it
+    // captured alongside the lifecycle events for support reports.
     serverProcess.stdout?.on("data", (data: Buffer) => {
-      console.log("Server:", data.toString().trim());
+      const text = data.toString().trim();
+      if (text) {
+        console.log("Server:", text);
+        diag(`server.stdout: ${text}`);
+      }
     });
 
     serverProcess.stderr?.on("data", (data: Buffer) => {
-      console.error("Server error:", data.toString().trim());
+      const text = data.toString().trim();
+      if (text) {
+        console.error("Server error:", text);
+        diag(`server.stderr: ${text}`);
+      }
     });
 
     serverProcess.on("spawn", () => {
+      diag("server spawned");
       // Wait for the server to respond to HTTP requests
       waitForServer(PORT).then(resolve).catch(reject);
     });
 
     serverProcess.on("exit", (code) => {
+      diag(`server exit code=${code}`);
       if (code !== 0) {
         reject(new Error(`Server exited with code ${code}`));
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",


### PR DESCRIPTION
## What broke

The asar packaging shipped in v1.14.2 ([PR #179](https://github.com/hyiger/filament-db/pull/179)) caused the standalone server's utility process to exit with code 1 immediately on spawn. Users see a \"Server Startup Failed / Server exited with code 1\" dialog and the app is unusable.

Confirmed by the diagnostic log from a real install:

\`\`\`
[20:16:10.804] createWindow: urlPath=/
[20:16:10.928] child-process-gone type=Utility reason=killed exitCode=1
[20:16:13.649] did-fail-load url=http://localhost:3456/ code=-102 desc=ERR_CONNECTION_REFUSED
\`\`\`

The standalone bundle ships sharp's \`.node\` binary built for Node's ABI (we have \`npmRebuild: false\`), which most likely fails to load under Electron's Node runtime when wrapped in asar. We don't have hard proof of the exact stack because the server's stderr wasn't being captured into the diag log — only the lifecycle events from the main process were.

## Changes

1. **\`asar: false\` again** ([electron-builder.yml](electron-builder.yml)). Slow Windows install returns. Preferable to a release that doesn't start.
2. **Server stdio piped into the diag log** ([electron/main.ts](electron/main.ts) — \`startProductionServer\`). \`server.stdout\` / \`server.stderr\` / \`server spawned\` / \`server exit\` events now write to \`userData/logs/main.log\`, so the next asar attempt can be diagnosed instead of guessed at.
3. **Version bump** to 1.14.3 — necessary so the auto-updater on v1.14.2 actually pulls the corrected build (overwriting v1.14.2 in place wouldn't trigger any client to re-download).

The window-show safety net and lifecycle diagnostics from PR #179 stay in place; they're net-positive on their own and not implicated in the regression.

## Test plan

- [x] \`npm run electron:compile\` — clean
- [x] \`npm test\` — 994/994
- [ ] Smoke test on Windows after CI artifacts land — confirm server actually reaches \"listening on 3456\"
- [ ] @tonysurma / @GLAFEBE6 — confirm app starts again

🤖 Generated with [Claude Code](https://claude.com/claude-code)