### PR TITLE
fix: restore focus on dialog close and move focus on wizard step change

### DIFF
--- a/src/components/ImportAtlasDialog.tsx
+++ b/src/components/ImportAtlasDialog.tsx
@@ -31,9 +31,11 @@ export default function ImportAtlasDialog({ onClose, onImported }: Props) {
   const [importProgress, setImportProgress] = useState("");
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  // Focus trap
+  // Focus trap: capture previous focus, trap tab, restore on cleanup
   useEffect(() => {
     if (!dialogRef.current) return;
+    
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     dialogRef.current.focus();
 
     const dialog = dialogRef.current;
@@ -59,8 +61,21 @@ export default function ImportAtlasDialog({ onClose, onImported }: Props) {
       }
     };
     document.addEventListener("keydown", handleTab);
-    return () => document.removeEventListener("keydown", handleTab);
+    return () => {
+      document.removeEventListener("keydown", handleTab);
+      previouslyFocused?.focus?.();
+    };
   }, [onClose]);
+
+  // Move focus to first interactive element when step changes
+  useEffect(() => {
+    if (!dialogRef.current) return;
+    const dialog = dialogRef.current;
+    const firstFocusable = dialog.querySelector<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    firstFocusable?.focus();
+  }, [step]);
 
   const handleConnect = async () => {
     if (!uri.trim()) return;

--- a/src/components/NfcReadDialog.tsx
+++ b/src/components/NfcReadDialog.tsx
@@ -25,9 +25,12 @@ export default function NfcReadDialog() {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [visible, dismissTagRead]);
 
-  // Focus trap: focus the dialog when it appears and trap tab within it
+  // Focus trap: capture previous focus, focus the dialog when it appears,
+  // trap tab within it, and restore focus on cleanup
   useEffect(() => {
     if (!visible || !dialogRef.current) return;
+    
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     dialogRef.current.focus();
 
     const dialog = dialogRef.current;
@@ -52,7 +55,10 @@ export default function NfcReadDialog() {
       }
     };
     document.addEventListener("keydown", handleTab);
-    return () => document.removeEventListener("keydown", handleTab);
+    return () => {
+      document.removeEventListener("keydown", handleTab);
+      previouslyFocused?.focus?.();
+    };
   }, [visible]);
 
   if (!visible || !tagReadResult) return null;

--- a/src/components/PrusamentImportDialog.tsx
+++ b/src/components/PrusamentImportDialog.tsx
@@ -67,10 +67,13 @@ export default function PrusamentImportDialog({
   );
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  // Focus trap & escape
+  // Focus trap & escape: capture previous focus, trap tab, restore on cleanup
   useEffect(() => {
     if (!dialogRef.current) return;
+    
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     dialogRef.current.focus();
+    
     const dialog = dialogRef.current;
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -95,8 +98,21 @@ export default function PrusamentImportDialog({
       }
     };
     document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      previouslyFocused?.focus?.();
+    };
   }, [onClose]);
+
+  // Move focus to first interactive element when step changes
+  useEffect(() => {
+    if (!dialogRef.current) return;
+    const dialog = dialogRef.current;
+    const firstFocusable = dialog.querySelector<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    firstFocusable?.focus();
+  }, [step]);
 
   const handleLookup = async () => {
     const input = spoolInput.trim();


### PR DESCRIPTION
Fixes #320

## Problem

Three dialog components (`NfcReadDialog`, `ImportAtlasDialog`, `PrusamentImportDialog`) never capture/restore `document.activeElement`, so focus drops to the document body on close. The wizard dialogs also never move focus into the newly-rendered step on a connect-select-confirm transition.

## Impact

Keyboard and screen-reader users lose their place when the NFC dialog (which auto-opens on every scan) closes, and after each wizard step. This is a **P2 accessibility** issue.

## Solution

Applied the same focus management pattern already used in `UnsavedChangesDialog`:

### 1. Capture previous focus on mount

```ts
const previouslyFocused = document.activeElement as HTMLElement | null;
```

### 2. Restore focus on cleanup

```ts
return () => {
  document.removeEventListener('keydown', handleTab);
  previouslyFocused?.focus?.();
};
```

### 3. Move focus to first interactive element on wizard step change

```ts
useEffect(() => {
  const firstFocusable = dialog.querySelector<HTMLElement>(
    'button:not([disabled]), [href], input:not([disabled]), ...'
  );
  firstFocusable?.focus();
}, [step]);
```

## Changes

- **NfcReadDialog.tsx**: Added `previouslyFocused` capture/restore
- **ImportAtlasDialog.tsx**: Added `previouslyFocused` capture/restore + step focus management
- **PrusamentImportDialog.tsx**: Added `previouslyFocused` capture/restore + step focus management

## Testing

**Manual keyboard navigation test:**
1. Focus an input field
2. Trigger NFC scan (dialog auto-opens)
3. Press Escape to close
4. ✅ Verify focus returns to the input field

**Wizard step test:**
1. Open `ImportAtlasDialog` or `PrusamentImportDialog`
2. Complete first step (connect/input)
3. ✅ Verify focus moves to first interactive element in next step
4. Complete wizard or press Escape
5. ✅ Verify focus returns to trigger element

## Size

**S** — 3 files, ~15 lines added per file (focus capture/restore + step focus management)