### PR TITLE
Audit sweep: address #215-#220

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,103 @@ jobs:
         with:
           name: coverage-report
           path: coverage/
+
+  smoke:
+    # Boot the production standalone build and curl a handful of routes so a
+    # bad next.config / standalone-output regression is caught before release.
+    # `npm run build` already runs on the test matrix above; we rebuild here
+    # because workflow jobs don't share build artifacts and copying them
+    # across jobs costs more time than just rebuilding.
+    runs-on: ubuntu-latest
+    needs: test
+
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok' | grep -q 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # Standalone server reads MONGODB_URI from env at request time.
+      MONGODB_URI: mongodb://localhost:27017/filament-db-smoke
+      # Bind to 3456 (the project's canonical dev/desktop port) so the curl
+      # URLs match what a developer would hit locally.
+      PORT: "3456"
+      HOSTNAME: "127.0.0.1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install PC/SC development headers (Linux)
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (standalone)
+        run: npm run build
+
+      - name: Stage standalone runtime (public + static)
+        # `output: "standalone"` copies node_modules + server.js but not
+        # public/ or .next/static — Next's docs say to copy those in
+        # manually so the production server can serve assets and routes
+        # like /api/openapi (which reads public/openapi.json).
+        run: |
+          cp -R public .next/standalone/public
+          mkdir -p .next/standalone/.next
+          cp -R .next/static .next/standalone/.next/static
+
+      - name: Start standalone server
+        run: |
+          npm start &
+          echo "$!" > .smoke-server.pid
+          # Wait until the server is accepting connections (max ~60s).
+          for i in $(seq 1 60); do
+            if curl -sS -o /dev/null "http://127.0.0.1:${PORT}/api/openapi"; then
+              echo "server is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server failed to start within 60s" >&2
+          exit 1
+
+      - name: Smoke check core routes
+        run: |
+          set -euo pipefail
+          fail=0
+          check() {
+            local path="$1"
+            local code
+            code=$(curl -sS -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}${path}")
+            if [ "$code" = "200" ]; then
+              echo "  ok  $path → $code"
+            else
+              echo "  FAIL $path → $code" >&2
+              fail=1
+            fi
+          }
+          check /
+          check /dashboard
+          check /api-docs
+          check /api/openapi
+          check /api/filaments
+          exit $fail
+
+      - name: Stop standalone server
+        if: always()
+        run: |
+          if [ -f .smoke-server.pid ]; then
+            kill "$(cat .smoke-server.pid)" 2>/dev/null || true
+          fi

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -222,6 +222,8 @@ npm run dev                   # development at http://localhost:3456
 npm run build && npm start    # production at http://localhost:3000 (set PORT=3456 to match dev)
 ```
 
+`npm start` runs the standalone server entrypoint (`node .next/standalone/server.js`) — `next start` is not compatible with the `output: "standalone"` build mode the project uses for Docker and Electron packaging.
+
 #### Desktop App (from source)
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2257,9 +2257,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2273,9 +2273,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -2305,11 +2305,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2321,11 +2324,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2337,11 +2343,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2353,11 +2362,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2369,9 +2381,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -2385,9 +2397,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -8315,9 +8327,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -11180,12 +11192,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -11199,14 +11211,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -11230,34 +11242,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/nfc-pcsc": {
@@ -11977,10 +11961,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "next dev -p 3456",
     "build": "next build",
-    "start": "next start",
+    "start": "node .next/standalone/server.js",
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -39,6 +39,9 @@
     "tar": "^7.5.0",
     "undici": "^6.25.0",
     "yaml": "^2.8.3"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -270,9 +270,15 @@
       "delete": {
         "tags": ["Filaments"],
         "summary": "Delete filament",
-        "description": "Soft-deletes a filament by setting _deletedAt. Cannot delete a parent that still has variants.",
+        "description": "By default this is a soft delete that sets _deletedAt — the filament moves to the trash and can be restored via POST /api/filaments/{id}/restore. Pass ?permanent=true to mark the row as purged (sets _purged so the hybrid sync engine propagates the deletion to peers); the filament must already be in the trash. Cannot delete a parent that still has variants.",
         "parameters": [
-          { "$ref": "#/components/parameters/FilamentId" }
+          { "$ref": "#/components/parameters/FilamentId" },
+          {
+            "name": "permanent",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["true", "false"] },
+            "description": "When 'true', permanently purges a trashed filament instead of soft-deleting. The filament must already be in the trash (i.e. previously soft-deleted)."
+          }
         ],
         "responses": {
           "200": {
@@ -289,7 +295,7 @@
             }
           },
           "400": {
-            "description": "Cannot delete — has variants",
+            "description": "Cannot delete — has variants, or permanent delete attempted on a filament that isn't in the trash",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Error" }
@@ -298,6 +304,96 @@
           },
           "404": {
             "description": "Filament not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/filaments/trash": {
+      "get": {
+        "tags": ["Filaments"],
+        "summary": "List trashed filaments",
+        "description": "Returns soft-deleted filaments (those with a non-null _deletedAt), sorted by deletion time descending. Permanently-purged tombstones (_purged: true) are excluded — they remain in the collection only so the hybrid sync engine can propagate the purge to peers and should never reappear in the trash UI.",
+        "responses": {
+          "200": {
+            "description": "List of trashed filaments (lightweight projection)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "_id": { "type": "string" },
+                      "name": { "type": "string" },
+                      "vendor": { "type": "string" },
+                      "type": { "type": "string" },
+                      "color": { "type": "string" },
+                      "cost": { "type": "number", "nullable": true },
+                      "parentId": { "type": "string", "nullable": true },
+                      "_deletedAt": { "type": "string", "format": "date-time" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to list trash",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/filaments/{id}/restore": {
+      "post": {
+        "tags": ["Filaments"],
+        "summary": "Restore filament from trash",
+        "description": "Un-soft-deletes a trashed filament by clearing _deletedAt. Refuses with 409 if another active filament now uses the same name — the partial unique index on `name` only covers non-deleted documents, so the caller has to rename one or the other before the restore can succeed.",
+        "parameters": [
+          { "$ref": "#/components/parameters/FilamentId" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Restored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": { "type": "string", "example": "Restored" },
+                    "_id": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Filament not in trash (either does not exist, was never soft-deleted, or has already been permanently purged)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "409": {
+            "description": "Name conflict — another active filament already uses this name",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to restore filament",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Error" }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -142,7 +142,7 @@ async function seed() {
     const nozzle = await Nozzle.findOneAndUpdate(
       { name },
       { name, diameter: spec.diameter, type: "Brass", highFlow: spec.highFlow },
-      { upsert: true, new: true, returnDocument: "after" }
+      { upsert: true, returnDocument: "after" }
     );
     nozzleIdMap.set(name, nozzle._id);
     console.log(`  ✓ ${name} (${spec.diameter}mm, ${spec.highFlow ? "high-flow" : "standard"})`);
@@ -159,7 +159,7 @@ async function seed() {
     await Filament.findOneAndUpdate(
       { name: filament.name },
       { ...filament, compatibleNozzles: nozzleIds },
-      { upsert: true, new: true, returnDocument: "after" }
+      { upsert: true, returnDocument: "after" }
     );
 
     const nozzleInfo = nozzleNames.length > 0 ? ` [${nozzleNames.join(", ")}]` : "";

--- a/src/app/api/filaments/import/route.ts
+++ b/src/app/api/filaments/import/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
         const existing = await Filament.findOneAndUpdate(
           { name, _deletedAt: null },
           { $set: rest, $setOnInsert: { name } },
-          { upsert: true, new: false },
+          { upsert: true, returnDocument: "before" },
         );
         if (existing) {
           updated++;

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -811,8 +811,9 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
       )}
 
       <div>
-        <label className={labelClass}>{t("form.name")} *</label>
+        <label className={labelClass} htmlFor="filament-name">{t("form.name")} *</label>
         <input
+          id="filament-name"
           className={inputClass}
           value={form.name}
           onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -2161,6 +2162,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
                 <div className="flex items-center gap-2 mb-2">
                   <input
                     type="text"
+                    aria-label={t("form.placeholder.presetLabel")}
                     className={inputClass}
                     value={preset.label}
                     onChange={(e) => updatePreset(idx, "label", e.target.value)}

--- a/tests/compare-route-spoolweight.test.ts
+++ b/tests/compare-route-spoolweight.test.ts
@@ -20,13 +20,18 @@ describe("/api/filaments/compare — inherited spoolWeight (Codex P2 PR #190)", 
   let Filament: any;
 
   beforeEach(async () => {
+    // Static imports — see compare-route.test.ts for the Vite warning detail.
     const filamentMod = await import("@/models/Filament");
     if (!mongoose.models.Filament) {
       mongoose.model("Filament", filamentMod.default.schema);
     }
-    for (const name of ["Nozzle", "Printer", "BedType"] as const) {
+    const referenced = [
+      ["Nozzle", await import("@/models/Nozzle")],
+      ["Printer", await import("@/models/Printer")],
+      ["BedType", await import("@/models/BedType")],
+    ] as const;
+    for (const [name, mod] of referenced) {
       if (!mongoose.models[name]) {
-        const mod = await import(`@/models/${name}`);
         mongoose.model(name, mod.default.schema);
       }
     }

--- a/tests/compare-route.test.ts
+++ b/tests/compare-route.test.ts
@@ -24,14 +24,22 @@ describe("/api/filaments/compare — variant inheritance (GH #184)", () => {
   let Filament: any;
 
   beforeEach(async () => {
+    // Static imports — `await import("@/models/${name}")` triggered a Vite
+    // dynamic-import warning ("file extension must be included in the static
+    // part") because the matcher couldn't pre-resolve the path. A static
+    // lookup table keeps each import string fully literal.
     const filamentMod = await import("@/models/Filament");
     if (!mongoose.models.Filament) {
       mongoose.model("Filament", filamentMod.default.schema);
     }
     // Models populate() walks
-    for (const name of ["Nozzle", "Printer", "BedType"] as const) {
+    const referenced = [
+      ["Nozzle", await import("@/models/Nozzle")],
+      ["Printer", await import("@/models/Printer")],
+      ["BedType", await import("@/models/BedType")],
+    ] as const;
+    for (const [name, mod] of referenced) {
       if (!mongoose.models[name]) {
-        const mod = await import(`@/models/${name}`);
         mongoose.model(name, mod.default.schema);
       }
     }

--- a/tests/variant-edit-preserves-inheritance.test.ts
+++ b/tests/variant-edit-preserves-inheritance.test.ts
@@ -28,15 +28,22 @@ describe("variant edit round-trip preserves inheritance", () => {
   let Filament: any;
 
   beforeEach(async () => {
+    // Static imports — `await import("@/models/${name}")` triggered a Vite
+    // dynamic-import warning ("file extension must be included in the static
+    // part") because the matcher couldn't pre-resolve the path.
     const filamentMod = await import("@/models/Filament");
     if (!mongoose.models.Filament) {
       mongoose.model("Filament", filamentMod.default.schema);
     }
     // Models that GET populates — without these registered the
     // populate() call throws "Schema hasn't been registered".
-    for (const name of ["Nozzle", "Printer", "BedType"] as const) {
+    const referenced = [
+      ["Nozzle", await import("@/models/Nozzle")],
+      ["Printer", await import("@/models/Printer")],
+      ["BedType", await import("@/models/BedType")],
+    ] as const;
+    for (const [name, mod] of referenced) {
       if (!mongoose.models[name]) {
-        const mod = await import(`@/models/${name}`);
         mongoose.model(name, mod.default.schema);
       }
     }


### PR DESCRIPTION
## Summary

Addresses the six audit-tagged issues opened after the v1.16.0 release:

- **#215** — npm audit moderate (postcss): added `overrides` block in `package.json` to force the patched version past Next's nested copy.
- **#216** — `npm start` was running `next start`, which is incompatible with the project's `output: "standalone"` build mode. Now points at `.next/standalone/server.js`; `docs/setup.md` calls out the reason.
- **#217** — Documented the trash + restore endpoints in `public/openapi.json`: `GET /api/filaments/trash`, `POST /api/filaments/{id}/restore`, and the `?permanent=true` query param on the filament DELETE (including the `_purged` tombstone semantics and the 409 name-collision response).
- **#218** — Required Name input in `FilamentForm` now has `id` + paired `htmlFor`; preset-row label inputs gain `aria-label`. Vendor / Type were already wired up via `aria-labelledby`.
- **#219** — New `smoke` CI job: spins up `mongo:7` as a service, runs the production standalone build, copies in `public/` and `.next/static` per Next's standalone docs, and curls `/`, `/dashboard`, `/api-docs`, `/api/openapi`, `/api/filaments`. Catches standalone / Mongo bootstrap regressions before release.
- **#220** — Replaced Mongoose `findOneAndUpdate({ new: true|false })` calls with `returnDocument: "after"|"before"` in `scripts/seed.ts` + `src/app/api/filaments/import/route.ts`. Three route-level tests that re-registered referenced models from template-literal dynamic imports now use a static-import map to silence Vite's "request of a dependency is an expression" warning.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1106 / 1106 passing
- [x] `npm run build` — succeeds in standalone mode
- [ ] CI `smoke` job passes on first PR run (verifies the curl checks against a real standalone server backed by `mongo:7`)
- [ ] Manual: open `/api-docs`, expand the **Filaments** tag — confirm `GET /api/filaments/trash`, `POST /api/filaments/{id}/restore`, and the `?permanent=true` param on `DELETE /api/filaments/{id}` all render with their descriptions

Closes #215, closes #216, closes #217, closes #218, closes #219, closes #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)