### PR TITLE
NFC/tag binary parsing robustness (#274, #275, #311, #313, #314)

### DIFF
--- a/electron/bambu-tag.ts
+++ b/electron/bambu-tag.ts
@@ -72,7 +72,21 @@ function readString(buf: Buffer, start: number, length: number): string {
  * Sector trailers (blocks 3, 7, 11, ...) are excluded.
  */
 export function parseBambuBlocks(blocks: (Buffer | undefined)[]): BambuTagData {
-  const block = (n: number): Buffer => blocks[n] ?? Buffer.alloc(16);
+  // GH #314: every block is normalised to exactly 16 bytes before the
+  // fixed-offset readUInt16LE / readFloatLE calls below. A
+  // successful-but-short MIFARE read (a malformed-but-authenticated
+  // response) is stored as-is; without this, an offset read past the
+  // end of a short buffer throws an unhandled RangeError out of the
+  // parser. A missing block → all-zero; a short block → zero-padded;
+  // an over-long block → truncated.
+  const block = (n: number): Buffer => {
+    const b = blocks[n];
+    if (!b) return Buffer.alloc(16);
+    if (b.length === 16) return b;
+    const normalised = Buffer.alloc(16);
+    b.copy(normalised, 0, 0, Math.min(b.length, 16));
+    return normalised;
+  };
 
   // Block 1: Material Variant ID (0-7) + Material ID (8-15)
   const b1 = block(1);

--- a/electron/ndef.ts
+++ b/electron/ndef.ts
@@ -311,10 +311,15 @@ function parseNdefRecord(
   offset: number,
   messageLen: number,
 ): Uint8Array {
-  const messageEnd = offset + messageLen;
+  // GH #313: bound every read against the enclosing TLV's end, not the
+  // whole tag image. A crafted record could otherwise declare a
+  // payloadLength that fits inside `data.length` but spills past the
+  // NDEF message TLV, pulling in trailing bytes from outside it. Clamp
+  // messageEnd to the buffer so it's also a hard upper bound on reads.
+  const messageEnd = Math.min(offset + messageLen, data.length);
 
   while (offset < messageEnd) {
-    if (offset + 2 > data.length) {
+    if (offset + 2 > messageEnd) {
       throw new Error("NDEF record truncated: not enough bytes for record header");
     }
 
@@ -327,10 +332,10 @@ function parseNdefRecord(
 
     let payloadLength: number;
     if (isShortRecord) {
-      if (offset >= data.length) throw new Error("NDEF record truncated: missing payload length");
+      if (offset >= messageEnd) throw new Error("NDEF record truncated: missing payload length");
       payloadLength = data[offset++];
     } else {
-      if (offset + 4 > data.length) throw new Error("NDEF record truncated: incomplete payload length");
+      if (offset + 4 > messageEnd) throw new Error("NDEF record truncated: incomplete payload length");
       payloadLength =
         ((data[offset] << 24) |
         (data[offset + 1] << 16) |
@@ -341,12 +346,12 @@ function parseNdefRecord(
 
     let idLength = 0;
     if (hasIdLength) {
-      if (offset >= data.length) throw new Error("NDEF record truncated: missing ID length");
+      if (offset >= messageEnd) throw new Error("NDEF record truncated: missing ID length");
       idLength = data[offset++];
     }
 
-    if (offset + typeLength + idLength + payloadLength > data.length) {
-      throw new Error("NDEF record truncated: type + id + payload exceeds available data");
+    if (offset + typeLength + idLength + payloadLength > messageEnd) {
+      throw new Error("NDEF record truncated: type + id + payload exceeds the NDEF message TLV");
     }
 
     // Read type

--- a/src/lib/openprinttag-decode.ts
+++ b/src/lib/openprinttag-decode.ts
@@ -103,26 +103,36 @@ function decodeCBORItem(
     offset += 2;
   } else if (additional === 26) {
     if (offset + 4 > data.length) throw new Error("CBOR decode: unexpected end of data reading 4-byte argument");
+    // GH #275: the `|` chain is signed 32-bit arithmetic — a value with
+    // the high bit set would otherwise come out negative (a negative
+    // array/map count silently decodes an empty container; a negative
+    // uint returns a wrong value). The trailing `>>> 0` coerces the
+    // whole assembly back to an unsigned 32-bit integer.
     argument =
-      ((data[offset] << 24) >>> 0) |
-      (data[offset + 1] << 16) |
-      (data[offset + 2] << 8) |
-      data[offset + 3];
+      (((data[offset] << 24) >>> 0) |
+        (data[offset + 1] << 16) |
+        (data[offset + 2] << 8) |
+        data[offset + 3]) >>>
+      0;
     offset += 4;
   } else if (additional === 27) {
     if (offset + 8 > data.length) throw new Error("CBOR decode: unexpected end of data reading 8-byte argument");
-    // 64-bit - read as two 32-bit values
+    // 64-bit - read as two 32-bit values. GH #275: each half is coerced
+    // unsigned (`>>> 0`) for the same signed-arithmetic reason as the
+    // 4-byte case above.
     const hi =
-      ((data[offset] << 24) >>> 0) |
-      (data[offset + 1] << 16) |
-      (data[offset + 2] << 8) |
-      data[offset + 3];
+      (((data[offset] << 24) >>> 0) |
+        (data[offset + 1] << 16) |
+        (data[offset + 2] << 8) |
+        data[offset + 3]) >>>
+      0;
     offset += 4;
     const lo =
-      ((data[offset] << 24) >>> 0) |
-      (data[offset + 1] << 16) |
-      (data[offset + 2] << 8) |
-      data[offset + 3];
+      (((data[offset] << 24) >>> 0) |
+        (data[offset + 1] << 16) |
+        (data[offset + 2] << 8) |
+        data[offset + 3]) >>>
+      0;
     offset += 4;
     argument = hi * 0x100000000 + lo;
   } else if (additional === 31) {
@@ -375,8 +385,16 @@ export function decodeOpenPrintTagBinary(data: Uint8Array): DecodedOpenPrintTag 
       .filter(Boolean);
   }
 
-  // Decode auxiliary region if present
-  if (meta.AUX_REGION_OFFSET != null && meta.AUX_REGION_OFFSET < data.length) {
+  // Decode auxiliary region if present. GH #311: AUX_REGION_OFFSET comes
+  // from untrusted tag bytes — require a non-negative integer strictly
+  // inside the buffer, otherwise decodeCBORItem would read at a negative
+  // index (→ undefined → silently-wrong decode instead of a clean skip).
+  if (
+    meta.AUX_REGION_OFFSET != null &&
+    Number.isInteger(meta.AUX_REGION_OFFSET) &&
+    meta.AUX_REGION_OFFSET >= 0 &&
+    meta.AUX_REGION_OFFSET < data.length
+  ) {
     try {
       const [auxRaw] = decodeCBORItem(data, meta.AUX_REGION_OFFSET);
       const auxMap = auxRaw as Record<string, unknown>;

--- a/src/lib/openprinttag.ts
+++ b/src/lib/openprinttag.ts
@@ -174,6 +174,16 @@ for (const [name, val] of Object.entries(OPT_TAG)) {
 
 // ── Low-level CBOR helpers ──────────────────────────────────────────
 
+/**
+ * Clamp a temperature to a non-negative integer before CBOR encoding
+ * (GH #274). `encodeCBORUint` rejects negatives and mis-encodes
+ * fractional values; temperatures can arrive negative/fractional from
+ * imports or manual edits.
+ */
+function clampTemp(value: number): number {
+  return Math.max(0, Math.round(value));
+}
+
 /** Encode a CBOR unsigned integer (major type 0) and push bytes to `buf`. */
 export function encodeCBORUint(buf: number[], value: number): void {
   if (value < 0) throw new RangeError("CBOR unsigned int must be >= 0");
@@ -618,15 +628,18 @@ function buildMainMap(input: OpenPrintTagInput): number[] {
     encodeCBORUint(buf, input.shoreHardnessD);
   }
 
-  // Temperatures – all type: int, unit: °C
+  // Temperatures – all type: int, unit: °C.
+  // GH #274: encodeCBORUint throws RangeError on any value < 0, and a
+  // non-integer would encode a bad byte. Temperatures can arrive
+  // negative or fractional from a bad import, AI-extracted garbage, or a
+  // manual edit — clamp every value through clampTemp() (max(0, round))
+  // before it reaches the encoder so a bad input can't crash the whole
+  // NFC-write path.
   if (input.nozzleTemp != null) {
     // Use nozzle temp as max, derive min as temp - 20
-    const maxTemp = input.nozzleTemp;
-    const minTemp = Math.max(
-      0,
-      (input.nozzleTempFirstLayer ?? maxTemp) - 20,
-    );
-    const preheatTemp = Math.max(0, minTemp - 20);
+    const maxTemp = clampTemp(input.nozzleTemp);
+    const minTemp = clampTemp((input.nozzleTempFirstLayer ?? maxTemp) - 20);
+    const preheatTemp = clampTemp(minTemp - 20);
 
     encodeCBORKey(buf, OPT_KEY.MIN_PRINT_TEMPERATURE);
     encodeCBORUint(buf, minTemp);
@@ -637,8 +650,8 @@ function buildMainMap(input: OpenPrintTagInput): number[] {
   }
 
   if (input.bedTemp != null) {
-    const maxBed = input.bedTemp;
-    const minBed = input.bedTempFirstLayer ?? Math.max(0, maxBed - 10);
+    const maxBed = clampTemp(input.bedTemp);
+    const minBed = clampTemp(input.bedTempFirstLayer ?? maxBed - 10);
 
     encodeCBORKey(buf, OPT_KEY.MIN_BED_TEMPERATURE);
     encodeCBORUint(buf, Math.min(minBed, maxBed));
@@ -648,7 +661,7 @@ function buildMainMap(input: OpenPrintTagInput): number[] {
 
   if (input.chamberTemp != null && input.chamberTemp > 0) {
     encodeCBORKey(buf, OPT_KEY.CHAMBER_TEMPERATURE);
-    encodeCBORUint(buf, input.chamberTemp);
+    encodeCBORUint(buf, clampTemp(input.chamberTemp));
   }
 
   // material_abbreviation (max 7 chars)

--- a/tests/nfc-binary-parsing.test.ts
+++ b/tests/nfc-binary-parsing.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateOpenPrintTagBinary,
+  type OpenPrintTagInput,
+} from "@/lib/openprinttag";
+import { decodeOpenPrintTagBinary } from "@/lib/openprinttag-decode";
+import { parseBambuBlocks } from "../electron/bambu-tag";
+import { parseNdefFromTag } from "../electron/ndef";
+
+/**
+ * Robustness tests for the NFC binary parsers/encoders — code-review
+ * issues #274, #275, #311, #313, #314. These paths consume bytes that
+ * come straight off a physical tag (or off a bad import for the
+ * encoder), so they must fail cleanly rather than crash or silently
+ * decode garbage.
+ */
+describe("NFC binary parsing robustness", () => {
+  // ── #274: generateOpenPrintTagBinary tolerates negative temps ──────
+
+  describe("#274 — negative temperature input", () => {
+    const base: OpenPrintTagInput = {
+      materialName: "Test PLA",
+      brandName: "Test",
+      materialType: "PLA",
+    };
+
+    it("does not throw on a negative nozzle temperature", () => {
+      expect(() =>
+        generateOpenPrintTagBinary({ ...base, nozzleTemp: -40 }),
+      ).not.toThrow();
+    });
+
+    it("does not throw on a negative bed temperature", () => {
+      expect(() =>
+        generateOpenPrintTagBinary({ ...base, bedTemp: -10 }),
+      ).not.toThrow();
+    });
+
+    it("does not throw on a negative chamber temperature", () => {
+      expect(() =>
+        generateOpenPrintTagBinary({ ...base, chamberTemp: -5 }),
+      ).not.toThrow();
+    });
+
+    it("a negative nozzle temp round-trips as a clamped (>= 0) value", () => {
+      const bin = generateOpenPrintTagBinary({ ...base, nozzleTemp: -40 });
+      const decoded = decodeOpenPrintTagBinary(bin);
+      // Every encoded temperature must be a non-negative integer.
+      for (const [k, v] of Object.entries(decoded.main)) {
+        if (k.includes("TEMPERATURE") && typeof v === "number") {
+          expect(v).toBeGreaterThanOrEqual(0);
+        }
+      }
+    });
+  });
+
+  // ── #275: 4-byte CBOR uint with the high bit set decodes unsigned ──
+
+  it("#275 — a 4-byte CBOR uint with the high bit set decodes as positive", () => {
+    // Meta map { 2: 0x80000001 } — value uses the 4-byte uint form
+    // (0x1A) with the high bit set. Followed by an empty main map.
+    // Pre-fix the signed `|` chain decoded this as a negative number.
+    const data = new Uint8Array([
+      0xa1, // map, 1 pair
+      0x02, // key: uint 2
+      0x1a, 0x80, 0x00, 0x00, 0x01, // value: uint32 0x80000001
+      0xa0, // main map: empty
+    ]);
+    const decoded = decodeOpenPrintTagBinary(data);
+    // The single meta value must come back as the true unsigned value.
+    expect(Object.values(decoded.meta)).toContain(0x80000001);
+    // And nothing in meta is negative.
+    for (const v of Object.values(decoded.meta)) {
+      expect(v).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  // ── #311: negative aux-region offset is rejected, not dereferenced ──
+
+  it("#311 — a negative AUX_REGION_OFFSET is skipped cleanly", () => {
+    // Meta map { 2: -5 } (AUX_REGION_OFFSET = -5) + empty main map.
+    // -5 in CBOR is major type 1: 0x20 + 4 = 0x24.
+    const data = new Uint8Array([
+      0xa1, // map, 1 pair
+      0x02, // key: uint 2 (AUX_REGION_OFFSET)
+      0x24, // value: negative int -5
+      0xa0, // main map: empty
+    ]);
+    // Must not throw, and must not populate `aux` from a bogus offset.
+    let decoded: ReturnType<typeof decodeOpenPrintTagBinary>;
+    expect(() => {
+      decoded = decodeOpenPrintTagBinary(data);
+    }).not.toThrow();
+    expect(decoded!.aux).toBeUndefined();
+  });
+
+  // ── #313: NDEF payload bounded by the TLV, not the whole buffer ────
+
+  it("#313 — a record claiming a payload past the TLV end is rejected", () => {
+    // CC (4 bytes) + NDEF TLV (tag 0x03, len 5) whose single record
+    // declares a 100-byte payload — well past the 5-byte TLV — but the
+    // overall buffer is long enough that a `data.length` bound would
+    // have let it through.
+    const raw = new Uint8Array(120);
+    raw[0] = 0xe1; // CC magic
+    raw[1] = 0x40;
+    raw[4] = 0x03; // NDEF Message TLV tag
+    raw[5] = 0x05; // TLV length = 5
+    raw[6] = 0x12; // record flags: SR | TNF=2
+    raw[7] = 0x00; // type length = 0
+    raw[8] = 0x64; // payload length = 100 — exceeds the 5-byte TLV
+    expect(() => parseNdefFromTag(raw)).toThrow(/NDEF message TLV/);
+  });
+
+  // ── #314: parseBambuBlocks tolerates a short block ─────────────────
+
+  it("#314 — a short MIFARE block does not throw a RangeError", () => {
+    // Block 5 (read with readUInt16LE(4) / readFloatLE(8)) supplied as
+    // a 4-byte buffer — shorter than the 16 bytes the fixed offsets
+    // assume. Pre-fix this threw an unhandled RangeError.
+    const blocks: (Buffer | undefined)[] = [];
+    blocks[1] = Buffer.alloc(16);
+    blocks[5] = Buffer.from([0x01, 0x02, 0x03, 0x04]); // only 4 bytes
+    let result: ReturnType<typeof parseBambuBlocks>;
+    expect(() => {
+      result = parseBambuBlocks(blocks);
+    }).not.toThrow();
+    // The short block's missing bytes read back as zero-padded.
+    expect(result!.spoolWeight).toBe(0);
+    expect(result!.filamentDiameter).toBe(0);
+    // The present colour bytes still come through.
+    expect(result!.colorRGBA).toEqual([1, 2, 3, 4]);
+  });
+
+  it("#314 — an over-long block is truncated to 16 bytes, not rejected", () => {
+    const blocks: (Buffer | undefined)[] = [];
+    blocks[5] = Buffer.alloc(64, 0xff); // 64 bytes, all 0xff
+    expect(() => parseBambuBlocks(blocks)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of 8 in the code-review issue sweep. Fixes 5 robustness issues in the tag binary encoders/parsers — paths that consume bytes straight off a physical tag (or off a bad import).

| Issue | Fix |
|---|---|
| **#274** P2 | `generateOpenPrintTagBinary` crashed (RangeError) on a negative temperature → `clampTemp()` applied to every temp before encoding |
| **#275** P2 | `decodeCBORItem` assembled 4/8-byte arguments with signed `|` → high-bit values decoded negative → `>>> 0` coercion |
| **#311** P2 | aux-region offset used with only a `< data.length` guard → negative-offset reads → require a non-negative integer in-bounds |
| **#313** P2 | NDEF record reads bounded against the whole buffer, not the enclosing TLV → clamp `messageEnd` + bound every read against it |
| **#314** P2 | `parseBambuBlocks` read fixed offsets without a length check → RangeError on short blocks → normalise every block to 16 bytes |

## Test plan

- [x] `tests/nfc-binary-parsing.test.ts` — 9 new cases, one+ per issue
- [x] Existing NFC suites pass — openprinttag / openprinttag-decode / bambu-tag / nfc-roundtrip (196 tests)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run electron:compile` — clean (ndef.ts + bambu-tag.ts are electron-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)