### PR TITLE
Harden SSRF guards and cap external fetches (#254, #256-258)

### DIFF
--- a/src/app/api/embed-check/route.ts
+++ b/src/app/api/embed-check/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { assertExternalUrl } from "@/lib/externalUrlGuard";
+import { assertExternalUrl, ssrfDispatcher } from "@/lib/externalUrlGuard";
 import { errorResponse, getErrorMessage } from "@/lib/apiErrorHandler";
 
 /**
@@ -58,7 +58,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           Accept: "text/html,application/xhtml+xml,application/pdf,*/*",
         },
         redirect: "manual",
-      });
+        // GH #256: pin the connection to the SSRF-validated IP. The
+        // per-hop assertExternalUrl above resolves the host once; the
+        // dispatcher re-validates at connect time so a DNS rebind
+        // between the two can't land the socket on a private address.
+        dispatcher: ssrfDispatcher,
+      } as RequestInit & { dispatcher?: typeof ssrfDispatcher });
 
       // Treat 3xx (except 304) as a redirect we follow ourselves.
       const isRedirect = hopRes.status >= 300 && hopRes.status < 400 && hopRes.status !== 304;

--- a/src/app/api/filaments/import-atlas/route.ts
+++ b/src/app/api/filaments/import-atlas/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { MongoClient } from "mongodb";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
+import { assertSafeMongoUri } from "@/lib/mongoUriGuard";
 
 // POST with { uri } — list filaments from remote Atlas
 // POST with { uri, filaments: [...ids] } — import selected filaments
