### PR TITLE
Fix SpoolCard label reverting after a sibling spool update (#263)

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -1467,7 +1467,14 @@ function SpoolCard({
             />
           ) : (
             <button
-              onClick={() => setEditingLabel(true)}
+              // GH #263: re-seed labelInput from the current prop when
+              // the editor opens. `labelInput` is useState-initialised
+              // from `spool.label` only once; SpoolCard is keyed by a
+              // stable `spool._id`, so after any sibling spool mutation
+              // the parent re-renders this card with a fresh `spool`
+              // prop WITHOUT remounting — leaving `labelInput` stale.
+              // Editing then would write or show the old value.
+              onClick={() => { setLabelInput(spool.label); setEditingLabel(true); }}
               className="text-sm font-medium hover:text-blue-600 transition-colors"
               title={t("detail.spool.clickToRename")}
             >


### PR DESCRIPTION
## Summary

Closes #263 — a P1 UI data-loss bug missed from the audit-sweep grouping.

`SpoolCard` initialised `labelInput` from `spool.label` once via `useState`. The card is keyed by a stable `spool._id`, so any *other* spool mutation (logging usage, a dry cycle, a weight update) re-renders it with a fresh `spool` prop **without remounting** — leaving `labelInput` stale. Opening the label editor afterwards then showed, and could persist, the old label.

Fix: re-seed `labelInput` from the current `spool.label` in the click handler that opens the editor. The displayed (non-editing) label already reads `spool.label` directly, so it was never stale.

## Test plan

- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)