### PR TITLE
Harden import paths: validation, prototype-pollution, BOM, trash safety

### DIFF
--- a/src/app/api/filaments/import-csv/route.ts
+++ b/src/app/api/filaments/import-csv/route.ts
@@ -48,7 +48,11 @@ export async function POST(request: NextRequest) {
     const sizeError = checkFileSize(file);
     if (sizeError) return sizeError;
 
-    const content = await file.text();
+    // GH #309: strip a leading UTF-8 BOM (U+FEFF). Excel-saved CSVs —
+    // and the app's own xlsx exports — begin with a BOM; left in place
+    // it becomes part of the first header cell, fails HEADER_MAP, and
+    // the required-column check rejects an otherwise-valid file.
+    const content = (await file.text()).replace(/^\uFEFF/, "");
     const lines = content.split(/\r?\n/).filter((l) => l.trim() !== "");
 
     if (lines.length < 2) {

--- a/src/app/api/filaments/import/route.ts
+++ b/src/app/api/filaments/import/route.ts
@@ -48,59 +48,52 @@ export async function POST(request: NextRequest) {
       try {
         const { name, ...rest } = filament;
 
-        // Update an existing active filament with this name.
-        const active = await Filament.findOne({ name, _deletedAt: null });
-        if (active) {
-          // GH #308: runValidators so the update branch enforces the
-          // same schema constraints (cost.min, etc.) as a create.
-          await Filament.updateOne(
-            { _id: active._id },
-            { $set: rest },
-            { runValidators: true, context: "query" },
-          );
+        // GH #327 (Codex): each branch is a single atomic operation so
+        // there is no findOne→write window for a concurrent soft-delete
+        // or insert to slip through. `runValidators` keeps the update
+        // path enforcing the same schema constraints as a create (#308).
+
+        // 1) Update an existing ACTIVE filament with this name.
+        const activeUpdated = await Filament.findOneAndUpdate(
+          { name, _deletedAt: null },
+          { $set: rest },
+          { runValidators: true, context: "query", returnDocument: "after" },
+        );
+        if (activeUpdated) {
           updated++;
           continue;
         }
 
-        // GH #297: if a TRASHED (non-purged) filament owns this name,
+        // 2) GH #297: if a TRASHED (non-purged) filament owns this name,
         // resurrect-and-update it rather than creating a second active
-        // row. Creating a duplicate would strand the trashed one — its
-        // restore would then 409 on the name conflict, forever. Mirrors
-        // the resurrect behaviour of the CSV importer.
-        const trashed = await Filament.findOne({
-          name,
-          _deletedAt: { $ne: null },
-          _purged: { $ne: true },
-        });
-        if (trashed) {
-          await Filament.updateOne(
-            { _id: trashed._id },
-            { $set: { ...rest, _deletedAt: null } },
-            { runValidators: true, context: "query" },
-          );
+        // row — a duplicate would strand the trashed one (its restore
+        // would 409 on the name conflict forever).
+        const trashedResurrected = await Filament.findOneAndUpdate(
+          { name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
+          { $set: { ...rest, _deletedAt: null } },
+          { runValidators: true, context: "query", returnDocument: "after" },
+        );
+        if (trashedResurrected) {
           updated++;
           continue;
         }
 
-        // No active or trashed row — create. GH #327 (Codex): a
-        // concurrent import of the same new name can race two requests
-        // past the lookups above and both into create(); the
-        // partial-unique index then throws E11000 for the loser. Treat
-        // that as "another request just created it" and fall through to
-        // an update, so identical parallel imports stay idempotent
-        // instead of intermittently erroring.
+        // 3) No active or trashed row — create. A concurrent import of
+        // the same new name can still race two requests into create();
+        // the partial-unique index throws E11000 for the loser. Treat
+        // that as "another request just created it" and resolve it as
+        // an update, so identical parallel imports stay idempotent.
         try {
           await Filament.create({ name, ...rest });
           created++;
         } catch (createErr) {
           if (!isDuplicateKeyError(createErr)) throw createErr;
-          const raced = await Filament.findOne({ name, _deletedAt: null });
-          if (!raced) throw createErr;
-          await Filament.updateOne(
-            { _id: raced._id },
+          const raced = await Filament.findOneAndUpdate(
+            { name, _deletedAt: null },
             { $set: rest },
-            { runValidators: true, context: "query" },
+            { runValidators: true, context: "query", returnDocument: "after" },
           );
+          if (!raced) throw createErr;
           updated++;
         }
       } catch (err) {

--- a/src/app/api/filaments/import/route.ts
+++ b/src/app/api/filaments/import/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import { parseIniFilaments } from "@/lib/parseIni";
-import { checkFileSize } from "@/lib/apiErrorHandler";
+import { checkFileSize, isDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 export async function POST(request: NextRequest) {
   try {
@@ -82,8 +82,27 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        await Filament.create({ name, ...rest });
-        created++;
+        // No active or trashed row — create. GH #327 (Codex): a
+        // concurrent import of the same new name can race two requests
+        // past the lookups above and both into create(); the
+        // partial-unique index then throws E11000 for the loser. Treat
+        // that as "another request just created it" and fall through to
+        // an update, so identical parallel imports stay idempotent
+        // instead of intermittently erroring.
+        try {
+          await Filament.create({ name, ...rest });
+          created++;
+        } catch (createErr) {
+          if (!isDuplicateKeyError(createErr)) throw createErr;
+          const raced = await Filament.findOne({ name, _deletedAt: null });
+          if (!raced) throw createErr;
+          await Filament.updateOne(
+            { _id: raced._id },
+            { $set: rest },
+            { runValidators: true, context: "query" },
+          );
+          updated++;
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         errors.push(`${filament.name}: ${msg}`);

--- a/src/app/api/filaments/import/route.ts
+++ b/src/app/api/filaments/import/route.ts
@@ -26,6 +26,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // GH #297: cap the bundle size — mirrors parseCsv's 10k maxRows.
+    // A huge bundle would otherwise drive unbounded sequential writes.
+    const MAX_IMPORT_FILAMENTS = 10_000;
+    if (filaments.length > MAX_IMPORT_FILAMENTS) {
+      return NextResponse.json(
+        {
+          error: `Import too large: ${filaments.length} profiles exceeds the ${MAX_IMPORT_FILAMENTS} limit.`,
+        },
+        { status: 400 },
+      );
+    }
+
     await dbConnect();
 
     let created = 0;
@@ -35,16 +47,43 @@ export async function POST(request: NextRequest) {
     for (const filament of filaments) {
       try {
         const { name, ...rest } = filament;
-        const existing = await Filament.findOneAndUpdate(
-          { name, _deletedAt: null },
-          { $set: rest, $setOnInsert: { name } },
-          { upsert: true, returnDocument: "before" },
-        );
-        if (existing) {
+
+        // Update an existing active filament with this name.
+        const active = await Filament.findOne({ name, _deletedAt: null });
+        if (active) {
+          // GH #308: runValidators so the update branch enforces the
+          // same schema constraints (cost.min, etc.) as a create.
+          await Filament.updateOne(
+            { _id: active._id },
+            { $set: rest },
+            { runValidators: true, context: "query" },
+          );
           updated++;
-        } else {
-          created++;
+          continue;
         }
+
+        // GH #297: if a TRASHED (non-purged) filament owns this name,
+        // resurrect-and-update it rather than creating a second active
+        // row. Creating a duplicate would strand the trashed one — its
+        // restore would then 409 on the name conflict, forever. Mirrors
+        // the resurrect behaviour of the CSV importer.
+        const trashed = await Filament.findOne({
+          name,
+          _deletedAt: { $ne: null },
+          _purged: { $ne: true },
+        });
+        if (trashed) {
+          await Filament.updateOne(
+            { _id: trashed._id },
+            { $set: { ...rest, _deletedAt: null } },
+            { runValidators: true, context: "query" },
+          );
+          updated++;
+          continue;
+        }
+
+        await Filament.create({ name, ...rest });
+        created++;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         errors.push(`${filament.name}: ${msg}`);

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -162,52 +162,47 @@ export async function POST(request: NextRequest) {
         settings: f.settings,
       };
 
-      const active = await Filament.findOne({ name: f.name, _deletedAt: null });
-      if (active) {
-        await Filament.updateOne(
-          { _id: active._id },
-          { $set: doc },
-          { runValidators: true, context: "query" },
-        );
+      // GH #327 (Codex): each branch is a single atomic operation so
+      // there is no findOne→write window for a concurrent soft-delete
+      // or insert to slip through.
+
+      // 1) Update an existing ACTIVE filament with this name.
+      const activeUpdated = await Filament.findOneAndUpdate(
+        { name: f.name, _deletedAt: null },
+        { $set: doc },
+        { runValidators: true, context: "query", returnDocument: "after" },
+      );
+      if (activeUpdated) {
         updated++;
       } else {
-        // GH #297: a trashed (non-purged) filament owning this name is
-        // resurrected-and-updated rather than shadowed by a duplicate
+        // 2) GH #297: a trashed (non-purged) filament owning this name
+        // is resurrected-and-updated rather than shadowed by a duplicate
         // active row — a duplicate would strand the trashed one (its
         // restore would 409 forever on the name conflict).
-        const trashed = await Filament.findOne({
-          name: f.name,
-          _deletedAt: { $ne: null },
-          _purged: { $ne: true },
-        });
-        if (trashed) {
-          await Filament.updateOne(
-            { _id: trashed._id },
-            { $set: { ...doc, _deletedAt: null } },
-            { runValidators: true, context: "query" },
-          );
+        const trashedResurrected = await Filament.findOneAndUpdate(
+          { name: f.name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
+          { $set: { ...doc, _deletedAt: null } },
+          { runValidators: true, context: "query", returnDocument: "after" },
+        );
+        if (trashedResurrected) {
           updated++;
         } else {
-          // GH #327 (Codex): retry-on-duplicate. Two concurrent imports
-          // of the same new name can both pass the lookups above and
-          // race into create(); the partial-unique index then throws
-          // E11000 for the loser. Resolve that as an update so parallel
-          // identical imports stay idempotent instead of 500-ing.
+          // 3) Create; retry-on-duplicate. Two concurrent imports of the
+          // same new name can both pass the lookups above and race into
+          // create(); the partial-unique index throws E11000 for the
+          // loser. Resolve that as an update so parallel identical
+          // imports stay idempotent instead of 500-ing.
           try {
             await Filament.create(doc);
             created++;
           } catch (createErr) {
             if (!isDuplicateKeyError(createErr)) throw createErr;
-            const raced = await Filament.findOne({
-              name: f.name,
-              _deletedAt: null,
-            });
-            if (!raced) throw createErr;
-            await Filament.updateOne(
-              { _id: raced._id },
+            const raced = await Filament.findOneAndUpdate(
+              { name: f.name, _deletedAt: null },
               { $set: doc },
-              { runValidators: true, context: "query" },
+              { runValidators: true, context: "query", returnDocument: "after" },
             );
+            if (!raced) throw createErr;
             updated++;
           }
         }

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -127,6 +127,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // GH #297: cap the bundle size — a huge bundle would otherwise drive
+    // unbounded sequential writes. Mirrors parseCsv's 10k maxRows.
+    const MAX_IMPORT_FILAMENTS = 10_000;
+    if (parsed.length > MAX_IMPORT_FILAMENTS) {
+      return NextResponse.json(
+        {
+          error: `Import too large: ${parsed.length} sections exceeds the ${MAX_IMPORT_FILAMENTS} limit.`,
+        },
+        { status: 400 },
+      );
+    }
+
     let created = 0;
     let updated = 0;
     const names: string[] = [];
@@ -134,11 +146,6 @@ export async function POST(request: NextRequest) {
     for (const f of parsed) {
       // Skip internal/abstract presets (PrusaSlicer uses *name* convention)
       if (f.name.startsWith("*") && f.name.endsWith("*")) continue;
-
-      const existing = await Filament.findOne({
-        name: f.name,
-        _deletedAt: null,
-      });
 
       const doc = {
         name: f.name,
@@ -154,12 +161,35 @@ export async function POST(request: NextRequest) {
         settings: f.settings,
       };
 
-      if (existing) {
-        await Filament.updateOne({ _id: existing._id }, { $set: doc });
+      const active = await Filament.findOne({ name: f.name, _deletedAt: null });
+      if (active) {
+        await Filament.updateOne(
+          { _id: active._id },
+          { $set: doc },
+          { runValidators: true, context: "query" },
+        );
         updated++;
       } else {
-        await Filament.create(doc);
-        created++;
+        // GH #297: a trashed (non-purged) filament owning this name is
+        // resurrected-and-updated rather than shadowed by a duplicate
+        // active row — a duplicate would strand the trashed one (its
+        // restore would 409 forever on the name conflict).
+        const trashed = await Filament.findOne({
+          name: f.name,
+          _deletedAt: { $ne: null },
+          _purged: { $ne: true },
+        });
+        if (trashed) {
+          await Filament.updateOne(
+            { _id: trashed._id },
+            { $set: { ...doc, _deletedAt: null } },
+            { runValidators: true, context: "query" },
+          );
+          updated++;
+        } else {
+          await Filament.create(doc);
+          created++;
+        }
       }
 
       names.push(f.name);

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -7,6 +7,7 @@ import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
 import { generatePrusaSlicerBundle } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
+import { isDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 /**
  * GET /api/filaments/prusaslicer
@@ -187,8 +188,28 @@ export async function POST(request: NextRequest) {
           );
           updated++;
         } else {
-          await Filament.create(doc);
-          created++;
+          // GH #327 (Codex): retry-on-duplicate. Two concurrent imports
+          // of the same new name can both pass the lookups above and
+          // race into create(); the partial-unique index then throws
+          // E11000 for the loser. Resolve that as an update so parallel
+          // identical imports stay idempotent instead of 500-ing.
+          try {
+            await Filament.create(doc);
+            created++;
+          } catch (createErr) {
+            if (!isDuplicateKeyError(createErr)) throw createErr;
+            const raced = await Filament.findOne({
+              name: f.name,
+              _deletedAt: null,
+            });
+            if (!raced) throw createErr;
+            await Filament.updateOne(
+              { _id: raced._id },
+              { $set: doc },
+              { runValidators: true, context: "query" },
+            );
+            updated++;
+          }
         }
       }
 

--- a/src/app/api/prusament/import/route.ts
+++ b/src/app/api/prusament/import/route.ts
@@ -4,6 +4,48 @@ import Filament from "@/models/Filament";
 import type { PrusamentScrapeResult } from "../route";
 
 /**
+ * GH #307: validate a renderer-supplied Prusament spool payload before
+ * any DB write. The spool's `totalWeight` reaches the Filament via a
+ * `$push`, which skips the subdocument validators the dedicated spool
+ * routes rely on — so a non-numeric weight or a garbage colour would
+ * otherwise be persisted. Returns a rejection reason, or null when ok.
+ */
+function validatePrusamentSpool(spool: unknown): string | null {
+  if (!spool || typeof spool !== "object") {
+    return "spool must be an object";
+  }
+  const s = spool as Record<string, unknown>;
+  if (typeof s.spoolId !== "string" || s.spoolId.trim() === "") {
+    return "spool.spoolId is required";
+  }
+  for (const field of [
+    "diameter",
+    "lengthMeters",
+    "netWeight",
+    "totalWeight",
+    "spoolWeight",
+  ]) {
+    const v = s[field];
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0) {
+      return `spool.${field} must be a non-negative number`;
+    }
+  }
+  if (typeof s.colorHex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(s.colorHex)) {
+    return "spool.colorHex must be a #RRGGBB hex colour";
+  }
+  if (typeof s.material !== "string" || s.material.trim() === "") {
+    return "spool.material is required";
+  }
+  if (typeof s.colorName !== "string") {
+    return "spool.colorName must be a string";
+  }
+  if (typeof s.manufactureDate !== "string") {
+    return "spool.manufactureDate must be a string";
+  }
+  return null;
+}
+
+/**
  * POST /api/prusament/import
  *
  * Imports a scraped Prusament spool into the database.
@@ -32,11 +74,10 @@ export async function POST(request: NextRequest) {
   const action: string = body.action; // "create" or "add-spool"
   const filamentId: string | undefined = body.filamentId;
 
-  if (!spool?.spoolId) {
-    return NextResponse.json(
-      { error: "Missing spool data" },
-      { status: 400 },
-    );
+  // GH #307: full shape validation — not just a spoolId truthiness check.
+  const spoolError = validatePrusamentSpool(spool);
+  if (spoolError) {
+    return NextResponse.json({ error: spoolError }, { status: 400 });
   }
 
   if (action && action !== "create" && action !== "add-spool") {

--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -22,6 +22,20 @@ export function errorResponse(
 }
 
 /**
+ * True when an error is a MongoDB duplicate-key error (code 11000) —
+ * e.g. a `create` that collided with a partial-unique index. Useful for
+ * retry-on-duplicate logic where a concurrent insert raced this one.
+ */
+export function isDuplicateKeyError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: unknown }).code === 11000
+  );
+}
+
+/**
  * Checks if an error is a MongoDB duplicate-key error (code 11000).
  * Returns a formatted 409 response if so, otherwise null.
  */
@@ -29,12 +43,7 @@ export function handleDuplicateKeyError(
   err: unknown,
   entityName: string,
 ): NextResponse | null {
-  if (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code: number }).code === 11000
-  ) {
+  if (isDuplicateKeyError(err)) {
     const keyValue = (err as { keyValue?: Record<string, unknown> }).keyValue;
     const field = keyValue ? Object.keys(keyValue)[0] : "field";
     const value = keyValue ? Object.values(keyValue)[0] : "unknown";

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -284,7 +284,14 @@ export async function upsertImportRows(
       for (const [tempKey, tempVal] of Object.entries(temps)) {
         $set[`temperatures.${tempKey}`] = tempVal;
       }
-      await Filament.updateOne({ _id: existing._id }, { $set });
+      // GH #276: runValidators so a CSV updating an existing filament
+      // (e.g. `cost = -50`) can't bypass the schema validators — the
+      // sibling resurrect path below was already hardened the same way.
+      await Filament.updateOne(
+        { _id: existing._id },
+        { $set },
+        { runValidators: true, context: "query" },
+      );
       updated++;
     } else {
       const softDeleted = deletedByName.get(row.name);

--- a/src/lib/parseCsv.ts
+++ b/src/lib/parseCsv.ts
@@ -123,7 +123,13 @@ export function parseCsv(
   for (let r = 1; r < trimmed.length; r++) {
     // Skip fully-empty rows (common when a file ends with a blank line)
     if (trimmed[r].every((v) => v === "")) continue;
-    const obj: Record<string, string> = {};
+    // GH #296: build the row with a null prototype. With a plain `{}`,
+    // a header literally named `__proto__` would trigger the prototype
+    // setter instead of creating an own property — silently dropping
+    // that column's data and mutating the object's prototype. A
+    // null-prototype object has no such setter; `__proto__` /
+    // `constructor` / `prototype` become ordinary own keys.
+    const obj: Record<string, string> = Object.create(null);
     for (let c = 0; c < headers.length; c++) {
       obj[headers[c]] = trimmed[r][c] ?? "";
     }

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -111,11 +111,13 @@ filament_diameter = 1.75
       expect(updated.vendor).toBe("NewVendor");
     });
 
-    it("does not match a soft-deleted filament when upserting (creates a new one instead)", async () => {
-      // A filament with this name is in the trash. Importing the same name
-      // should create a brand-new active filament rather than reviving the
-      // trashed one (the partial unique index permits coexistence).
-      await Filament.create({
+    it("resurrects a soft-deleted filament when upserting (no duplicate)", async () => {
+      // GH #297: a filament with this name is in the trash. Importing the
+      // same name resurrects-and-updates the trashed row rather than
+      // creating a second active row that would shadow it — a duplicate
+      // would strand the trashed one (its restore would 409 forever on
+      // the name conflict).
+      const trashed = await Filament.create({
         name: "Trashed PLA",
         vendor: "Old",
         type: "PLA",
@@ -132,12 +134,12 @@ filament_vendor = New
       );
       expect(res.status).toBe(200);
 
-      const all = await Filament.find({ name: "Trashed PLA" }).sort({ _deletedAt: 1 });
-      // We now have 2: the trashed (oldest, _deletedAt is a Date) and the new active one
-      expect(all).toHaveLength(2);
-      const active = all.find((f: { _deletedAt: unknown }) => f._deletedAt === null);
-      expect(active).toBeTruthy();
-      expect(active.vendor).toBe("New");
+      const all = await Filament.find({ name: "Trashed PLA" });
+      // Only one row — the trashed one was revived, not duplicated.
+      expect(all).toHaveLength(1);
+      expect(String(all[0]._id)).toBe(String(trashed._id));
+      expect(all[0]._deletedAt).toBeNull();
+      expect(all[0].vendor).toBe("New");
     });
   });
 

--- a/tests/import-validation.test.ts
+++ b/tests/import-validation.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { parseCsv } from "@/lib/parseCsv";
+import { POST as importIni } from "@/app/api/filaments/import/route";
+import { POST as importCsv } from "@/app/api/filaments/import-csv/route";
+import { POST as prusamentImport } from "@/app/api/prusament/import/route";
+
+/**
+ * Code-review issues #296, #297, #307, #309 — import-path validation
+ * and security. (#308 / #276 are one-line `runValidators` additions on
+ * existing update calls, the pattern already covered by #228.)
+ */
+describe("import validation & security", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const mod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", mod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  function multipartReq(url: string, file: File) {
+    const fd = new FormData();
+    fd.append("file", file);
+    return new NextRequest(url, { method: "POST", body: fd });
+  }
+
+  // ── #296: parseCsv prototype pollution ─────────────────────────────
+
+  describe("#296 — parseCsv handles a __proto__ header safely", () => {
+    it("keeps a __proto__ column as own data, does not pollute the prototype", () => {
+      const rows = parseCsv("name,__proto__\nfoo,evil\n", { header: true }) as Record<
+        string,
+        string
+      >[];
+      expect(rows).toHaveLength(1);
+      // The column's data survives as an OWN property...
+      expect(Object.prototype.hasOwnProperty.call(rows[0], "__proto__")).toBe(true);
+      expect(rows[0]["__proto__"]).toBe("evil");
+      expect(rows[0].name).toBe("foo");
+      // ...and the global Object prototype is untouched.
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it("keeps a constructor-named column as own data", () => {
+      const rows = parseCsv("constructor,name\nx,foo\n", { header: true }) as Record<
+        string,
+        string
+      >[];
+      expect(rows[0].constructor).toBe("x");
+      expect(rows[0].name).toBe("foo");
+    });
+  });
+
+  // ── #297: INI import resurrects a trashed filament ─────────────────
+
+  describe("#297 — INI import doesn't strand a trashed filament", () => {
+    it("resurrects a trashed filament instead of creating a duplicate", async () => {
+      // A filament named "Galaxy Black" is in the trash.
+      const trashed = await Filament.create({
+        name: "Galaxy Black",
+        vendor: "Prusament",
+        type: "PLA",
+        _deletedAt: new Date(),
+      });
+
+      const ini =
+        "[filament:Galaxy Black]\nfilament_vendor = Prusament\nfilament_type = PLA\n";
+      const res = await importIni(
+        multipartReq(
+          "http://localhost/api/filaments/import",
+          new File([ini], "b.ini", { type: "text/plain" }),
+        ),
+      );
+      expect(res.status).toBe(200);
+
+      // No second active row was created — the trashed one was revived.
+      const active = await Filament.find({
+        name: "Galaxy Black",
+        _deletedAt: null,
+      }).lean();
+      expect(active).toHaveLength(1);
+      expect(String(active[0]._id)).toBe(String(trashed._id));
+    });
+  });
+
+  // ── #307: prusament import validates the spool payload ─────────────
+
+  describe("#307 — prusament import validates the spool shape", () => {
+    function prusamentReq(spool: unknown) {
+      return new NextRequest("http://localhost/api/prusament/import", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ spool, action: "create" }),
+      });
+    }
+    const validSpool = {
+      spoolId: "SP-1",
+      material: "PLA",
+      colorName: "Galaxy Black",
+      colorHex: "#1a1a1a",
+      diameter: 1.75,
+      lengthMeters: 330,
+      netWeight: 1000,
+      totalWeight: 1250,
+      spoolWeight: 250,
+      manufactureDate: "2026-01-01 12:00",
+      nozzleTempMin: 215,
+      nozzleTempMax: 230,
+      bedTempMin: 50,
+      bedTempMax: 60,
+      priceUsd: 29.99,
+      pageUrl: "https://prusament.com/x",
+    };
+
+    it("rejects a non-numeric totalWeight with 400", async () => {
+      const res = await prusamentImport(
+        prusamentReq({ ...validSpool, totalWeight: "heavy" }),
+      );
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/totalWeight/);
+    });
+
+    it("rejects a malformed colorHex with 400", async () => {
+      const res = await prusamentImport(
+        prusamentReq({ ...validSpool, colorHex: "not-a-color" }),
+      );
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/colorHex/);
+    });
+
+    it("accepts a well-formed spool", async () => {
+      const res = await prusamentImport(prusamentReq(validSpool));
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // ── #309: import-csv strips a UTF-8 BOM ────────────────────────────
+
+  it("#309 — import-csv accepts an Excel CSV that begins with a UTF-8 BOM", async () => {
+    // U+FEFF is the BOM Excel prepends. Pre-fix the first header cell
+    // became "<BOM>Name", failed HEADER_MAP, and the import was
+    // rejected as missing required columns.
+    const csv = "\uFEFF" + "Name,Vendor,Type\nBOM PLA,TestCo,PLA\n";
+    const res = await importCsv(
+      multipartReq(
+        "http://localhost/api/filaments/import-csv",
+        new File([csv], "excel.csv", { type: "text/csv" }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const created = await Filament.findOne({ name: "BOM PLA" }).lean();
+    expect(created).not.toBeNull();
+    expect(created.vendor).toBe("TestCo");
+  });
+});


### PR DESCRIPTION
## Summary

Audit sweep #3 — import-path correctness and security. Closes #276, #296, #297, #307, #308, #309.

- **#296 — parseCsv prototype pollution**: row objects are built with `Object.create(null)`, so a header literally named `__proto__` / `constructor` / `prototype` becomes an ordinary own key instead of triggering the prototype setter (which silently dropped the column *and* mutated `Object.prototype`).
- **#297 — INI / PrusaSlicer import strands a trashed filament**: both import loops now resurrect-and-update a trashed (non-purged) filament that owns the imported name rather than creating a duplicate active row. A duplicate would strand the trashed one — its restore would 409 forever on the name conflict. Both loops also gained a 10k-section import cap mirroring `parseCsv`'s `maxRows`.
- **#307 — prusament import validates the spool shape**: the renderer-supplied spool payload is fully validated (numeric weights/diameter, `#RRGGBB` colour, required strings) before any DB write — the `$push` bypasses subdocument validators the dedicated spool routes rely on.
- **#308 / #276 — `runValidators` on import updates**: import update calls pass `{ runValidators: true, context: "query" }` so schema validators (including the `tdsUrl` scheme guard) run on the upsert path.
- **#309 — import-csv BOM**: import-csv strips a leading UTF-8 BOM so Excel-saved CSVs no longer fail the required-column check on a `<BOM>Name` first header cell.

## Test plan

- [x] New `tests/import-validation.test.ts` — 7 tests covering each issue
- [x] Existing INI-upsert test updated to assert the new resurrect behavior
- [x] `npm test` — 1232 passed
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)