### PR TITLE
Fix #204: analytics shows '+N manual' hint when manual entries cover the totals

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -914,7 +914,7 @@ Aggregates PrintHistory rows plus any manual per-spool usageHistory entries (the
 {
   "since": "2026-03-23T00:00:00Z",
   "days": 30,
-  "totals": { "grams": 3240, "cost": 82.50, "jobs": 17 },
+  "totals": { "grams": 3240, "cost": 82.50, "jobs": 17, "manualEntries": 2 },
   "usageByDay": [{ "date": "2026-03-23", "grams": 0 }, …],
   "byFilament":  [{ "_id": "…", "name": "PLA Black", "vendor": "Vendor A", "cost": 25, "grams": 1200 }, …],
   "byVendor":    [{ "vendor": "Vendor A", "grams": 2100 }, …],
@@ -923,6 +923,8 @@ Aggregates PrintHistory rows plus any manual per-spool usageHistory entries (the
 ```
 
 `usageHistory` entries are only pulled in when `source === "manual"`. Entries with `source: "job"` or `"slicer"` are owned by a PrintHistory row and already counted in the primary aggregation — including them here would double-count the same grams.
+
+`totals.manualEntries` (added GH #204) counts the manual `usageHistory` rows that contributed to the window — distinguishes inventory drained via PrintHistory jobs from inventory drained via direct spool-UI logs. The renderer surfaces this as a `+N manual` hint under the **Print jobs** stat box when > 0, so a fresh DB with only manual logs no longer shows `0 g · $0 · 0 jobs` despite having recorded usage.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -488,7 +488,7 @@ These writes run inside a MongoDB transaction when the deployment supports it (A
 The **Analytics** page at `/analytics` draws from PrintHistory records plus any manual per-spool usage entries (the ones you logged directly on the spool UI without going through the print-history endpoint).
 
 - **Window**: 7, 30, 90, or 365 days
-- **Totals**: grams, estimated cost, jobs
+- **Totals**: grams, estimated cost, jobs (`+N manual` is shown under the jobs counter when at least one manual per-spool entry contributed to the totals — distinguishes inventory drained via PrintHistory jobs from inventory drained via direct spool-UI logs)
 - **Usage by day**: bar chart
 - **Breakdown**: by filament, by vendor, by printer
 

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -8,7 +8,7 @@ import { useCurrency } from "@/hooks/useCurrency";
 interface AnalyticsData {
   since: string;
   days: number;
-  totals: { grams: number; cost: number; jobs: number };
+  totals: { grams: number; cost: number; jobs: number; manualEntries: number };
   usageByDay: { date: string; grams: number }[];
   byFilament: { _id: string; name: string; vendor: string; cost: number | null; grams: number }[];
   byVendor: { vendor: string; grams: number }[];
@@ -91,7 +91,20 @@ export default function AnalyticsPage() {
                 data.totals.cost > 0 ? `${currencySymbol}${data.totals.cost.toFixed(2)}` : "—"
               }
             />
-            <StatBox label={t("analytics.totalJobs")} value={String(data.totals.jobs)} />
+            {/* GH #204: when there are no PrintHistory rows but the
+                grams + cost totals are non-zero, the value came from
+                manual per-spool usage entries. Show the "+N manual"
+                hint underneath the Print jobs counter so the user can
+                attribute the totals. */}
+            <StatBox
+              label={t("analytics.totalJobs")}
+              value={String(data.totals.jobs)}
+              hint={
+                data.totals.manualEntries > 0
+                  ? t("analytics.manualEntriesHint", { count: data.totals.manualEntries })
+                  : undefined
+              }
+            />
           </div>
 
           {/* Single page-level empty state when no usage was recorded in the
@@ -231,11 +244,14 @@ export default function AnalyticsPage() {
   );
 }
 
-function StatBox({ label, value }: { label: string; value: string }) {
+function StatBox({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
     <div className="border border-gray-200 dark:border-gray-700 rounded px-3 py-2 bg-white dark:bg-gray-900">
       <div className="text-xs text-gray-500 uppercase tracking-wide">{label}</div>
       <div className="text-xl font-semibold mt-0.5">{value}</div>
+      {hint ? (
+        <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">{hint}</div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -46,6 +46,13 @@ export async function GET(request: NextRequest) {
     const byPrinter = new Map<string, { name: string; grams: number }>();
     let totalGrams = 0;
     let totalCost = 0;
+    // GH #204: per-spool `usageHistory` entries logged directly on the
+    // spool UI (source: "manual") count toward grams + cost but are not
+    // PrintHistory documents, so the existing `jobs` counter doesn't
+    // include them. Surface a separate count so the user can attribute
+    // the "Grams used" total — pre-fix the page showed `50 g · $1.10 ·
+    // 0 jobs` with no hint that the 50 g came from a manual entry.
+    let manualEntries = 0;
 
     // Seed all days in the window with 0 so the chart has no gaps.
     for (let i = 0; i <= days; i++) {
@@ -121,6 +128,7 @@ export async function GET(request: NextRequest) {
           byVendor.set(f.vendor, (byVendor.get(f.vendor) ?? 0) + u.grams);
           totalGrams += u.grams;
           if (f.cost != null) totalCost += (u.grams / 1000) * f.cost;
+          manualEntries++;
         }
       }
     }
@@ -148,6 +156,7 @@ export async function GET(request: NextRequest) {
         grams: Math.round(totalGrams),
         cost: Math.round(totalCost * 100) / 100,
         jobs: history.length,
+        manualEntries,
       },
       usageByDay,
       byFilament: byFilamentArr,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -183,6 +183,7 @@
   "analytics.totalGrams": "Gramm verbraucht",
   "analytics.totalCost": "Geschätzte Kosten",
   "analytics.totalJobs": "Druckaufträge",
+  "analytics.manualEntriesHint": "+{count} manuell",
   "analytics.usageByDay": "Verbrauch pro Tag",
   "analytics.topFilaments": "Top-Filamente",
   "analytics.byVendor": "Nach Hersteller",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -183,6 +183,7 @@
   "analytics.totalGrams": "Grams used",
   "analytics.totalCost": "Estimated cost",
   "analytics.totalJobs": "Print jobs",
+  "analytics.manualEntriesHint": "+{count} manual",
   "analytics.usageByDay": "Usage by day",
   "analytics.topFilaments": "Top filaments",
   "analytics.byVendor": "By vendor",

--- a/tests/analytics-route.test.ts
+++ b/tests/analytics-route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as getAnalytics } from "@/app/api/analytics/route";
+
+/**
+ * Per-spool manual usage entries (logged via the spool detail UI, not via
+ * /api/print-history) count toward grams + cost in /api/analytics, but
+ * are NOT PrintHistory documents — so they don't show up in `totals.jobs`.
+ *
+ * Pre-fix the analytics page rendered "Grams used 50 g · $1.10 · 0 jobs"
+ * with no way for the user to attribute the 50 g. Now the route exposes
+ * `totals.manualEntries` so the renderer can show "+N manual" alongside
+ * the jobs counter (GH #204).
+ */
+describe("/api/analytics — manualEntries counter (GH #204)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    delete mongoose.models.Filament;
+    Filament = (await import("@/models/Filament")).default;
+    // PrintHistory needs to be registered too — analytics queries it.
+    delete mongoose.models.PrintHistory;
+    await import("@/models/PrintHistory");
+  });
+
+  it("counts each manual usageHistory entry in the window", async () => {
+    const recent = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
+    await Filament.create({
+      name: "Test PLA",
+      vendor: "Vendor",
+      type: "PLA",
+      cost: 22,
+      spools: [
+        {
+          label: "main",
+          totalWeight: 950,
+          usageHistory: [
+            // 3 manual entries — all should count.
+            { grams: 25, date: recent, source: "manual", jobId: null },
+            { grams: 15, date: recent, source: "manual", jobId: null },
+            { grams: 10, date: recent, source: "manual", jobId: null },
+          ],
+        },
+      ],
+    });
+
+    const res = await getAnalytics(new NextRequest("http://localhost/api/analytics?days=30"));
+    const body = await res.json();
+    expect(body.totals.grams).toBe(50);
+    expect(body.totals.jobs).toBe(0);
+    expect(body.totals.manualEntries).toBe(3);
+  });
+
+  it("does NOT count manual entries outside the window", async () => {
+    const tooOld = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000); // 60 days
+    await Filament.create({
+      name: "Test PLA",
+      vendor: "Vendor",
+      type: "PLA",
+      spools: [
+        {
+          label: "main",
+          totalWeight: 950,
+          usageHistory: [{ grams: 25, date: tooOld, source: "manual", jobId: null }],
+        },
+      ],
+    });
+
+    const res = await getAnalytics(new NextRequest("http://localhost/api/analytics?days=30"));
+    const body = await res.json();
+    expect(body.totals.manualEntries).toBe(0);
+  });
+
+  it("does NOT count `source: 'job'` entries (they're owned by PrintHistory and would double-count)", async () => {
+    const recent = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    await Filament.create({
+      name: "Test PLA",
+      vendor: "Vendor",
+      type: "PLA",
+      spools: [
+        {
+          label: "main",
+          totalWeight: 950,
+          usageHistory: [
+            { grams: 25, date: recent, source: "manual", jobId: null },
+            { grams: 100, date: recent, source: "job", jobId: new mongoose.Types.ObjectId() },
+            { grams: 50, date: recent, source: "slicer", jobId: null },
+          ],
+        },
+      ],
+    });
+
+    const res = await getAnalytics(new NextRequest("http://localhost/api/analytics?days=30"));
+    const body = await res.json();
+    // Only the "manual" entry counts — same-loop guard for `source !== 'manual'`.
+    expect(body.totals.manualEntries).toBe(1);
+  });
+
+  it("totals.manualEntries is 0 when no manual entries exist", async () => {
+    await Filament.create({
+      name: "Test PLA",
+      vendor: "Vendor",
+      type: "PLA",
+      spools: [{ label: "main", totalWeight: 950 }],
+    });
+
+    const res = await getAnalytics(new NextRequest("http://localhost/api/analytics?days=30"));
+    const body = await res.json();
+    expect(body.totals.manualEntries).toBe(0);
+    expect(body.totals.jobs).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
The analytics route correctly aggregates per-spool \`usageHistory\` entries with \`source === "manual"\` into the grams + cost totals, but the existing \`totals.jobs\` counter only counts PrintHistory documents. So the page rendered:

\`\`\`
Grams used   50 g
Estimated    \$1.10
Print jobs   0     ← user has no idea where the 50 g came from
\`\`\`

## Fix
- Surface a new \`totals.manualEntries\` count from \`/api/analytics\`.
- Render it as a small \`+N manual\` hint under the Print jobs StatBox when \`> 0\`.
- New i18n key (EN + DE) — \`analytics.manualEntriesHint\`.
- StatBox component takes an optional \`hint\` prop so the layout stays consistent.

## Verified live
Dev server with 2 manual entries (50 g total): the StatBox now reads:

\`\`\`
PRINT JOBS
0
+2 manual
\`\`\`

## Test plan
- [x] \`npx vitest run tests/analytics-route.test.ts\` — 4 passed (count, window-exclusion, source-filter, zero case)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)