### PR TITLE
Docs sweep: snapshot includes shared catalogs (#185), filament delete (#187), unified Import File (#188), OpenPrintTag counts (#189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A desktop and web application for managing 3D printing filament profiles. Import
 - **PrusaSlicer** -- import and export INI config bundles via browser upload or CLI
 - **Bulk spool import** -- paste or upload a CSV of spool rows (filament, weight, vendor, lot, dates, location); auto-creates missing locations and reports per-row errors
 - **PrusaSlicer Filament Edition** -- live bidirectional sync of filament presets with [PrusaSlicer Filament Edition](https://github.com/hyiger/PrusaSlicer) via REST API; presets appear in the filament dropdown on startup, changes sync back with per-nozzle calibration context, and calibration overrides are applied dynamically when switching printers/nozzles
-- **OpenPrintTag database** -- browse the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) (11,000+ materials from 97 brands), filter by type/brand/data quality, and selectively import filaments with completeness scoring
+- **OpenPrintTag database** -- browse the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) (thousands of FDM materials from many brands; live counts shown in the UI), filter by type/brand/data quality, and selectively import filaments with completeness scoring
 - **CSV / XLSX** -- import and export spreadsheets with column mapping
 - **Prusament QR** -- scan a spool QR code or enter spool ID to auto-import specs, temps, weights, and pricing
 - **Import from Atlas** -- connect to a remote MongoDB Atlas database and selectively import filaments