@@ -17,6 +18,20 @@ export async function POST(request: NextRequest) {
 
   if (!uri || typeof uri !== "string") {
     return NextResponse.json({ error: "Connection string is required" }, { status: 400 });
+  }
+
+  // GH #254: SSRF guard — without this, a request body with
+  // `uri: "mongodb://10.0.0.5:27017"` turns the server into an
+  // internal-network port scanner. Importing from a remote Atlas
+  // legitimately uses a public `mongodb+srv://` host, so require that
+  // scheme and reject any host resolving to a private/internal address.
+  try {
+    await assertSafeMongoUri(uri, { requireSrv: true, blockPrivateHosts: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Invalid connection string" },
+      { status: 400 },
+    );
   }
 
   const client = new MongoClient(uri, {

--- a/src/app/api/prusament/route.ts
+++ b/src/app/api/prusament/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { extractSpoolData } from "@/lib/prusament";
+import { readBodyCapped } from "@/lib/externalUrlGuard";
+
+/** GH #258: cap the Prusament HTML page. A real spool page is well under
+ * 1 MB; the cap stops a hostile/compromised response from buffering an
+ * unbounded body into memory before the regex/JSON.parse step. */
+const MAX_PRUSAMENT_HTML_BYTES = 4 * 1024 * 1024;
 
 /** Shape of the spoolData JSON embedded in the Prusament spool page. */
 interface PrusamentSpoolData {
@@ -102,7 +108,7 @@ export async function GET(request: NextRequest) {
           { status: 502 },
         );
       }
-      html = await res.text();
+      html = (await readBodyCapped(res, MAX_PRUSAMENT_HTML_BYTES)).toString("utf-8");
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Network error";
       return NextResponse.json(

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { MongoClient } from "mongodb";
+import { assertSafeMongoUri } from "@/lib/mongoUriGuard";
 
 export async function POST(request: NextRequest) {
   let body;
@@ -13,6 +14,20 @@ export async function POST(request: NextRequest) {
 
   if (!mongodbUri || typeof mongodbUri !== "string") {
     return NextResponse.json({ error: "MongoDB URI is required" }, { status: 400 });
+  }
+
+  // GH #254: reject non-mongodb schemes outright. Unlike import-atlas,
+  // `setup` configures the app's OWN database — a local/Docker install
+  // legitimately points at `mongodb://localhost` or a private
+  // Docker-network host, so private-IP blocking is deliberately NOT
+  // applied here; restricting who may reach this route is GH #252.
+  try {
+    await assertSafeMongoUri(mongodbUri, { requireSrv: false, blockPrivateHosts: false });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Invalid connection string" },
+      { status: 400 },
+    );
   }
 
   const client = new MongoClient(mongodbUri, {

--- a/src/lib/externalUrlGuard.ts
+++ b/src/lib/externalUrlGuard.ts
@@ -5,59 +5,115 @@
  *   - src/lib/tdsExtractor.ts — TDS document fetcher
  *   - src/app/api/embed-check/route.ts — iframe-embeddability probe
  *
- * Both validate the *initial* URL only. Catching redirect-based SSRF
- * requires `redirect: "manual"` plus per-hop validation; intentionally
- * out of scope here to avoid breaking shorteners/CDNs. Callers that
- * need stronger guarantees should also re-check the response URL after
- * following redirects.
+ * Two layers of defence:
+ *   1. `assertExternalUrl` — a pre-flight scheme + resolved-IP check.
+ *   2. `ssrfDispatcher` — an undici dispatcher that re-validates the IP
+ *      at *connection* time. The pre-flight check alone is defeated by
+ *      DNS rebinding (the guard resolves one IP, then `fetch` resolves
+ *      again and may get a different, private one — GH #256); the
+ *      dispatcher closes that TOCTOU by pinning the connection to the
+ *      exact IP it validated. Callers fetching user URLs MUST pass
+ *      `dispatcher: ssrfDispatcher`.
  */
 
+import dns from "node:dns";
 import { lookup } from "node:dns/promises";
+import { Agent, interceptors } from "undici";
+
+/** Range-check a dotted-quad IPv4 string. Conservative on parse failure. */
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((n) => Number(n));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) {
+    return true; // unparseable → block conservatively
+  }
+  const [a, b, c] = parts;
+  if (a === 0) return true;                              // 0.0.0.0/8
+  if (a === 10) return true;                             // 10.0.0.0/8 (RFC1918)
+  if (a === 127) return true;                            // 127.0.0.0/8 (loopback)
+  if (a === 169 && b === 254) return true;               // 169.254.0.0/16 (link-local + cloud metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12 (RFC1918)
+  if (a === 192 && b === 168) return true;               // 192.168.0.0/16 (RFC1918)
+  if (a === 100 && b >= 64 && b <= 127) return true;     // 100.64.0.0/10 (CG-NAT, RFC6598)
+  if (a === 192 && b === 0 && c === 0) return true;      // 192.0.0.0/24 (IETF protocol assignments)
+  if (a === 198 && (b === 18 || b === 19)) return true;  // 198.18.0.0/15 (network benchmark)
+  if (a >= 224) return true;                             // 224.0.0.0/4 multicast + 240/4 reserved
+  return false;
+}
+
+/**
+ * Expand an IPv6 literal to its 8 numeric 16-bit groups, or null if it
+ * isn't a parseable IPv6 address. Handles `::` zero-compression and a
+ * trailing embedded IPv4 dotted-quad (`::ffff:1.2.3.4`).
+ */
+function expandIpv6(ip: string): number[] | null {
+  // Drop a zone id (fe80::1%eth0) before parsing.
+  let s = ip.toLowerCase().trim().split("%")[0];
+
+  // A trailing embedded IPv4 dotted-quad → fold into two hex groups.
+  const v4Match = s.match(/^(.*:)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (v4Match) {
+    const quad = v4Match[2].split(".").map(Number);
+    if (quad.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return null;
+    const h1 = ((quad[0] << 8) | quad[1]).toString(16);
+    const h2 = ((quad[2] << 8) | quad[3]).toString(16);
+    s = `${v4Match[1]}${h1}:${h2}`;
+  }
+
+  const halves = s.split("::");
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(":") : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  let groups: string[];
+  if (halves.length === 2) {
+    const missing = 8 - head.length - tail.length;
+    if (missing < 1) return null; // `::` must stand for at least one group
+    groups = [...head, ...Array<string>(missing).fill("0"), ...tail];
+  } else {
+    groups = head;
+  }
+  if (groups.length !== 8) return null;
+
+  const nums = groups.map((g) => (/^[0-9a-f]{1,4}$/.test(g) ? parseInt(g, 16) : NaN));
+  return nums.some((n) => Number.isNaN(n)) ? null : nums;
+}
 
 /**
  * Block-list for SSRF defence: loopback, RFC1918 private, link-local,
  * cloud-metadata IPs, multicast, and the IPv6 equivalents. Returns true
- * when an address must NOT be fetched.
+ * when an address must NOT be fetched. Conservative on parse failure.
  *
- * Conservative on parse failure (treat unparseable as private). Relies on
- * the OS DNS resolver to expand hostnames; does not attempt to defeat DNS
- * rebinding, which would require re-resolving and comparing against the
- * connection's actual peer address.
+ * GH #257: IPv4-mapped IPv6 is canonicalised to its embedded IPv4 and
+ * range-checked there — covering the dotted form (`::ffff:127.0.0.1`),
+ * the hex-group form (`::ffff:7f00:1`) and the fully-expanded form
+ * (`0:0:0:0:0:ffff:7f00:1`), all of which the old string-prefix check
+ * let through.
  */
 export function isPrivateIp(ip: string): boolean {
-  if (ip.includes(".")) {
-    const parts = ip.split(".").map((n) => Number(n));
-    if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) {
-      return true; // unparseable → block conservatively
-    }
-    const [a, b, c] = parts;
-    if (a === 0) return true;                              // 0.0.0.0/8
-    if (a === 10) return true;                             // 10.0.0.0/8 (RFC1918)
-    if (a === 127) return true;                            // 127.0.0.0/8 (loopback)
-    if (a === 169 && b === 254) return true;               // 169.254.0.0/16 (link-local + AWS/GCP/Azure metadata)
-    if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12 (RFC1918)
-    if (a === 192 && b === 168) return true;               // 192.168.0.0/16 (RFC1918)
-    if (a === 100 && b >= 64 && b <= 127) return true;     // 100.64.0.0/10 (CG-NAT, RFC6598)
-    // GH #228: 192.0.0.0/24 (IETF Protocol Assignments, RFC 6890) and
-    // 198.18.0.0/15 (RFC 2544 network-benchmark) are reserved and
-    // should not be reachable from the public internet. Some labs and
-    // carrier infrastructure route them, so allowing them through the
-    // SSRF guard would let an attacker probe internal address space
-    // via DNS rebinding.
-    if (a === 192 && b === 0 && c === 0) return true;      // 192.0.0.0/24 (IETF protocol assignments)
-    if (a === 198 && (b === 18 || b === 19)) return true;  // 198.18.0.0/15 (network benchmark)
-    if (a >= 224) return true;                             // 224.0.0.0/4 multicast + 240/4 reserved
-    return false;
+  const cleaned = ip.trim().replace(/^\[|\]$/g, "");
+
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(cleaned)) {
+    return isPrivateIpv4(cleaned);
   }
-  // IPv6
-  const lc = ip.toLowerCase();
-  if (lc === "::" || lc === "::1") return true;
-  if (lc.startsWith("fe80:")) return true;                 // link-local
-  if (lc.startsWith("fc") || lc.startsWith("fd")) return true; // unique-local fc00::/7
-  if (lc.startsWith("ff")) return true;                    // multicast
-  if (lc.startsWith("::ffff:")) {
-    return isPrivateIp(lc.slice(7)); // IPv4-mapped IPv6 → recurse on the v4 form
+
+  const groups = expandIpv6(cleaned);
+  if (!groups) return true; // unparseable → block conservatively
+
+  // IPv4-mapped (::ffff:0:0/96) and IPv4-compatible (::/96, deprecated):
+  // the address is really IPv4 — range-check the embedded quad. This is
+  // what closes the hex-group bypass (e.g. ::ffff:a9fe:a9fe → metadata).
+  if (
+    groups[0] === 0 && groups[1] === 0 && groups[2] === 0 &&
+    groups[3] === 0 && groups[4] === 0 &&
+    (groups[5] === 0xffff || groups[5] === 0)
+  ) {
+    const v4 = `${groups[6] >> 8}.${groups[6] & 0xff}.${groups[7] >> 8}.${groups[7] & 0xff}`;
+    return isPrivateIpv4(v4);
   }
+
+  const first = groups[0];
+  if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  if ((first & 0xff00) === 0xff00) return true; // ff00::/8 multicast
   return false;
 }
 
@@ -67,6 +123,8 @@ export function isPrivateIp(ip: string): boolean {
  *   - hostnames that resolve to loopback / private / link-local / metadata IPs
  *
  * Returns the parsed URL on success so callers don't need to parse twice.
+ * This is the pre-flight check; the fetch itself must still go through
+ * `ssrfDispatcher` to be safe against DNS rebinding (GH #256).
  */
 export async function assertExternalUrl(url: string): Promise<URL> {
   let parsed: URL;
@@ -103,4 +161,90 @@ export async function assertExternalUrl(url: string): Promise<URL> {
     }
   }
   return parsed;
+}
+
+/**
+ * GH #256: a DNS `lookup` that resolves the host AND rejects the request
+ * if any returned address is private/internal. undici's DNS interceptor
+ * pins the connection to the address this returns, so validating here —
+ * rather than in a separate pre-flight resolve — eliminates the rebinding
+ * TOCTOU: the IP that is checked is the exact IP that is connected to.
+ */
+function ssrfValidatingLookup(
+  origin: { hostname: string },
+  _opts: unknown,
+  cb: (err: Error | null, addresses?: dns.LookupAddress[]) => void,
+): void {
+  dns.lookup(
+    origin.hostname,
+    { all: true, family: 0, order: "ipv4first" },
+    (err, addresses) => {
+      if (err) {
+        cb(err);
+        return;
+      }
+      for (const addr of addresses) {
+        if (isPrivateIp(addr.address)) {
+          cb(
+            new Error(
+              `Blocked SSRF: ${origin.hostname} resolved to a private/internal address (${addr.address}).`,
+            ),
+          );
+          return;
+        }
+      }
+      cb(null, addresses);
+    },
+  );
+}
+
+/**
+ * undici dispatcher for fetching user-supplied URLs. The DNS interceptor
+ * resolves the host through `ssrfValidatingLookup` and pins the socket to
+ * that validated IP — so `fetch(url, { dispatcher: ssrfDispatcher })`
+ * cannot be rebound onto a private address between guard and connect.
+ *
+ * The cast bridges a known undici quirk: at runtime the interceptor
+ * invokes `lookup` with an origin OBJECT (it reads `origin.hostname`),
+ * but the published `.d.ts` types the first parameter as a bare string.
+ */
+type DnsInterceptorLookup = NonNullable<
+  NonNullable<Parameters<typeof interceptors.dns>[0]>["lookup"]
+>;
+export const ssrfDispatcher = new Agent().compose(
+  interceptors.dns({
+    lookup: ssrfValidatingLookup as unknown as DnsInterceptorLookup,
+  }),
+);
+
+/**
+ * Read a `fetch` Response body as text with a hard byte budget, aborting
+ * the stream once the budget is exceeded. A `content-length` header is
+ * advisory — a hostile host can omit or lie about it — so the cap is
+ * enforced on the bytes actually received (GH #258).
+ */
+export async function readBodyCapped(res: Response, maxBytes: number): Promise<Buffer> {
+  if (!res.body) return Buffer.alloc(0);
+  const reader = res.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value && value.byteLength > 0) {
+        total += value.byteLength;
+        if (total > maxBytes) {
+          await reader.cancel().catch(() => {});
+          throw new Error(
+            `Response body exceeds the ${Math.round(maxBytes / 1024 / 1024)} MB limit.`,
+          );
+        }
+        chunks.push(Buffer.from(value));
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks);
 }

--- a/src/lib/externalUrlGuard.ts
+++ b/src/lib/externalUrlGuard.ts
@@ -204,9 +204,17 @@ function ssrfValidatingLookup(
  * that validated IP — so `fetch(url, { dispatcher: ssrfDispatcher })`
  * cannot be rebound onto a private address between guard and connect.
  *
- * The cast bridges a known undici quirk: at runtime the interceptor
- * invokes `lookup` with an origin OBJECT (it reads `origin.hostname`),
- * but the published `.d.ts` types the first parameter as a bare string.
+ * GH #258 (Codex P1): `maxItems` bounds the interceptor's per-hostname
+ * DNS cache. It defaults to `Infinity`, and this is a process-wide
+ * singleton fed user-controlled hosts (embed-check / TDS) — so without
+ * a cap an attacker could trigger endless distinct lookups and grow
+ * the cache until the process is OOM-killed. 256 is far above any
+ * legitimate working set; `maxTTL` (10s default) also ages entries out.
+ *
+ * The `lookup` cast bridges a known undici quirk: at runtime the
+ * interceptor invokes `lookup` with an origin OBJECT (it reads
+ * `origin.hostname`), but the published `.d.ts` types the first
+ * parameter as a bare string.
  */
 type DnsInterceptorLookup = NonNullable<
   NonNullable<Parameters<typeof interceptors.dns>[0]>["lookup"]
@@ -214,6 +222,7 @@ type DnsInterceptorLookup = NonNullable<
 export const ssrfDispatcher = new Agent().compose(
   interceptors.dns({
     lookup: ssrfValidatingLookup as unknown as DnsInterceptorLookup,
+    maxItems: 256,
   }),
 );
 

--- a/src/lib/mongoUriGuard.ts
+++ b/src/lib/mongoUriGuard.ts
@@ -1,0 +1,109 @@
+/**
+ * SSRF guard for user-supplied MongoDB connection strings (GH #254).
+ *
+ * `POST /api/filaments/import-atlas` and `POST /api/setup` take a `uri`
+ * straight from the request body and hand it to `new MongoClient(uri)`
+ * + `connect()`. Without a guard, `mongodb://10.0.0.5:27017` turns the
+ * server into an internal-network port scanner / service prober — and
+ * because the app runs an unauthenticated HTTP server, any web page the
+ * user visits can drive it cross-origin.
+ *
+ * Policy:
+ *   - The scheme must be `mongodb://` or `mongodb+srv://`.
+ *   - `import-atlas` (importing from a *remote* Atlas) additionally
+ *     requires `mongodb+srv://` and rejects hosts that resolve to a
+ *     private/internal address — it never legitimately targets a LAN
+ *     host.
+ *   - `setup` (configuring the app's OWN database) only gets the scheme
+ *     check: a local/Docker deployment legitimately points at
+ *     `mongodb://localhost` or a private Docker-network host, so
+ *     IP-blocking there is wrong. Restricting *who* may call `setup`
+ *     is the job of the destructive-route access guard (GH #252).
+ */
+
+import { lookup } from "node:dns/promises";
+import { isPrivateIp } from "@/lib/externalUrlGuard";
+
+export interface MongoUriGuardOptions {
+  /** Require the `mongodb+srv://` scheme (reject plain `mongodb://`). */
+  requireSrv?: boolean;
+  /** Resolve every host and reject private/internal addresses. */
+  blockPrivateHosts?: boolean;
+}
+
+/** Strip `:port` and IPv6 brackets from a single `host[:port]` spec. */
+function extractHost(spec: string): string {
+  const trimmed = spec.trim();
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    return end !== -1 ? trimmed.slice(1, end) : trimmed.slice(1);
+  }
+  const colon = trimmed.indexOf(":");
+  return colon !== -1 ? trimmed.slice(0, colon) : trimmed;
+}
+
+async function resolveHostIps(host: string): Promise<string[]> {
+  const isIpLiteral = /^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(":");
+  if (isIpLiteral) return [host];
+  const records = await lookup(host, { all: true }).catch(() => []);
+  if (records.length === 0) {
+    throw new Error(`Database host does not resolve: ${host}`);
+  }
+  return records.map((r) => r.address);
+}
+
+/**
+ * Validate a user-supplied MongoDB connection string before it is passed
+ * to a `MongoClient`. Throws an `Error` describing the rejection.
+ */
+export async function assertSafeMongoUri(
+  uri: string,
+  opts: MongoUriGuardOptions = {},
+): Promise<void> {
+  const match = /^(mongodb(?:\+srv)?):\/\/(.+)$/i.exec(uri.trim());
+  if (!match) {
+    throw new Error(
+      "Connection string must be a mongodb:// or mongodb+srv:// URI.",
+    );
+  }
+  const isSrv = match[1].toLowerCase() === "mongodb+srv";
+  if (opts.requireSrv && !isSrv) {
+    throw new Error(
+      "Only mongodb+srv:// connection strings are accepted here.",
+    );
+  }
+
+  // authority = everything before the first '/' or '?'; drop userinfo
+  // (everything up to and including the last '@').
+  let authority = match[2].split(/[/?]/)[0];
+  const at = authority.lastIndexOf("@");
+  if (at !== -1) authority = authority.slice(at + 1);
+
+  const hostSpecs = authority
+    .split(",")
+    .map((h) => h.trim())
+    .filter(Boolean);
+  if (hostSpecs.length === 0) {
+    throw new Error("Connection string has no host.");
+  }
+  if (isSrv && hostSpecs.length > 1) {
+    throw new Error(
+      "A mongodb+srv:// connection string must have exactly one host.",
+    );
+  }
+
+  if (!opts.blockPrivateHosts) return;
+
+  for (const spec of hostSpecs) {
+    const host = extractHost(spec);
+    if (!host) throw new Error("Connection string has an empty host.");
+    const ips = await resolveHostIps(host);
+    for (const ip of ips) {
+      if (isPrivateIp(ip)) {
+        throw new Error(
+          "Connection string points at a private/internal address — only public database hosts are allowed.",
+        );
+      }
+    }
+  }
+}

--- a/src/lib/mongoUriGuard.ts
+++ b/src/lib/mongoUriGuard.ts
@@ -21,8 +21,12 @@
  *     is the job of the destructive-route access guard (GH #252).
  */
 
-import { lookup } from "node:dns/promises";
+import { lookup, resolveSrv } from "node:dns/promises";
 import { isPrivateIp } from "@/lib/externalUrlGuard";
+
+/** Message used whenever a host resolves into private/internal space. */
+const PRIVATE_HOST_ERROR =
+  "Connection string resolves to a private/internal address — only public database hosts are allowed.";
 
 export interface MongoUriGuardOptions {
   /** Require the `mongodb+srv://` scheme (reject plain `mongodb://`). */
@@ -94,16 +98,40 @@ export async function assertSafeMongoUri(
 
   if (!opts.blockPrivateHosts) return;
 
+  if (isSrv) {
+    // GH #332 (Codex P1): a `mongodb+srv://` connection does NOT connect
+    // to the seed host — the driver does a DNS SRV lookup of
+    // `_mongodb._tcp.<seed>` and connects to the hosts in those records.
+    // A seed host with a public A record but SRV targets pointing at
+    // RFC1918 space would otherwise pass the guard and still let
+    // MongoClient open internal connections. Resolve and validate the
+    // SRV TARGETS, not the seed host.
+    const seedHost = extractHost(hostSpecs[0]);
+    if (!seedHost) throw new Error("Connection string has an empty host.");
+    const srvRecords = await resolveSrv(`_mongodb._tcp.${seedHost}`).catch(
+      () => [] as { name: string }[],
+    );
+    if (srvRecords.length === 0) {
+      throw new Error(
+        `No SRV records found for ${seedHost} — not a reachable mongodb+srv host.`,
+      );
+    }
+    for (const record of srvRecords) {
+      const ips = await resolveHostIps(record.name);
+      for (const ip of ips) {
+        if (isPrivateIp(ip)) throw new Error(PRIVATE_HOST_ERROR);
+      }
+    }
+    return;
+  }
+
+  // Plain mongodb:// — the listed hosts ARE the connection targets.
   for (const spec of hostSpecs) {
     const host = extractHost(spec);
     if (!host) throw new Error("Connection string has an empty host.");
     const ips = await resolveHostIps(host);
     for (const ip of ips) {
-      if (isPrivateIp(ip)) {
-        throw new Error(
-          "Connection string points at a private/internal address — only public database hosts are allowed.",
-        );
-      }
+      if (isPrivateIp(ip)) throw new Error(PRIVATE_HOST_ERROR);
     }
   }
 }

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -446,12 +446,44 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
 
     // tar.x is a Writable transform that auto-detects gzip; pipeline()
     // resolves once the entire tarball has been extracted to disk.
+    //
+    // GH #258: bound the extraction so a hostile/compromised tarball
+    // (tar bomb) can't fill the disk. The `filter` runs per entry with
+    // the header-declared size, so a single entry claiming a huge size
+    // — or a flood of small entries — trips the limit before the data
+    // is written. It also rejects absolute paths and `..` traversal as
+    // defence-in-depth over tar's own path sanitisation.
+    const MAX_TARBALL_EXTRACT_BYTES = 256 * 1024 * 1024;
+    const MAX_TARBALL_FILES = 50_000;
+    let extractedBytes = 0;
+    let fileCount = 0;
     await pipeline(
       // Cast: response.body is a Web ReadableStream, Readable.fromWeb wants
       // the same shape but the type lib for streams/web is a bit loose
       // across Node versions. Functionally identical.
       Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
-      tar.x({ cwd: tmpDir }),
+      tar.x({
+        cwd: tmpDir,
+        filter: (entryPath: string, entry: { size?: number }) => {
+          if (
+            entryPath.startsWith("/") ||
+            entryPath.split(/[\\/]/).includes("..")
+          ) {
+            throw new Error(`Unsafe tarball entry path: ${entryPath}`);
+          }
+          fileCount += 1;
+          extractedBytes += entry.size ?? 0;
+          if (
+            fileCount > MAX_TARBALL_FILES ||
+            extractedBytes > MAX_TARBALL_EXTRACT_BYTES
+          ) {
+            throw new Error(
+              "OpenPrintTag tarball exceeds extraction limits (possible tar bomb).",
+            );
+          }
+          return true;
+        },
+      }),
     );
 
     // The tarball extracts to a subdirectory like OpenPrintTag-openprinttag-database-<sha>/

--- a/src/lib/tdsExtractor.ts
+++ b/src/lib/tdsExtractor.ts
@@ -7,7 +7,7 @@
  * Supported providers: Google Gemini, Anthropic Claude, OpenAI ChatGPT.
  */
 
-import { assertExternalUrl } from "@/lib/externalUrlGuard";
+import { assertExternalUrl, ssrfDispatcher, readBodyCapped } from "@/lib/externalUrlGuard";
 
 export type AiProvider = "gemini" | "claude" | "openai";
 
@@ -145,7 +145,11 @@ async function fetchTdsContent(url: string): Promise<TdsContent> {
           Accept: "text/html,application/xhtml+xml,application/pdf,*/*",
         },
         redirect: "manual",
-      });
+        // GH #256: pin the socket to the SSRF-validated IP so a DNS
+        // rebind between assertExternalUrl and connect can't reach
+        // private space.
+        dispatcher: ssrfDispatcher,
+      } as RequestInit & { dispatcher?: typeof ssrfDispatcher });
 
       // Treat 3xx (except 304) as a redirect we follow ourselves so the
       // next hop is re-validated.
@@ -177,28 +181,22 @@ async function fetchTdsContent(url: string): Promise<TdsContent> {
     }
 
     const contentType = res.headers.get("content-type") || "";
-    const contentLength = parseInt(res.headers.get("content-length") || "0", 10);
-
-    if (contentLength > MAX_CONTENT_SIZE) {
-      throw new Error(`TDS content too large (${(contentLength / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`);
-    }
-
     const isPdf = contentType.includes("application/pdf") || url.toLowerCase().endsWith(".pdf");
 
+    // GH #258: enforce the size cap on the bytes ACTUALLY received.
+    // A `content-length` header is advisory — a hostile host can omit
+    // it or lie, and `res.text()` / `res.arrayBuffer()` would then
+    // buffer an unbounded body into memory. readBodyCapped aborts the
+    // stream the moment it crosses the limit.
+    const body = await readBodyCapped(res, MAX_CONTENT_SIZE);
+
     if (isPdf) {
-      const buffer = await res.arrayBuffer();
-      if (buffer.byteLength > MAX_CONTENT_SIZE) {
-        throw new Error(`PDF too large (${(buffer.byteLength / 1024 / 1024).toFixed(1)} MB). Maximum is 10 MB.`);
-      }
-      const base64 = Buffer.from(buffer).toString("base64");
+      const base64 = body.toString("base64");
       return { type: "pdf", data: base64, mimeType: "application/pdf" };
     }
 
     // HTML/text content
-    let text = await res.text();
-    if (text.length > MAX_CONTENT_SIZE) {
-      text = text.slice(0, MAX_CONTENT_SIZE);
-    }
+    let text = body.toString("utf-8");
 
     // Strip HTML tags, scripts, styles to get clean text
     text = text

--- a/tests/externalUrlGuard.test.ts
+++ b/tests/externalUrlGuard.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:dns/promises", () => ({
   lookup: mockLookup,
 }));
 
-import { isPrivateIp, assertExternalUrl } from "@/lib/externalUrlGuard";
+import { isPrivateIp, assertExternalUrl, readBodyCapped } from "@/lib/externalUrlGuard";
 
 /**
  * SSRF guard tests. The module is security-critical (used by the TDS
@@ -116,9 +116,50 @@ describe("isPrivateIp — IPv6 block list", () => {
     expect(isPrivateIp("::ffff:169.254.169.254")).toBe(true);
   });
 
+  it("blocks IPv4-mapped IPv6 in hex-group form (GH #257)", () => {
+    // The dotted form was handled; the equivalent hex-group form fell
+    // through to the IPv6 branch, matched no private prefix, and was
+    // wrongly treated as public.
+    expect(isPrivateIp("::ffff:7f00:1")).toBe(true);          // 127.0.0.1
+    expect(isPrivateIp("::ffff:a9fe:a9fe")).toBe(true);       // 169.254.169.254 metadata
+    expect(isPrivateIp("::ffff:0a00:0001")).toBe(true);       // 10.0.0.1
+    expect(isPrivateIp("0:0:0:0:0:ffff:7f00:1")).toBe(true);  // fully-expanded form
+  });
+
+  it("blocks IPv4-compatible IPv6 that points at private space", () => {
+    // Deprecated ::/96 form — ::169.254.169.254 still reaches metadata.
+    expect(isPrivateIp("::a9fe:a9fe")).toBe(true);
+    expect(isPrivateIp("::7f00:1")).toBe(true);
+  });
+
+  it("blocks an unparseable IPv6 literal (fail closed)", () => {
+    expect(isPrivateIp("1:2:3:4:5:6:7:8:9")).toBe(true); // too many groups
+    expect(isPrivateIp("gggg::1")).toBe(true);            // non-hex
+    expect(isPrivateIp("12345::1")).toBe(true);           // group out of range
+  });
+
   it("allows public IPv6 (Google / Cloudflare DNS)", () => {
     expect(isPrivateIp("2001:4860:4860::8888")).toBe(false);
     expect(isPrivateIp("2606:4700:4700::1111")).toBe(false);
+  });
+});
+
+describe("readBodyCapped — GH #258 response-size guard", () => {
+  it("returns the full body when it is under the cap", async () => {
+    const res = new Response("x".repeat(100));
+    const buf = await readBodyCapped(res, 1024);
+    expect(buf.length).toBe(100);
+  });
+
+  it("throws once the streamed body exceeds the cap", async () => {
+    const res = new Response("x".repeat(5000));
+    await expect(readBodyCapped(res, 1024)).rejects.toThrow(/limit/i);
+  });
+
+  it("handles an empty body", async () => {
+    const res = new Response(null);
+    const buf = await readBodyCapped(res, 1024);
+    expect(buf.length).toBe(0);
   });
 });
 

--- a/tests/mongoUriGuard.test.ts
+++ b/tests/mongoUriGuard.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockLookup } = vi.hoisted(() => ({ mockLookup: vi.fn() }));
+const { mockLookup, mockResolveSrv } = vi.hoisted(() => ({
+  mockLookup: vi.fn(),
+  mockResolveSrv: vi.fn(),
+}));
 
-// Stub DNS so the host-resolution path is deterministic in CI.
-vi.mock("node:dns/promises", () => ({ lookup: mockLookup }));
+// Stub DNS so host resolution + SRV lookups are deterministic in CI.
+vi.mock("node:dns/promises", () => ({
+  lookup: mockLookup,
+  resolveSrv: mockResolveSrv,
+}));
 
 import { assertSafeMongoUri } from "@/lib/mongoUriGuard";
 
@@ -13,7 +19,10 @@ import { assertSafeMongoUri } from "@/lib/mongoUriGuard";
  * this guard a request body can drive the server to probe internal hosts.
  */
 describe("assertSafeMongoUri", () => {
-  beforeEach(() => mockLookup.mockReset());
+  beforeEach(() => {
+    mockLookup.mockReset();
+    mockResolveSrv.mockReset();
+  });
 
   it("rejects a non-mongodb scheme", async () => {
     await expect(assertSafeMongoUri("http://evil.example/")).rejects.toThrow(/mongodb/i);
@@ -32,16 +41,6 @@ describe("assertSafeMongoUri", () => {
       assertSafeMongoUri("mongodb://10.0.0.5:27017/db", { blockPrivateHosts: true }),
     ).rejects.toThrow(/private\/internal/);
     expect(mockLookup).not.toHaveBeenCalled();
-  });
-
-  it("rejects a hostname that resolves to a private address", async () => {
-    mockLookup.mockResolvedValue([{ address: "10.1.2.3", family: 4 }]);
-    await expect(
-      assertSafeMongoUri("mongodb+srv://internal.corp/db", {
-        requireSrv: true,
-        blockPrivateHosts: true,
-      }),
-    ).rejects.toThrow(/private\/internal/);
   });
 
   it("rejects mongodb://localhost when blocking private hosts", async () => {
@@ -65,7 +64,39 @@ describe("assertSafeMongoUri", () => {
     ).rejects.toThrow(/private\/internal/);
   });
 
-  it("accepts a public mongodb+srv host (Atlas)", async () => {
+  // ── mongodb+srv: the SRV *targets* are the real connection hosts ──
+
+  it("rejects a mongodb+srv URI whose SRV target resolves to a private address", async () => {
+    // GH #332: the seed host can be public while its SRV records point
+    // at RFC1918 space — the guard must validate the SRV targets.
+    mockResolveSrv.mockResolvedValue([
+      { name: "shard0.internal.corp", port: 27017, priority: 0, weight: 0 },
+    ]);
+    mockLookup.mockResolvedValue([{ address: "10.1.2.3", family: 4 }]);
+    await expect(
+      assertSafeMongoUri("mongodb+srv://seed.example.com/db", {
+        requireSrv: true,
+        blockPrivateHosts: true,
+      }),
+    ).rejects.toThrow(/private\/internal/);
+    expect(mockResolveSrv).toHaveBeenCalledWith("_mongodb._tcp.seed.example.com");
+  });
+
+  it("rejects a mongodb+srv host with no SRV records", async () => {
+    mockResolveSrv.mockRejectedValue(new Error("ENOTFOUND"));
+    await expect(
+      assertSafeMongoUri("mongodb+srv://not-a-cluster.example.com/db", {
+        requireSrv: true,
+        blockPrivateHosts: true,
+      }),
+    ).rejects.toThrow(/SRV records/i);
+  });
+
+  it("accepts a mongodb+srv host whose SRV targets are all public (Atlas)", async () => {
+    mockResolveSrv.mockResolvedValue([
+      { name: "shard0.abcd.mongodb.net", port: 27017, priority: 0, weight: 0 },
+      { name: "shard1.abcd.mongodb.net", port: 27017, priority: 0, weight: 0 },
+    ]);
     mockLookup.mockResolvedValue([{ address: "13.37.13.37", family: 4 }]);
     await expect(
       assertSafeMongoUri(
@@ -82,5 +113,6 @@ describe("assertSafeMongoUri", () => {
       assertSafeMongoUri("mongodb://localhost:27017/db", { blockPrivateHosts: false }),
     ).resolves.toBeUndefined();
     expect(mockLookup).not.toHaveBeenCalled();
+    expect(mockResolveSrv).not.toHaveBeenCalled();
   });
 });

--- a/tests/mongoUriGuard.test.ts
+++ b/tests/mongoUriGuard.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockLookup } = vi.hoisted(() => ({ mockLookup: vi.fn() }));
+
+// Stub DNS so the host-resolution path is deterministic in CI.
+vi.mock("node:dns/promises", () => ({ lookup: mockLookup }));
+
+import { assertSafeMongoUri } from "@/lib/mongoUriGuard";
+
+/**
+ * GH #254 — SSRF guard for user-supplied MongoDB connection strings.
+ * `import-atlas` / `setup` pass `uri` straight to `MongoClient`; without
+ * this guard a request body can drive the server to probe internal hosts.
+ */
+describe("assertSafeMongoUri", () => {
+  beforeEach(() => mockLookup.mockReset());
+
+  it("rejects a non-mongodb scheme", async () => {
+    await expect(assertSafeMongoUri("http://evil.example/")).rejects.toThrow(/mongodb/i);
+    await expect(assertSafeMongoUri("file:///etc/passwd")).rejects.toThrow(/mongodb/i);
+    await expect(assertSafeMongoUri("not a uri")).rejects.toThrow(/mongodb/i);
+  });
+
+  it("rejects plain mongodb:// when requireSrv is set (import-atlas policy)", async () => {
+    await expect(
+      assertSafeMongoUri("mongodb://cluster.example.com/db", { requireSrv: true }),
+    ).rejects.toThrow(/mongodb\+srv/i);
+  });
+
+  it("rejects a literal RFC1918 host without a DNS lookup", async () => {
+    await expect(
+      assertSafeMongoUri("mongodb://10.0.0.5:27017/db", { blockPrivateHosts: true }),
+    ).rejects.toThrow(/private\/internal/);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hostname that resolves to a private address", async () => {
+    mockLookup.mockResolvedValue([{ address: "10.1.2.3", family: 4 }]);
+    await expect(
+      assertSafeMongoUri("mongodb+srv://internal.corp/db", {
+        requireSrv: true,
+        blockPrivateHosts: true,
+      }),
+    ).rejects.toThrow(/private\/internal/);
+  });
+
+  it("rejects mongodb://localhost when blocking private hosts", async () => {
+    mockLookup.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+    await expect(
+      assertSafeMongoUri("mongodb://localhost:27017/db", { blockPrivateHosts: true }),
+    ).rejects.toThrow(/private\/internal/);
+  });
+
+  it("checks every host of a multi-host plain URI", async () => {
+    mockLookup.mockImplementation((host: string) =>
+      host === "bad.example.com"
+        ? Promise.resolve([{ address: "192.168.1.1", family: 4 }])
+        : Promise.resolve([{ address: "8.8.8.8", family: 4 }]),
+    );
+    await expect(
+      assertSafeMongoUri(
+        "mongodb://good.example.com:27017,bad.example.com:27017/db",
+        { blockPrivateHosts: true },
+      ),
+    ).rejects.toThrow(/private\/internal/);
+  });
+
+  it("accepts a public mongodb+srv host (Atlas)", async () => {
+    mockLookup.mockResolvedValue([{ address: "13.37.13.37", family: 4 }]);
+    await expect(
+      assertSafeMongoUri(
+        "mongodb+srv://user:p%40ss@cluster0.abcd.mongodb.net/filament-db?retryWrites=true",
+        { requireSrv: true, blockPrivateHosts: true },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("only validates the scheme when blockPrivateHosts is false (setup policy)", async () => {
+    // setup legitimately targets the app's own DB — localhost / Docker
+    // hosts must pass; only the scheme is enforced here.
+    await expect(
+      assertSafeMongoUri("mongodb://localhost:27017/db", { blockPrivateHosts: false }),
+    ).resolves.toBeUndefined();
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Security batch A — SSRF & external-fetch hardening. Closes #254, #256, #257, #258.

- **#254** — `import-atlas` / `setup` handed a user-supplied MongoDB URI straight to `MongoClient`, turning the server into an internal-network port scanner (`mongodb://10.0.0.5:27017`). New `src/lib/mongoUriGuard.ts` validates the scheme; for `import-atlas` it requires `mongodb+srv://` and rejects hosts resolving to a private/internal address. `setup` legitimately targets the app's *own* DB (localhost / Docker), so it gets the scheme check only — gating *who* can call it is #252.
- **#256** — `assertExternalUrl` resolved a host, then `fetch()` resolved it again independently — a DNS-rebinding TOCTOU. User-URL fetches (`embed-check`, TDS) now use `ssrfDispatcher`, an undici `Agent` whose DNS interceptor validates **and pins** the connection to the resolved IP.
- **#257** — `isPrivateIp` missed IPv4-mapped IPv6 in hex-group form (`::ffff:7f00:1`) and the fully-expanded form. It now canonicalises any IPv6 to 8 numeric groups and range-checks embedded IPv4 — covering every IPv4-mapped/compatible encoding.
- **#258** — external responses are read with a hard byte budget (`readBodyCapped`) instead of unbounded `res.text()` / `arrayBuffer()` (TDS, Prusament); the OpenPrintTag tarball extraction caps total extracted size + file count and rejects absolute / `..` paths (tar-bomb / tar-slip).

## Test plan

- [x] `tests/externalUrlGuard.test.ts` — new IPv4-mapped-IPv6 hex-form cases + `readBodyCapped` cases
- [x] New `tests/mongoUriGuard.test.ts`
- [x] `npm test` — 1284 passed
- [x] `npm run build` + lint + `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)