### PR TITLE
Add native Windows ARM64 release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,10 @@ jobs:
             arch: x64
           - os: windows-latest
             platform: win
-            arch: ""
+            arch: x64
+          - os: windows-latest
+            platform: win-arm64-cross
+            arch: arm64
           - os: ubuntu-latest
             platform: linux
             arch: x64
@@ -90,10 +93,31 @@ jobs:
           npm run electron:compile
 
       - name: Rebuild native modules and package (default — host arch matches target)
-        if: matrix.platform != 'linux-arm64' && matrix.platform != 'mac-x64-cross'
+        if: matrix.platform != 'linux-arm64' && matrix.platform != 'mac-x64-cross' && matrix.platform != 'win-arm64-cross'
         run: |
           npm run electron:rebuild
           npx electron-builder --config electron-builder.yml ${{ matrix.arch != '' && format('--{0}', matrix.arch) || '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebuild native modules and package (Windows arm64 cross-compile on x64)
+        if: matrix.platform == 'win-arm64-cross'
+        shell: pwsh
+        run: |
+          # MSVC on windows-latest already ships an x64→arm64 cross toolchain
+          # (Microsoft.VisualStudio.Component.VC.Tools.ARM64), so this just
+          # works once --arch is set. Sanity-check the produced .node by
+          # parsing its PE header so a silent fallback to host arch fails
+          # fast instead of shipping an x64 binary inside an arm64 installer.
+          npx electron-rebuild -f -o "@pokusew/pcsclite" --arch=arm64
+          $node = "node_modules/@pokusew/pcsclite/build/Release/pcsclite.node"
+          $bytes = [System.IO.File]::ReadAllBytes($node)
+          $peOffset = [BitConverter]::ToUInt32($bytes, 0x3C)
+          $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+          $archName = switch ($machine) { 0x8664 {"x64"} 0xAA64 {"arm64"} default {"unknown:0x{0:X4}" -f $_} }
+          Write-Host "pcsclite.node arch: $archName (machine=0x$('{0:X4}' -f $machine))"
+          if ($archName -ne "arm64") { throw "pcsclite.node was rebuilt as $archName, expected arm64" }
+          npx electron-builder --config electron-builder.yml --arm64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,13 +64,19 @@ mac:
     - dmg
 
 win:
+  # Arch list is enumerated here but the release workflow scopes each CI job
+  # to a single arch via --x64 / --arm64 — that way cross-compiled native
+  # modules (pcsclite for arm64, rebuilt via electron-rebuild --arch=arm64)
+  # can't accidentally bleed into the wrong installer.
   target:
     - target: nsis
       arch:
         - x64
+        - arm64
     - target: zip
       arch:
         - x64
+        - arm64
 
 nsis:
   oneClick: false


### PR DESCRIPTION
## Summary

- Follow-up to [#211](https://github.com/hyiger/filament-db/pull/211) (Windows ARM64 launch fix). That PR shipped a probe-based fix that works fine under x64 emulation, but Windows ARM64 users have been getting an emulated x64 installer all along — this adds a **native ARM64 installer**.
- Splits the existing windows job into `x64` and `win-arm64-cross` siblings, both on `windows-latest`. MSVC's x64→arm64 cross toolchain is part of the standard runner image, so no extra setup step is needed.
- pcsclite is rebuilt for arm64 via `electron-rebuild --arch=arm64`, then a PE-header check on the resulting `.node` fails the job fast if it silently fell back to host arch (same defensive pattern the existing macOS x64-on-arm64 cross step uses).

## Files

- [`electron-builder.yml`](electron-builder.yml) — add `arm64` to both `nsis` and `zip` targets alongside `x64`. Existing `nsis.artifactName` template (`FilamentDB-${version}-windows-${arch}-setup.${ext}`) produces `FilamentDB-X.Y.Z-windows-arm64-setup.exe` for free.
- [`.github/workflows/release.yml`](.github/workflows/release.yml) — split windows job into x64 + win-arm64-cross; new step does the cross-rebuild + arch sanity check + arm64 packaging.

## Why split into two jobs (rather than building both archs in one)

Same reason the macOS targets are split today: cross-compiled native modules can bleed into the wrong installer if both archs are built in the same dir. Scoping each job to one arch via `--x64` / `--arm64` keeps them clean.

## Test plan

- [ ] CI matrix produces 6 builds (was 5): mac/arm64, mac/x64, win/x64, win/arm64, linux/x64, linux/arm64
- [ ] `dist-electron/FilamentDB-1.14.x-windows-arm64-setup.exe` and matching `.zip` show up on the next release
- [ ] PE-header sanity check confirms `pcsclite.node` is `0xAA64` (ARM64) — fails fast if it ever isn't
- [ ] electron-updater picks up `latest-arm64.yml` from the existing `latest*.yml` upload glob, so auto-update on a native arm64 install can find its own metadata
- [ ] Smoke-test: install the new `arm64-setup.exe` on a Windows ARM64 host, confirm it launches without going through Prism emulation

The smoke-test is the one that genuinely needs human verification — everything before it can be inferred from CI logs. I don't have a clean way to install a fresh release MSI on this host inside the agent loop, so flagging it as "verify after the next tagged release."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
