### PR TITLE
Fix #202: invalid ObjectId path param returns 400, not 500

### DIFF
--- a/src/app/api/bed-types/[id]/route.ts
+++ b/src/app/api/bed-types/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import BedType from "@/models/BedType";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -17,7 +17,7 @@ export async function GET(
     }
     return NextResponse.json(bedType);
   } catch (err) {
-    return errorResponse("Failed to fetch bed type", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to fetch bed type");
   }
 }
 
@@ -86,6 +86,6 @@ export async function DELETE(
     }
     return NextResponse.json({ message: "Deleted" });
   } catch (err) {
-    return errorResponse("Failed to delete bed type", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to delete bed type");
   }
 }

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -5,7 +5,7 @@ import Nozzle from "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament, hasVariants } from "@/lib/resolveFilament";
-import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 /**
  * GET /api/filaments/{id}
@@ -92,7 +92,7 @@ export async function GET(
 
     return NextResponse.json({ ...resolved, _variants: variants });
   } catch (err) {
-    return errorResponse("Failed to fetch filament", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to fetch filament");
   }
 }
 

--- a/src/app/api/locations/[id]/route.ts
+++ b/src/app/api/locations/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Location from "@/models/Location";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -17,7 +17,7 @@ export async function GET(
     }
     return NextResponse.json(location);
   } catch (err) {
-    return errorResponse("Failed to fetch location", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to fetch location");
   }
 }
 
@@ -87,6 +87,6 @@ export async function DELETE(
     }
     return NextResponse.json({ message: "Deleted" });
   } catch (err) {
-    return errorResponse("Failed to delete location", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to delete location");
   }
 }

--- a/src/app/api/nozzles/[id]/route.ts
+++ b/src/app/api/nozzles/[id]/route.ts
@@ -3,7 +3,7 @@ import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import Filament from "@/models/Filament";
 import Printer from "@/models/Printer";
-import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -27,7 +27,7 @@ export async function GET(
       .lean();
     return NextResponse.json({ ...nozzle, printers });
   } catch (err) {
-    return errorResponse("Failed to fetch nozzle", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to fetch nozzle");
   }
 }
 

--- a/src/app/api/printers/[id]/route.ts
+++ b/src/app/api/printers/[id]/route.ts
@@ -3,7 +3,7 @@ import dbConnect from "@/lib/mongodb";
 import Printer from "@/models/Printer";
 import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
-import { getErrorMessage, errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
 export async function GET(
   _request: NextRequest,
@@ -20,7 +20,7 @@ export async function GET(
     }
     return NextResponse.json(printer);
   } catch (err) {
-    return errorResponse("Failed to fetch printer", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to fetch printer");
   }
 }
 
@@ -102,6 +102,6 @@ export async function DELETE(
     }
     return NextResponse.json({ message: "Deleted" });
   } catch (err) {
-    return errorResponse("Failed to delete printer", 500, getErrorMessage(err));
+    return errorResponseFromCaught(err, "Failed to delete printer");
   }
 }

--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -67,9 +67,11 @@ export function isClientInputErrorMessage(message: string): boolean {
 
 /**
  * True when an error is a client-input rejection rather than a server fault —
- * Mongoose schema validators (`ValidationError`), our pre-update hooks
- * (`tdsUrl must be a valid http(s) URL`), and the shared SSRF guard
- * (`assertExternalUrl` rejections from src/lib/externalUrlGuard.ts).
+ * Mongoose schema validators (`ValidationError`), Mongoose ObjectId-cast
+ * rejections (`CastError` — fired when a route's path param like `{id}` is
+ * not a parseable ObjectId — GH #202), our pre-update hooks (`tdsUrl must
+ * be a valid http(s) URL`), and the shared SSRF guard (`assertExternalUrl`
+ * rejections from src/lib/externalUrlGuard.ts).
  *
  * Used by route handlers to distinguish 4xx-worthy "your input was bad"
  * from 5xx "the server crashed". Without this, validators throw a generic
@@ -79,7 +81,8 @@ export function isClientInputErrorMessage(message: string): boolean {
  */
 export function isClientInputError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  if (err.name === "ValidationError") return true; // Mongoose
+  if (err.name === "ValidationError") return true; // Mongoose validators
+  if (err.name === "CastError") return true; // Mongoose ObjectId/cast rejections (GH #202)
   return isClientInputErrorMessage(err.message);
 }
 

