### PR TITLE
Fix #182: subtract empty-spool weight from inventory totals

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -50,6 +50,16 @@ export async function GET() {
       threshold: number;
     }[] = [];
 
+    // Build a parentMap up front — variants intentionally inherit
+    // `spoolWeight` from their parent (see src/lib/resolveFilament.ts),
+    // so subtracting only the variant's own field treats the inherited
+    // case as 0 and re-introduces the GH #182 over-reporting for every
+    // variant. Codex P1 on PR #190.
+    const parentMap = new Map<string, (typeof filaments)[number]>();
+    for (const f of filaments) {
+      if (!f.parentId) parentMap.set(f._id.toString(), f);
+    }
+
     for (const f of filaments) {
       let remaining = 0;
       // Subtracting the empty-spool weight is the bit GH #182 was about:
@@ -58,7 +68,13 @@ export async function GET() {
       // raw scale value, which inflated `totalGrams` by one empty-spool
       // mass per tracked spool and let low-stock alerts hide while the
       // gross weight still cleared the threshold.
-      const spoolMass = typeof f.spoolWeight === "number" ? f.spoolWeight : 0;
+      //
+      // Resolve the parent's spoolWeight when the variant's is null so
+      // inherited values are honoured.
+      const ownMass = typeof f.spoolWeight === "number" ? f.spoolWeight : null;
+      const parent = f.parentId ? parentMap.get(f.parentId.toString()) : undefined;
+      const inheritedMass = parent && typeof parent.spoolWeight === "number" ? parent.spoolWeight : 0;
+      const spoolMass = ownMass ?? inheritedMass;
       for (const s of f.spools || []) {
         if (s.retired) {
           retiredSpools++;
@@ -90,11 +106,7 @@ export async function GET() {
     // filament needs drying. A variant with no own dryingTemperature must
     // inherit from its parent; pre-v1.12.5 this branch only checked the
     // variant's own field, so child filaments with inherited drying values
-    // were silently skipped (GH #133).
-    const parentMap = new Map<string, (typeof filaments)[number]>();
-    for (const f of filaments) {
-      if (!f.parentId) parentMap.set(f._id.toString(), f);
-    }
+    // were silently skipped (GH #133). Reuses the parentMap built above.
     const now = Date.now();
     const dryThresholdMs = 30 * 24 * 60 * 60 * 1000;
     const dryDue: {

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -52,6 +52,13 @@ export async function GET() {
 
     for (const f of filaments) {
       let remaining = 0;
+      // Subtracting the empty-spool weight is the bit GH #182 was about:
+      // `spool.totalWeight` is the live scale reading (filament + empty
+      // spool), not remaining filament. Pre-fix the dashboard summed the
+      // raw scale value, which inflated `totalGrams` by one empty-spool
+      // mass per tracked spool and let low-stock alerts hide while the
+      // gross weight still cleared the threshold.
+      const spoolMass = typeof f.spoolWeight === "number" ? f.spoolWeight : 0;
       for (const s of f.spools || []) {
         if (s.retired) {
           retiredSpools++;
@@ -59,7 +66,7 @@ export async function GET() {
         }
         spoolCount++;
         if (typeof s.totalWeight === "number") {
-          remaining += s.totalWeight;
+          remaining += Math.max(0, s.totalWeight - spoolMass);
         }
       }
       totalGrams += remaining;

--- a/src/app/api/filaments/compare/route.ts
+++ b/src/app/api/filaments/compare/route.ts
@@ -12,6 +12,14 @@ import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
  *
  * Returns populated calibration refs so the UI can render printer/nozzle/
  * bedType names directly.
+ *
+ * GH #182 / Codex P2 on PR #190: variants commonly store
+ * `spoolWeight: null` and inherit from their parent. Resolve the inherited
+ * value here so the compare page's "On hand" math (which subtracts
+ * spoolWeight from each spool's totalWeight) doesn't fall through to 0
+ * for inherited cases. A future broader-resolution change (#184) will
+ * resolve every inheritable field; this PR scopes the fix to the field
+ * the on-hand math needs.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -38,9 +46,35 @@ export async function GET(request: NextRequest) {
       .populate("calibrations.bedType")
       .lean();
 
+    // Resolve inherited spoolWeight for any variant whose own field is null.
+    // One batched fetch covers every parent in the result set.
+    const parentIds = Array.from(
+      new Set(
+        filaments
+          .filter((f) => f.parentId && (f.spoolWeight === null || f.spoolWeight === undefined))
+          .map((f) => String(f.parentId)),
+      ),
+    );
+    const parentSpoolWeights = parentIds.length
+      ? new Map(
+          (
+            await Filament.find({ _id: { $in: parentIds } })
+              .select("spoolWeight")
+              .lean()
+          ).map((p) => [String(p._id), p.spoolWeight ?? null]),
+        )
+      : new Map<string, number | null>();
+
+    const resolved = filaments.map((f) => {
+      if (f.spoolWeight !== null && f.spoolWeight !== undefined) return f;
+      if (!f.parentId) return f;
+      const inherited = parentSpoolWeights.get(String(f.parentId));
+      return inherited != null ? { ...f, spoolWeight: inherited } : f;
+    });
+
     // Return in the same order the caller requested so the UI's columns
     // match the incoming list.
-    const byId = new Map(filaments.map((f) => [String(f._id), f]));
+    const byId = new Map(resolved.map((f) => [String(f._id), f]));
     const ordered = ids.map((id) => byId.get(id)).filter(Boolean);
 
     return NextResponse.json(ordered);

--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -25,13 +25,30 @@ export async function GET(request: NextRequest) {
     // without the client having to re-query filaments. Uses a single
     // aggregation over Filament.spools since spools are embedded.
     //
-    // GH #182: subtract the parent filament's `spoolWeight` from each
+    // GH #182: subtract the filament's effective `spoolWeight` from each
     // spool's `totalWeight` (clamped at 0) so the per-location grams
     // figure reports remaining filament, not the gross scale reading.
-    // Without it, a location with N spools would over-report inventory
-    // by N × empty-spool-mass.
+    // Without it, a location with N spools over-reports inventory by
+    // N × empty-spool-mass.
+    //
+    // Codex P2 on PR #190: `spoolWeight` is inheritable — variants commonly
+    // store null and inherit from their parent. Use $lookup to resolve the
+    // parent's value when the variant's is null, then $ifNull-chain
+    // (variant own → parent → 0) inside the subtract.
     const counts = await Filament.aggregate([
       { $match: { _deletedAt: null } },
+      // Pull the parent doc (if any) so we can resolve inherited spoolWeight.
+      // Variants without a parentId get an empty array; the $arrayElemAt
+      // below safely returns null for the inherited fallback.
+      {
+        $lookup: {
+          from: "filaments",
+          localField: "parentId",
+          foreignField: "_id",
+          as: "_parent",
+          pipeline: [{ $project: { spoolWeight: 1 } }],
+        },
+      },
       { $unwind: "$spools" },
       { $match: { "spools.retired": { $ne: true }, "spools.locationId": { $ne: null } } },
       {
@@ -45,7 +62,12 @@ export async function GET(request: NextRequest) {
                 {
                   $subtract: [
                     { $ifNull: ["$spools.totalWeight", 0] },
-                    { $ifNull: ["$spoolWeight", 0] },
+                    {
+                      $ifNull: [
+                        "$spoolWeight",
+                        { $ifNull: [{ $arrayElemAt: ["$_parent.spoolWeight", 0] }, 0] },
+                      ],
+                    },
                   ],
                 },
               ],

--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -24,6 +24,12 @@ export async function GET(request: NextRequest) {
     // Attach spool counts per location so the list page can show "N spools"
     // without the client having to re-query filaments. Uses a single
     // aggregation over Filament.spools since spools are embedded.
+    //
+    // GH #182: subtract the parent filament's `spoolWeight` from each
+    // spool's `totalWeight` (clamped at 0) so the per-location grams
+    // figure reports remaining filament, not the gross scale reading.
+    // Without it, a location with N spools would over-report inventory
+    // by N × empty-spool-mass.
     const counts = await Filament.aggregate([
       { $match: { _deletedAt: null } },
       { $unwind: "$spools" },
@@ -32,7 +38,19 @@ export async function GET(request: NextRequest) {
         $group: {
           _id: "$spools.locationId",
           spoolCount: { $sum: 1 },
-          totalGrams: { $sum: { $ifNull: ["$spools.totalWeight", 0] } },
+          totalGrams: {
+            $sum: {
+              $max: [
+                0,
+                {
+                  $subtract: [
+                    { $ifNull: ["$spools.totalWeight", 0] },
+                    { $ifNull: ["$spoolWeight", 0] },
+                  ],
+                },
+              ],
+            },
+          },
         },
       },
     ]);

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -40,6 +40,7 @@ interface CompareFilament {
   minPrintSpeed: number | null;
   maxPrintSpeed: number | null;
   spools: { totalWeight: number | null; retired?: boolean }[];
+  spoolWeight: number | null;
 }
 
 export default function ComparePage() {
@@ -108,10 +109,17 @@ function ComparePageInner() {
 
   const totalGrams = useMemo(() => {
     return comparison.map((f) => {
+      // GH #182: subtract the empty-spool weight so the "On hand" row
+      // reports remaining filament, not the gross scale reading. The
+      // pre-fix sum was inflated by one empty-spool mass per tracked
+      // spool — same root cause as the dashboard / locations totals.
+      const spoolMass = typeof f.spoolWeight === "number" ? f.spoolWeight : 0;
       let grams = 0;
       for (const s of f.spools || []) {
         if (s.retired) continue;
-        if (typeof s.totalWeight === "number") grams += s.totalWeight;
+        if (typeof s.totalWeight === "number") {
+          grams += Math.max(0, s.totalWeight - spoolMass);
+        }
       }
       return grams;
     });

--- a/tests/compare-route-spoolweight.test.ts
+++ b/tests/compare-route-spoolweight.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as compareFilaments } from "@/app/api/filaments/compare/route";
+
+/**
+ * Codex P2 on PR #190: the GH #182 fix (subtract empty-spool mass from
+ * inventory totals) used the variant's own `spoolWeight` only. Variants
+ * commonly store `spoolWeight: null` and inherit it from the parent (see
+ * src/lib/resolveFilament.ts), so the original over-reporting bug stayed
+ * in place for variant spools on the compare page's "On hand" row.
+ *
+ * The compare API now resolves the parent's spoolWeight inline when the
+ * variant's is null. This test asserts that resolution works end-to-end:
+ * the body for a variant carries the inherited spoolWeight so the page's
+ * `f.spoolWeight ?? 0` math gives the right remaining grams.
+ */
+describe("/api/filaments/compare — inherited spoolWeight (Codex P2 PR #190)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    for (const name of ["Nozzle", "Printer", "BedType"] as const) {
+      if (!mongoose.models[name]) {
+        const mod = await import(`@/models/${name}`);
+        mongoose.model(name, mod.default.schema);
+      }
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  function req(ids: string[]) {
+    return new NextRequest(`http://localhost/api/filaments/compare?ids=${ids.join(",")}`);
+  }
+
+  it("variant body carries the inherited spoolWeight from its parent", async () => {
+    const parent = await Filament.create({
+      name: "Inherit-Parent",
+      vendor: "V",
+      type: "PLA",
+      spoolWeight: 250,
+    });
+    const variant = await Filament.create({
+      name: "Inherit-Variant",
+      vendor: "V",
+      type: "PLA",
+      color: "#0a0a0a",
+      parentId: parent._id,
+      // spoolWeight intentionally omitted — inherit.
+      spools: [{ label: "v1", totalWeight: 1000 }],
+    });
+
+    const res = await compareFilaments(req([String(variant._id)]));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].spoolWeight).toBe(250);
+  });
+
+  it("explicit variant spoolWeight wins over the parent's value", async () => {
+    const parent = await Filament.create({
+      name: "Override-Parent",
+      vendor: "V",
+      type: "PLA",
+      spoolWeight: 250,
+    });
+    const variant = await Filament.create({
+      name: "Override-Variant",
+      vendor: "V",
+      type: "PLA",
+      color: "#fff",
+      parentId: parent._id,
+      spoolWeight: 300,
+    });
+
+    const res = await compareFilaments(req([String(variant._id)]));
+    const body = await res.json();
+    expect(body[0].spoolWeight).toBe(300);
+  });
+
+  it("non-variant filament passes through unchanged", async () => {
+    const standalone = await Filament.create({
+      name: "Solo",
+      vendor: "V",
+      type: "PLA",
+      spoolWeight: 200,
+    });
+    const res = await compareFilaments(req([String(standalone._id)]));
+    const body = await res.json();
+    expect(body[0].spoolWeight).toBe(200);
+  });
+
+  it("variant with no parent.spoolWeight either falls back to null (renderer treats as 0)", async () => {
+    const parent = await Filament.create({ name: "PNP", vendor: "V", type: "PLA" });
+    const variant = await Filament.create({
+      name: "VNP",
+      vendor: "V",
+      type: "PLA",
+      color: "#fff",
+      parentId: parent._id,
+    });
+    const res = await compareFilaments(req([String(variant._id)]));
+    const body = await res.json();
+    // Neither set ⇒ null; the page treats null as 0 in the on-hand math.
+    expect(body[0].spoolWeight).toBeNull();
+  });
+});

--- a/tests/dashboard-route.test.ts
+++ b/tests/dashboard-route.test.ts
@@ -189,3 +189,98 @@ describe("/api/dashboard — counts.spools is active-only (excludes retired)", (
     expect(body.counts.totalSpools).toBe(2);
   });
 });
+
+/**
+ * GH #182 regression guard.
+ *
+ * `spool.totalWeight` is the live scale reading (filament + empty spool),
+ * not remaining filament. Pre-fix the dashboard's `totalGrams` and
+ * low-stock check summed the raw scale value, which inflated inventory
+ * by one empty-spool mass per tracked spool and let low-stock alerts
+ * hide while the gross weight still cleared the threshold.
+ */
+describe("/api/dashboard — totalGrams + low-stock subtract empty-spool mass (GH #182)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  it("totalGrams sums (totalWeight − spoolWeight) per spool, clamped at 0", async () => {
+    // Two spools at 1000g scale, 250g empty-spool mass → 750g remaining each
+    // ⇒ totalGrams should be 1500, NOT the raw 2000.
+    await Filament.create({
+      name: "PLA",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 250,
+      netFilamentWeight: 1000,
+      spools: [
+        { label: "A", totalWeight: 1000 },
+        { label: "B", totalWeight: 1000 },
+      ],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+    expect(body.totalGrams).toBe(1500);
+  });
+
+  it("a spool whose scale reading is below the empty-spool weight clamps to 0 (no negative)", async () => {
+    // totalWeight=200 with spoolWeight=250 means the scale is below the
+    // empty mass — should contribute 0 (not -50) to totalGrams.
+    await Filament.create({
+      name: "Empty PLA",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 250,
+      netFilamentWeight: 1000,
+      spools: [{ label: "almost-empty", totalWeight: 200 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+    expect(body.totalGrams).toBe(0);
+  });
+
+  it("low-stock check uses remaining filament, so a high-gross / low-net spool surfaces", async () => {
+    // 600g gross with 500g empty-spool mass = 100g remaining. Threshold
+    // 200 → should be flagged as low stock. Pre-fix the check compared
+    // 600 < 200 (false) and the warning was hidden.
+    const f = await Filament.create({
+      name: "Almost Empty PLA",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 500,
+      netFilamentWeight: 1000,
+      lowStockThreshold: 200,
+      spools: [{ label: "low", totalWeight: 600 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+    const ids = (body.lowStock as { _id: string }[]).map((x) => x._id);
+    expect(ids).toContain(String(f._id));
+    const entry = (body.lowStock as { _id: string; remainingGrams: number }[]).find((x) => x._id === String(f._id));
+    expect(entry?.remainingGrams).toBe(100);
+  });
+
+  it("a filament with no spoolWeight defaults to subtracting 0 (back-compat for legacy docs)", async () => {
+    await Filament.create({
+      name: "Legacy",
+      vendor: "Test",
+      type: "PLA",
+      // spoolWeight intentionally omitted (undefined / null)
+      spools: [{ label: "X", totalWeight: 1000 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+    expect(body.totalGrams).toBe(1000);
+  });
+});

--- a/tests/dashboard-route.test.ts
+++ b/tests/dashboard-route.test.ts
@@ -283,4 +283,56 @@ describe("/api/dashboard — totalGrams + low-stock subtract empty-spool mass (G
     const body = await res.json();
     expect(body.totalGrams).toBe(1000);
   });
+
+  it("a variant inherits spoolWeight from its parent (Codex P1 PR #190)", async () => {
+    // Parent has spoolWeight=250; variant leaves it null. Pre-Codex-fix the
+    // dashboard treated the variant's null as 0 and contributed the full
+    // gross weight (1000) to totalGrams, re-introducing the original bug.
+    const parent = await Filament.create({
+      name: "Parent PLA",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 250,
+      netFilamentWeight: 1000,
+    });
+    await Filament.create({
+      name: "Variant Galaxy Black",
+      vendor: "Test",
+      type: "PLA",
+      color: "#1a1a2e",
+      parentId: parent._id,
+      // spoolWeight + netFilamentWeight intentionally omitted — inherit.
+      spools: [{ label: "v1", totalWeight: 1000 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+    // Variant should contribute (1000 - 250) = 750, NOT 1000.
+    expect(body.totalGrams).toBe(750);
+  });
+
+  it("low-stock alert fires for a variant whose remaining (after inherited spoolWeight) is below threshold", async () => {
+    const parent = await Filament.create({
+      name: "LS Parent",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 500,
+      netFilamentWeight: 1000,
+    });
+    const variant = await Filament.create({
+      name: "LS Variant",
+      vendor: "Test",
+      type: "PLA",
+      color: "#fff",
+      parentId: parent._id,
+      lowStockThreshold: 200,
+      // 600 - inherited 500 = 100 remaining → below threshold 200.
+      spools: [{ label: "low", totalWeight: 600 }],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+    const ids = (body.lowStock as { _id: string }[]).map((x) => x._id);
+    expect(ids).toContain(String(variant._id));
+  });
 });

--- a/tests/locations-route.test.ts
+++ b/tests/locations-route.test.ts
@@ -129,6 +129,53 @@ describe("/api/locations", () => {
       expect(stats.spoolCount).toBe(2);
       expect(stats.totalGrams).toBe(800);
     });
+
+    it("totalGrams subtracts the parent filament's spoolWeight per spool (GH #182)", async () => {
+      // Same gross weights as the test above but with spoolWeight=250 set on
+      // the filament. Expected remaining = (500-250) + (300-250) = 300.
+      // Pre-fix the aggregation summed the raw scale value (800), which
+      // over-reported by N × empty-spool mass per location.
+      const loc = await Location.create({ name: "Drybox A", kind: "drybox" });
+      await Filament.create({
+        name: "Per-spool-mass Test",
+        vendor: "Test",
+        type: "PLA",
+        spoolWeight: 250,
+        netFilamentWeight: 1000,
+        spools: [
+          { label: "", totalWeight: 500, locationId: loc._id, retired: false },
+          { label: "", totalWeight: 300, locationId: loc._id, retired: false },
+        ],
+      });
+
+      const res = await listLocations(jsonReq("http://localhost/api/locations?stats=true"));
+      const body = await res.json();
+      const stats = body.find((l: { name: string }) => l.name === "Drybox A");
+      expect(stats.spoolCount).toBe(2);
+      expect(stats.totalGrams).toBe(300);
+    });
+
+    it("spool below empty-spool weight clamps at 0 — no negative grams (GH #182)", async () => {
+      const loc = await Location.create({ name: "Drybox B", kind: "drybox" });
+      await Filament.create({
+        name: "Underweight Test",
+        vendor: "Test",
+        type: "PLA",
+        spoolWeight: 250,
+        netFilamentWeight: 1000,
+        spools: [
+          // 200 < 250 ⇒ contributes 0, not -50
+          { label: "", totalWeight: 200, locationId: loc._id, retired: false },
+          // 1000 - 250 = 750
+          { label: "", totalWeight: 1000, locationId: loc._id, retired: false },
+        ],
+      });
+
+      const res = await listLocations(jsonReq("http://localhost/api/locations?stats=true"));
+      const body = await res.json();
+      const stats = body.find((l: { name: string }) => l.name === "Drybox B");
+      expect(stats.totalGrams).toBe(750);
+    });
   });
 
   describe("GET /api/locations/[id]", () => {

--- a/tests/locations-route.test.ts
+++ b/tests/locations-route.test.ts
@@ -176,6 +176,38 @@ describe("/api/locations", () => {
       const stats = body.find((l: { name: string }) => l.name === "Drybox B");
       expect(stats.totalGrams).toBe(750);
     });
+
+    it("variant inherits spoolWeight from parent in the location aggregation (Codex P2 PR #190)", async () => {
+      // Parent spoolWeight=250; variant inherits. Spool on the variant
+      // assigned to a location. Pre-Codex-fix the $lookup was missing
+      // and the variant's null spoolWeight fell through to 0, leaving
+      // the over-reporting bug intact for variant spools.
+      const loc = await Location.create({ name: "Drybox C", kind: "drybox" });
+      const parent = await Filament.create({
+        name: "Inherit Parent",
+        vendor: "Test",
+        type: "PLA",
+        spoolWeight: 250,
+      });
+      await Filament.create({
+        name: "Inherit Variant",
+        vendor: "Test",
+        type: "PLA",
+        color: "#abc",
+        parentId: parent._id,
+        // spoolWeight intentionally omitted — inherit.
+        spools: [
+          // 1000 - 250 = 750 expected (NOT 1000).
+          { label: "", totalWeight: 1000, locationId: loc._id, retired: false },
+        ],
+      });
+
+      const res = await listLocations(jsonReq("http://localhost/api/locations?stats=true"));
+      const body = await res.json();
+      const stats = body.find((l: { name: string }) => l.name === "Drybox C");
+      expect(stats.spoolCount).toBe(1);
+      expect(stats.totalGrams).toBe(750);
+    });
   });
 
   describe("GET /api/locations/[id]", () => {


### PR DESCRIPTION
## Summary
\`spool.totalWeight\` is the live scale reading (filament + empty spool), not remaining filament. Three inventory surfaces summed the raw scale value:

- [dashboard route](src/app/api/dashboard/route.ts) — \`totalGrams\` and the low-stock comparison
- [compare page](src/app/compare/page.tsx) — the "On hand" row
- [locations route](src/app/api/locations/route.ts) — per-location \`totalGrams\` aggregation

Each over-reported by one empty-spool mass per tracked spool. The dashboard's low-stock alerts could even hide while the gross weight still cleared the threshold despite actual filament being below it — so the warning never fired when it most needed to.

Apply the same \`max(0, totalWeight - spoolWeight)\` formula the existing [inventoryStats](src/lib/inventoryStats.ts) helper already uses. Clamp at zero so a spool below the empty-spool mass contributes 0 rather than a negative. Locations does the subtract in \`$project\`/\`$group\` so it stays a single round trip. Back-compat: when \`spoolWeight\` is unset on the filament, fallback to 0 so legacy docs preserve their existing totals.

## Test plan
- [x] \`npx vitest run tests/dashboard-route.test.ts tests/locations-route.test.ts\` — 23 passed (4 new dashboard + 2 new locations regression cases)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)