### PR TITLE
Fix #230: NFC reader plug-in fires spurious 'Cannot connect to tag' error

### DIFF
--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -73,16 +73,32 @@ export class NfcService extends EventEmitter {
 
         // Ignore the first status event per reader — it reflects the reader's
         // initial state which can falsely report SCARD_STATE_PRESENT on some
-        // interfaces (e.g. the SAM slot on Linux reports present=true with no
-        // tag). We must skip setting readerPresent here too, otherwise the SAM
-        // reader's phantom "present" permanently blocks tag removal detection.
+        // interfaces. Two known false positives:
+        //
+        //   1. The SAM slot on Linux reports present=true with no tag. We must
+        //      skip setting readerPresent here too, otherwise the SAM
+        //      reader's phantom "present" permanently blocks tag removal
+        //      detection.
+        //
+        //   2. The ACR1552U on macOS (and likely other ACS-driver readers)
+        //      reports present=true WITH a non-empty `status.atr` on the
+        //      first event even when no tag is in the field (GH #230). The
+        //      previous code carved out an exception when
+        //      `status.atr?.length` was truthy, on the theory that ATR
+        //      presence meant a tag was already on the reader at plug-in.
+        //      That theory was wrong for at least one driver and caused
+        //      every reader plug-in to surface a "Cannot connect to tag"
+        //      toast — because the auto-read in main.ts saw tagPresent
+        //      flip true and tried to read a tag that wasn't there.
+        //
+        // Trade-off: a user who plugs in the reader with a tag already on it
+        // doesn't get an auto-read on plug-in. They lift + re-place the tag
+        // once (or any other physical perturbation) and the next status
+        // event runs through the normal `isPresent` path below. That minor
+        // friction is far less disruptive than the previous behaviour of
+        // throwing a scary error on every plug-in.
         if (firstStatus) {
           firstStatus = false;
-          if (isPresent && !isEmpty && status.atr?.length) {
-            // ATR present means a tag is genuinely on the reader at startup
-            this.readerPresent.set(reader.name, true);
-            this.updateStatus({ tagPresent: true, tagUid: null });
-          }
           return;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "dependencies": {
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",


### PR DESCRIPTION
## Summary

User plugged in an NFC reader (ACR1552U on macOS) and immediately saw a toast:

> NFC Read Error
> Cannot connect to tag — the reader detected a tag but could not establish a connection. Try removing and replacing the tag.

No tag was near the reader. The error fires once on plug-in.

## Root cause

`electron/nfc-service.ts` first-status handler had a carve-out at lines 81-85 that set `tagPresent: true` when `status.atr?.length > 0` on the first event after reader discovery. The intent was to catch "user plugged in with a tag already on the reader." But at least one driver (ACS on macOS) ships a phantom ATR on the first event with no tag actually present.

The chain:
1. Reader plugged in → `reader.on("status")` fires first event with phantom ATR
2. firstStatus block sees `status.atr?.length > 0` → sets `tagPresent: true`
3. main.ts auto-read handler sees `tagPresent` flip false→true → calls `readTag()`
4. `readTag()` → `withConnection()` → `connect()` → all SHARED-mode connects + retries fail (no real tag)
5. Throws "Cannot connect to tag…" → surfaces to renderer

## Fix

Skip the first status event entirely, no ATR carve-out. The inline comment documents the trade-off: users who plug in WITH a tag already on the reader need to lift + re-place the tag once to trigger auto-read. That's a minor one-action friction for the edge case, and eliminates the scary error in the common case.

The previous fix had two known false-positive sources (SAM slot on Linux, ACS driver on macOS); the ATR-carve-out tried to thread the needle and only addressed one. Dropping the carve-out is the simpler correct fix.

## Test plan

- [ ] Plug reader in with no tag → no toast appears
- [ ] Place a tag → auto-read fires, decoded data shows
- [ ] Lift tag → status returns to "no tag"
- [ ] Place + re-place tag rapidly → auto-read cooldown prevents spam (existing 4s cooldown)
- [ ] Plug reader in WITH tag already on it → no auto-read (expected regression for this edge case); lifting + replacing the tag triggers a normal read

This is hardware-driven so it can't be unit-tested against `pcsclite()` without significant mocking infrastructure that doesn't exist yet for this service. The change is small (~4 lines of behaviour) and documented inline.

Closes #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)