### PR TITLE
Fix #186: bump afterAll hook timeout so MongoMemoryServer stop() can finish

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -29,6 +29,16 @@ afterEach(async () => {
   }
 });
 
+// Bump the hook timeout — vitest's default of 10s isn't enough for the
+// disconnect + mongod stop pipeline on slow / first-run machines.
+// mongodb-memory-server's stop() sends SIGINT to mongod, waits 10s, then
+// falls back to SIGKILL (the warning is hardcoded inside
+// node_modules/mongodb-memory-server-core/.../utils.js). Worst case the
+// teardown takes ~20s (10s SIGINT wait + the kill+exit roundtrip), so
+// 30s gives the test suite enough headroom to exit cleanly even when
+// mongod refuses the soft signal (GH #186).
+const TEARDOWN_TIMEOUT_MS = 30_000;
+
 afterAll(async () => {
   // Guard each step — if beforeAll failed, mongoServer may be null and
   // mongoose may not be connected. A throwing teardown would mask the real
@@ -43,4 +53,4 @@ afterAll(async () => {
   if (mongoServer) {
     await mongoServer.stop().catch(() => {});
   }
-});
+}, TEARDOWN_TIMEOUT_MS);


### PR DESCRIPTION
## Summary
\`vitest\`'s default 10s hook timeout was racing mongodb-memory-server's \`stop()\`. The library hardcodes a 10s SIGINT-then-SIGKILL fallback (the warning \`An Process didnt exit with signal SIGINT within 10 seconds, using SIGKILL!\` comes from \`node_modules/mongodb-memory-server-core/.../utils.js\`), so a teardown where mongod didn't honor SIGINT immediately routinely took ~10–20s. The hook timed out before stop() returned, and \`npm test\` exited non-zero (\`Tests 994 passed; Test Files 1 failed\`) even though every assertion passed.

**Fix:** bump the \`afterAll\` hook timeout to 30s.

## Test plan
- [x] \`npm test\` — 51/51 test files pass, 994/994 tests pass, exit clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)