### PR TITLE
Fix #183: importer no longer resets color/diameter on existing filaments

### DIFF
--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -222,13 +222,24 @@ export async function upsertImportRows(
     // Build the update doc using only fields that were actually present in the
     // import row. This prevents overwriting existing data (e.g. temperatures,
     // calibrations) with nulls when the CSV simply doesn't have those columns.
+    //
+    // GH #183: pre-fix `color` and `diameter` were unconditionally set with
+    // defaults (`#808080` / `1.75`), so importing a row that only carried
+    // name/vendor/type would silently reset an existing filament's color
+    // and diameter. Only attach them to `doc` when the row supplied them;
+    // for the create path the Mongoose schema-level defaults still kick in
+    // for missing fields.
     const doc: Record<string, unknown> = {
       name: row.name,
       vendor: row.vendor,
       type: row.type,
-      color: row.color || "#808080",
-      diameter: row.diameter ?? 1.75,
     };
+    if (row.color !== undefined && row.color !== "" && row.color !== null) {
+      doc.color = row.color;
+    }
+    if (row.diameter !== undefined && row.diameter !== null) {
+      doc.diameter = row.diameter;
+    }
 
     // Only set optional scalar fields if they were explicitly provided
     if (row.cost !== undefined) doc.cost = row.cost ?? null;

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -144,6 +144,64 @@ describe("upsertImportRows", () => {
     expect(updated!.cost).toBe(29.99);
   });
 
+  it("does NOT reset color/diameter on existing filaments when those columns are absent (GH #183)", async () => {
+    // Seed a filament with explicit non-default color + diameter.
+    const seeded = await Filament.create({
+      name: "Existing PETG",
+      vendor: "Vendor",
+      type: "PETG",
+      color: "#123ABC",
+      diameter: 2.85,
+    });
+
+    // Re-import with only the required columns — same name/vendor/type
+    // but neither color nor diameter present in the row. Pre-fix the
+    // importer would silently overwrite color → "#808080" and diameter
+    // → 1.75 because they were always included with defaults.
+    const result = await upsertImportRows([
+      { name: "Existing PETG", vendor: "Vendor", type: "PETG" },
+    ]);
+
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(0);
+
+    const fresh = await Filament.findById(seeded._id);
+    expect(fresh!.color).toBe("#123ABC");   // preserved
+    expect(fresh!.diameter).toBe(2.85);     // preserved
+  });
+
+  it("still applies provided color/diameter on update (GH #183)", async () => {
+    const seeded = await Filament.create({
+      name: "Updatable PLA",
+      vendor: "Vendor",
+      type: "PLA",
+      color: "#000000",
+      diameter: 1.75,
+    });
+
+    const result = await upsertImportRows([
+      { name: "Updatable PLA", vendor: "Vendor", type: "PLA", color: "#FF00FF", diameter: 2.85 },
+    ]);
+
+    expect(result.updated).toBe(1);
+    const fresh = await Filament.findById(seeded._id);
+    expect(fresh!.color).toBe("#FF00FF");
+    expect(fresh!.diameter).toBe(2.85);
+  });
+
+  it("falls back to schema defaults for color/diameter when creating a new filament without them (GH #183)", async () => {
+    // Create-path defaults still apply via the Mongoose schema even after
+    // the fix removed the explicit defaults from the importer's `doc`.
+    const result = await upsertImportRows([
+      { name: "Defaults New PLA", vendor: "Vendor", type: "PLA" },
+    ]);
+
+    expect(result.created).toBe(1);
+    const created = await Filament.findOne({ name: "Defaults New PLA" });
+    expect(created!.color).toBe("#808080");  // schema default
+    expect(created!.diameter).toBe(1.75);    // schema default
+  });
+
   it("resurrects soft-deleted filaments", async () => {
     await Filament.create({
       name: "Deleted PLA",


### PR DESCRIPTION
## Summary
The CSV/XLSX importer documents partial-update semantics: only fields present in the source row should overwrite existing values when matching by name. But [\`importFilaments.ts\`](src/lib/importFilaments.ts) always set \`color\` and \`diameter\` on the build doc with defaults (\`#808080\` / \`1.75\`), so a CSV with just \`Name\`, \`Vendor\`, \`Type\` columns silently reset both on every existing match.

**Fix:** only attach \`color\`/\`diameter\` to the doc when the row supplied them. The create path keeps its defaults via the Mongoose schema; the update path no longer touches them when the column is absent.

## Test plan
- [x] \`npx vitest run tests/importFilaments.test.ts\` — 23 passed (3 new GH #183 cases: partial-column preservation, explicit-value-overwrite still works, brand-new row gets schema defaults)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)