### PR TITLE
Harden mass-assignment / data-integrity surfaces (#255, #259-261)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -511,6 +511,16 @@ export async function DELETE(
           400,
         );
       }
+      // GH #261/#333: drop this filament's spools from every printer AMS
+      // slot BEFORE the purge write. `_purged` is a one-way tombstone — if
+      // slot cleanup ran afterwards and failed, the precondition above
+      // (`_purged: { $ne: true }`) would reject every retry, leaving the
+      // dangling slot refs uncleanable forever. Clearing first keeps the
+      // operation retryable: a failure here leaves the filament in the
+      // trash, exactly the state the retry expects.
+      await clearFilamentSpoolsFromSlots(
+        (trashed as { spools?: { _id?: unknown }[] }).spools,
+      );
       // Don't physically `deleteOne` here. The hybrid sync engine pairs
       // docs across peers by syncId and treats "missing on one side" as a
       // fresh insert from the other side — so a hard delete on one peer
@@ -521,10 +531,6 @@ export async function DELETE(
       await Filament.updateOne(
         { _id: id },
         { $set: { _purged: true, _deletedAt: new Date() } },
-      );
-      // GH #261: drop this filament's spools from every printer AMS slot.
-      await clearFilamentSpoolsFromSlots(
-        (trashed as { spools?: { _id?: unknown }[] }).spools,
       );
       return NextResponse.json({ message: "Permanently deleted" });
     }
@@ -537,18 +543,23 @@ export async function DELETE(
       );
     }
 
-    const filament = await Filament.findOneAndUpdate(
-      { _id: id, _deletedAt: null },
-      { _deletedAt: new Date() },
-      { returnDocument: "after" }
-    ).lean();
+    const filament = await Filament.findOne({ _id: id, _deletedAt: null })
+      .select("_id spools")
+      .lean();
     if (!filament) {
       return errorResponse("Not found", 404);
     }
