### PR TITLE
Electron security & process-lifecycle hardening (#262, #278-279, #299-301, #315-316, #318)

### DIFF
--- a/electron/auto-updater.ts
+++ b/electron/auto-updater.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import { autoUpdater } from "electron-updater";
+import { assertTrustedSender } from "./ipc-security";
 
 /**
  * Thin wrapper around electron-updater that ships silently while the app is
@@ -101,13 +102,16 @@ export function initAutoUpdater(win: BrowserWindow) {
     }
   });
 
-  ipcMain.handle("update-install", async (_evt, strings?: {
+  ipcMain.handle("update-install", async (evt, strings?: {
     title?: string;
     message?: string;
     detail?: string;
     installButton?: string;
     laterButton?: string;
   }) => {
+    // GH #299: update-install restarts the app — only the app's own
+    // top-level frame may invoke it.
+    assertTrustedSender(evt, "update-install");
     if (!app.isPackaged) return { ok: false, error: "dev-mode" };
     if (currentState.state !== "ready") {
       return { ok: false, error: "No update ready to install" };

--- a/electron/ipc-security.ts
+++ b/electron/ipc-security.ts
@@ -1,0 +1,90 @@
+import type { IpcMainInvokeEvent } from "electron";
+
+/**
+ * Shared IPC hardening helpers (GH #299, #300).
+ *
+ * Privileged ipcMain.handle handlers — save-config, reset-config,
+ * test-connection, nfc-write-tag, nfc-format-tag, update-install — can
+ * rewrite the Mongo connection string, erase NFC tags, or restart the
+ * app. Without a sender check, any frame loaded in the renderer
+ * (including a sub-frame such as an embedded TDS document, or an XSS
+ * payload in a user-supplied filament field) could invoke them.
+ */
+
+/** The renderer is always served from the embedded Next.js server on
+ * this port (see getAppURL in main.ts), in both dev and production. */
+const PORT = parseInt(process.env.PORT || "3456", 10);
+const APP_ORIGIN = `http://localhost:${PORT}`;
+
+/**
+ * Reject an IPC invocation that doesn't originate from the app's own
+ * top-level frame at the expected origin. Throws — the thrown error
+ * propagates back to the renderer as a rejected `invoke` promise.
+ */
+export function assertTrustedSender(
+  event: IpcMainInvokeEvent,
+  channel: string,
+): void {
+  const frame = event.senderFrame;
+  if (!frame) {
+    throw new Error(`IPC "${channel}" rejected: no sender frame`);
+  }
+  // A sub-frame (embedded document, iframe) has a non-null parent.
+  // Privileged handlers may only be reached from the top-level frame.
+  if (frame.parent !== null) {
+    throw new Error(`IPC "${channel}" rejected: sender is a sub-frame`);
+  }
+  let origin: string;
+  try {
+    origin = new URL(frame.url).origin;
+  } catch {
+    throw new Error(`IPC "${channel}" rejected: unparseable sender URL`);
+  }
+  if (origin !== APP_ORIGIN) {
+    throw new Error(`IPC "${channel}" rejected: untrusted origin "${origin}"`);
+  }
+}
+
+/**
+ * MongoDB connection-string options that can reference a local
+ * filesystem path. A renderer-supplied URI must not set these — they
+ * would let a compromised page read arbitrary local files through the
+ * TLS handshake (GH #300). Compared case-insensitively.
+ */
+const FILESYSTEM_URI_OPTIONS = [
+  "tlscafile",
+  "tlscertificatekeyfile",
+  "tlscrlfile",
+  "sslca",
+  "sslcert",
+  "sslkey",
+];
+
+/**
+ * Validate a renderer-supplied MongoDB connection string. Returns null
+ * when the URI is safe to use, or a human-readable rejection reason.
+ *
+ * Guards against:
+ *  - non-mongodb schemes (an SSRF pivot, or file:/http: probes)
+ *  - TLS options that point at local files (arbitrary file read)
+ *
+ * The scheme check is a regex rather than `new URL()` because a valid
+ * multi-host mongodb URI (`mongodb://h1,h2,h3/db`) doesn't always
+ * round-trip through the WHATWG URL parser.
+ */
+export function validateMongoUri(uri: unknown): string | null {
+  if (typeof uri !== "string" || uri.trim() === "") {
+    return "MongoDB URI must be a non-empty string";
+  }
+  const trimmed = uri.trim();
+  if (!/^mongodb(\+srv)?:\/\//i.test(trimmed)) {
+    return "MongoDB URI must start with mongodb:// or mongodb+srv://";
+  }
+  const lower = trimmed.toLowerCase();
+  for (const opt of FILESYSTEM_URI_OPTIONS) {
+    if (lower.includes(`${opt}=`)) {
+      return `MongoDB URI option "${opt}" is not allowed — it can reference a local file`;
+    }
+  }
+  return null;
+}

--- a/electron/local-mongo.ts
+++ b/electron/local-mongo.ts
@@ -34,6 +34,11 @@ export async function startLocalMongo(): Promise<string> {
       dbPath,
       storageEngine: "wiredTiger",
       launchTimeout: 60000,
+      // GH #318: pin the bind address to loopback explicitly. The
+      // embedded database is unauthenticated; relying on the library's
+      // default bind would silently expose it to the LAN if a future
+      // mongodb-memory-server release changed that default.
+      ip: "127.0.0.1",
     },
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -472,7 +472,17 @@ async function startProductionServer(mongoUri?: string): Promise<void> {
       const backoffMs = Math.min(serverRestartCount * 2000, 30_000);
       diag(`server crashed (code=${code}); restart ${serverRestartCount}/${MAX_SERVER_RESTARTS} in ${backoffMs}ms`);
       setTimeout(() => {
-        if (isQuitting) return;
+        // GH #315 (Codex review): re-check the SAME guard the exit
+        // handler used, but now at timer-fire time. Between the crash
+        // and this delayed restart (backoff up to 30s) an intentional
+        // restart — e.g. save-config's stopServer() + startProduction-
+        // Server() — may already have replaced `serverProcess`.
+        // Restarting anyway would fork a duplicate server (EADDRINUSE)
+        // and leave `serverProcess` pointing at the wrong instance.
+        // `serverProcess !== thisProc` also covers a bare stopServer()
+        // (serverProcess === null): an intentional stop must not be
+        // undone by a stale crash timer.
+        if (isQuitting || serverProcess !== thisProc) return;
         startProductionServer((store.get("mongodbUri") as string) || undefined)
           .then(() => {
             diag("server restarted successfully after crash");

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1127,14 +1127,22 @@ app.on("before-quit", (event) => {
 
   // GH #316: never let a hung mongod.stop() strand the app. Race the
   // local-Mongo shutdown against a hard timeout — whichever finishes
-  // first triggers the exit. `app.exit(0)` (not `app.quit()`) so a
-  // second before-quit can't re-enter and re-preventDefault.
+  // first re-triggers the quit.
+  //
+  // GH #315 (Codex P1): use `app.quit()`, NOT `app.exit(0)`. The
+  // `isQuitting` guard at the top of this handler already stops a
+  // second before-quit from re-preventDefault-ing, so the original
+  // reason for forcing `app.exit` doesn't hold — and `app.exit(0)`
+  // hard-skips the rest of the quit lifecycle: renderer `beforeunload`
+  // handlers (the unsaved-changes prompt) never fire, and the
+  // auto-updater's install-on-quit never runs. `app.quit()` preserves
+  // both.
   const QUIT_TIMEOUT_MS = 5000;
-  let exited = false;
+  let finished = false;
   const finish = () => {
-    if (exited) return;
-    exited = true;
-    app.exit(0);
+    if (finished) return;
+    finished = true;
+    app.quit();
   };
   stopLocalMongo().finally(finish);
   setTimeout(finish, QUIT_TIMEOUT_MS);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import { NfcService } from "./nfc-service";
 import { startLocalMongo, stopLocalMongo } from "./local-mongo";
 import { SyncService, SyncStatus, getDbNameFromUri } from "./sync-service";
 import { initAutoUpdater } from "./auto-updater";
+import { assertTrustedSender, validateMongoUri } from "./ipc-security";
 
 // ── Diagnostic log ──
 // Writes lifecycle and crash events to a file in userData so users on
@@ -73,6 +74,11 @@ const isDev = !app.isPackaged;
 let isQuitting = false;
 let mainWindow: BrowserWindow | null = null;
 let serverProcess: UtilityProcess | null = null;
+/** GH #315: crash-restart attempt counter. Reset to 0 each time a
+ * server reaches a healthy startup; capped so an immediately-crashing
+ * server can't tight-loop forever. */
+let serverRestartCount = 0;
+const MAX_SERVER_RESTARTS = 5;
 let nfcService: NfcService | null = null;
 /** Guards initNfc() so the deferred init runs only once even though it's
  * wired to every window's "show" event (macOS dock-reopen creates a new
@@ -151,6 +157,13 @@ function createWindow(urlPath = "/") {
       preload: path.join(__dirname, "preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
+      // GH #262: run the renderer in the OS-level sandbox. The preload
+      // only uses contextBridge + ipcRenderer, both of which are
+      // sandbox-safe, so nothing in the renderer path needs Node access.
+      // This contains any XSS in user-supplied filament data / community
+      // DB content / TDS-extracted HTML so it can't reach beyond the
+      // renderer process.
+      sandbox: true,
     },
   });
 
@@ -406,17 +419,70 @@ async function startProductionServer(mongoUri?: string): Promise<void> {
       }
     });
 
+    // Capture the process this closure owns — `serverProcess` is
+    // reassigned on every (re)start, so the crash-restart guard below
+    // must compare against the module-level current process, not this.
+    const thisProc = serverProcess;
+
     serverProcess.on("spawn", () => {
       diag("server spawned");
       // Wait for the server to respond to HTTP requests
-      waitForServer(PORT).then(resolve).catch(reject);
+      waitForServer(PORT)
+        .then(() => {
+          // GH #315: a healthy startup resets the crash counter, so a
+          // server that runs fine for a while and then crashes still
+          // gets a fresh set of restart attempts.
+          serverRestartCount = 0;
+          resolve();
+        })
+        .catch(reject);
     });
 
     serverProcess.on("exit", (code) => {
       diag(`server exit code=${code}`);
+      // Startup-phase failure: reject so the caller surfaces it. Harmless
+      // once the promise has already resolved (reject on a settled
+      // promise is a no-op).
       if (code !== 0) {
         reject(new Error(`Server exited with code ${code}`));
       }
+
+      // GH #315: crash-restart. Attached to EVERY spawned process (not
+      // just the first), so a crash after the first restart is still
+      // handled. Skipped when:
+      //   - the app is quitting (intentional shutdown), or
+      //   - this exited process is no longer the current one — it was
+      //     replaced by an intentional stopServer() + restart (e.g. a
+      //     save-config connection change), so restarting it would
+      //     spawn a duplicate server.
+      if (isQuitting || thisProc !== serverProcess) return;
+      if (code === 0 || code === null) return; // clean exit, not a crash
+
+      if (serverRestartCount >= MAX_SERVER_RESTARTS) {
+        diag(`server crash-restart cap reached (${MAX_SERVER_RESTARTS})`);
+        dialog.showErrorBox(
+          "Server Crashed",
+          `The embedded web server crashed repeatedly (${MAX_SERVER_RESTARTS} restart attempts) and has been left stopped.`,
+        );
+        return;
+      }
+      serverRestartCount++;
+      // Linear backoff, capped — avoids a tight loop on a server that
+      // crashes immediately every time.
+      const backoffMs = Math.min(serverRestartCount * 2000, 30_000);
+      diag(`server crashed (code=${code}); restart ${serverRestartCount}/${MAX_SERVER_RESTARTS} in ${backoffMs}ms`);
+      setTimeout(() => {
+        if (isQuitting) return;
+        startProductionServer((store.get("mongodbUri") as string) || undefined)
+          .then(() => {
+            diag("server restarted successfully after crash");
+            mainWindow?.reload();
+          })
+          .catch((restartErr) => {
+            console.error("Server restart failed:", restartErr);
+            diag(`server restart failed: ${restartErr instanceof Error ? restartErr.message : String(restartErr)}`);
+          });
+      }, backoffMs);
     });
   });
 }
@@ -424,9 +490,23 @@ async function startProductionServer(mongoUri?: string): Promise<void> {
 /** Maximum wait time (ms) for IPC calls before they're considered timed out. */
 const IPC_TIMEOUT_MS = 15_000;
 
+/** Upper bound on a renderer-supplied NFC write payload (GH #278). The
+ * largest tag this app targets (SLIX2) holds ~320 bytes; 4 KB is a
+ * generous ceiling that still rejects a memory-pressure payload before
+ * any allocation happens. */
+const MAX_NFC_PAYLOAD_BYTES = 4096;
+
 /**
  * Wraps an async IPC handler with a timeout to prevent hanging calls
  * when the server becomes unresponsive.
+ *
+ * GH #279: the timeout only *rejects the promise* — it does not cancel
+ * the underlying operation. Use it ONLY for genuinely bounded calls
+ * (NFC read/write/format, where exceeding 15s means the reader is
+ * stuck). Do NOT use it for inherently long-running work such as sync,
+ * which keeps mutating data after the race is lost; long-running
+ * operations should report progress through their own status channel
+ * instead.
  */
 function withIpcTimeout<T>(fn: () => Promise<T>, label: string): Promise<T> {
   return Promise.race([
@@ -559,7 +639,7 @@ ipcMain.handle("get-config", () => {
   };
 });
 
-ipcMain.handle("save-config", async (_event, config: {
+ipcMain.handle("save-config", async (event, config: {
   mongodbUri?: string;
   connectionMode?: ConnectionMode;
   atlasUri?: string;
@@ -570,6 +650,17 @@ ipcMain.handle("save-config", async (_event, config: {
   customCurrencies?: string;
   locale?: string;
 }) => {
+  assertTrustedSender(event, "save-config");
+
+  // GH #300: any connection string reaching the store / child-process
+  // env must be a real mongodb URI with no local-file TLS options.
+  for (const candidate of [config.atlasUri, config.mongodbUri]) {
+    if (candidate !== undefined) {
+      const reason = validateMongoUri(candidate);
+      if (reason) return { success: false, error: reason };
+    }
+  }
+
   // Update individual fields
   if (config.connectionMode !== undefined) {
     store.set("connectionMode", config.connectionMode);
@@ -653,7 +744,8 @@ ipcMain.handle("save-config", async (_event, config: {
   return { success: true };
 });
 
-ipcMain.handle("reset-config", async () => {
+ipcMain.handle("reset-config", async (event) => {
+  assertTrustedSender(event, "reset-config");
   store.delete("mongodbUri");
   store.delete("connectionMode");
   store.delete("atlasUri");
@@ -669,7 +761,14 @@ ipcMain.handle("reset-config", async () => {
   return { success: true };
 });
 
-ipcMain.handle("test-connection", async (_event, uri: string) => {
+ipcMain.handle("test-connection", async (event, uri: string) => {
+  assertTrustedSender(event, "test-connection");
+  // GH #300: refuse non-mongodb schemes and local-file TLS options
+  // before handing the string to the driver — otherwise a compromised
+  // renderer could pivot through the main process (SSRF / file read).
+  const reason = validateMongoUri(uri);
+  if (reason) return { success: false, error: reason };
+
   const { MongoClient } = await import("mongodb");
   const client = new MongoClient(uri, {
     serverSelectionTimeoutMS: 5000,
@@ -712,7 +811,13 @@ ipcMain.handle("trigger-sync", async () => {
   if (!syncService) {
     return { error: "Sync not available in current mode" };
   }
-  const results = await withIpcTimeout(() => syncService!.sync(), "trigger-sync");
+  // GH #279: do NOT wrap sync in withIpcTimeout. A 15s race that
+  // abandons an in-flight sync doesn't stop it — the engine keeps
+  // mutating BOTH databases while the renderer is told it "timed out".
+  // Sync is inherently long-running and reports its own progress via
+  // get-sync-status, which the renderer already polls; let it run to
+  // completion.
+  const results = await syncService.sync();
   return { results };
 });
 
@@ -748,8 +853,31 @@ ipcMain.handle("nfc-read-tag", async () => {
   return withIpcTimeout(() => nfcService!.readTag(), "nfc-read-tag");
 });
 
-ipcMain.handle("nfc-write-tag", async (_event, payload: number[], productUrl?: string) => {
+ipcMain.handle("nfc-write-tag", async (event, payload: number[], productUrl?: string) => {
+  assertTrustedSender(event, "nfc-write-tag");
   if (!nfcService) throw new Error("NFC not initialized");
+
+  // GH #278: the payload is a renderer-supplied number[] that gets
+  // encoded onto a physical tag. Validate it BEFORE allocating — cap
+  // the length, and confirm every element is a 0-255 byte.
+  if (!Array.isArray(payload)) {
+    throw new Error("nfc-write-tag: payload must be an array");
+  }
+  if (payload.length > MAX_NFC_PAYLOAD_BYTES) {
+    throw new Error(
+      `nfc-write-tag: payload too large (${payload.length} > ${MAX_NFC_PAYLOAD_BYTES} bytes)`,
+    );
+  }
+  if (!payload.every((b) => Number.isInteger(b) && b >= 0 && b <= 255)) {
+    throw new Error("nfc-write-tag: payload must contain only 0-255 integers");
+  }
+  // GH #278: productUrl is written onto the tag and acted on by
+  // downstream readers (the Prusa app) — only http(s) is safe. A
+  // javascript:/file: URL must never be persisted to physical media.
+  if (productUrl !== undefined && !/^https?:\/\//i.test(productUrl)) {
+    throw new Error("nfc-write-tag: productUrl must be an http(s) URL");
+  }
+
   await withIpcTimeout(() => nfcService!.writeTag(new Uint8Array(payload), productUrl), "nfc-write-tag");
 
   // After a successful write, schedule a delayed read-back so the UI shows
@@ -767,7 +895,8 @@ ipcMain.handle("nfc-write-tag", async (_event, payload: number[], productUrl?: s
   return { success: true };
 });
 
-ipcMain.handle("nfc-format-tag", async () => {
+ipcMain.handle("nfc-format-tag", async (event) => {
+  assertTrustedSender(event, "nfc-format-tag");
   if (!nfcService) throw new Error("NFC not initialized");
   await withIpcTimeout(() => nfcService!.formatTag(), "nfc-format-tag");
   return { success: true };
@@ -897,7 +1026,14 @@ app.whenReady().then(async () => {
     callback({
       responseHeaders: {
         ...details.responseHeaders,
-        "Content-Security-Policy": ["default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* http://localhost:*; font-src 'self' data:;"],
+        // GH #262: `'unsafe-eval'` dropped — the production Electron build
+        // loads a compiled Next.js bundle that does not need runtime
+        // eval(), so allowing it only weakened CSP for no benefit.
+        // `'unsafe-inline'` on script-src is still required because
+        // Next.js streams the RSC payload via inline <script> tags and
+        // the theme-init bootstrap is inline; migrating those to a
+        // per-request nonce is tracked separately in #225.
+        "Content-Security-Policy": ["default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* http://localhost:*; font-src 'self' data:;"],
       },
     });
   });
@@ -930,30 +1066,11 @@ app.whenReady().then(async () => {
   }
 
   if (!isDev) {
-    // Always start the server — even without mongoUri, the setup page needs it
+    // Always start the server — even without mongoUri, the setup page needs it.
+    // Crash-restart is handled inside startProductionServer (GH #315), so
+    // every spawned process — including restarts — gets the handler.
     try {
       await startProductionServer(mongoUri || undefined);
-
-      // Watch for unexpected server crashes after successful startup
-      if (serverProcess) {
-        serverProcess.on("exit", (code) => {
-          if (code !== null && code !== 0) {
-            console.error(`Server crashed with exit code ${code}, attempting restart...`);
-            startProductionServer((store.get("mongodbUri") as string) || undefined)
-              .then(() => {
-                console.log("Server restarted successfully after crash");
-                mainWindow?.reload();
-              })
-              .catch((restartErr) => {
-                console.error("Server restart failed:", restartErr);
-                dialog.showErrorBox(
-                  "Server Crashed",
-                  `The embedded web server crashed and could not be restarted.\n\n${restartErr instanceof Error ? restartErr.message : String(restartErr)}`,
-                );
-              });
-          }
-        });
-      }
     } catch (err) {
       console.error("Failed to start server:", err);
       dialog.showErrorBox(
@@ -997,7 +1114,20 @@ app.on("before-quit", (event) => {
   stopServer();
   if (syncService) syncService.destroy();
   if (nfcService) nfcService.destroy();
-  stopLocalMongo().finally(() => app.quit());
+
+  // GH #316: never let a hung mongod.stop() strand the app. Race the
+  // local-Mongo shutdown against a hard timeout — whichever finishes
+  // first triggers the exit. `app.exit(0)` (not `app.quit()`) so a
+  // second before-quit can't re-enter and re-preventDefault.
+  const QUIT_TIMEOUT_MS = 5000;
+  let exited = false;
+  const finish = () => {
+    if (exited) return;
+    exited = true;
+    app.exit(0);
+  };
+  stopLocalMongo().finally(finish);
+  setTimeout(finish, QUIT_TIMEOUT_MS);
 });
 
 } // end single-instance lock else block

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -44,21 +44,22 @@ const EXPECTED_MLEN = (DEFAULT_BLOCK_COUNT * BLOCK_SIZE) / 8;
 
 /**
  * Sanitize the raw MLEN byte read from a tag's Capability Container
- * (GH #301). MLEN is "memory length / 8". The value comes straight off
- * the tag, so a corrupt or non-standard byte must not be trusted:
+ * (GH #301). MLEN is "memory length / 8" and comes straight off the
+ * tag. Only a genuinely UNUSABLE value is rejected — zero, a
+ * non-integer, or out of byte range (block0 too short → `block0[2]`
+ * is `undefined`) — and replaced with the SLIX2 default.
  *
- *  - too small → reads/writes truncate; if `formatTag` then writes that
- *    byte back into the CC the tag is effectively bricked for the app;
- *  - too large → reads/writes run off the end of the chip.
- *
- * Accept the byte only within the plausible SLIX2-class band
- * (EXPECTED_MLEN/2 .. EXPECTED_MLEN); otherwise fall back to the
- * expected SLIX2 value.
+ * GH #322 (Codex P1): a value merely OUTSIDE the SLIX2 band is
+ * preserved. It is the real declared capacity of a non-SLIX2 NFC-V
+ * chip; clamping it would make `formatTag()` write a wrong CC and
+ * corrupt an otherwise-valid tag. The bounds that actually matter for
+ * safety are enforced at the USE sites instead — the read loops clamp
+ * the block count to DEFAULT_BLOCK_COUNT, and `writeTag()` caps its
+ * write extent at EXPECTED_MLEN — so a large MLEN can't drive reads or
+ * writes off the end of the chip.
  */
 function sanitizeMlen(rawByte: number): number {
-  return Number.isInteger(rawByte) &&
-    rawByte >= EXPECTED_MLEN / 2 &&
-    rawByte <= EXPECTED_MLEN
+  return Number.isInteger(rawByte) && rawByte > 0 && rawByte <= 255
     ? rawByte
     : EXPECTED_MLEN;
 }
@@ -448,7 +449,12 @@ export class NfcService extends EventEmitter {
     return this.withConnection(async (protocol) => {
       const block0 = await this.readBlock(protocol, 0);
       const mlen = sanitizeMlen(block0[2]);
-      const tagMemorySize = mlen * 8;
+      // GH #301/#322: cap the write extent at the SLIX2-class size the
+      // app's own payloads are built for. sanitizeMlen now preserves a
+      // larger real MLEN (so formatTag writes a correct CC), but the
+      // write loop must not run far past a normal chip when the tag
+      // reports an over-large — or corrupt-but-in-byte-range — MLEN.
+      const tagMemorySize = Math.min(mlen, EXPECTED_MLEN) * 8;
 
       const tagMemory = wrapNdefForTag(cborPayload, tagMemorySize, productUrl);
 

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -38,6 +38,31 @@ interface CardReaderStatus {
 const BLOCK_SIZE = 4;
 const DEFAULT_BLOCK_COUNT = 80;
 
+/** The MLEN byte a healthy SLIX2 tag reports: total memory / 8 =
+ * 80 blocks × 4 bytes / 8 = 40. */
+const EXPECTED_MLEN = (DEFAULT_BLOCK_COUNT * BLOCK_SIZE) / 8;
+
+/**
+ * Sanitize the raw MLEN byte read from a tag's Capability Container
+ * (GH #301). MLEN is "memory length / 8". The value comes straight off
+ * the tag, so a corrupt or non-standard byte must not be trusted:
+ *
+ *  - too small → reads/writes truncate; if `formatTag` then writes that
+ *    byte back into the CC the tag is effectively bricked for the app;
+ *  - too large → reads/writes run off the end of the chip.
+ *
+ * Accept the byte only within the plausible SLIX2-class band
+ * (EXPECTED_MLEN/2 .. EXPECTED_MLEN); otherwise fall back to the
+ * expected SLIX2 value.
+ */
+function sanitizeMlen(rawByte: number): number {
+  return Number.isInteger(rawByte) &&
+    rawByte >= EXPECTED_MLEN / 2 &&
+    rawByte <= EXPECTED_MLEN
+    ? rawByte
+    : EXPECTED_MLEN;
+}
+
 export class NfcService extends EventEmitter {
   private pcsc: PCSCLite;
   private readers: Map<string, CardReader> = new Map();
@@ -368,7 +393,7 @@ export class NfcService extends EventEmitter {
   /** Read an OpenPrintTag (NFC-V / ISO 15693) tag. */
   private async readOpenPrintTag(protocol: number): Promise<DecodedOpenPrintTag> {
     const block0 = await this.readBlock(protocol, 0);
-    const mlen = block0[2];
+    const mlen = sanitizeMlen(block0[2]);
     const numBlocks = Math.min(Math.ceil((mlen * 8) / BLOCK_SIZE), DEFAULT_BLOCK_COUNT);
 
     const allData = Buffer.alloc(numBlocks * BLOCK_SIZE);
@@ -422,8 +447,8 @@ export class NfcService extends EventEmitter {
   async writeTag(cborPayload: Uint8Array, productUrl?: string): Promise<void> {
     return this.withConnection(async (protocol) => {
       const block0 = await this.readBlock(protocol, 0);
-      const mlen = block0[2];
-      const tagMemorySize = mlen * 8 || DEFAULT_BLOCK_COUNT * BLOCK_SIZE;
+      const mlen = sanitizeMlen(block0[2]);
+      const tagMemorySize = mlen * 8;
 
       const tagMemory = wrapNdefForTag(cborPayload, tagMemorySize, productUrl);
 
@@ -462,14 +487,17 @@ export class NfcService extends EventEmitter {
 
   async formatTag(): Promise<void> {
     return this.withConnection(async (protocol) => {
-      // Read block 0 to get memory size from the CC
+      // Read block 0 to get memory size from the CC. GH #301: the raw
+      // MLEN byte is sanitized before it's trusted for numBlocks OR
+      // written back into the CC — a corrupt byte written here would
+      // brick the tag for the app.
       const block0 = await this.readBlock(protocol, 0);
-      const mlen = block0[2];
-      const numBlocks = mlen ? Math.min(Math.ceil((mlen * 8) / BLOCK_SIZE), DEFAULT_BLOCK_COUNT) : DEFAULT_BLOCK_COUNT;
+      const mlen = sanitizeMlen(block0[2]);
+      const numBlocks = Math.min(Math.ceil((mlen * 8) / BLOCK_SIZE), DEFAULT_BLOCK_COUNT);
 
       // Write CC with valid NFC Forum Type 5 header, then zero everything else
       // CC: E1 40 <size/8> 01 — magic, v1.0 RW, size, read-multiple-blocks supported
-      const cc = Buffer.from([0xe1, 0x40, mlen || (DEFAULT_BLOCK_COUNT * BLOCK_SIZE / 8), 0x01]);
+      const cc = Buffer.from([0xe1, 0x40, mlen, 0x01]);
       await this.writeBlock(protocol, 0, cc);
 
       // Write TLV terminator in block 1, zero the rest


### PR DESCRIPTION
## Summary

PR 1 of 8 in the code-review issue sweep (#262–#321). Fixes 9 issues in the Electron main process — security hardening + reliability.

| Issue | Fix |
|---|---|
| **#262** P1 | `sandbox: true` on the renderer; dropped `'unsafe-eval'` from the CSP |
| **#299** P1 sec | `assertTrustedSender()` on privileged IPC handlers — rejects calls from sub-frames / wrong origin |
| **#300** P1 sec | `validateMongoUri()` on test-connection + save-config — blocks non-mongodb schemes & local-file TLS options (SSRF / file-read) |
| **#301** P1 | `sanitizeMlen()` validates the tag's Capability-Container MLEN byte before it's trusted or written back (was bricking tags) |
| **#315** P2 | Crash-restart handler moved into `startProductionServer` (every process gets it), with an identity guard + 5-attempt backoff cap |
| **#316** P2 | `before-quit` races `stopLocalMongo()` against a 5s timeout → `app.exit(0)` |
| **#318** P2 | Embedded MongoDB pinned to `instance.ip: 127.0.0.1` |
| **#279** P2 | Removed the 15s timeout from `trigger-sync` (it never cancelled the sync, just lied to the UI) |
| **#278** P2 | `nfc-write-tag` validates payload length + element range, and rejects non-http(s) `productUrl` |

New file: `electron/ipc-security.ts` — shared `assertTrustedSender` + `validateMongoUri`, used by both `main.ts` and `auto-updater.ts`.

## Notes / scoped follow-ups

- **#262** keeps `'unsafe-inline'` on `script-src` — Next.js streams the RSC payload via inline `<script>` and the theme-init bootstrap is inline. Nonce migration stays tracked in **#225**.
- **#279** removes the broken sync timeout (the clear bug). Full *cancellation* of an in-flight NFC write needs `AbortSignal` plumbing into `nfc-service` — deliberately left as a follow-up; the wrapper's doc comment now says so.

## Test plan

- [x] `npm run electron:compile` — clean (esbuild)
- [x] `tsconfig.electron.json` error count unchanged vs `main` (66 = 66 — all pre-existing electron-store / nfc-pcsc typing; **zero new**)
- [x] `npm run lint` — clean
- [ ] Manual: app launches with `sandbox: true`, renderer functions normally
- [ ] Manual: Settings → save a connection change → server restarts cleanly (no duplicate)
- [ ] Manual: quit the app on a hybrid-mode install → exits within 5s even if mongod is slow
- [ ] Manual: test-connection rejects `http://...` and a URI with `tlsCAFile=`

Electron has no automated test suite — verification is compile + typecheck-delta + manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)