### PR TITLE
Fix two NFC bugs: wrong-type scan match and stale erase pill

### DIFF
--- a/src/app/api/filaments/match/route.ts
+++ b/src/app/api/filaments/match/route.ts
@@ -2,6 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 
+/**
+ * Match a scanned NFC tag against the filament database.
+ *
+ * A non-null `match` is only ever returned for a *confident* match:
+ *   1. an exact (case-insensitive) name match, or
+ *   2. exactly one filament agreeing on BOTH vendor and type.
+ *
+ * Vendor alone is never enough — a PC spool must not silently match the
+ * user's only Bambu PLA filament. The vendor-only fallback returns the
+ * vendor's filaments as `candidates` for the user to pick from, with
+ * `match: null`.
+ */
 export async function GET(request: NextRequest) {
   try {
     await dbConnect();
@@ -11,7 +23,7 @@ export async function GET(request: NextRequest) {
     const vendor = params.get("vendor");
     const type = params.get("type");
 
-    // 1. Exact name match (case-insensitive)
+    // 1. Exact name match (case-insensitive) — a confident match.
     if (name) {
       const exact = await Filament.findOne({
         name: { $regex: `^${escapeRegex(name)}$`, $options: "i" },
@@ -22,22 +34,33 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // 2. Vendor + type match
-    const candidates = [];
-    if (vendor && type) {
-      const vendorTypeMatches = await Filament.find({
-        vendor: { $regex: escapeRegex(vendor), $options: "i" },
-        type: { $regex: `^${escapeRegex(type)}$`, $options: "i" },
-        _deletedAt: null,
-      })
-        .sort({ name: 1 })
-        .limit(5)
-        .lean();
-      candidates.push(...vendorTypeMatches);
+    // 2. Vendor + type match. A confident auto-match requires BOTH vendor
+    //    and type to agree.
+    const vendorTypeMatches =
+      vendor && type
+        ? await Filament.find({
+            vendor: { $regex: escapeRegex(vendor), $options: "i" },
+            type: { $regex: `^${escapeRegex(type)}$`, $options: "i" },
+            _deletedAt: null,
+          })
+            .sort({ name: 1 })
+            .limit(5)
+            .lean()
+        : [];
+
+    // Exactly one vendor+type hit → confident match. More than one → hand
+    // them back as candidates for the user to disambiguate.
+    if (vendorTypeMatches.length === 1) {
+      return NextResponse.json({ match: vendorTypeMatches[0], candidates: [] });
+    }
+    if (vendorTypeMatches.length > 1) {
+      return NextResponse.json({ match: null, candidates: vendorTypeMatches });
     }
 
-    // 3. Vendor-only matches (if vendor+type found nothing)
-    if (candidates.length === 0 && vendor) {
+    // 3. Vendor-only fallback — suggestions ONLY, never an auto-match. The
+    //    type didn't agree (or none was supplied), so the most we can do
+    //    is surface the vendor's filaments for the user to pick from.
+    if (vendor) {
       const vendorMatches = await Filament.find({
         vendor: { $regex: escapeRegex(vendor), $options: "i" },
         _deletedAt: null,
@@ -45,16 +68,10 @@ export async function GET(request: NextRequest) {
         .sort({ name: 1 })
         .limit(5)
         .lean();
-      candidates.push(...vendorMatches);
+      return NextResponse.json({ match: null, candidates: vendorMatches });
     }
 
-    // Best candidate becomes the match if there's exactly one vendor+type hit
-    const match = candidates.length === 1 ? candidates[0] : null;
-
-    return NextResponse.json({
-      match,
-      candidates: match ? [] : candidates,
-    });
+    return NextResponse.json({ match: null, candidates: [] });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json(

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,9 +8,11 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import { LOCALES } from "@/i18n";
 import { useTheme, type ThemePreference } from "@/components/ThemeProvider";
 import { useIsElectron } from "@/hooks/useIsElectron";
+import { useNfcContext } from "@/components/NfcProvider";
 
 export default function SettingsPage() {
   const { t, locale, setLocale } = useTranslation();
+  const { notifyTagErased } = useNfcContext();
   const [restoring, setRestoring] = useState(false);
   const [restoreResult, setRestoreResult] = useState<{ ok: boolean; message: string } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -164,6 +166,10 @@ export default function SettingsPage() {
         throw new Error("NFC format not available — restart the app to load updated NFC support");
       }
       await window.electronAPI.nfcFormatTag();
+      // The tag is now blank — clear the status pill's "Loaded: <name>"
+      // label immediately instead of leaving it stale until the user
+      // lifts the erased tag off the reader.
+      notifyTagErased();
       setFormatResult({ ok: true, message: t("settings.nfcEraseSuccess") });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/components/NfcProvider.tsx
+++ b/src/components/NfcProvider.tsx
@@ -48,6 +48,13 @@ interface NfcContextValue {
    * and replace it to trigger a fresh read.
    */
   notifyTagWritten: (filament: FilamentMatch) => void;
+  /**
+   * Call this after a successful Erase Tag. The tag is now blank, so the
+   * status pill's "Loaded: <name>" label and the lingering read result
+   * must clear immediately rather than waiting for the user to lift the
+   * (now-erased) tag off the reader.
+   */
+  notifyTagErased: () => void;
 }
 
 const NfcContext = createContext<NfcContextValue | null>(null);
@@ -99,6 +106,7 @@ export function useNfcContext(): NfcContextValue {
       dialogOpen: false,
       dismissTagRead: () => {},
       notifyTagWritten: () => {},
+      notifyTagErased: () => {},
     };
   }
   return ctx;
@@ -170,6 +178,15 @@ export default function NfcProvider({ children }: { children: ReactNode }) {
     // of that workflow would be jarring. The pill update is enough.
   }, []);
 
+  // Called by Settings → Erase Tag after a successful erase. The tag is
+  // now blank, so clear the pill label and the stale read result rather
+  // than reporting the just-erased filament until the user lifts the tag.
+  const notifyTagErased = useCallback(() => {
+    setLoadedTagName(null);
+    setTagReadResult(null);
+    setDialogOpen(false);
+  }, []);
+
   return (
     <NfcContext.Provider
       value={{
@@ -183,6 +200,7 @@ export default function NfcProvider({ children }: { children: ReactNode }) {
         dialogOpen,
         dismissTagRead,
         notifyTagWritten,
+        notifyTagErased,
       }}
     >
       {children}

--- a/tests/filaments-match-route.test.ts
+++ b/tests/filaments-match-route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as matchFilaments } from "@/app/api/filaments/match/route";
+
+/**
+ * Route-level tests for /api/filaments/match — the endpoint the NFC scan
+ * flow uses to match a decoded tag against the filament DB.
+ *
+ * Regression focus: a confident `match` must require type agreement.
+ * Vendor alone is not enough — a scanned PC spool once matched the user's
+ * only Bambu PLA filament because the vendor-only fallback promoted a
+ * lone vendor hit to a definitive match.
+ */
+describe("/api/filaments/match", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filamentMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", filamentMod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  function matchReq(query: Record<string, string>) {
+    const qs = new URLSearchParams(query).toString();
+    return new NextRequest(`http://localhost/api/filaments/match?${qs}`);
+  }
+
+  const names = (list: { name: string }[]) => list.map((c) => c.name).sort();
+
+  it("returns a confident match on an exact (case-insensitive) name", async () => {
+    await Filament.create({ name: "Bambu PC Black", vendor: "Bambu Lab", type: "PC" });
+    const res = await matchFilaments(
+      matchReq({ name: "bambu pc black", vendor: "Bambu Lab", type: "PC" }),
+    );
+    const body = await res.json();
+    expect(body.match?.name).toBe("Bambu PC Black");
+    expect(body.candidates).toEqual([]);
+  });
+
+  it("promotes a single vendor+type hit to the match", async () => {
+    await Filament.create({ name: "Bambu PC Black", vendor: "Bambu Lab", type: "PC" });
+    const res = await matchFilaments(
+      matchReq({ name: "PC", vendor: "Bambu Lab", type: "PC" }),
+    );
+    const body = await res.json();
+    expect(body.match?.name).toBe("Bambu PC Black");
+    expect(body.candidates).toEqual([]);
+  });
+
+  it("returns multiple vendor+type hits as candidates, with no auto-match", async () => {
+    await Filament.create({ name: "Bambu PC Black", vendor: "Bambu Lab", type: "PC" });
+    await Filament.create({ name: "Bambu PC Clear", vendor: "Bambu Lab", type: "PC" });
+    const res = await matchFilaments(
+      matchReq({ name: "PC", vendor: "Bambu Lab", type: "PC" }),
+    );
+    const body = await res.json();
+    expect(body.match).toBeNull();
+    expect(names(body.candidates)).toEqual(["Bambu PC Black", "Bambu PC Clear"]);
+  });
+
+  it("does NOT auto-match on vendor alone when the type differs", async () => {
+    // The DB's only Bambu filament is PLA. A PC tag must not match it —
+    // it may only be offered as a candidate for the user to confirm.
+    await Filament.create({ name: "PLA Silk+", vendor: "Bambu Lab", type: "PLA" });
+    const res = await matchFilaments(
+      matchReq({ name: "PC", vendor: "Bambu Lab", type: "PC" }),
+    );
+    const body = await res.json();
+    expect(body.match).toBeNull();
+    expect(names(body.candidates)).toEqual(["PLA Silk+"]);
+  });
+
+  it("returns no match and no candidates for an unknown vendor", async () => {
+    await Filament.create({ name: "PLA Silk+", vendor: "Bambu Lab", type: "PLA" });
+    const res = await matchFilaments(
+      matchReq({ name: "PC", vendor: "Polymaker", type: "PC" }),
+    );
+    const body = await res.json();
+    expect(body.match).toBeNull();
+    expect(body.candidates).toEqual([]);
+  });
+
+  it("excludes soft-deleted filaments from matches and candidates", async () => {
+    await Filament.create({
+      name: "Bambu PC Black",
+      vendor: "Bambu Lab",
+      type: "PC",
+      _deletedAt: new Date(),
+    });
+    const res = await matchFilaments(
+      matchReq({ name: "PC", vendor: "Bambu Lab", type: "PC" }),
+    );
+    const body = await res.json();
+    expect(body.match).toBeNull();
+    expect(body.candidates).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two independent NFC-area bug fixes, bundled to ship together.

## 1. NFC scan matched a spool to a wrong-type filament

Scanning a Bambu **PC** spool matched it against the user's only Bambu filament — a **PLA** ("PLA Silk+") — and the scan dialog confidently reported *"Found in Database: PLA Silk+"*.

**Root cause:** `/api/filaments/match` step 3, the vendor-only fallback, promoted a lone vendor hit to a definitive `match`. With one Bambu filament in the DB and no Bambu PC, the PC tag fell through to vendor-only and auto-matched the PLA.

**Fix:** a non-null `match` now requires either an exact name match, or exactly one filament agreeing on **both vendor and type**. The vendor-only fallback returns its hits as `candidates` only — never as a `match`.

Verified against live data: the Bambu PC tag now returns `match: null` (PLA Silk+ offered only as a candidate); a Bambu PLA tag still matches correctly. Adds `tests/filaments-match-route.test.ts` — 6 tests (the route had none).

## 2. NFC status pill stayed "Loaded" after erasing a tag

After **Settings → Erase Tag**, the pill kept showing `Loaded: <filament>` until the user physically lifted the now-blank tag — its `loadedTagName` only cleared via the tag-removed effect, and the erase flow never touched `NfcProvider` state.

**Fix:** added `notifyTagErased()` to the NFC context (mirroring `notifyTagWritten()`); the Settings erase handler calls it on success, clearing the pill label, the stale read result, and any open dialog immediately.

## Test plan
- [x] `tests/filaments-match-route.test.ts` — 6 tests incl. the PC→PLA regression
- [x] `eslint` + `tsc` clean
- [x] Scan-match verified against live data
- [ ] Erase-pill fix needs a hardware check (renderer-only NFC state wiring — not exercisable in the web preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)