### PR TITLE
Fix #203: empty POST /api/filaments/{id}/spools no longer creates phantom

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1152,6 +1152,7 @@
       "post": {
         "tags": ["Spools"],
         "summary": "Add spool to filament",
+        "description": "Adds a new spool subdoc to the filament. At least one of label, totalWeight, lotNumber, purchaseDate, openedDate, locationId, photoDataUrl, or retired must be supplied — an empty body returns 400 (GH #203).",
         "parameters": [
           { "$ref": "#/components/parameters/FilamentId" }
         ],
@@ -1161,9 +1162,16 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "minProperties": 1,
                 "properties": {
                   "label": { "type": "string", "description": "Spool label (e.g. spool ID or date)" },
-                  "totalWeight": { "type": "number", "nullable": true, "description": "Total weight in grams (spool + filament)" }
+                  "totalWeight": { "type": "number", "nullable": true, "description": "Total weight in grams (spool + filament). Null = weight unknown." },
+                  "lotNumber": { "type": "string", "nullable": true, "description": "Manufacturer lot / batch number" },
+                  "purchaseDate": { "type": "string", "nullable": true, "description": "ISO date string (YYYY-MM-DD)" },
+                  "openedDate": { "type": "string", "nullable": true, "description": "ISO date string (YYYY-MM-DD) — when the spool was first opened" },
+                  "locationId": { "type": "string", "nullable": true, "description": "Reference to a Location document (drybox/shelf/cabinet/etc)" },
+                  "photoDataUrl": { "type": "string", "nullable": true, "description": "Inline base64 image (JPEG/PNG/GIF/WebP/AVIF/HEIC; SVG rejected)" },
+                  "retired": { "type": "boolean", "description": "True if the spool is empty / no longer in use; excluded from inventory totals" }
                 }
               }
             }
@@ -1177,6 +1185,10 @@
                 "schema": { "$ref": "#/components/schemas/Filament" }
               }
             }
