### PR TITLE
Fix Windows release: drop the universal installer + stop shipping cross-arch native modules

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,19 +64,19 @@ mac:
     - dmg
 
 win:
-  # Arch list is enumerated here but the release workflow scopes each CI job
-  # to a single arch via --x64 / --arm64 — that way cross-compiled native
-  # modules (pcsclite for arm64, rebuilt via electron-rebuild --arch=arm64)
-  # can't accidentally bleed into the wrong installer.
+  # Do NOT hardcode arch here (mirrors the mac config above). Each CI matrix
+  # job rebuilds pcsclite for exactly one arch and then invokes electron-
+  # builder with the matching --x64 or --arm64 flag. Listing both arches
+  # under `target.arch[]` would make electron-builder build BOTH per-arch
+  # installers PLUS a universal combined one in every Windows CI job —
+  # which (a) ships ~398 MB of duplicated content as the no-arch
+  # `windows-setup.exe` and (b) silently smuggles the wrong pcsclite.node
+  # into the off-arch installer (the arm64 CI job has only the arm64
+  # native module, so its windows-x64-setup.exe is broken — and vice
+  # versa). Leaving arch unset means the CLI flag alone scopes the build.
   target:
     - target: nsis
-      arch:
-        - x64
-        - arm64
     - target: zip
-      arch:
-        - x64
-        - arm64
 
 nsis:
   oneClick: false


### PR DESCRIPTION
Started as \"drop the universal Windows installer\" (the 398 MB \`FilamentDB-x.x.x-windows-setup.exe\` next to the per-arch ones) and uncovered something worse on the way: the per-arch installers themselves have been wrong since #212.

## What I found in the v1.20.0 release logs

Each Windows CI job ran \`electron-builder --x64\` or \`electron-builder --arm64\` and produced **three** NSIS installers, not one:

\`\`\`
file=...windows-setup.exe       archs=arm64, x64   ← 398 MB universal
file=...windows-arm64-setup.exe archs=arm64
file=...windows-x64-setup.exe   archs=x64
\`\`\`

Because both arches were listed in \`win.target.arch[]\`, electron-builder treats the CLI \`--x64\`/\`--arm64\` flag as **additive**, not as a filter. So every Windows CI job builds all three. And since each job only rebuilds \`pcsclite\` for its own arch, the off-arch installer ships with the **wrong native module**:

| CI job | Has native module for | Built installers |
|---|---|---|
| \`win\` (x64) | x64 only | x64 ✓, arm64 ✗, universal ✗ |
| \`win-arm64-cross\` (arm64) | arm64 only | arm64 ✓, x64 ✗, universal ✗ |

Whichever job uploads last is what ends up on the release page. Half the time the \`windows-x64-setup.exe\` is actually broken (arm64 \`pcsclite.node\`), and the universal one is always broken (it always has one arch's native module in both branches of the runtime selector).

## The fix

The mac section of \`electron-builder.yml\` already documented this exact pitfall:

> Do NOT hardcode arch here. The release workflow passes --arm64 or --x64 per matrix job, and electron-builder treats CLI arch flags as additive when a target has an arch list, so both archs would be built per job.

The win section was doing the very thing that comment warns against. Mirroring the mac pattern — drop the \`arch:\` lists from the win targets — makes the CLI flag the sole arch source. Each Windows CI job then produces exactly:

- one \`windows-\${arch}-setup.exe\` matching the rebuilt \`pcsclite.node\`
- one \`win-\${arch}.zip\` matching the rebuilt \`pcsclite.node\`

…and the universal \`windows-setup.exe\` disappears.

## What the next release page should look like

Before (v1.20.0):
- ~~FilamentDB-1.20.0-windows-setup.exe (398 MB)~~ ← gone
- FilamentDB-1.20.0-windows-arm64-setup.exe (200 MB) ← now actually arm64
- FilamentDB-1.20.0-windows-x64-setup.exe (199 MB) ← now actually x64
- FilamentDB-1.20.0-win-arm64.zip / win-x64.zip (unchanged shape)

## Tests

Config-only change; no app code or tests touched. The first release after this lands is the verification — I'll spot-check the NSIS installers' bundled \`pcsclite.node\` arch matches their filename suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)