### PR TITLE
Fix #184: Compare route resolves variant inheritance

### DIFF
--- a/src/app/api/filaments/compare/route.ts
+++ b/src/app/api/filaments/compare/route.ts
@@ -1,25 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
-import Filament from "@/models/Filament";
+import Filament, { IFilament } from "@/models/Filament";
 import "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
+import { resolveFilament } from "@/lib/resolveFilament";
 import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
 
 /**
  * GET /api/filaments/compare?ids=a,b,c — fetch multiple filaments for the
  * comparison view in one round trip.
  *
+ * Variants are resolved against their parent so columns like cost, density,
+ * temperatures, drying-time, and spoolWeight (the on-hand math reads it)
+ * render the inherited values when the variant left those fields blank —
+ * matching the detail page, list, and exports. Pre-fix Compare returned
+ * the raw documents and showed `—` for any inheritable field the variant
+ * didn't override (GH #184) and miscalculated the "On hand" row for
+ * inherited spoolWeight (Codex P2 on PR #190). The single resolveFilament
+ * pass handles both.
+ *
  * Returns populated calibration refs so the UI can render printer/nozzle/
  * bedType names directly.
- *
- * GH #182 / Codex P2 on PR #190: variants commonly store
- * `spoolWeight: null` and inherit from their parent. Resolve the inherited
- * value here so the compare page's "On hand" math (which subtracts
- * spoolWeight from each spool's totalWeight) doesn't fall through to 0
- * for inherited cases. A future broader-resolution change (#184) will
- * resolve every inheritable field; this PR scopes the fix to the field
- * the on-hand math needs.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -46,30 +48,31 @@ export async function GET(request: NextRequest) {
       .populate("calibrations.bedType")
       .lean();
 
-    // Resolve inherited spoolWeight for any variant whose own field is null.
-    // One batched fetch covers every parent in the result set.
+    // Fetch parents for any variant in the result so resolveFilament can
+    // merge inherited fields (cost, density, temperatures, drying info,
+    // spoolWeight, etc.). One batched query for all parent ids; the
+    // common case (no variants) hits zero extra queries.
     const parentIds = Array.from(
       new Set(
         filaments
-          .filter((f) => f.parentId && (f.spoolWeight === null || f.spoolWeight === undefined))
-          .map((f) => String(f.parentId)),
+          .map((f) => f.parentId && String(f.parentId))
+          .filter((id): id is string => !!id),
       ),
     );
-    const parentSpoolWeights = parentIds.length
-      ? new Map(
-          (
-            await Filament.find({ _id: { $in: parentIds } })
-              .select("spoolWeight")
-              .lean()
-          ).map((p) => [String(p._id), p.spoolWeight ?? null]),
-        )
-      : new Map<string, number | null>();
+    const parents = parentIds.length
+      ? ((await Filament.find({ _id: { $in: parentIds }, _deletedAt: null })
+          .populate("compatibleNozzles")
+          .populate("calibrations.nozzle")
+          .populate("calibrations.printer")
+          .populate("calibrations.bedType")
+          .lean()) as IFilament[])
+      : [];
+    const parentById = new Map(parents.map((p) => [String(p._id), p]));
 
     const resolved = filaments.map((f) => {
-      if (f.spoolWeight !== null && f.spoolWeight !== undefined) return f;
       if (!f.parentId) return f;
-      const inherited = parentSpoolWeights.get(String(f.parentId));
-      return inherited != null ? { ...f, spoolWeight: inherited } : f;
+      const parent = parentById.get(String(f.parentId));
+      return parent ? resolveFilament(f, parent) : f;
     });
 
     // Return in the same order the caller requested so the UI's columns

--- a/tests/compare-route.test.ts
+++ b/tests/compare-route.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as compareFilaments } from "@/app/api/filaments/compare/route";
+
+/**
+ * GH #184 regression guard.
+ *
+ * Pre-fix the Compare route ran a flat `Filament.find({_id: {$in: ids}})`
+ * and returned the raw documents — so a variant that inherited fields
+ * from its parent showed `—` for cost, density, temperatures, etc on
+ * the Compare page even though the detail page, list, and exports all
+ * resolved those values via `resolveFilament`.
+ *
+ * The fix batched-loads parent docs for any variant in the result and
+ * merges via the same helper. Tests assert:
+ *   - inherited fields are returned (not null)
+ *   - explicit overrides on the variant still win
+ *   - non-variants pass through unchanged
+ *   - response order matches the requested ids
+ */
+describe("/api/filaments/compare — variant inheritance (GH #184)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    // Models populate() walks
+    for (const name of ["Nozzle", "Printer", "BedType"] as const) {
+      if (!mongoose.models[name]) {
+        const mod = await import(`@/models/${name}`);
+        mongoose.model(name, mod.default.schema);
+      }
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  function req(ids: string[]) {
+    return new NextRequest(`http://localhost/api/filaments/compare?ids=${ids.join(",")}`);
+  }
+
+  it("returns inherited values for a variant whose fields are blank", async () => {
+    const parent = await Filament.create({
+      name: "Parent PETG",
+      vendor: "Vendor",
+      type: "PETG",
+      cost: 35,
+      density: 1.27,
+      diameter: 1.75,
+      temperatures: { nozzle: 240, bed: 80 },
+      dryingTemperature: 65,
+      dryingTime: 240,
+    });
+    const variant = await Filament.create({
+      name: "Parent PETG — Forest Green",
+      vendor: "Vendor",
+      type: "PETG",
+      color: "#0a4a2a",
+      parentId: parent._id,
+      // No cost, density, diameter, temps, drying — all inherited.
+    });
+
+    const res = await compareFilaments(req([String(variant._id)]));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].cost).toBe(35);
+    expect(body[0].density).toBe(1.27);
+    expect(body[0].diameter).toBe(1.75);
+    expect(body[0].temperatures.nozzle).toBe(240);
+    expect(body[0].temperatures.bed).toBe(80);
+    expect(body[0].dryingTemperature).toBe(65);
+    expect(body[0].dryingTime).toBe(240);
+  });
+
+  it("explicit variant overrides win over the parent's value", async () => {
+    const parent = await Filament.create({
+      name: "Override Parent",
+      vendor: "Vendor",
+      type: "PLA",
+      cost: 25,
+    });
+    const variant = await Filament.create({
+      name: "Override Variant",
+      vendor: "Vendor",
+      type: "PLA",
+      color: "#abcdef",
+      parentId: parent._id,
+      cost: 40,
+    });
+
+    const res = await compareFilaments(req([String(variant._id)]));
+    const body = await res.json();
+    expect(body[0].cost).toBe(40);
+  });
+
+  it("non-variant filaments pass through with no parent lookup", async () => {
+    const standalone = await Filament.create({
+      name: "Standalone",
+      vendor: "Vendor",
+      type: "PLA",
+      cost: 19.99,
+    });
+    const res = await compareFilaments(req([String(standalone._id)]));
+    const body = await res.json();
+    expect(body[0].cost).toBe(19.99);
+  });
+
+  it("returns docs in the requested id order, even when DB returns them differently", async () => {
+    const a = await Filament.create({ name: "A", vendor: "V", type: "PLA" });
+    const b = await Filament.create({ name: "B", vendor: "V", type: "PLA" });
+    const c = await Filament.create({ name: "C", vendor: "V", type: "PLA" });
+
+    // Request in reverse insertion order.
+    const ids = [String(c._id), String(a._id), String(b._id)];
+    const res = await compareFilaments(req(ids));
+    const body = await res.json();
+    expect(body.map((f: { name: string }) => f.name)).toEqual(["C", "A", "B"]);
+  });
+
+  it("mixes variant + standalone in one call without losing either's data", async () => {
+    const parent = await Filament.create({
+      name: "Mixed Parent",
+      vendor: "V",
+      type: "PETG",
+      cost: 30,
+      density: 1.27,
+    });
+    const variant = await Filament.create({
+      name: "Mixed Variant",
+      vendor: "V",
+      type: "PETG",
+      color: "#fff",
+      parentId: parent._id,
+    });
+    const solo = await Filament.create({
+      name: "Mixed Solo",
+      vendor: "V",
+      type: "PLA",
+      cost: 19,
+      density: 1.24,
+    });
+
+    const ids = [String(variant._id), String(solo._id)];
+    const res = await compareFilaments(req(ids));
+    const body = await res.json();
+    expect(body[0].cost).toBe(30);     // inherited
+    expect(body[0].density).toBe(1.27); // inherited
+    expect(body[1].cost).toBe(19);     // own value
+    expect(body[1].density).toBe(1.24); // own value
+  });
+});


### PR DESCRIPTION
## Summary
The [Compare API](src/app/api/filaments/compare/route.ts) returned raw filament documents from a flat \`Filament.find\`. Variants that inherited fields from their parent (cost, density, temperatures, drying info, etc.) showed \`—\` for those columns on the [Compare page](src/app/compare/page.tsx) even though the detail page, list, and exports all resolved them via \`resolveFilament\`.

**Fix:** batched-load parents for any variant in the result and merge via the existing helper. The common case (no variants) costs zero extra queries; otherwise one parent fetch for all variants in the call.

## Test plan
- [x] \`npx vitest run tests/compare-route.test.ts\` — 5 passed (inherited fields surface, explicit overrides win, non-variants pass through, requested order preserved, mixed variant+standalone)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)