+          },
+          "400": {
+            "description": "Empty body, invalid field type, or no recognised fields supplied",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
           },
           "404": {
             "description": "Filament not found",

--- a/src/app/api/filaments/[id]/spools/route.ts
+++ b/src/app/api/filaments/[id]/spools/route.ts
@@ -7,7 +7,7 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  let body;
+  let body: unknown;
   try {
     body = await request.json();
   } catch {
@@ -21,20 +21,55 @@ export async function POST(
     return NextResponse.json({ error: validation.error }, { status: 400 });
   }
 
+  // GH #203: validateSpoolBody (POST mode) defaults missing fields to
+  // empty string / null, so an empty `{}` request previously created a
+  // phantom spool with no label, no weight, no metadata. Require the
+  // caller to explicitly supply something — totalWeight or any of the
+  // other meaningful fields. The CSV importer enforces the same
+  // contract via its required-column check on `totalWeight`.
+  const rawBody = body as Record<string, unknown>;
+  const meaningfulKeys = [
+    "label",
+    "totalWeight",
+    "lotNumber",
+    "purchaseDate",
+    "openedDate",
+    "locationId",
+    "photoDataUrl",
+    "retired",
+  ];
+  const supplied = meaningfulKeys.some((k) => rawBody[k] !== undefined);
+  if (!supplied) {
+    return NextResponse.json(
+      {
+        error:
+          "At least one of label, totalWeight, lotNumber, purchaseDate, openedDate, locationId, photoDataUrl, or retired is required",
+      },
+      { status: 400 },
+    );
+  }
+
   try {
     await dbConnect();
     const { id } = await params;
 
+    // Only push fields the validator captured. Previously the $push
+    // dropped lotNumber / purchaseDate / openedDate / locationId /
+    // photoDataUrl / retired even when the client supplied them — a
+    // separate latent bug paired with the empty-body phantom (GH #203).
+    const newSpool: Record<string, unknown> = {};
+    if (validation.label !== undefined) newSpool.label = validation.label;
+    if (validation.totalWeight !== undefined) newSpool.totalWeight = validation.totalWeight;
+    if (validation.lotNumber !== undefined) newSpool.lotNumber = validation.lotNumber;
+    if (validation.purchaseDate !== undefined) newSpool.purchaseDate = validation.purchaseDate;
+    if (validation.openedDate !== undefined) newSpool.openedDate = validation.openedDate;
+    if (validation.locationId !== undefined) newSpool.locationId = validation.locationId;
+    if (validation.photoDataUrl !== undefined) newSpool.photoDataUrl = validation.photoDataUrl;
+    if (validation.retired !== undefined) newSpool.retired = validation.retired;
+
     const filament = await Filament.findOneAndUpdate(
       { _id: id, _deletedAt: null },
-      {
-        $push: {
-          spools: {
-            label: validation.label,
-            totalWeight: validation.totalWeight,
-          },
-        },
-      },
+      { $push: { spools: newSpool } },
       { returnDocument: "after" }
     ).lean();
 

--- a/tests/spool-create-validation.test.ts
+++ b/tests/spool-create-validation.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { POST as createSpool } from "@/app/api/filaments/[id]/spools/route";
+
+/**
+ * GH #203 regression guard.
+ *
+ * `POST /api/filaments/{id}/spools` previously called `validateSpoolBody`
+ * (which defaults missing fields to empty/null on POST) and pushed
+ * `{ label, totalWeight }` regardless of whether the caller supplied
+ * any meaningful data. So an empty `{}` body created a phantom spool
+ * with all-null fields, polluting the inventory list.
+ *
+ * The fix requires at least one of the spool's meaningful fields to be
+ * present in the body, and pushes every field the validator captured
+ * (lotNumber / purchaseDate / openedDate / locationId / photoDataUrl /
+ * retired) instead of dropping them.
+ */
+describe("POST /api/filaments/[id]/spools — body validation (GH #203)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  async function seed() {
+    return Filament.create({
+      name: "Spool Test PLA",
+      vendor: "Test",
+      type: "PLA",
+    });
+  }
+
+  function postReq(filamentId: string, body: unknown) {
+    return new NextRequest(`http://localhost/api/filaments/${filamentId}/spools`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("rejects an empty body with 400 (no phantom spool created)", async () => {
+    const f = await seed();
+    const res = await createSpool(postReq(String(f._id), {}), {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/at least one of/i);
+    // Verify nothing was actually persisted.
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.spools).toHaveLength(0);
+  });
+
+  it("accepts a body with only totalWeight", async () => {
+    const f = await seed();
+    const res = await createSpool(postReq(String(f._id), { totalWeight: 1000 }), {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.spools).toHaveLength(1);
+    expect(fresh.spools[0].totalWeight).toBe(1000);
+  });
+
+  it("accepts a body with only label", async () => {
+    const f = await seed();
+    const res = await createSpool(postReq(String(f._id), { label: "Drybox A" }), {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.spools[0].label).toBe("Drybox A");
+  });
+
+  it("accepts a body with only locationId", async () => {
+    delete mongoose.models.Location;
+    const Location = (await import("@/models/Location")).default;
+    const loc = await Location.create({ name: "Drybox B", kind: "drybox" });
+    const f = await seed();
+    const res = await createSpool(postReq(String(f._id), { locationId: String(loc._id) }), {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    expect(String(fresh.spools[0].locationId)).toBe(String(loc._id));
+  });
+
+  it("persists every supplied field (no silent drop of lotNumber/dates)", async () => {
+    const f = await seed();
+    const res = await createSpool(
+      postReq(String(f._id), {
+        label: "Yellow",
+        totalWeight: 950,
+        lotNumber: "LOT-007",
+        purchaseDate: "2025-01-15",
+        openedDate: "2025-02-01",
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    const s = fresh.spools[0];
+    expect(s.label).toBe("Yellow");
+    expect(s.totalWeight).toBe(950);
+    expect(s.lotNumber).toBe("LOT-007");
+    expect(s.purchaseDate?.toISOString().slice(0, 10)).toBe("2025-01-15");
+    expect(s.openedDate?.toISOString().slice(0, 10)).toBe("2025-02-01");
+  });
+
+  it("returns 400 for non-numeric totalWeight (existing validateSpoolBody guard)", async () => {
+    const f = await seed();
+    const res = await createSpool(
+      postReq(String(f._id), { totalWeight: "abc" }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
Two issues in the [single-spool create handler](src/app/api/filaments/[id]/spools/route.ts):

1. **Empty body silently created a phantom spool** — \`validateSpoolBody\` (non-partial mode) defaults missing label/totalWeight to \`""\`/\`null\`, and the route pushed them with no required-field check. \`POST {}\` returned 200 and added a useless row to the spool list.
2. **Validated optional fields were silently dropped** — the route only pushed \`{ label, totalWeight }\`, so a client supplying \`lotNumber\` / \`purchaseDate\` / \`openedDate\` / \`locationId\` / \`photoDataUrl\` / \`retired\` would see them ignored.

## Fix
- Up-front presence check: at least one of the spool's meaningful fields must be supplied; otherwise 400.
- Build \`newSpool\` from every validated field (using the validator's \`=== undefined\` distinction between "not supplied" and "explicitly null") so legitimate metadata flows through.

## Verified live (dev server)

| Body | Before | After |
|---|---|---|
| \`{}\` | 200 (phantom row) | **400** |
| \`{ totalWeight: 1000 }\` | 200 (only label+weight persisted) | **200** (correct) |
| \`{ label, totalWeight, lotNumber, purchaseDate }\` | 200 (lotNumber/dates dropped) | **200** (all persisted) |

## Test plan
- [x] \`npx vitest run tests/spool-create-validation.test.ts\` — 6 passed
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)