### PR TITLE
Fix Windows release: raise vitest hookTimeout to 30s

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,16 @@ export default defineConfig({
       },
     },
     testTimeout: 15000,
+    // Bumped from the 10s default. Several route-level test files use a
+    // beforeEach that dynamically imports Mongoose models and re-registers
+    // them on the connection (setup.ts wipes mongoose.models between
+    // tests). On Windows the cold-import + ESM-resolution path can blow
+    // past 10s on the first iteration of a file, which used to fail the
+    // Windows release build (e.g. tests/locations-route.test.ts beforeEach
+    // timed out in CI but passed locally on macOS / Linux). 30s gives
+    // enough headroom for the slowest Windows runner without masking real
+    // hangs — the testTimeout above still catches stuck tests at 15s.
+    hookTimeout: 30000,
     setupFiles: ["./tests/setup.ts"],
   },
   resolve: {


### PR DESCRIPTION
## Summary
The Windows job in the v1.14.5 release CI failed with two \`beforeEach\` hook timeouts in \`tests/locations-route.test.ts\`:

\`\`\`
Error: Hook timed out in 10000ms.
 ❯ tests/locations-route.test.ts:23:3
\`\`\`

The hook dynamically imports Mongoose models and re-registers them against the test connection (the per-test \`mongoose.models\` wipe is set up in \`tests/setup.ts\`). On Windows the cold ESM-resolution + Mongoose schema setup blew past vitest's default 10s \`hookTimeout\` on the first iteration of the file. Same root cause as #186 (\`afterAll\` timeout for slow Windows teardown).

## Fix
Bump global \`hookTimeout\` to 30s. \`testTimeout\` stays at 15s so stuck tests still fail quickly — the bump only loosens \`beforeAll\` / \`beforeEach\` / \`afterEach\` / \`afterAll\`, which are infrastructure work, not test logic.

## Test plan
- [x] \`npx vitest run tests/locations-route.test.ts\` locally — 14 passing in 7s on macOS
- [ ] Tag-push CI on Windows confirms the fix (will run on next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)