### PR TITLE
Fix cramped Color/Cost/Density row in the Edit Filament form

### DIFF
--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -1119,7 +1119,12 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
         </div>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      {/* Two columns, not four: at the form's width four cells were too
+          narrow to fit the colour swatch + hex input together, and the
+          "Density (g/cm³)" label wrapped to two lines, pushing its input
+          out of alignment with the rest of the row. Two columns matches
+          the vendor/type row above and gives every field room. */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
           <label className={labelClass}>{t("form.color")}</label>
           <div className="flex gap-2">
@@ -1133,7 +1138,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
             <input
               type="text"
               inputMode="text"
-              className={`${inputClass} font-mono uppercase`}
+              className={`${inputClass} font-mono uppercase min-w-0`}
               value={form.color}
               placeholder="#RRGGBB"
               maxLength={7}


### PR DESCRIPTION
## Summary

Two layout bugs in the Edit Filament form's **Color / Color Name / Cost / Density** row, both from the same cause — a 4-column grid (`grid-cols-2 sm:grid-cols-4`) too cramped for the form's actual width:

1. **Hex-code input too narrow** — it shares its grid cell with the colour swatch, and at ~4-column width there wasn't room. `#RRGGBB` was squeezed to ~2 visible characters.
2. **Density input misaligned** — "Density (g/cm³)" wrapped to two lines while the other labels stayed single-line, so the Density input sat a line lower than Cost / Color Name.

## Fix

- Row switched to `grid-cols-1 sm:grid-cols-2`, matching the vendor/type row directly above it. Two columns give the colour cell room for the swatch + a full-width hex input, and "Density (g/cm³)" fits on one line → all inputs align.
- Added `min-w-0` to the hex input so it shrinks cleanly inside its flex row.

## Test plan

- [x] `npm run lint` — clean
- [ ] Manual: open Edit Filament → Color row → hex input shows the full `#RRGGBB`
- [ ] Manual: Cost and Density inputs are vertically aligned
- [ ] Manual: narrow the window → row collapses to one column cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)