### PR TITLE
Fix #205: anti-FOUC script no longer trips React's 'script tag in component' warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import Script from "next/script";
 import "./globals.css";
 import AppHeader from "@/components/AppHeader";
 import ClientProviders from "@/components/ClientProviders";
@@ -35,17 +34,27 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <head>
+      <body className="min-h-full flex flex-col">
         {/* Anti-FOUC: applies the stored theme preference to <html> before
          *  the React tree mounts. Without it, dark-mode users see a
-         *  light-flash on every cold load. */}
-        <Script
-          id="theme-init"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{ __html: themeInitScript() }}
-        />
-      </head>
-      <body className="min-h-full flex flex-col">
+         *  light-flash on every cold load.
+         *
+         *  Plain <script dangerouslySetInnerHTML> instead of next/script's
+         *  `beforeInteractive` strategy. In Next 16 + React 19, the
+         *  next/script wrapper still tripped React's "Scripts inside React
+         *  components are never executed when rendering on the client"
+         *  warning on every render — the warning is informational (the
+         *  script does execute on SSR) but spammed the browser console
+         *  (GH #205). React's rendering of a static <script> with
+         *  `dangerouslySetInnerHTML` in the SSR HTML is silent in the
+         *  same React-19 path; the browser parses + executes the inline
+         *  script during initial paint, which is exactly what the
+         *  anti-FOUC pattern needs.
+         *
+         *  Position: top of <body>, before any of ClientProviders /
+         *  AppHeader / children, so the .dark class lands on <html>
+         *  before body content paints. */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript() }} />
         <ClientProviders>
           <AppHeader />
           {children}


### PR DESCRIPTION
## Summary
Two changes to the theme-init script in [src/app/layout.tsx](src/app/layout.tsx):

1. **Moved out of \`<head>\` into the top of \`<body>\`.** Per the Next 16 App Router contract ([\`node_modules/next/dist/docs/01-app/03-api-reference/02-components/script.md\`](https://nextjs.org/docs/app/api-reference/components/script#strategy)), \`<Script beforeInteractive>\` belongs inside \`<body>\`, not \`<head>\`. Putting it in \`<head>\` emitted React's "Encountered a script tag while rendering React component" warning on every page render.
2. **Switched from \`next/script\` with \`strategy="beforeInteractive"\` to a plain \`<script dangerouslySetInnerHTML>\`.** In Next 16 + React 19, the \`next/script\` wrapper still emits the warning because it renders a real \`<script>\` element via the \`__next_s\` push pattern that the React reconciler then warns about. A plain inline script gets serialised once into the SSR HTML, executes during initial parse (exactly what anti-FOUC needs), and React reconciles silently on hydration because the element already exists in the DOM.

## Position
Top of \`<body>\`, before \`<ClientProviders>\` / \`<AppHeader>\` / \`{children}\`. The browser parses + executes the script before laying out body content, so the \`.dark\` class lands on \`<html>\` before any content paints.

## Verified live
- \`document.documentElement.classList.contains('dark')\` ✓ — anti-FOUC still works
- Patched \`console.error\` to count fresh occurrences of the warning across 4 client-side navigations: **0** (was firing once per render before)
- SSR HTML contains a plain \`<script>(() => { try { … } catch (_) {} })();</script>\` with the inline theme code; the \`__next_s\` next/script shim is gone
- Existing \`tests/themeInitScript.test.ts\` (6 tests) still pass — the helper that produces the inline JS is unchanged; only how it gets into the page changed

## Test plan
- [x] \`npx vitest run tests/themeInitScript.test.ts\` — 6 passed
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean
- [x] Manual: 0 React warnings across home / dashboard / compare / analytics / share

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)