### PR TITLE
Database index correctness + connection resilience (#282, #302, #303, #304, #312)

### DIFF
--- a/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
@@ -3,6 +3,11 @@ import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
+/** GH #304: hard cap on a spool's embedded dryCycles array — same
+ * unbounded-growth concern as usageHistory. The `$slice: -N` modifier
+ * on the `$push` keeps only the most recent N entries atomically. */
+const MAX_DRY_CYCLES = 1000;
+
 /**
  * POST /api/filaments/{id}/spools/{spoolId}/dry-cycles — log a dry cycle.
  *
@@ -50,7 +55,10 @@ export async function POST(
     const { id, spoolId } = await params;
     const filament = await Filament.findOneAndUpdate(
       { _id: id, _deletedAt: null, "spools._id": spoolId },
-      { $push: { "spools.$.dryCycles": entry } },
+      // GH #304: $slice: -N keeps only the most recent MAX_DRY_CYCLES
+      // entries, so a looping client can't grow the filament document
+      // toward the 16MB BSON limit.
+      { $push: { "spools.$.dryCycles": { $each: [entry], $slice: -MAX_DRY_CYCLES } } },
       { returnDocument: "after" },
     ).lean();
     if (!filament) {

--- a/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
@@ -3,6 +3,12 @@ import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 
+/** GH #304: hard cap on a spool's embedded usageHistory array. Far
+ * above any realistic per-spool history; exists to stop a client
+ * looping POSTs from growing the filament document toward the 16MB
+ * BSON limit. Oldest entries roll off once the cap is reached. */
+const MAX_SPOOL_HISTORY = 1000;
+
 /**
  * POST /api/filaments/{id}/spools/{spoolId}/usage — manually log grams used.
  *
@@ -70,6 +76,11 @@ export async function POST(
       // explicit at every call site.
       jobId: null,
     });
+    // GH #304: roll off the oldest entries once the cap is reached so
+    // the embedded array can't grow the filament document unbounded.
+    if (spool.usageHistory.length > MAX_SPOOL_HISTORY) {
+      spool.usageHistory = spool.usageHistory.slice(-MAX_SPOOL_HISTORY);
+    }
     await filament.save();
     return NextResponse.json(filament.toObject(), { status: 201 });
   } catch (err) {

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -129,6 +129,22 @@ export async function POST(request: NextRequest) {
         ? new Date(body.expiresAt)
         : null;
 
+    // GH #282: the catalog document must stay under MongoDB's 16MB BSON
+    // limit. Spool subdocuments (which carry base64 photoDataUrl images
+    // + usage/dry history) are already stripped from each filament
+    // above, but a very large catalog could still approach the limit
+    // from filament count alone. Reject with a clear message before the
+    // write rather than letting Mongo hard-fail mid-insert.
+    const MAX_PAYLOAD_BYTES = 12 * 1024 * 1024; // 12MB — headroom under 16MB
+    const payloadBytes = Buffer.byteLength(JSON.stringify(payload), "utf8");
+    if (payloadBytes > MAX_PAYLOAD_BYTES) {
+      return errorResponse(
+        `This catalog is too large to publish (${(payloadBytes / 1024 / 1024).toFixed(1)}MB). ` +
+          `Select fewer filaments — the limit is ${MAX_PAYLOAD_BYTES / 1024 / 1024}MB.`,
+        413,
+      );
+    }
+
     const catalog = await SharedCatalog.create({
       title: body.title.trim(),
       description: typeof body.description === "string" ? body.description : "",

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -15,6 +15,10 @@ interface MongooseCache {
      * one physical instance per printer. Idempotent: on a clean DB the
      * pass finds no duplicates and the flag is set on first connect. */
     nozzlePhysicalInstances: boolean;
+    /** GH #303 — run syncIndexes() on the core models so a pre-existing
+     * plain unique `name` (or `instanceId`) index is dropped and rebuilt
+     * as the partial-unique-on-non-deleted index the schema declares. */
+    coreModelIndexes: boolean;
   };
 }
 