--- a/docs/api.md
+++ b/docs/api.md
@@ -719,7 +719,7 @@ Extracted fields include: name, vendor, type, density, diameter, temperatures (n
 
 ### GET /api/snapshot
 
-Downloads a JSON snapshot of core app data: filaments, nozzles, printers, bed types, locations, and print history (including soft-deleted documents). The snapshot preserves `_id` values, timestamps, and references so it can be restored exactly. Shared catalog records are not included in snapshot export/restore.
+Downloads a JSON snapshot of core app data: filaments, nozzles, printers, bed types, locations, print history, and shared catalogs (including soft-deleted documents and tombstones). The snapshot preserves `_id` values, timestamps, and references so it can be restored exactly. Snapshot schema version is `4` as of v1.14.0; older v1/v2/v3 snapshots still restore (missing collections come back as empty).
 
 Returns a JSON file with `Content-Disposition: attachment` header.
 
@@ -741,7 +741,8 @@ Returns:
     "printers": 2,
     "bedTypes": 3,
     "locations": 4,
-    "printHistory": 12
+    "printHistory": 12,
+    "sharedCatalogs": 1
   }
 }
 ```

--- a/docs/importing.md
+++ b/docs/importing.md
@@ -115,7 +115,7 @@ This also works from a filament's detail page to add another spool of the same m
 
 ## CSV / XLSX Import
 
-1. Open the **Import/Export** dropdown on the home page and click **"Import CSV"** or **"Import XLSX"**
+1. Open the **Import/Export** dropdown on the home page and click **"Import File (INI / CSV / XLSX)"** — the app routes by extension (`.csv` → CSV importer, `.xlsx` → XLSX importer, `.ini` → PrusaSlicer bundle)
 2. Select a file with a header row containing at minimum `Name`, `Vendor`, and `Type` columns (max 10 MB)
 3. Additional supported columns: `Color`, `Color Name`, `Diameter`, `Cost`, `Density`, `Nozzle Temp`, `Bed Temp`, `Nozzle First Layer`, `Bed First Layer`, `Max Volumetric Speed`, `Spool Weight`, `Net Filament Weight`, `TDS URL`, `Instance ID`, `Drying Temp`, `Drying Time`, `Transmission Distance` (HueForge TD), `Glass Transition` / `Tg`, `Heat Deflection` / `HDT`, `Shore A`, `Shore D`, `Min Print Speed`, `Max Print Speed`, `Nozzle Range Min`, `Nozzle Range Max`, `Standby Temp`, `Spool Type`
 4. Column names are matched case-insensitively with common aliases (e.g. "HueForge TD" maps to Transmission Distance, "Tg" maps to Glass Transition)
@@ -126,7 +126,7 @@ This also works from a filament's detail page to add another spool of the same m
 
 ## Snapshot Restore
 
-You can restore a previously exported snapshot to import core app data: filaments, nozzles, printers, bed types, locations, and print history. Shared catalog records are not included in snapshot export/restore.
+You can restore a previously exported snapshot to import core app data: filaments, nozzles, printers, bed types, locations, print history, and shared catalogs (including soft-deleted documents and tombstones).
 
 1. Go to **Settings** and click **"Restore"** in the Database Snapshots section
 2. Select a snapshot JSON file (exported via **"Backup"**)
@@ -143,7 +143,7 @@ Open the **Import/Export** dropdown on the home page and click **"Export CSV"** 
 
 ## OpenPrintTag Community Database Import
 
-Browse the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) (11,000+ materials from 100+ brands) and selectively import filaments into your library.
+Browse the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) (thousands of FDM materials from many brands; the browser subtitle shows the live count from the upstream database) and selectively import filaments into your library.
 
 1. From the home page, open the **Import/Export** dropdown and click **"Browse OpenPrintTag DB"**
 2. The browser loads all FDM filaments from the OpenPrintTag database (SLA resins are filtered out)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -215,7 +215,7 @@ You can also click **"+ Prusament QR"** on a filament's detail page (in the Spoo
 
 ### From CSV or XLSX
 
-1. On the home page, open the **Import/Export** dropdown and click **Import CSV** or **Import XLSX**.
+1. On the home page, open the **Import/Export** dropdown and click **Import File (INI / CSV / XLSX)**. The app routes by extension (`.csv` → CSV importer, `.xlsx` → XLSX importer, `.ini` → PrusaSlicer bundle).
 2. Select a file with a header row containing at minimum `Name`, `Vendor`, and `Type` columns.
 3. A toast confirms how many filaments were imported. Only fields present in the file are updated — existing data for unmapped columns is preserved.
 
@@ -452,10 +452,10 @@ If a filament has a single `totalWeight` but no spools yet, click **"Migrate to 
 
 ## Step 16: Browse the OpenPrintTag Community Database
 
-Discover filaments from 100+ brands (10,000+ FDM materials) in the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) and selectively import them into your library. The page shows live counts in its subtitle.
+Discover thousands of FDM filaments from many brands in the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) and selectively import them into your library. The page shows live counts in its subtitle (the database grows as the community contributes more entries).
 
 1. From the home page, open the **Import/Export** dropdown and click **"Browse OpenPrintTag DB"**.
-2. The browser loads all FDM filaments (11,000+ materials; SLA resins are filtered out automatically).
+2. The browser loads all FDM filaments (SLA resins are filtered out automatically).
 3. Materials are color-coded by data completeness:
    - 🟢 **Rich** (7-10 fields) -- green progress bar, fully opaque
    - 🟡 **Partial** (4-6 fields) -- yellow progress bar, fully opaque
@@ -581,7 +581,7 @@ Missing locations are auto-created, so you don't need to seed locations in advan
 | Import from TDS | Add Filament > Import from TDS |
 | Configure AI provider | Settings > AI Features |
 | Import from PrusaSlicer | Home > Import/Export > Import INI |
-| Import from CSV/XLSX | Home > Import/Export > Import CSV / Import XLSX |
+| Import from CSV/XLSX | Home > Import/Export > Import File (INI / CSV / XLSX) — routed by extension |
 | Import Prusament spool | Home > Import/Export > Prusament QR |
 | Import from Atlas | Home > Import/Export > Import from Atlas |
 | Browse OpenPrintTag DB | Home > Import/Export > Browse OpenPrintTag DB |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,7 +47,13 @@ Click any filament name in the table to see its full details:
 
 ## Deleting a Filament
 
-Click **"Delete"** next to any filament in the list. You will be prompted to confirm before deletion.
+Deletion goes through the bulk-actions selection bar:
+
+1. Tick the checkbox(es) next to one or more rows in the filament list.
+2. A red selection bar appears above the table with **"Delete {count}"**.
+3. Click it and confirm.
+
+Parent filaments that still have color variants are blocked from deletion — remove or reparent the variants first.
 
 ---
 
@@ -336,7 +342,7 @@ XLSX exports include styled headers, color-coded cells, auto-filter, and a froze
 
 ### Importing
 
-Open the **Import/Export** dropdown on the home page and click **"Import CSV"** or **"Import XLSX"** to upload a file (max 10 MB). The file must have a header row with at minimum `Name`, `Vendor`, and `Type` columns. Additional columns are mapped by header name (case-insensitive), including glass transition (Tg), heat deflection (HDT), shore hardness (A/D), print speed ranges, nozzle temp ranges, standby temp, color name, and spool type. Only fields present in the file are updated — existing data for unmapped columns is preserved. Rows missing required fields are reported with row numbers and reasons.
+Open the **Import/Export** dropdown on the home page and click **"Import File (INI / CSV / XLSX)"** to upload a file (max 10 MB). The app routes by extension: `.ini` → PrusaSlicer bundle import, `.csv` → CSV importer, `.xlsx` → XLSX importer. The file must have a header row with at minimum `Name`, `Vendor`, and `Type` columns. Additional columns are mapped by header name (case-insensitive), including glass transition (Tg), heat deflection (HDT), shore hardness (A/D), print speed ranges, nozzle temp ranges, standby temp, color name, and spool type. Only fields present in the file are updated — existing data for unmapped columns is preserved. Rows missing required fields are reported with row numbers and reasons.
 
 ---
 
@@ -344,7 +350,7 @@ Open the **Import/Export** dropdown on the home page and click **"Import CSV"** 
 
 ### Exporting a Snapshot
 
-Go to **Settings** and click **"Backup"** in the Database Snapshots section to download a JSON snapshot of core app data. The snapshot includes filaments, nozzles, printers, bed types, locations, and print history (including soft-deleted documents) with references and timestamps preserved. Shared catalog records are not included in snapshot export/restore.
+Go to **Settings** and click **"Backup"** in the Database Snapshots section to download a JSON snapshot of core app data. The snapshot includes filaments, nozzles, printers, bed types, locations, print history, and shared catalogs (including soft-deleted documents and tombstones) with references and timestamps preserved.
 
 ### Restoring a Snapshot
 
@@ -360,7 +366,7 @@ Each filament has a unique instance identifier (5-byte hex string, e.g. `2acc210
 
 ## OpenPrintTag Community Database Browser
 
