### PR TITLE
Sync engine: conflict-resolution + clone-name regex fixes (#298, #317)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -464,14 +464,18 @@ export class SyncService extends EventEmitter {
         }
 
         if (localDeleted && !remoteDeleted) {
-          // Deleted locally — propagate if deletion is newer
-          const localDeletedAt = new Date(localDoc._deletedAt).getTime();
-          const remoteUpdatedAt = new Date(remoteDoc.updatedAt).getTime();
-          if (localDeletedAt > remoteUpdatedAt) {
+          // Deleted locally — propagate if the deletion is at least as
+          // recent as the remote update. GH #317: `>=` (not `>`) so the
+          // delete wins on a timestamp tie — an equal-millisecond
+          // delete-right-after-edit must not resurrect the row. NaN-safe
+          // via readTimestamp ?? 0.
+          const localDeletedAt = SyncService.readTimestamp(localDoc._deletedAt) ?? 0;
+          const remoteUpdatedAt = SyncService.readUpdatedAt(remoteDoc) ?? 0;
+          if (localDeletedAt >= remoteUpdatedAt) {
             await remoteCol.updateOne({ _id: remoteDoc._id }, { $set: { _deletedAt: localDoc._deletedAt } });
             result.deleted++;
           } else {
-            // Remote was updated after local delete — resurrect locally
+            // Remote was updated strictly after local delete — resurrect locally
             const doc = this.stripForTransfer(remoteDoc);
             const transformed = transformDoc ? transformDoc(doc, "toLocal") : doc;
             await localCol.updateOne({ _id: localDoc._id }, { $set: { ...transformed, _deletedAt: null } });
@@ -481,9 +485,10 @@ export class SyncService extends EventEmitter {
         }
 
         if (!localDeleted && remoteDeleted) {
-          const remoteDeletedAt = new Date(remoteDoc._deletedAt).getTime();
-          const localUpdatedAt = new Date(localDoc.updatedAt).getTime();
-          if (remoteDeletedAt > localUpdatedAt) {
+          // Mirror of the branch above — delete wins on a tie (GH #317).
+          const remoteDeletedAt = SyncService.readTimestamp(remoteDoc._deletedAt) ?? 0;
+          const localUpdatedAt = SyncService.readUpdatedAt(localDoc) ?? 0;
+          if (remoteDeletedAt >= localUpdatedAt) {
             await localCol.updateOne({ _id: localDoc._id }, { $set: { _deletedAt: remoteDoc._deletedAt } });
             result.deleted++;
           } else {
@@ -495,9 +500,11 @@ export class SyncService extends EventEmitter {
           continue;
         }
 
-        // Both active — last-write-wins
-        const localTime = new Date(localDoc.updatedAt).getTime();
-        const remoteTime = new Date(remoteDoc.updatedAt).getTime();
+        // Both active — last-write-wins. GH #317: NaN-safe timestamps so
+        // a doc missing `updatedAt` doesn't stall the merge (it sorts as
+        // epoch 0 rather than making every comparison false).
+        const localTime = SyncService.readUpdatedAt(localDoc) ?? 0;
+        const remoteTime = SyncService.readUpdatedAt(remoteDoc) ?? 0;
 
         if (localTime > remoteTime) {
           // Local is newer — push to remote
@@ -872,14 +879,34 @@ export class SyncService extends EventEmitter {
    * inserts can store strings — handle both, and return undefined for
    * anything we can't read. */
   private static readUpdatedAt(doc: Document): number | undefined {
-    const u = doc.updatedAt;
-    if (!u) return undefined;
-    if (u instanceof Date) return u.getTime();
-    if (typeof u === "string") {
-      const t = Date.parse(u);
+    return SyncService.readTimestamp(doc.updatedAt);
+  }
+
+  /**
+   * Parse any timestamp-ish value (Date | ISO string | epoch ms) to
+   * epoch milliseconds. Returns undefined for a missing or unparseable
+   * value, so callers can apply an explicit fallback.
+   *
+   * GH #317: the conflict-resolution comparisons used
+   * `new Date(value).getTime()` directly — a doc missing `updatedAt`
+   * yielded NaN, every `NaN > x` / `NaN >= x` comparison was false, and
+   * the row never synced in either direction (a silent stall). Callers
+   * now do `readTimestamp(...) ?? 0` so a missing timestamp is treated
+   * as "epoch", not NaN.
+   */
+  private static readTimestamp(value: unknown): number | undefined {
+    if (!value) return undefined;
+    if (value instanceof Date) {
+      const t = value.getTime();
       return Number.isNaN(t) ? undefined : t;
     }
-    if (typeof u === "number") return u;
+    if (typeof value === "string") {
+      const t = Date.parse(value);
+      return Number.isNaN(t) ? undefined : t;
+    }
+    if (typeof value === "number") {
+      return Number.isNaN(value) ? undefined : value;
+    }
     return undefined;
   }
 

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -895,7 +895,11 @@ export class SyncService extends EventEmitter {
    * as "epoch", not NaN.
    */
   private static readTimestamp(value: unknown): number | undefined {
-    if (!value) return undefined;
+    // GH #317 (Codex review): only `null`/`undefined` counts as
+    // "missing". A `!value` check also swallowed a numeric `0` — a
+    // legitimate epoch timestamp — making an `updatedAt: 0` row look
+    // untimed and altering conflict resolution.
+    if (value == null) return undefined;
     if (value instanceof Date) {
       const t = value.getTime();
       return Number.isNaN(t) ? undefined : t;

--- a/src/app/api/nozzles/[id]/clone/route.ts
+++ b/src/app/api/nozzles/[id]/clone/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
-import { nextCloneName } from "@/lib/nozzleConflicts";
+import { nextCloneName, clonePeerNamePattern } from "@/lib/nozzleConflicts";
 
 /**
  * POST /api/nozzles/{id}/clone
@@ -37,10 +37,12 @@ export async function POST(
 
     // Pick the next available "Name #N" suffix among non-deleted nozzles
     // so the clone is visually distinguishable from its siblings in the
-    // /nozzles list.
+    // /nozzles list. GH #298: the pattern is anchored at both ends, so
+    // it matches only the base name + its numbered clones — not
+    // unrelated siblings that share a prefix.
     const peers = await Nozzle.find({
       _deletedAt: null,
-      name: { $regex: `^${escapeRegExp(source.name)}` },
+      name: { $regex: clonePeerNamePattern(source.name) },
     })
       .select("name")
       .lean();
@@ -65,13 +67,4 @@ export async function POST(
   } catch (err) {
     return errorResponseFromCaught(err, "Failed to clone nozzle");
   }
-}
-
-/**
- * Regex-escape a string so it can be safely embedded in a Mongo `$regex`
- * filter. Names like "0.4mm" contain a `.` which would otherwise match
- * any char.
- */
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -140,7 +140,7 @@ export default async function dbConnect() {
     try {
       const Printer = (await import("@/models/Printer")).default;
       const Nozzle = (await import("@/models/Nozzle")).default;
-      const { nextCloneName } = await import("@/lib/nozzleConflicts");
+      const { nextCloneName, clonePeerNamePattern } = await import("@/lib/nozzleConflicts");
 
       const printers = await Printer.find({ _deletedAt: null })
         .select("_id name installedNozzles")
@@ -171,9 +171,12 @@ export default async function dbConnect() {
         if (!source) continue; // soft-deleted between count and read; skip
 
         // Existing peer names (for "Name #N" collision avoidance).
+        // GH #298: the pattern is anchored at both ends, so it matches
+        // only the base name + its numbered clones — not unrelated
+        // siblings that merely share a prefix.
         const peers = (await Nozzle.find({
           _deletedAt: null,
-          name: { $regex: `^${escapeForRegex(source.name)}` },
+          name: { $regex: clonePeerNamePattern(source.name) },
         })
           .select("name")
           .lean()) as { name: string }[];
@@ -262,9 +265,4 @@ export default async function dbConnect() {
   }
 
   return cached.conn;
-}
-
-/** Escape a string for inclusion in a Mongo `$regex` filter. */
-function escapeForRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/lib/nozzleConflicts.ts
+++ b/src/lib/nozzleConflicts.ts
@@ -132,22 +132,41 @@ export class NozzleConflictError extends Error {
   }
 }
 
+/** Regex-escape a string for safe embedding in a RegExp / Mongo `$regex`
+ * (names like "0.4mm" contain a `.` that would otherwise match any char). */
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * A `$regex` / RegExp source that matches exactly a nozzle's base name,
+ * OR that base name followed by a numbered clone suffix (" #<digits>")
+ * — and nothing else.
+ *
+ * GH #298: anchored at BOTH ends. A prefix-only anchor (`^base`) made
+ * cloning "E3D" pull in unrelated siblings like "E3D V6" / "E3D Revo",
+ * and a peer such as "E3D Revo #5" pushed the clone counter to "#6"
+ * for a completely different nozzle.
+ */
+export function clonePeerNamePattern(baseName: string): string {
+  return `^${escapeRegExp(baseName)}( #\\d+)?$`;
+}
+
 /**
  * Pick the next available "Name #N" for a clone of an existing nozzle.
- * Walks active nozzles whose name starts with `baseName`, scrapes the
- * trailing "#N" suffix, picks max + 1. If no clones exist yet returns
- * "<baseName> #2" (the original is implicitly "#1").
+ * Only the exact base name and its numbered clones ("Name #N") count;
+ * unrelated siblings are ignored (GH #298). If no clones exist yet
+ * returns "<baseName> #2" (the original is implicitly "#1").
  */
 export function nextCloneName(
   baseName: string,
   existingNames: string[],
 ): string {
-  const numberSuffixRe = /\s+#(\d+)$/;
+  // Matches ONLY "<baseName> #<digits>" exactly — both ends anchored.
+  const cloneSuffixRe = new RegExp(`^${escapeRegExp(baseName)} #(\\d+)$`);
   let maxN = 1; // the original counts as #1
   for (const name of existingNames) {
-    if (name === baseName) continue; // the original
-    if (!name.startsWith(baseName)) continue;
-    const m = name.slice(baseName.length).match(numberSuffixRe);
+    const m = cloneSuffixRe.exec(name);
     if (m) {
       const n = parseInt(m[1], 10);
       if (Number.isFinite(n) && n > maxN) maxN = n;

--- a/tests/nozzle-clone-naming.test.ts
+++ b/tests/nozzle-clone-naming.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  nextCloneName,
+  clonePeerNamePattern,
+  escapeRegExp,
+} from "@/lib/nozzleConflicts";
+
+/**
+ * GH #298 — the nozzle clone-naming helpers must restrict "peers" to the
+ * exact base name and its numbered clones. A prefix-only match pulled in
+ * unrelated siblings ("E3D" → "E3D V6", "E3D Revo") and let an
+ * unrelated "#N" suffix bump the clone counter.
+ */
+describe("GH #298 — nozzle clone naming is exact, not prefix", () => {
+  describe("nextCloneName", () => {
+    it("returns #2 when only the base name exists", () => {
+      expect(nextCloneName("E3D", ["E3D"])).toBe("E3D #2");
+    });
+
+    it("counts numbered clones of the exact base name", () => {
+      expect(nextCloneName("E3D", ["E3D", "E3D #2", "E3D #3"])).toBe("E3D #4");
+    });
+
+    it("ignores a prefix-sharing sibling that is NOT a numbered clone", () => {
+      // "E3D V6" / "E3D Revo" share the prefix but aren't clones of
+      // "E3D" — they must not affect the counter.
+      expect(nextCloneName("E3D", ["E3D", "E3D V6", "E3D Revo"])).toBe("E3D #2");
+    });
+
+    it("ignores a numbered clone that belongs to a DIFFERENT base name", () => {
+      // "E3D Revo #5" is a clone of "E3D Revo", not of "E3D". Pre-fix it
+      // pushed the "E3D" counter to #6.
+      expect(nextCloneName("E3D", ["E3D", "E3D Revo #5"])).toBe("E3D #2");
+    });
+
+    it("handles base names with regex metacharacters", () => {
+      // "0.4mm" — the "." must be escaped or it would match "0X4mm".
+      expect(nextCloneName("0.4mm", ["0.4mm", "0.4mm #2"])).toBe("0.4mm #3");
+      expect(nextCloneName("0.4mm", ["0.4mm", "0X4mm #9"])).toBe("0.4mm #2");
+    });
+  });
+
+  describe("clonePeerNamePattern", () => {
+    it("matches the exact base name and its numbered clones only", () => {
+      const re = new RegExp(clonePeerNamePattern("E3D"));
+      expect(re.test("E3D")).toBe(true);
+      expect(re.test("E3D #2")).toBe(true);
+      expect(re.test("E3D #17")).toBe(true);
+      // Not a clone of "E3D":
+      expect(re.test("E3D V6")).toBe(false);
+      expect(re.test("E3D Revo #5")).toBe(false);
+      expect(re.test("My E3D")).toBe(false);
+      expect(re.test("E3D #")).toBe(false);
+      expect(re.test("E3D#2")).toBe(false); // suffix requires a space
+    });
+
+    it("escapes regex metacharacters in the base name", () => {
+      const re = new RegExp(clonePeerNamePattern("0.4mm"));
+      expect(re.test("0.4mm")).toBe(true);
+      expect(re.test("0X4mm")).toBe(false); // the "." is literal, not "any char"
+    });
+  });
+
+  describe("escapeRegExp", () => {
+    it("escapes characters that are special in a RegExp", () => {
+      expect(escapeRegExp("a.b*c")).toBe("a\\.b\\*c");
+      expect(escapeRegExp("plain")).toBe("plain");
+    });
+  });
+});

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -649,4 +649,66 @@ describe("SyncService — v1.12 sync expansion", () => {
       expect(remoteRow?._purged).toBe(true);
     });
   });
+
+  // ── GH #317 — conflict-resolution edge cases ──────────────────────────
+
+  describe("#317 — conflict resolution", () => {
+    it("a soft-delete wins over a same-millisecond remote update (no resurrection)", async () => {
+      // The exact tie the bug hit: a row deleted locally at time T while
+      // the remote copy's updatedAt is also T (a delete right after an
+      // edit, equal-ms). Pre-fix the `>` comparison fell through to the
+      // else branch and resurrected the row.
+      const T = new Date("2026-01-01T12:00:00.000Z");
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      await localDb.collection("bedtypes").insertOne({
+        name: "Tie Plate", material: "PEI", notes: "",
+        syncId: "tie-syncid",
+        _deletedAt: T, createdAt: T, updatedAt: T,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Tie Plate", material: "PEI", notes: "",
+        syncId: "tie-syncid",
+        _deletedAt: null, createdAt: T, updatedAt: T,
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      // Delete must win the tie on BOTH sides — the row stays deleted.
+      const localRow = await localDb.collection("bedtypes").findOne({ syncId: "tie-syncid" });
+      const remoteRow = await remoteDb.collection("bedtypes").findOne({ syncId: "tie-syncid" });
+      expect(localRow?._deletedAt).not.toBeNull();
+      expect(remoteRow?._deletedAt).not.toBeNull();
+    });
+
+    it("a doc missing updatedAt does not stall the merge (NaN-safe)", async () => {
+      // Pre-fix: `new Date(undefined).getTime()` is NaN, every
+      // comparison is false, and the row never syncs. The local row has
+      // a real updatedAt, the remote one has none — local must win and
+      // propagate to remote.
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+
+      await localDb.collection("bedtypes").insertOne({
+        name: "NaN Plate", material: "LOCAL-WINS", notes: "",
+        syncId: "nan-syncid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "NaN Plate", material: "stale", notes: "",
+        syncId: "nan-syncid",
+        _deletedAt: null, createdAt: new Date(),
+        // updatedAt intentionally absent
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      // Local (the only side with a timestamp) wins — remote is updated.
+      const remoteRow = await remoteDb.collection("bedtypes").findOne({ syncId: "nan-syncid" });
+      expect(remoteRow?.material).toBe("LOCAL-WINS");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

PR 4 of 8 in the code-review issue sweep.

### #317 — sync conflict-resolution (P2)

Three defects were flagged in `syncCollection`. **Two are real and fixed; the third doesn't hold up.**

1. **Resurrection on a timestamp tie** — a row soft-deleted locally at time `T` while the remote `updatedAt` was also `T` (a delete right after an edit — equal-ms is common) fell through to the resurrect branch. Both delete-vs-update comparisons now use `>=` so the delete wins the tie.
2. **NaN timestamp stall** — comparisons used `new Date(doc.updatedAt).getTime()` directly; a doc missing `updatedAt` → `NaN` → every comparison false → the row never synced. New NaN-safe `SyncService.readTimestamp()` helper; conflict comparisons use `readTimestamp(...) ?? 0`.
3. **"Fresh `_id` breaks SharedCatalog embedded refs" — verified NOT a bug.** The `payload` is a self-contained snapshot copied verbatim; its embedded ids reference each other *within the blob*, not live rows. A fresh document `_id` never touches the payload. No code change — documented in the commit for issue close-out.

### #298 — nozzle clone-name regex over-match (P1)

The clone-name helpers matched peers with a prefix-only anchor (`^base`): cloning "E3D" pulled in "E3D V6" / "E3D Revo", and a peer "E3D Revo #5" pushed the "E3D" counter to "#6". Added `clonePeerNamePattern` (anchored at **both** ends) used by `nextCloneName`, the clone route, and the dbConnect nozzle-split migration. Removed two now-dead `escapeRegExp` copies.

## Test plan

- [x] `tests/nozzle-clone-naming.test.ts` — 9 new cases (exact-match naming, regex-metachar base names, prefix-sibling exclusion)
- [x] `tests/sync-service-expansion.test.ts` — 2 new #317 cases (tie → delete wins; missing `updatedAt` → still merges)
- [x] Existing `nozzle-printer-uniqueness` suite (15) still green
- [x] `npm run lint`, `npx tsc --noEmit`, `npm run electron:compile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)