--- a/tests/apiErrorHandler.test.ts
+++ b/tests/apiErrorHandler.test.ts
@@ -103,6 +103,15 @@ describe("isClientInputError", () => {
     expect(isClientInputError(err)).toBe(true);
   });
 
+  it("returns true for Mongoose CastError (GH #202 — invalid ObjectId on path param)", () => {
+    // CastError fires when a route's {id} path param isn't a parseable
+    // ObjectId, e.g. GET /api/filaments/notavalidobjectid. Bad client
+    // input — the route should return 400, not 500.
+    const err = new Error('Cast to ObjectId failed for value "notavalidobjectid" (type string) at path "_id" for model "Filament"');
+    err.name = "CastError";
+    expect(isClientInputError(err)).toBe(true);
+  });
+
   it("returns true when the message matches a known client-input pattern", () => {
     expect(isClientInputError(new Error("tdsUrl must be a valid http(s) URL"))).toBe(true);
     expect(isClientInputError(new Error('Disallowed URL scheme "file:"'))).toBe(true);

--- a/tests/filament-put-validation-status.test.ts
+++ b/tests/filament-put-validation-status.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import mongoose from "mongoose";
 import { NextRequest } from "next/server";
-import { PUT as putFilament } from "@/app/api/filaments/[id]/route";
+import { GET as getFilament, PUT as putFilament } from "@/app/api/filaments/[id]/route";
 
 /**
  * GH #160 regression guard.
@@ -84,5 +84,28 @@ describe("PUT /api/filaments/[id] — client-input rejections return 400", () =>
     const res = await putFilament(req, { params: Promise.resolve({ id: String(filament._id) }) });
 
     expect(res.status).toBe(200);
+  });
+
+  it("GET with an invalid ObjectId path param returns 400, not 500 (GH #202)", async () => {
+    // Pre-fix the route used `errorResponse(..., 500, getErrorMessage)` and
+    // Mongoose's CastError leaked through as a 500 server-fault status —
+    // bad UX (renderers couldn't tell input from server failure) and bad
+    // for monitoring (alerts on copy-paste typos).
+    const req = new NextRequest("http://localhost/api/filaments/notavalidobjectid");
+    const res = await getFilament(req, { params: Promise.resolve({ id: "notavalidobjectid" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    // Mongoose's CastError message includes "Cast to ObjectId failed"
+    expect(body.error).toMatch(/Cast to ObjectId failed/i);
+  });
+
+  it("PUT with an invalid ObjectId path param returns 400, not 500 (GH #202)", async () => {
+    const req = new NextRequest("http://localhost/api/filaments/notavalidobjectid", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "anything" }),
+    });
+    const res = await putFilament(req, { params: Promise.resolve({ id: "notavalidobjectid" }) });
+    expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
## Summary
Mongoose's \`CastError\` fires when a route's \`{id}\` path param isn't a parseable ObjectId. The catch-all was wrapping it as HTTP 500 with the raw "Cast to ObjectId failed for value..." message under \`detail\` — same family as #160/#161 (validation/SSRF rejections should be 4xx, not 5xx).

\`\`\`bash
$ curl -s -w 'HTTP %{http_code}\n' http://localhost:3456/api/filaments/notavalidobjectid
{"error":"Failed to fetch filament","detail":"Cast to ObjectId failed..."}
HTTP 500   ← should be 400
\`\`\`

## Fix
Add \`err.name === "CastError"\` to [\`isClientInputError\`](src/lib/apiErrorHandler.ts) so the existing \`errorResponseFromCaught\` helper maps it to 400. Sweep the 5 single-resource routes so every GET / DELETE catch goes through the helper instead of the older \`errorResponse(..., 500, getErrorMessage)\` pattern that bypassed the classifier. Drop now-unused \`getErrorMessage\` imports.

## Verified live (dev server)

| Route | Method | Before | After |
|---|---|---|---|
| /api/filaments/notavalidobjectid | GET, DELETE | 500 | **400** |
| /api/nozzles/notavalidobjectid | GET, DELETE | 500 | **400** |
| /api/printers/notavalidobjectid | GET, DELETE | 500 | **400** |
| /api/bed-types/notavalidobjectid | GET, DELETE | 500 | **400** |
| /api/locations/notavalidobjectid | GET, DELETE | 500 | **400** |

## Test plan
- [x] \`npx vitest run tests/apiErrorHandler.test.ts tests/filament-put-validation-status.test.ts\` — 28 passed
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean
- [x] Manual: all 10 endpoints return 400 with the CastError message in \`error\`

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)