-    // GH #261: drop this filament's spools from every printer AMS slot
-    // so the soft-deleted filament doesn't leave dangling slot refs.
+    // GH #261/#333: drop this filament's spools from every printer AMS slot
+    // BEFORE the soft-delete write. If slot cleanup fails the filament is
+    // still active and the whole DELETE is retryable; clearing afterwards
+    // would 404 the retry (`_deletedAt: null` no longer matches) and leave
+    // dangling slot refs behind.
     await clearFilamentSpoolsFromSlots(
       (filament as { spools?: { _id?: unknown }[] }).spools,
+    );
+    await Filament.updateOne(
+      { _id: id, _deletedAt: null },
+      { _deletedAt: new Date() },
     );
     return NextResponse.json({ message: "Deleted" });
   } catch (err) {

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -2,11 +2,29 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament, { IFilament } from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
-import "@/models/Printer";
+import Printer from "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament, hasVariants } from "@/lib/resolveFilament";
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
+import { assignSpoolToSlot } from "@/lib/spoolSlots";
+
+/**
+ * GH #261: clear every spool of a filament out of all printer AMS slots.
+ * Deleting a filament removes its spools, but `Printer.amsSlots[].spoolId`
+ * still references them — leaving printers showing a phantom spool that
+ * can never be cleared from the (now-gone) spool side. The spool DELETE
+ * handler already does this per-spool; the filament DELETE must too.
+ */
+async function clearFilamentSpoolsFromSlots(
+  spools: { _id?: unknown }[] | undefined | null,
+): Promise<void> {
+  for (const spool of spools ?? []) {
+    if (spool?._id) {
+      await assignSpoolToSlot(Printer, String(spool._id), null);
+    }
+  }
+}
 
 /**
  * GET /api/filaments/{id}
@@ -134,6 +152,13 @@ export async function PUT(
     delete body._parent;
     delete body._variants;
     delete body._inherited;
+    // GH #260: `spools` is NOT editable through the filament PUT. Spools
+    // have dedicated CRUD endpoints (POST/PUT/DELETE /spools/...) that
+    // validate via validateSpoolBody — a bulk PUT of the whole `spools`
+    // array would bypass that and let a client rewrite a spool's
+    // usageHistory ledger, inject a non-numeric totalWeight, etc. The
+    // edit form never sends `spools`; strip it as a hard guarantee.
+    delete body.spools;
 
     // Validate parentId if provided
     if (body.parentId) {
@@ -462,7 +487,7 @@ export async function DELETE(
         _deletedAt: { $ne: null },
         _purged: { $ne: true },
       })
-        .select("_id")
+        .select("_id spools")
         .lean();
       if (!trashed) {
         return errorResponse(
@@ -497,6 +522,10 @@ export async function DELETE(
         { _id: id },
         { $set: { _purged: true, _deletedAt: new Date() } },
       );
+      // GH #261: drop this filament's spools from every printer AMS slot.
+      await clearFilamentSpoolsFromSlots(
+        (trashed as { spools?: { _id?: unknown }[] }).spools,
+      );
       return NextResponse.json({ message: "Permanently deleted" });
     }
 
@@ -516,6 +545,11 @@ export async function DELETE(
     if (!filament) {
       return errorResponse("Not found", 404);
     }
+    // GH #261: drop this filament's spools from every printer AMS slot
+    // so the soft-deleted filament doesn't leave dangling slot refs.
+    await clearFilamentSpoolsFromSlots(
+      (filament as { spools?: { _id?: unknown }[] }).spools,
+    );
     return NextResponse.json({ message: "Deleted" });
   } catch (err) {
     return errorResponseFromCaught(err, "Failed to delete filament");

--- a/src/app/api/filaments/import-atlas/route.ts
+++ b/src/app/api/filaments/import-atlas/route.ts
@@ -3,6 +3,27 @@ import { MongoClient } from "mongodb";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 
+/**
+ * GH #255: explicit ALLOW-LIST of filament fields that may be copied
+ * from a remote Atlas document. The remote DB is whatever URI the
+ * caller supplied — fully attacker-controlled — so spreading the remote
+ * document and stripping a fixed deny-list let everything unlisted
+ * through, including `syncId` / `instanceId` (a sync-engine collision /
+ * takeover vector). Cross-DB ObjectId refs (`parentId`,
+ * `compatibleNozzles`, `calibrations`) are deliberately NOT listed —
+ * they point at the source database and are force-emptied below.
+ */
+const IMPORTABLE_FILAMENT_FIELDS = [
+  "name", "vendor", "type", "color", "colorName", "cost", "density",
+  "diameter", "temperatures", "bedTypeTemps", "maxVolumetricSpeed",
+  "presets", "spools", "spoolWeight", "netFilamentWeight", "totalWeight",
+  "lowStockThreshold", "dryingTemperature", "dryingTime",
+  "transmissionDistance", "glassTempTransition", "heatDeflectionTemp",
+  "shoreHardnessA", "shoreHardnessD", "shrinkageXY", "shrinkageZ",
+  "minPrintSpeed", "maxPrintSpeed", "spoolType", "optTags", "tdsUrl",
+  "inherits", "settings",
+] as const;
+
 // POST with { uri } — list filaments from remote Atlas
 // POST with { uri, filaments: [...ids] } — import selected filaments
 export async function POST(request: NextRequest) {
@@ -63,41 +84,47 @@ export async function POST(request: NextRequest) {
       let updated = 0;
 
       for (const remote of remoteFilaments) {
-        // Strip MongoDB internal fields. GH #222: include `_purged` so an
-        // import from an Atlas source that has the tombstone flag set
-        // doesn't inadvertently mark the local copy purged — and so a
-        // crafted Atlas connection can't be used as a tombstone-injection
-        // vector against a victim's local DB.
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { _id: _remoteId, __v: _remoteV, createdAt: _createdAt, updatedAt: _updatedAt, _deletedAt: _remoteDeleted, _purged: _remotePurged, ...filamentData } = remote;
+        // GH #255: copy ONLY allow-listed fields from the (attacker-
+        // controlled) remote document — `syncId` / `instanceId` /
+        // `_purged` and any other unlisted key never make it through.
+        const filamentData: Record<string, unknown> = {};
+        for (const key of IMPORTABLE_FILAMENT_FIELDS) {
+          if (remote[key] !== undefined) filamentData[key] = remote[key];
+        }
 
-        // Strip every foreign-ObjectId reference — they point at documents
-        // in the *source* Atlas database and won't resolve locally. Leaving
-        // them would surface as dangling refs in calibration/nozzle UIs.
-        //
-        // Set these to explicit empty values rather than `delete`ing them so
-        // that when `Filament.updateOne(..., filamentData)` runs on an
-        // existing row, Mongoose actually *clears* the previously-stored
-        // Atlas values. Keys absent from the update doc would otherwise
-        // leave stale Atlas IDs in place on re-import/update.
+        // Foreign-ObjectId references point at documents in the *source*
+        // Atlas database and won't resolve locally. Set them to explicit
+        // empty values (rather than omitting them) so an updateOne on an
+        // existing row actually *clears* any previously-stored Atlas IDs.
         filamentData.parentId = null;
         filamentData.compatibleNozzles = [];
         filamentData.calibrations = [];
         if (Array.isArray(filamentData.spools)) {
           for (const s of filamentData.spools) {
-            if (s && typeof s === "object") s.locationId = null;
+            if (s && typeof s === "object") (s as Record<string, unknown>).locationId = null;
           }
         }
 
-        const existing = await Filament.findOne({ name: filamentData.name, _deletedAt: null });
+        const importName = String(filamentData.name ?? "");
+        const existing = await Filament.findOne({ name: importName, _deletedAt: null });
         if (existing) {
-          await Filament.updateOne({ _id: existing._id }, filamentData);
+          // GH #255: runValidators so schema constraints (cost.min, etc.)
+          // are enforced on the update path, not just on create.
+          await Filament.updateOne(
+            { _id: existing._id },
+            filamentData,
+            { runValidators: true, context: "query" },
+          );
           updated++;
         } else {
           // If a soft-deleted doc with the same name exists, resurrect it
-          const softDeleted = await Filament.findOne({ name: filamentData.name, _deletedAt: { $ne: null } });
+          const softDeleted = await Filament.findOne({ name: importName, _deletedAt: { $ne: null } });
           if (softDeleted) {
-            await Filament.updateOne({ _id: softDeleted._id }, { ...filamentData, _deletedAt: null });
+            await Filament.updateOne(
+              { _id: softDeleted._id },
+              { ...filamentData, _deletedAt: null },
+              { runValidators: true, context: "query" },
+            );
             updated++;
           } else {
             await Filament.create(filamentData);

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -277,9 +277,15 @@ async function restoreSnapshot(request: NextRequest) {
     // Mongoose hydration entirely — so casting, schema validation, and
     // strict-mode unknown-key stripping were all bypassed, making
     // restore an arbitrary-document-write primitive (negative numerics,
-    // injected keys, bad types). Hydrating each doc applies the schema;
-    // an invalid document now fails the restore (and the catch below
-    // rolls every collection back to the pre-restore backup).
+    // injected keys, bad types). Hydrating each doc applies the schema.
+    //
+    // GH #259 (Codex P1): `ordered: true` (NOT `ordered: false`). With
+    // `ordered: false` Mongoose inserts the valid subset and — with the
+    // default `throwOnValidationError: false` — does NOT throw, so an
+    // invalid snapshot would be acknowledged as a successful restore
+    // while silently dropping records. `ordered: true` throws on the
+    // first invalid document, and the catch below rolls every
+    // collection back to the pre-restore backup — true all-or-nothing.
     const results = {
       filaments: 0,
       nozzles: 0,
@@ -292,43 +298,43 @@ async function restoreSnapshot(request: NextRequest) {
 
     if (nozzles.length > 0) {
       const docs = (nozzles as Record<string, unknown>[]).map(restoreTypes);
-      await Nozzle.insertMany(docs, { ordered: false });
+      await Nozzle.insertMany(docs, { ordered: true });
       results.nozzles = nozzles.length;
     }
 
     if (printers.length > 0) {
       const docs = (printers as Record<string, unknown>[]).map(restoreTypes);
-      await Printer.insertMany(docs, { ordered: false });
+      await Printer.insertMany(docs, { ordered: true });
       results.printers = printers.length;
     }
 
     if (bedTypes.length > 0) {
       const docs = (bedTypes as Record<string, unknown>[]).map(restoreTypes);
-      await BedType.insertMany(docs, { ordered: false });
+      await BedType.insertMany(docs, { ordered: true });
       results.bedTypes = bedTypes.length;
     }
 
     if (locations.length > 0) {
       const docs = (locations as Record<string, unknown>[]).map(restoreTypes);
-      await Location.insertMany(docs, { ordered: false });
+      await Location.insertMany(docs, { ordered: true });
       results.locations = locations.length;
     }
 
     if (filaments.length > 0) {
       const docs = (filaments as Record<string, unknown>[]).map(restoreTypes);
-      await Filament.insertMany(docs, { ordered: false });
+      await Filament.insertMany(docs, { ordered: true });
       results.filaments = filaments.length;
     }
 
     if (printHistory.length > 0) {
       const docs = (printHistory as Record<string, unknown>[]).map(restoreTypes);
-      await PrintHistory.insertMany(docs, { ordered: false });
+      await PrintHistory.insertMany(docs, { ordered: true });
       results.printHistory = printHistory.length;
     }
 
     if (sharedCatalogs.length > 0) {
       const docs = (sharedCatalogs as Record<string, unknown>[]).map(restoreTypes);
-      await SharedCatalog.insertMany(docs, { ordered: false });
+      await SharedCatalog.insertMany(docs, { ordered: true });
       results.sharedCatalogs = sharedCatalogs.length;
     }
 

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -271,7 +271,15 @@ async function restoreSnapshot(request: NextRequest) {
 
     // Insert snapshot data (order matters: reference targets before referrers
     // — nozzles, printers, bedTypes, locations all exist before filaments
-    // that reference them via calibrations / spools.locationId)
+    // that reference them via calibrations / spools.locationId).
+    //
+    // GH #259: `insertMany` runs WITHOUT `lean: true`. `lean` skipped
+    // Mongoose hydration entirely — so casting, schema validation, and
+    // strict-mode unknown-key stripping were all bypassed, making
+    // restore an arbitrary-document-write primitive (negative numerics,
+    // injected keys, bad types). Hydrating each doc applies the schema;
+    // an invalid document now fails the restore (and the catch below
+    // rolls every collection back to the pre-restore backup).
     const results = {
       filaments: 0,
       nozzles: 0,
@@ -284,43 +292,43 @@ async function restoreSnapshot(request: NextRequest) {
 
     if (nozzles.length > 0) {
       const docs = (nozzles as Record<string, unknown>[]).map(restoreTypes);
-      await Nozzle.insertMany(docs, { lean: true, ordered: false });
+      await Nozzle.insertMany(docs, { ordered: false });
       results.nozzles = nozzles.length;
     }
 
     if (printers.length > 0) {
       const docs = (printers as Record<string, unknown>[]).map(restoreTypes);
-      await Printer.insertMany(docs, { lean: true, ordered: false });
+      await Printer.insertMany(docs, { ordered: false });
       results.printers = printers.length;
     }
 
     if (bedTypes.length > 0) {
       const docs = (bedTypes as Record<string, unknown>[]).map(restoreTypes);
-      await BedType.insertMany(docs, { lean: true, ordered: false });
+      await BedType.insertMany(docs, { ordered: false });
       results.bedTypes = bedTypes.length;
     }
 
     if (locations.length > 0) {
       const docs = (locations as Record<string, unknown>[]).map(restoreTypes);
-      await Location.insertMany(docs, { lean: true, ordered: false });
+      await Location.insertMany(docs, { ordered: false });
       results.locations = locations.length;
     }
 
     if (filaments.length > 0) {
       const docs = (filaments as Record<string, unknown>[]).map(restoreTypes);
-      await Filament.insertMany(docs, { lean: true, ordered: false });
+      await Filament.insertMany(docs, { ordered: false });
       results.filaments = filaments.length;
     }
 
     if (printHistory.length > 0) {
       const docs = (printHistory as Record<string, unknown>[]).map(restoreTypes);
-      await PrintHistory.insertMany(docs, { lean: true, ordered: false });
+      await PrintHistory.insertMany(docs, { ordered: false });
       results.printHistory = printHistory.length;
     }
 
     if (sharedCatalogs.length > 0) {
       const docs = (sharedCatalogs as Record<string, unknown>[]).map(restoreTypes);
-      await SharedCatalog.insertMany(docs, { lean: true, ordered: false });
+      await SharedCatalog.insertMany(docs, { ordered: false });
       results.sharedCatalogs = sharedCatalogs.length;
     }
 

--- a/tests/mass-assignment-hardening.test.ts
+++ b/tests/mass-assignment-hardening.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { PUT, DELETE } from "@/app/api/filaments/[id]/route";
+
+/**
+ * Security batch B — mass-assignment / data-integrity hardening.
+ *   #260 — PUT /api/filaments/{id} must not write the `spools` array.
+ *   #261 — deleting a filament must clear its spools from printer slots.
+ */
+describe("mass-assignment & data-integrity hardening", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let Filament: any;
+  let Printer: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    const filMod = await import("@/models/Filament");
+    const prtMod = await import("@/models/Nozzle");
+    const printerMod = await import("@/models/Printer");
+    const bedMod = await import("@/models/BedType");
+    if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
+    if (!mongoose.models.Nozzle) mongoose.model("Nozzle", prtMod.default.schema);
+    if (!mongoose.models.Printer) mongoose.model("Printer", printerMod.default.schema);
+    if (!mongoose.models.BedType) mongoose.model("BedType", bedMod.default.schema);
+    Filament = mongoose.models.Filament;
+    Printer = mongoose.models.Printer;
+  });
+
+  function jsonReq(url: string, body: unknown, method: string) {
+    return new NextRequest(url, {
+      method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  // ── #260: PUT must not mass-assign the spools array ─────────────────
+
+  it("#260 — PUT /api/filaments/{id} ignores a spools array in the body", async () => {
+    const f = await Filament.create({
+      name: "PUT Guard PLA",
+      vendor: "T",
+      type: "PLA",
+      spools: [{ label: "Original", totalWeight: 1000 }],
+    });
+    const spoolId = String(f.spools[0]._id);
+
+    const res = await PUT(
+      jsonReq(
+        `http://localhost/api/filaments/${f._id}`,
+        {
+          name: "PUT Guard PLA",
+          vendor: "T",
+          type: "PLA",
+          // Attempt to rewrite the spool ledger via the filament PUT.
+          spools: [
+            {
+              _id: spoolId,
+              label: "HACKED",
+              totalWeight: 5,
+              usageHistory: [{ grams: 999, jobLabel: "fabricated", source: "manual" }],
+            },
+          ],
+        },
+        "PUT",
+      ),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    // The spool is untouched — the PUT stripped `spools`.
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.spools).toHaveLength(1);
+    expect(fresh.spools[0].label).toBe("Original");
+    expect(fresh.spools[0].totalWeight).toBe(1000);
+    expect(fresh.spools[0].usageHistory ?? []).toHaveLength(0);
+  });
+
+  // ── #261: deleting a filament clears its spools from printer slots ──
+
+  it("#261 — soft-deleting a filament clears its spools from printer AMS slots", async () => {
+    const f = await Filament.create({
+      name: "Slot Owner PLA",
+      vendor: "T",
+      type: "PLA",
+      spools: [{ label: "Loaded", totalWeight: 1000 }],
+    });
+    const spoolId = String(f.spools[0]._id);
+    const printer = await Printer.create({
+      name: "MK4-A",
+      manufacturer: "Prusa",
+      printerModel: "MK4",
+      amsSlots: [{ slotName: "Slot 1", spoolId }],
+    });
+
+    const res = await DELETE(
+      new NextRequest(`http://localhost/api/filaments/${f._id}`, { method: "DELETE" }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const freshPrinter = await Printer.findById(printer._id);
+    expect(freshPrinter.amsSlots[0].spoolId).toBeNull();
+  });
+
+  it("#261 — permanently deleting a trashed filament clears its slot refs", async () => {
+    // A filament already in the trash, with a spool still loaded in a
+    // slot (the pre-fix orphan state).
+    const f = await Filament.create({
+      name: "Trashed Slot Owner",
+      vendor: "T",
+      type: "PLA",
+      spools: [{ label: "Loaded", totalWeight: 1000 }],
+      _deletedAt: new Date(),
+    });
+    const spoolId = String(f.spools[0]._id);
+    const printer = await Printer.create({
+      name: "MK4-B",
+      manufacturer: "Prusa",
+      printerModel: "MK4",
+      amsSlots: [{ slotName: "Slot 1", spoolId }],
+    });
+
+    const res = await DELETE(
+      new NextRequest(
+        `http://localhost/api/filaments/${f._id}?permanent=true`,
+        { method: "DELETE" },
+      ),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const freshPrinter = await Printer.findById(printer._id);
+    expect(freshPrinter.amsSlots[0].spoolId).toBeNull();
+  });
+});

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -440,4 +440,41 @@ describe("snapshot route — Location + PrintHistory round-trip", () => {
       restoredLoc._id.toString(),
     );
   });
+
+  it("rejects a snapshot with an invalid document and rolls back (GH #259/#333)", async () => {
+    // Pre-existing data that must survive a failed restore.
+    await Filament.create({ name: "Survivor PLA", vendor: "T", type: "PLA" });
+
+    const snapshot = {
+      version: 4,
+      createdAt: new Date().toISOString(),
+      collections: {
+        // `vendor` is a required field — this document fails schema
+        // validation, so the `ordered: true` insertMany throws.
+        filaments: [{ name: "Invalid Filament", type: "PLA" }],
+        nozzles: [],
+        printers: [],
+        bedTypes: [],
+        locations: [],
+        printHistory: [],
+        sharedCatalogs: [],
+      },
+    };
+
+    const res = await POST(
+      new NextRequest("http://localhost/api/snapshot", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(snapshot),
+      }),
+    );
+    // The restore must NOT silently succeed on an invalid import.
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/rolled back/i);
+
+    // Pre-existing data was restored; the invalid document never landed.
+    const all = await Filament.find({}).lean();
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("Survivor PLA");
+  });
 });


### PR DESCRIPTION
## Summary

Security batch B — mass-assignment & data-integrity hardening. Closes #255, #259, #260, #261.

- **#255** — `import-atlas` built the import doc by *spreading* the remote document and stripping a fixed deny-list, so `syncId` / `instanceId` and any other unlisted key from the (attacker-controlled) source Atlas were written through — a sync-engine collision/takeover vector. Replaced with an explicit **allow-list** of importable fields; the `updateOne` paths now pass `runValidators` so schema constraints apply on update too.
- **#259** — snapshot restore used `insertMany(docs, { lean: true })`. `lean` skips Mongoose hydration entirely — casting, validation, and strict-mode unknown-key stripping all bypassed — making restore an arbitrary-document-write primitive. Dropped `lean` so the schema is enforced; an invalid document fails the restore and the existing catch rolls every collection back.
- **#260** — `PUT /api/filaments/{id}` passed the body wholesale to `findOneAndUpdate`, letting a client rewrite the entire `spools` array (`usageHistory` ledger, `totalWeight`) — bypassing the validated dedicated spool endpoints. `spools` is now stripped from PUT bodies (it has dedicated CRUD endpoints).
- **#261** — deleting a filament left its spools referenced by `Printer.amsSlots[].spoolId` — a phantom spool the printer card could never clear. Both the soft-delete and permanent-delete paths now clear the filament's spools from every printer slot.

## Test plan

- [x] New `tests/mass-assignment-hardening.test.ts` — PUT-strips-spools + delete-clears-slots (soft & permanent)
- [x] `tests/snapshot.test.ts` still green with `lean` dropped
- [x] `npm test` — 1273 passed
- [x] `npm run build` + lint + `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)