### PR TITLE
Fix #176: skip NFC init on Windows when SCardSvr is stopped

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu, ipcMain, dialog, utilityProcess, UtilityProcess, shell, session } from "electron";
 import path from "path";
 import fs from "fs";
+import { execFile } from "child_process";
 import Store from "electron-store";
 import http from "http";
 import { NfcService } from "./nfc-service";
@@ -770,6 +771,39 @@ app.on("child-process-gone", (_evt, details) => {
   diag(`child-process-gone type=${details.type} reason=${details.reason} exitCode=${details.exitCode}`);
 });
 
+/**
+ * Probe whether Windows' Smart Card service (SCardSvr) is in the RUNNING
+ * state. On Windows ARM64 the service ships as Manual + Stopped by default
+ * and `pcsclite()` makes a synchronous SCardEstablishContext call that
+ * blocks the V8 event loop indefinitely in this state — the symptom users
+ * see is "process appears in Task Manager but no window ever opens" (GH
+ * #176). The probe shells out to `sc.exe query` (async, fast, immune to the
+ * sync trap) so the NFC init can be skipped cleanly on hosts where
+ * pcsclite would otherwise wedge the main process.
+ *
+ * Returns `true` on non-Windows platforms — Linux/macOS use pcscd /
+ * CryptoTokenKit and have no equivalent failure mode.
+ */
+function isSmartCardServiceRunning(timeoutMs = 5000): Promise<boolean> {
+  if (process.platform !== "win32") return Promise.resolve(true);
+  return new Promise((resolve) => {
+    execFile(
+      "sc.exe",
+      ["query", "SCardSvr"],
+      { timeout: timeoutMs, windowsHide: true },
+      (err, stdout) => {
+        if (err) {
+          resolve(false);
+          return;
+        }
+        // sc.exe state codes: 1 STOPPED, 2 START_PENDING, 3 STOP_PENDING,
+        // 4 RUNNING, 5 CONTINUE_PENDING, 6 PAUSE_PENDING, 7 PAUSED.
+        resolve(/STATE\s*:\s*4\s*RUNNING/.test(stdout));
+      },
+    );
+  });
+}
+
 app.whenReady().then(async () => {
   diag("app ready");
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
@@ -842,46 +876,11 @@ app.whenReady().then(async () => {
     }
   }
 
-  // Initialize NFC service
-  try {
-    nfcService = new NfcService();
-    let prevTagPresent = false;
-    let lastAutoReadAt = 0;
-    const AUTO_READ_COOLDOWN_MS = 4000;
-    nfcService.on("statusChange", (status) => {
-      mainWindow?.webContents.send("nfc-status-changed", status);
-
-      if (status.tagPresent && !prevTagPresent && nfcService) {
-        const now = Date.now();
-        if (now - lastAutoReadAt < AUTO_READ_COOLDOWN_MS) {
-          prevTagPresent = status.tagPresent;
-          return;
-        }
-        // Set timestamp BEFORE async read to prevent concurrent triggers
-        lastAutoReadAt = now;
-        nfcService.readTag()
-          .then((data) => {
-            mainWindow?.webContents.send("nfc-tag-detected", { data });
-          })
-          .catch((err) => {
-            // Blank/erased tags have no NDEF data — tell the renderer so it
-            // can show an "empty tag" indication instead of silently ignoring.
-            if (err.message?.includes("No NDEF TLV") || err.message?.includes("No NDEF record")) {
-              mainWindow?.webContents.send("nfc-tag-detected", { empty: true });
-              return;
-            }
-            mainWindow?.webContents.send("nfc-tag-detected", { error: err.message });
-          });
-      }
-      prevTagPresent = status.tagPresent;
-    });
-    nfcService.on("error", (err) => {
-      console.error("NFC error:", err.message);
-    });
-  } catch (err) {
-    console.error("NFC initialization failed (reader may not be available):", err);
-  }
-
+  // Create the window BEFORE touching NFC. `pcsclite()` can wedge the V8
+  // event loop synchronously on Windows when SCardSvr is unavailable
+  // (default state on Windows ARM64) — defense in depth: even if the
+  // SCardSvr probe below fails to detect that case, the user still sees a
+  // window instead of a phantom background process (GH #176).
   if (!connectionMode && !store.get("mongodbUri")) {
     createWindow("/setup");
   } else {
@@ -889,6 +888,57 @@ app.whenReady().then(async () => {
       process.env.MONGODB_URI = mongoUri;
     }
     createWindow("/");
+  }
+
+  // Initialize NFC service. Skipped on Windows when SCardSvr is stopped —
+  // pcsclite()'s sync SCardEstablishContext blocks the main thread there
+  // (GH #176). On Linux/Mac the probe is a no-op and the service is
+  // attempted unconditionally as before.
+  const skipNfcReason =
+    process.platform === "win32" && !(await isSmartCardServiceRunning())
+      ? "Smart Card service (SCardSvr) is not running on this Windows host"
+      : null;
+  if (skipNfcReason) {
+    diag(`skipping NFC init: ${skipNfcReason}`);
+  } else {
+    try {
+      nfcService = new NfcService();
+      let prevTagPresent = false;
+      let lastAutoReadAt = 0;
+      const AUTO_READ_COOLDOWN_MS = 4000;
+      nfcService.on("statusChange", (status) => {
+        mainWindow?.webContents.send("nfc-status-changed", status);
+
+        if (status.tagPresent && !prevTagPresent && nfcService) {
+          const now = Date.now();
+          if (now - lastAutoReadAt < AUTO_READ_COOLDOWN_MS) {
+            prevTagPresent = status.tagPresent;
+            return;
+          }
+          // Set timestamp BEFORE async read to prevent concurrent triggers
+          lastAutoReadAt = now;
+          nfcService.readTag()
+            .then((data) => {
+              mainWindow?.webContents.send("nfc-tag-detected", { data });
+            })
+            .catch((err) => {
+              // Blank/erased tags have no NDEF data — tell the renderer so it
+              // can show an "empty tag" indication instead of silently ignoring.
+              if (err.message?.includes("No NDEF TLV") || err.message?.includes("No NDEF record")) {
+                mainWindow?.webContents.send("nfc-tag-detected", { empty: true });
+                return;
+              }
+              mainWindow?.webContents.send("nfc-tag-detected", { error: err.message });
+            });
+        }
+        prevTagPresent = status.tagPresent;
+      });
+      nfcService.on("error", (err) => {
+        console.error("NFC error:", err.message);
+      });
+    } catch (err) {
+      console.error("NFC initialization failed (reader may not be available):", err);
+    }
   }
 
   app.on("activate", () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -786,9 +786,15 @@ app.on("child-process-gone", (_evt, details) => {
  */
 function isSmartCardServiceRunning(timeoutMs = 5000): Promise<boolean> {
   if (process.platform !== "win32") return Promise.resolve(true);
+  // Resolve sc.exe via SystemRoot rather than the bare command name. Windows'
+  // default executable search order checks the app / current-working
+  // directory before System32, so a `sc.exe` planted next to a portable run
+  // would be picked up first and turn this probe into an arbitrary-code-
+  // execution sink. Anchor to an absolute path to close that.
+  const scPath = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "sc.exe");
   return new Promise((resolve) => {
     execFile(
-      "sc.exe",
+      scPath,
       ["query", "SCardSvr"],
       { timeout: timeoutMs, windowsHide: true },
       (err, stdout) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.14.7",
+  "version": "1.14.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.14.7",
+      "version": "1.14.8",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.14.7",
+  "version": "1.14.8",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",


### PR DESCRIPTION
## Summary

- Fixes [#176](https://github.com/hyiger/filament-db/issues/176): the app launches as a phantom background process on Windows ARM64 with no window ever appearing.
- Root cause: `pcsclite()` (called inside `new NfcService()`) makes a synchronous `SCardEstablishContext` call that wedges the V8 event loop indefinitely when Windows' Smart Card service (`SCardSvr`) is `Stopped` — its default state on Windows ARM64 (Manual + Stopped, not auto-triggered).
- Why the v1.14.2 safety net didn't help: the 20s `setTimeout` inside `createWindow` was never set (we never reached `createWindow`), and `setTimeout` can't fire while main is sync-blocked anyway.

## Fix

- Added an async `isSmartCardServiceRunning()` probe that shells out to `sc.exe query SCardSvr` (immune to the sync trap). Windows-only; no-op on Linux/macOS.
- Skip NFC init on Windows when SCardSvr isn't `RUNNING`.
- Reordered: `createWindow` now runs **before** NFC init, as defense in depth — even an edge-case hang past the probe leaves a visible window instead of a phantom process.

## Verified locally on Windows 11 ARM64

This host's `SCardSvr` was `STATE: 1 STOPPED` — same state Tony's machine likely had.

- **Before fix**: process appeared in Task Manager, diag log frozen at "single-instance lock acquired" indefinitely (10+ minutes), no window. Reproduces #176 exactly.
- **After fix**: window appears in 1.2s. Diag log records `skipping NFC init: Smart Card service (SCardSvr) is not running on this Windows host`. UI shows "No NFC reader" pill (correct).

`npm run lint` and `npx tsc --noEmit` pass.

## Test plan

- [x] Verified on Windows 11 ARM64 with `SCardSvr` Stopped → window now opens
- [ ] Verify on a Windows host where `SCardSvr` is Running and a real PC/SC reader is plugged in — NFC should initialize as before
- [ ] Verify on Linux / macOS — `isSmartCardServiceRunning()` is a Promise-resolve-true no-op, so behavior should be identical to v1.14.7

## Trade-off / known follow-up

If a Windows user plugs in an NFC reader **after** the app has already launched, NFC stays disabled until they restart the app. (SCardSvr starts on smart-card-arrival, but our probe runs once at startup.) This is a known limitation of the simple fix; a follow-up could re-probe periodically and lazy-init NFC on the first transition to RUNNING. Restart-after-plug-in is acceptable given the alternative was "app never launches".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