-Browse the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) directly from Filament DB to discover and import filaments from 97 brands.
+Browse the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) directly from Filament DB to discover and import thousands of FDM filaments from many brands. The browser subtitle shows the live count fetched from the upstream database (it grows as the community contributes more entries).
 
 ### Accessing the Browser
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1821,7 +1821,7 @@
       "get": {
         "tags": ["Snapshot"],
         "summary": "Export database snapshot",
-        "description": "Downloads a JSON snapshot of core app data: filaments, nozzles, printers, bed types, locations, and print history. Shared catalog records are not included in snapshot export/restore.",
+        "description": "Downloads a JSON snapshot of core app data: filaments, nozzles, printers, bed types, locations, print history, and shared catalogs (including soft-deleted documents and tombstones). Snapshot schema version is 4 as of v1.14.0; older v1/v2/v3 snapshots still restore (missing collections come back as empty).",
         "responses": {
           "200": {
             "description": "JSON snapshot file",
@@ -1858,7 +1858,8 @@
                         "printers": { "type": "integer" },
                         "bedTypes": { "type": "integer" },
                         "locations": { "type": "integer" },
-                        "printHistory": { "type": "integer" }
+                        "printHistory": { "type": "integer" },
+                        "sharedCatalogs": { "type": "integer" }
                       }
                     }
                   }


### PR DESCRIPTION
## Summary
4 docs issues addressed in one focused sweep.

### #185 — snapshot includes shared catalogs
- [docs/api.md](docs/api.md): \`GET /api/snapshot\` description rewritten to list sharedCatalogs alongside the other 6 collections; restore-response JSON example gains a \`sharedCatalogs\` key. Snapshot version note bumped to v4 (older v1/v2/v3 still restore).
- [docs/usage.md](docs/usage.md), [docs/importing.md](docs/importing.md): drop "Shared catalog records are not included" wording.
- [public/openapi.json](public/openapi.json): description rewrite + \`restored.sharedCatalogs\` key added to the response schema.

### #187 — filament deletion docs match the actual UI
- [docs/usage.md](docs/usage.md): replace the per-row "Click Delete" instruction with the bulk-actions selection-bar flow (checkbox → Delete {count} → confirm). Adds the parent-with-variants guard.

### #188 — import docs use the unified Import File menu
- [docs/usage.md](docs/usage.md), [docs/importing.md](docs/importing.md), [docs/tutorial.md](docs/tutorial.md): replace the split "Import CSV / Import XLSX" wording with **Import File (INI / CSV / XLSX)** and explain the extension-based routing. Quick-reference row in tutorial.md updated.

### #189 — OpenPrintTag counts use stable wording
- [README.md](README.md), [docs/usage.md](docs/usage.md), [docs/importing.md](docs/importing.md), [docs/tutorial.md](docs/tutorial.md): replace the contradictory hard-coded counts (10k/11k materials, 97/100+ brands) with "thousands of FDM materials from many brands" and a pointer to the UI's live subtitle counts.

## Test plan
- [x] \`grep\` confirms zero remaining "shared catalog records are not included" mentions
- [x] \`grep\` confirms zero remaining "Import CSV"/"Import XLSX" menu-label references
- [x] \`grep\` confirms hard-coded OpenPrintTag counts are gone (10,000 mentions remaining are about the unrelated CSV row cap)

Closes #185
Closes #187
Closes #188
Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)