@@ -35,7 +39,7 @@ export default async function dbConnect() {
     conn: null,
     promise: null,
     uri: null,
-    migrations: { instanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false },
+    migrations: { instanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false },
   };
 
   if (!global.mongoose) {
@@ -49,7 +53,17 @@ export default async function dbConnect() {
     cached.conn = null;
     cached.promise = null;
     cached.uri = null;
-    cached.migrations = { instanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false };
+    cached.migrations = { instanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false };
+  }
+
+  // GH #312: a cached connection can go dead after a DB outage or an
+  // Atlas failover. mongoose.connection.readyState === 1 means
+  // "connected"; anything else (0 disconnected, 2 connecting,
+  // 3 disconnecting) means the cached handle is stale. Drop it so the
+  // reconnect path below runs instead of returning a dead handle.
+  if (cached.conn && mongoose.connection.readyState !== 1) {
+    cached.conn = null;
+    cached.promise = null;
   }
 
   // Short-circuit only when both the connection AND all migrations are
@@ -60,7 +74,8 @@ export default async function dbConnect() {
     cached.conn &&
     cached.migrations.instanceIds &&
     cached.migrations.sharedCatalogIndexes &&
-    cached.migrations.nozzlePhysicalInstances
+    cached.migrations.nozzlePhysicalInstances &&
+    cached.migrations.coreModelIndexes
   ) {
     return cached.conn;
   }
@@ -111,6 +126,39 @@ export default async function dbConnect() {
       cached.migrations.sharedCatalogIndexes = true;
     } catch (err) {
       console.error("[migration] Failed to sync SharedCatalog indexes (will retry on next connect):", err);
+    }
+  }
+
+  // GH #303: Filament / Location / BedType / Nozzle / Printer all declare
+  // a partial-unique index on `name` (and Filament also on `instanceId`,
+  // GH #302). Mongoose's autoIndex builds *missing* indexes but will not
+  // drop a pre-existing plain unique index and replace it with the
+  // partial one. On any DB whose `name` index predates the partial-index
+  // change, the soft-delete name-reuse feature silently fails with
+  // E11000. syncIndexes() drops mismatched indexes and recreates them —
+  // idempotent on fresh DBs, corrective on upgraded ones. Same
+  // retry-tracked pattern as the SharedCatalog block above.
+  if (!cached.migrations.coreModelIndexes) {
+    try {
+      const models = await Promise.all([
+        import("@/models/Filament"),
+        import("@/models/Location"),
+        import("@/models/BedType"),
+        import("@/models/Nozzle"),
+        import("@/models/Printer"),
+      ]);
+      for (const mod of models) {
+        const model = mod.default;
+        const dropped = await model.syncIndexes();
+        if (dropped.length > 0) {
+          console.log(
+            `[migration] Rebuilt ${model.modelName} indexes (dropped: ${dropped.join(", ")})`,
+          );
+        }
+      }
+      cached.migrations.coreModelIndexes = true;
+    } catch (err) {
+      console.error("[migration] Failed to sync core model indexes (will retry on next connect):", err);
     }
   }
 

