### PR TITLE
Fix #197: data pages use the full window width

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -54,7 +54,7 @@ export default function AnalyticsPage() {
   }, [data]);
 
   return (
-    <main className="max-w-5xl mx-auto px-4 py-8">
+    <main className="w-full px-4 py-8">
       <div className="flex items-end justify-between mb-6 flex-wrap gap-3">
         <div>
           <h1 className="text-3xl font-bold">{t("analytics.title")}</h1>

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -214,7 +214,7 @@ function ComparePageInner() {
   ];
 
   return (
-    <main className="max-w-7xl mx-auto px-4 py-8">
+    <main className="w-full px-4 py-8">
       <h1 className="text-3xl font-bold mb-2">{t("compare.title")}</h1>
       <p className="text-sm text-gray-500 mb-6">{t("compare.subtitle")}</p>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -73,7 +73,7 @@ export default function DashboardPage() {
 
   if (error) {
     return (
-      <main className="max-w-5xl mx-auto px-4 py-8">
+      <main className="w-full px-4 py-8">
         <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
       </main>
     );
@@ -81,7 +81,7 @@ export default function DashboardPage() {
 
   if (!data) {
     return (
-      <main className="max-w-5xl mx-auto px-4 py-8">
+      <main className="w-full px-4 py-8">
         <p className="text-sm text-gray-500">{t("common.loading")}</p>
       </main>
     );
@@ -90,7 +90,7 @@ export default function DashboardPage() {
   const kg = (data.totalGrams / 1000).toFixed(2);
 
   return (
-    <main className="max-w-5xl mx-auto px-4 py-8">
+    <main className="w-full px-4 py-8">
       <h1 className="text-3xl font-bold mb-6">{t("dashboard.title")}</h1>
 
       {/* Top metrics */}

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -101,7 +101,7 @@ export default function LocationsPage() {
   };
 
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
+    <main className="w-full px-4 py-8">
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-3xl font-bold">{t("locations.title")}</h1>

--- a/src/app/nozzles/page.tsx
+++ b/src/app/nozzles/page.tsx
@@ -101,7 +101,7 @@ export default function NozzlesPage() {
   };
 
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
+    <main className="w-full px-4 py-8">
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-3xl font-bold">{t("nozzles.title")}</h1>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -652,7 +652,7 @@ export default function Home() {
   };
 
   return (
-    <main className="max-w-7xl mx-auto px-4 py-8">
+    <main className="w-full px-4 py-8">
       {mounted && (
         <input
           ref={fileInputRef}

--- a/src/app/printers/page.tsx
+++ b/src/app/printers/page.tsx
@@ -106,7 +106,7 @@ export default function PrintersPage() {
   };
 
   return (
-    <main className="max-w-5xl mx-auto px-4 py-8">
+    <main className="w-full px-4 py-8">
       <div className="flex items-start justify-between mb-6">
         <div>
           <h1 className="text-3xl font-bold">{t("printers.title")}</h1>

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -48,7 +48,7 @@ export default function AppHeader() {
 
   return (
     <header className="sticky top-0 z-40 bg-white/95 dark:bg-gray-950/95 backdrop-blur border-b border-gray-200 dark:border-gray-800">
-      <div className="max-w-7xl mx-auto px-4 h-12 flex items-center justify-between gap-3">
+      <div className="w-full px-4 h-12 flex items-center justify-between gap-3">
         <Link
           href="/"
           className="flex items-baseline gap-2 whitespace-nowrap text-gray-900 dark:text-gray-100 hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
@@ -115,7 +115,7 @@ export default function AppHeader() {
           className="md:hidden border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950"
           aria-label="Primary mobile"
         >
-          <div className="max-w-7xl mx-auto px-4 py-2 flex flex-col gap-1">
+          <div className="w-full px-4 py-2 flex flex-col gap-1">
             {LINKS.map((link) => (
               <Link
                 key={link.href}


### PR DESCRIPTION
## Summary
List / dashboard / analytics pages wrapped their content in \`max-w-7xl mx-auto\` (1280px) or \`max-w-{4,5}xl\` (896-1024px). On a maximised window the user saw wide bands of empty space on each side, especially on the data-dense home table and the dashboard tile grid.

Switched to \`w-full px-4 py-8\` on data-dense pages:

| Page | Before | After |
|---|---|---|
| / (filament list) | max-w-7xl | full width |
| /compare | max-w-7xl | full width |
| /dashboard | max-w-5xl | full width |
| /analytics | max-w-5xl | full width |
| /locations, /printers | max-w-{4,5}xl | full width |
| /nozzles | max-w-4xl | full width |
| AppHeader (top + drawer) | max-w-7xl | full width — aligns with content |

**Forms keep their narrow widths** (filament new/edit, settings, setup wizard, sub-resource edit pages) because input forms read better at narrow widths.

## Verified
At 1920x900 dev viewport: main + header both span 1905px (8px gutter each side from px-4). The filament table now uses every column the screen affords.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)