### PR TITLE
Clear the NFC status pill after erasing a tag

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,9 +8,11 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import { LOCALES } from "@/i18n";
 import { useTheme, type ThemePreference } from "@/components/ThemeProvider";
 import { useIsElectron } from "@/hooks/useIsElectron";
+import { useNfcContext } from "@/components/NfcProvider";
 
 export default function SettingsPage() {
   const { t, locale, setLocale } = useTranslation();
+  const { notifyTagErased } = useNfcContext();
   const [restoring, setRestoring] = useState(false);
   const [restoreResult, setRestoreResult] = useState<{ ok: boolean; message: string } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -164,6 +166,10 @@ export default function SettingsPage() {
         throw new Error("NFC format not available — restart the app to load updated NFC support");
       }
       await window.electronAPI.nfcFormatTag();
+      // The tag is now blank — clear the status pill's "Loaded: <name>"
+      // label immediately instead of leaving it stale until the user
+      // lifts the erased tag off the reader.
+      notifyTagErased();
       setFormatResult({ ok: true, message: t("settings.nfcEraseSuccess") });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/components/NfcProvider.tsx
+++ b/src/components/NfcProvider.tsx
@@ -48,6 +48,13 @@ interface NfcContextValue {
    * and replace it to trigger a fresh read.
    */
   notifyTagWritten: (filament: FilamentMatch) => void;
+  /**
+   * Call this after a successful Erase Tag. The tag is now blank, so the
+   * status pill's "Loaded: <name>" label and the lingering read result
+   * must clear immediately rather than waiting for the user to lift the
+   * (now-erased) tag off the reader.
+   */
+  notifyTagErased: () => void;
 }
 
 const NfcContext = createContext<NfcContextValue | null>(null);
@@ -99,6 +106,7 @@ export function useNfcContext(): NfcContextValue {
       dialogOpen: false,
       dismissTagRead: () => {},
       notifyTagWritten: () => {},
+      notifyTagErased: () => {},
     };
   }
   return ctx;
@@ -170,6 +178,15 @@ export default function NfcProvider({ children }: { children: ReactNode }) {
     // of that workflow would be jarring. The pill update is enough.
   }, []);
 
+  // Called by Settings → Erase Tag after a successful erase. The tag is
+  // now blank, so clear the pill label and the stale read result rather
+  // than reporting the just-erased filament until the user lifts the tag.
+  const notifyTagErased = useCallback(() => {
+    setLoadedTagName(null);
+    setTagReadResult(null);
+    setDialogOpen(false);
+  }, []);
+
   return (
     <NfcContext.Provider
       value={{
@@ -183,6 +200,7 @@ export default function NfcProvider({ children }: { children: ReactNode }) {
         dialogOpen,
         dismissTagRead,
         notifyTagWritten,
+        notifyTagErased,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

After programming a tag, the status pill shows `Loaded: <filament>`. Going to **Settings → Erase Tag** and erasing the tag left the pill **still showing `Loaded: <filament>`** — it only cleared once the user physically lifted the now-blank tag off the reader.

**Root cause:** the pill's `loadedTagName` is only cleared by the tag-removed effect (`if (!status.tagPresent) setLoadedTagName(null)`). The erase flow in `settings/page.tsx` calls `nfcFormatTag()` but never touches the `NfcProvider` state — so a tag that's erased while still on the reader keeps reporting its old (now-wiped) filament.

## Fix

Add `notifyTagErased()` to the NFC context, mirroring the existing `notifyTagWritten()`. It clears `loadedTagName`, the lingering `tagReadResult`, and closes any open read dialog — all now stale once the tag is blank. The Settings erase handler calls it immediately after a successful `nfcFormatTag()`.

The pill then drops to its normal "tag present, not decoded" state (a blank tag is still physically on the reader), instead of falsely reporting the erased filament.

## Test plan
- [x] `eslint` + `tsc` clean
- [ ] **Needs hardware verification** — write a tag, confirm `Loaded: <name>`, erase via Settings, confirm the pill clears *without* lifting the tag. The change is renderer-only state wiring; it can't be exercised in the web preview (no NFC reader / Electron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)