### PR TITLE
Add a trusted-origin guard for destructive admin routes (#252)

### DIFF
--- a/src/app/api/filaments/import-atlas/route.ts
+++ b/src/app/api/filaments/import-atlas/route.ts
@@ -2,10 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { MongoClient } from "mongodb";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
+import { assertSameOriginRequest } from "@/lib/requestGuard";
 
 // POST with { uri } — list filaments from remote Atlas
 // POST with { uri, filaments: [...ids] } — import selected filaments
 export async function POST(request: NextRequest) {
+  // GH #252: this route connects to a caller-supplied MongoDB host and
+  // can overwrite local filaments — reject cross-origin (CSRF) callers.
+  const guard = assertSameOriginRequest(request);
+  if (guard) return guard;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let body: any;
   try {

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { MongoClient } from "mongodb";
+import { assertSameOriginRequest } from "@/lib/requestGuard";
 
 export async function POST(request: NextRequest) {
+  // GH #252: this route makes the server open an outbound MongoDB
+  // connection to a caller-supplied host — reject cross-origin (CSRF)
+  // callers so a hostile page can't drive it.
+  const guard = assertSameOriginRequest(request);
+  if (guard) return guard;
+
   let body;
   try {
     body = await request.json();

--- a/src/app/api/snapshot/delete/route.ts
+++ b/src/app/api/snapshot/delete/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
+import { assertSameOriginRequest } from "@/lib/requestGuard";
 import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
@@ -15,7 +16,12 @@ import SharedCatalog from "@/models/SharedCatalog";
  * a "reset" still surfaces stale data in the dashboard / analytics and can
  * leave published share links active after what the user asked to be a wipe.
  */
-export async function DELETE() {
+export async function DELETE(request: NextRequest) {
+  // GH #252: this route wipes every collection — reject cross-origin
+  // (CSRF) callers before touching the database.
+  const guard = assertSameOriginRequest(request);
+  if (guard) return guard;
+
   try {
     await dbConnect();
 

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
+import { assertSameOriginRequest } from "@/lib/requestGuard";
 import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
@@ -87,7 +88,12 @@ function restoreTypes(doc: Record<string, unknown>): Record<string, unknown> {
  * collection-name mismatch. The keys are kept stable so older
  * snapshots round-trip on the same shape.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // GH #252: a snapshot is a full data export — reject cross-origin
+  // (CSRF) callers so a hostile page can't trigger an exfiltration.
+  const guard = assertSameOriginRequest(request);
+  if (guard) return guard;
+
   await dbConnect();
 
   const [
@@ -155,6 +161,11 @@ export async function GET() {
  * the snapshot JSON.
  */
 export async function POST(request: NextRequest) {
+  // GH #252: restore wipes and replaces every collection — reject
+  // cross-origin (CSRF) callers before the destructive work begins.
+  const guard = assertSameOriginRequest(request);
+  if (guard) return guard;
+
   if (restoreInProgress) {
     return NextResponse.json(
       { error: "A snapshot restore is already in progress. Please wait." },

--- a/src/lib/requestGuard.ts
+++ b/src/lib/requestGuard.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { errorResponse } from "@/lib/apiErrorHandler";
+
+/**
+ * GH #252: trusted-origin guard for destructive / admin API routes —
+ * snapshot export·restore·wipe, the MongoDB connection test, and the
+ * Atlas import.
+ *
+ * The app serves an UNAUTHENTICATED HTTP server (the Electron renderer
+ * and a web/Docker deployment both talk to it same-origin). Without a
+ * guard, any web page the user visits can drive these routes
+ * cross-origin (CSRF): wipe the database, exfiltrate a snapshot, or
+ * make the server open MongoDB connections to probe the LAN.
+ *
+ * The guard rejects requests that carry cross-origin browser
+ * provenance:
+ *   - `Sec-Fetch-Site` present and not `same-origin` / `none` — every
+ *     modern browser tags each request; a CSRF request reads
+ *     `cross-site` or `same-site`.
+ *   - an `Origin` header whose host does not match the request `Host`.
+ *
+ * A non-browser client (curl, a slicer integration script) sends
+ * neither header and cannot be a CSRF vector, so it passes — this is a
+ * CSRF / trusted-origin guard, not an authentication layer. Protecting
+ * an instance that is reachable from an untrusted network is a
+ * deployment concern the README already calls out.
+ *
+ * Returns a 403 `NextResponse` to short-circuit the handler, or `null`
+ * when the request may proceed.
+ */
+export function assertSameOriginRequest(request: NextRequest): NextResponse | null {
+  const secFetchSite = request.headers.get("sec-fetch-site");
+  if (
+    secFetchSite &&
+    secFetchSite !== "same-origin" &&
+    secFetchSite !== "none"
+  ) {
+    return errorResponse(
+      "Cross-origin request to a protected route was rejected.",
+      403,
+    );
+  }
+
+  const origin = request.headers.get("origin");
+  if (origin) {
+    const host = request.headers.get("host");
+    let originHost: string;
+    try {
+      originHost = new URL(origin).host;
+    } catch {
+      return errorResponse(
+        "Cross-origin request to a protected route was rejected.",
+        403,
+      );
+    }
+    if (!host || originHost !== host) {
+      return errorResponse(
+        "Cross-origin request to a protected route was rejected.",
+        403,
+      );
+    }
+  }
+
+  return null;
+}

--- a/src/lib/requestGuard.ts
+++ b/src/lib/requestGuard.ts
@@ -1,6 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { errorResponse } from "@/lib/apiErrorHandler";
 
+/** Extract the bare, lower-cased hostname from a `host`, `host:port`,
+ * `[ipv6]` or `[ipv6]:port` value — i.e. strip the port and any IPv6
+ * brackets so two equivalent authorities compare equal. */
+function hostnameOf(value: string): string {
+  const v = value.trim();
+  if (v.startsWith("[")) {
+    const end = v.indexOf("]");
+    return (end !== -1 ? v.slice(1, end) : v.slice(1)).toLowerCase();
+  }
+  const colon = v.indexOf(":");
+  return (colon !== -1 ? v.slice(0, colon) : v).toLowerCase();
+}
+
 /**
  * GH #252: trusted-origin guard for destructive / admin API routes —
  * snapshot export·restore·wipe, the MongoDB connection test, and the
@@ -43,17 +56,26 @@ export function assertSameOriginRequest(request: NextRequest): NextResponse | nu
 
   const origin = request.headers.get("origin");
   if (origin) {
-    const host = request.headers.get("host");
-    let originHost: string;
+    const hostHeader = request.headers.get("host");
+    let originHostname: string;
     try {
-      originHost = new URL(origin).host;
+      originHostname = new URL(origin).hostname;
     } catch {
       return errorResponse(
         "Cross-origin request to a protected route was rejected.",
         403,
       );
     }
-    if (!host || originHost !== host) {
+    // Compare HOSTNAMES only. `Host` is `hostname[:port]`; matching the
+    // raw `host[:port]` string false-rejects a legitimate same-origin
+    // request whenever one side carries an explicit default port
+    // (`Origin: https://app` vs `Host: app:443`) — common behind a
+    // reverse proxy. A genuine cross-origin request that shares the
+    // hostname but differs in scheme or port reads `same-site` to the
+    // Sec-Fetch-Site check above, so hostname equality is sufficient
+    // here (Codex review).
+    const hostHostname = hostHeader ? hostnameOf(hostHeader) : "";
+    if (!hostHostname || hostnameOf(originHostname) !== hostHostname) {
       return errorResponse(
         "Cross-origin request to a protected route was rejected.",
         403,

--- a/src/lib/requestGuard.ts
+++ b/src/lib/requestGuard.ts
@@ -1,17 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { errorResponse } from "@/lib/apiErrorHandler";
 
-/** Extract the bare, lower-cased hostname from a `host`, `host:port`,
- * `[ipv6]` or `[ipv6]:port` value — i.e. strip the port and any IPv6
- * brackets so two equivalent authorities compare equal. */
-function hostnameOf(value: string): string {
+/** Split a `host`, `host:port`, `[ipv6]` or `[ipv6]:port` value into a
+ * lower-cased hostname and its (possibly empty) port. */
+function splitAuthority(value: string): { hostname: string; port: string } {
   const v = value.trim();
   if (v.startsWith("[")) {
     const end = v.indexOf("]");
-    return (end !== -1 ? v.slice(1, end) : v.slice(1)).toLowerCase();
+    const hostname = (end !== -1 ? v.slice(1, end) : v.slice(1)).toLowerCase();
+    const port = end !== -1 && v[end + 1] === ":" ? v.slice(end + 2) : "";
+    return { hostname, port };
   }
   const colon = v.indexOf(":");
-  return (colon !== -1 ? v.slice(0, colon) : v).toLowerCase();
+  return colon !== -1
+    ? { hostname: v.slice(0, colon).toLowerCase(), port: v.slice(colon + 1) }
+    : { hostname: v.toLowerCase(), port: "" };
 }
 
 /**
@@ -57,25 +60,35 @@ export function assertSameOriginRequest(request: NextRequest): NextResponse | nu
   const origin = request.headers.get("origin");
   if (origin) {
     const hostHeader = request.headers.get("host");
-    let originHostname: string;
+    if (!hostHeader) {
+      return errorResponse(
+        "Cross-origin request to a protected route was rejected.",
+        403,
+      );
+    }
+    let originUrl: URL;
     try {
-      originHostname = new URL(origin).hostname;
+      originUrl = new URL(origin);
     } catch {
       return errorResponse(
         "Cross-origin request to a protected route was rejected.",
         403,
       );
     }
-    // Compare HOSTNAMES only. `Host` is `hostname[:port]`; matching the
-    // raw `host[:port]` string false-rejects a legitimate same-origin
-    // request whenever one side carries an explicit default port
-    // (`Origin: https://app` vs `Host: app:443`) — common behind a
-    // reverse proxy. A genuine cross-origin request that shares the
-    // hostname but differs in scheme or port reads `same-site` to the
-    // Sec-Fetch-Site check above, so hostname equality is sufficient
-    // here (Codex review).
-    const hostHostname = hostHeader ? hostnameOf(hostHeader) : "";
-    if (!hostHostname || hostnameOf(originHostname) !== hostHostname) {
+    // Compare the full authority — hostname AND port. A hostname-only
+    // check is too lenient: when `Sec-Fetch-Site` is absent (older
+    // browsers, embedded webviews, intermediaries that strip Fetch
+    // Metadata) a cross-origin request from the SAME host but a
+    // different port would otherwise slip through (Codex review).
+    // Ports are normalised against the Origin's scheme default, so an
+    // explicit `:443`/`:80` on one side and an omitted default on the
+    // other still compare equal — no false-reject behind a proxy.
+    const defaultPort = originUrl.protocol === "https:" ? "443" : "80";
+    const originHostname = originUrl.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    const originPort = originUrl.port || defaultPort;
+    const hostParts = splitAuthority(hostHeader);
+    const hostPort = hostParts.port || defaultPort;
+    if (originHostname !== hostParts.hostname || originPort !== hostPort) {
       return errorResponse(
         "Cross-origin request to a protected route was rejected.",
         403,

--- a/tests/destructive-route-guard.test.ts
+++ b/tests/destructive-route-guard.test.ts
@@ -45,6 +45,17 @@ describe("assertSameOriginRequest", () => {
       assertSameOriginRequest(reqWith({ origin: "http://localhost:3456", host: "localhost:3456" })),
     ).toBeNull();
   });
+
+  it("allows an Origin/Host pair differing only by an explicit default port", () => {
+    // Codex review: matching raw host[:port] strings false-rejected a
+    // legitimate request when one side spelled out the default port.
+    expect(
+      assertSameOriginRequest(reqWith({ origin: "https://app.example", host: "app.example:443" })),
+    ).toBeNull();
+    expect(
+      assertSameOriginRequest(reqWith({ origin: "https://app.example:443", host: "app.example" })),
+    ).toBeNull();
+  });
 });
 
 describe("destructive route — snapshot/delete CSRF guard", () => {

--- a/tests/destructive-route-guard.test.ts
+++ b/tests/destructive-route-guard.test.ts
@@ -56,6 +56,15 @@ describe("assertSameOriginRequest", () => {
       assertSameOriginRequest(reqWith({ origin: "https://app.example:443", host: "app.example" })),
     ).toBeNull();
   });
+
+  it("rejects a same-host different-port Origin (CSRF gap with no Sec-Fetch-Site)", () => {
+    // Codex review: a hostname-only check would let a page on
+    // localhost:8080 POST to the API on localhost:3456 — a real
+    // cross-origin request. The port must be part of the comparison.
+    expect(
+      assertSameOriginRequest(reqWith({ origin: "http://localhost:8080", host: "localhost:3456" })),
+    ).not.toBeNull();
+  });
 });
 
 describe("destructive route — snapshot/delete CSRF guard", () => {

--- a/tests/destructive-route-guard.test.ts
+++ b/tests/destructive-route-guard.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { assertSameOriginRequest } from "@/lib/requestGuard";
+import { DELETE as snapshotDelete } from "@/app/api/snapshot/delete/route";
+
+/**
+ * GH #252 — trusted-origin guard for destructive admin routes.
+ * A cross-origin (CSRF) request must be rejected before any data is
+ * touched; same-origin and non-browser requests must still pass.
+ */
+describe("assertSameOriginRequest", () => {
+  function reqWith(headers: Record<string, string>) {
+    return new NextRequest("http://localhost:3456/api/snapshot", { headers });
+  }
+
+  it("rejects a cross-site browser request", () => {
+    expect(assertSameOriginRequest(reqWith({ "sec-fetch-site": "cross-site" }))).not.toBeNull();
+  });
+
+  it("rejects a same-site (but not same-origin) browser request", () => {
+    expect(assertSameOriginRequest(reqWith({ "sec-fetch-site": "same-site" }))).not.toBeNull();
+  });
+
+  it("allows a same-origin browser request", () => {
+    expect(assertSameOriginRequest(reqWith({ "sec-fetch-site": "same-origin" }))).toBeNull();
+  });
+
+  it("allows a user-initiated navigation (Sec-Fetch-Site: none)", () => {
+    expect(assertSameOriginRequest(reqWith({ "sec-fetch-site": "none" }))).toBeNull();
+  });
+
+  it("allows a non-browser client (no fetch-metadata / Origin headers)", () => {
+    expect(assertSameOriginRequest(reqWith({}))).toBeNull();
+  });
+
+  it("rejects a mismatched Origin header", () => {
+    expect(
+      assertSameOriginRequest(reqWith({ origin: "http://evil.example", host: "localhost:3456" })),
+    ).not.toBeNull();
+  });
+
+  it("allows an Origin header that matches the Host", () => {
+    expect(
+      assertSameOriginRequest(reqWith({ origin: "http://localhost:3456", host: "localhost:3456" })),
+    ).toBeNull();
+  });
+});
+
+describe("destructive route — snapshot/delete CSRF guard", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
+    Filament = mongoose.models.Filament;
+  });
+
+  it("rejects a cross-origin wipe with 403 and leaves the data intact", async () => {
+    await Filament.create({ name: "Keep Me", vendor: "T", type: "PLA" });
+
+    const res = await snapshotDelete(
+      new NextRequest("http://localhost:3456/api/snapshot/delete", {
+        method: "DELETE",
+        headers: { "sec-fetch-site": "cross-site" },
+      }),
+    );
+    expect(res.status).toBe(403);
+
+    // The wipe never ran.
+    expect(await Filament.countDocuments({})).toBe(1);
+  });
+
+  it("allows a same-origin wipe", async () => {
+    await Filament.create({ name: "Wipe Me", vendor: "T", type: "PLA" });
+
+    const res = await snapshotDelete(
+      new NextRequest("http://localhost:3456/api/snapshot/delete", {
+        method: "DELETE",
+        headers: { "sec-fetch-site": "same-origin" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await Filament.countDocuments({})).toBe(0);
+  });
+});

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -48,7 +48,7 @@ describe("snapshot route — bedTypes round-trip", () => {
     await BedType.create({ name: "Smooth PEI", material: "PEI" });
     await BedType.create({ name: "Textured PEI", material: "PEI" });
 
-    const res = await GET();
+    const res = await GET(new NextRequest("http://localhost/api/snapshot"));
     const snapshot = await res.json();
 
     // Snapshot version bumps whenever a new collection joins the payload —
@@ -149,7 +149,7 @@ describe("snapshot route — bedTypes round-trip", () => {
     });
 
     // Export
-    const exportRes = await GET();
+    const exportRes = await GET(new NextRequest("http://localhost/api/snapshot"));
     const snapshot = JSON.parse(await exportRes.text());
     expect(snapshot.version).toBeGreaterThanOrEqual(4);
     expect(Array.isArray(snapshot.collections.sharedCatalogs)).toBe(true);
@@ -237,7 +237,7 @@ describe("snapshot route — bedTypes round-trip", () => {
     });
 
     // Export
-    const exportRes = await GET();
+    const exportRes = await GET(new NextRequest("http://localhost/api/snapshot"));
     const snapshotPayload = JSON.parse(await exportRes.text());
 
     // Wipe and re-import
@@ -304,7 +304,7 @@ describe("snapshot route — Location + PrintHistory round-trip", () => {
     await Location.create({ name: "Drybox 1", kind: "drybox", humidity: 18 });
     await Location.create({ name: "Garage shelf", kind: "shelf" });
 
-    const res = await GET();
+    const res = await GET(new NextRequest("http://localhost/api/snapshot"));
     const snapshot = await res.json();
 
     expect(snapshot.version).toBeGreaterThanOrEqual(3);
@@ -376,7 +376,7 @@ describe("snapshot route — Location + PrintHistory round-trip", () => {
     });
 
     // Export full snapshot, wipe, restore.
-    const exportRes = await GET();
+    const exportRes = await GET(new NextRequest("http://localhost/api/snapshot"));
     const snapshotPayload = JSON.parse(await exportRes.text());
 
     await PrintHistory.deleteMany({});
@@ -418,7 +418,7 @@ describe("snapshot route — Location + PrintHistory round-trip", () => {
       spools: [{ label: "Spool 1", totalWeight: 1000, locationId: loc._id }],
     });
 
-    const exportRes = await GET();
+    const exportRes = await GET(new NextRequest("http://localhost/api/snapshot"));
     const snapshotPayload = JSON.parse(await exportRes.text());
 
     await Filament.deleteMany({});


### PR DESCRIPTION
## Summary

Security batch C. Closes #252.

Snapshot export / restore / wipe, the MongoDB connection test, and the Atlas import had no server-side guard. The app serves an **unauthenticated** HTTP server, so any web page the user visits could drive these routes cross-origin (CSRF) — wipe the database, exfiltrate a snapshot, or make the server open MongoDB connections to probe the LAN.

New `src/lib/requestGuard.ts` → `assertSameOriginRequest` rejects requests with cross-origin browser provenance:
- a `Sec-Fetch-Site` header that isn't `same-origin` / `none`, or
- an `Origin` header whose host doesn't match the request `Host`.

A non-browser client (curl, slicer scripts) sends neither header and cannot be a CSRF vector, so it still passes — this is a CSRF / trusted-origin guard, **not** an authentication layer. Protecting an instance reachable from an untrusted network remains a deployment concern (the README already states the API is for trusted localhost use).

Wired into `snapshot` GET + POST, `snapshot/delete`, `setup`, and `import-atlas`. The Electron renderer and the web UI call these same-origin, so the guard is transparent to normal use.

## Test plan

- [x] New `tests/destructive-route-guard.test.ts` — guard matrix + a cross-origin `snapshot/delete` is 403'd with data intact
- [x] `tests/snapshot.test.ts` updated for the new `GET(request)` signature
- [x] `npm test` — 1279 passed
- [x] `npm run build` + lint + `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)