--- a/src/models/Filament.ts
+++ b/src/models/Filament.ts
@@ -193,7 +193,12 @@ const FilamentSchema = new Schema<IFilament>(
   {
     name: { type: String, required: true },
     syncId: { type: String, unique: true, sparse: true, index: true },
-    instanceId: { type: String, unique: true, default: generateInstanceId },
+    // GH #302: NOT a field-level `unique: true` — that builds a plain
+    // unique index that collides with soft-delete / `_purged` tombstone
+    // rows (a snapshot restore / re-import can E11000 against a hidden
+    // tombstone). The partial-unique index registered below scopes
+    // uniqueness to non-deleted documents, matching the `name` index.
+    instanceId: { type: String, default: generateInstanceId },
     vendor: { type: String, required: true, index: true },
     type: { type: String, required: true, index: true },
     color: { type: String, default: "#808080" },
@@ -342,6 +347,15 @@ const FilamentSchema = new Schema<IFilament>(
 // Partial unique index: enforce unique names only among non-deleted documents
 FilamentSchema.index(
   { name: 1 },
+  { unique: true, partialFilterExpression: { _deletedAt: null } }
+);
+
+// GH #302: instanceId is unique only among non-deleted documents — see
+// the field definition above. Scoping to `_deletedAt: null` keeps a
+// re-imported / restored filament from colliding with a tombstone row
+// that still carries the same instanceId.
+FilamentSchema.index(
+  { instanceId: 1 },
   { unique: true, partialFilterExpression: { _deletedAt: null } }
 );
 

--- a/tests/db-indexes-connection.test.ts
+++ b/tests/db-indexes-connection.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { POST as logUsage } from "@/app/api/filaments/[id]/spools/[spoolId]/usage/route";
+import { POST as logDryCycle } from "@/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route";
+
+/**
+ * Code-review issues #302, #303, #304 — database index correctness and
+ * embedded-array growth bounds.
+ *
+ * (#312 dead-connection check and #282 SharedCatalog size guard are
+ * verified by inspection — both are small, self-evident guards whose
+ * trigger conditions — a mid-test DB outage, a 12MB payload — are not
+ * worth simulating in a unit test.)
+ */
+describe("DB index correctness + embedded-array bounds", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const mod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", mod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+    // Build the declared indexes against the in-memory server so the
+    // partial-unique constraints are actually enforced in these tests.
+    await Filament.syncIndexes();
+  });
+
+  // ── #302/#303: instanceId partial-unique index ─────────────────────
+
+  describe("#302 — instanceId is partial-unique on non-deleted docs", () => {
+    it("declares instanceId as a partial-unique index, not a plain one", () => {
+      // #303: the schema must declare the partial index — otherwise
+      // syncIndexes() can't migrate an upgraded DB off the plain one.
+      const indexes = Filament.schema.indexes() as [
+        Record<string, number>,
+        Record<string, unknown>,
+      ][];
+      const instanceIdIndex = indexes.find((ix) => ix[0].instanceId === 1);
+      expect(instanceIdIndex).toBeDefined();
+      expect(instanceIdIndex![1].unique).toBe(true);
+      expect(instanceIdIndex![1].partialFilterExpression).toEqual({
+        _deletedAt: null,
+      });
+    });
+
+    it("lets a new filament reuse the instanceId of a soft-deleted one", async () => {
+      const a = await Filament.create({
+        name: "Original",
+        vendor: "V",
+        type: "PLA",
+        instanceId: "shared-instance-id",
+      });
+      a._deletedAt = new Date();
+      await a.save();
+
+      // A plain unique index would E11000 here against the tombstone.
+      const b = await Filament.create({
+        name: "Reincarnation",
+        vendor: "V",
+        type: "PLA",
+        instanceId: "shared-instance-id",
+      });
+      expect(b._id).toBeDefined();
+    });
+
+    it("still rejects two ACTIVE filaments sharing an instanceId", async () => {
+      await Filament.create({
+        name: "First",
+        vendor: "V",
+        type: "PLA",
+        instanceId: "live-instance-id",
+      });
+      await expect(
+        Filament.create({
+          name: "Second",
+          vendor: "V",
+          type: "PLA",
+          instanceId: "live-instance-id",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── #304: embedded-array growth bounds ─────────────────────────────
+
+  describe("#304 — usageHistory / dryCycles are capped", () => {
+    function usageReq(grams: number) {
+      return new NextRequest("http://localhost/api/.../usage", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ grams }),
+      });
+    }
+    function dryReq() {
+      return new NextRequest("http://localhost/api/.../dry-cycles", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tempC: 55, durationMin: 240 }),
+      });
+    }
+
+    it("rolls off the oldest usageHistory entry once the 1000-entry cap is hit", async () => {
+      // Pre-seed a spool already at the cap. The marker entry is the
+      // oldest — it must be gone after one more POST.
+      const seeded = Array.from({ length: 1000 }, (_, i) => ({
+        grams: 1,
+        jobLabel: i === 0 ? "OLDEST-MARKER" : `seed-${i}`,
+        date: new Date(2020, 0, 1 + (i % 365)),
+        source: "manual" as const,
+        jobId: null,
+      }));
+      const f = await Filament.create({
+        name: "Usage Cap",
+        vendor: "V",
+        type: "PLA",
+        spools: [{ label: "s1", totalWeight: 100000, usageHistory: seeded }],
+      });
+      const spoolId = String(f.spools[0]._id);
+
+      const res = await logUsage(usageReq(5), {
+        params: Promise.resolve({ id: String(f._id), spoolId }),
+      });
+      expect(res.status).toBe(201);
+
+      const fresh = await Filament.findById(f._id).lean();
+      const hist = fresh.spools[0].usageHistory;
+      expect(hist).toHaveLength(1000); // capped, not 1001
+      expect(hist.some((h: { jobLabel: string }) => h.jobLabel === "OLDEST-MARKER")).toBe(false);
+      // The just-posted entry survives — it's the newest.
+      expect(hist[hist.length - 1].grams).toBe(5);
+    });
+
+    it("rolls off the oldest dryCycles entry once the 1000-entry cap is hit", async () => {
+      const seeded = Array.from({ length: 1000 }, (_, i) => ({
+        date: new Date(2020, 0, 1 + (i % 365)),
+        tempC: i === 0 ? -999 : 50, // sentinel temp on the oldest entry
+        durationMin: 60,
+        notes: "",
+      }));
+      const f = await Filament.create({
+        name: "Dry Cap",
+        vendor: "V",
+        type: "PLA",
+        spools: [{ label: "s1", totalWeight: 1000, dryCycles: seeded }],
+      });
+      const spoolId = String(f.spools[0]._id);
+
+      const res = await logDryCycle(dryReq(), {
+        params: Promise.resolve({ id: String(f._id), spoolId }),
+      });
+      expect(res.status).toBe(201);
+
+      const fresh = await Filament.findById(f._id).lean();
+      const cycles = fresh.spools[0].dryCycles;
+      expect(cycles).toHaveLength(1000); // $slice: -1000 kept it capped
+      expect(cycles.some((c: { tempC: number }) => c.tempC === -999)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR 3 of 8 in the code-review issue sweep. Fixes 5 issues around MongoDB indexes, connection caching, and embedded-array growth.

| Issue | Fix |
|---|---|
| **#302** P1 | `Filament.instanceId` plain unique index collided with tombstones → partial-unique on `{ _deletedAt: null }` |
| **#303** P1 | Partial-unique `name` indexes never applied on upgraded DBs → new `coreModelIndexes` migration runs `syncIndexes()` on all 5 core models |
| **#312** P2 | dbConnect fast path returned a dead cached connection after an outage → added `readyState === 1` liveness check |
| **#304** P2 | spool `usageHistory` / `dryCycles` could grow unbounded toward the 16MB BSON limit → capped at 1000 (roll-off / `$slice`) |
| **#282** P2 | SharedCatalog publish could exceed 16MB → 12MB serialized-size guard, rejects with 413 |

## Notes

- The `coreModelIndexes` migration (#303) also rolls out the new #302 `instanceId` partial index on existing databases.
- #312 and #282 are small self-evident guards (a 3-line `readyState` check; a `Buffer.byteLength` size gate). Their trigger conditions — a mid-test DB outage, a 12MB payload — aren't worth simulating in a unit test, so they're verified by inspection.

## Test plan

- [x] `tests/db-indexes-connection.test.ts` — 5 new cases: instanceId partial-index declaration, soft-deleted-instanceId reuse allowed, active collision still rejected, usageHistory + dryCycles roll-off at the cap
- [x] `npm test` — full suite **1230 passing** (mongodb.ts + Filament.ts have wide blast radius)
- [x] `npm run lint` + `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)