### PR TITLE
Fix TDS iframe CSP block + AI provider resolution (#250, #251)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1043,7 +1043,11 @@ app.whenReady().then(async () => {
         // Next.js streams the RSC payload via inline <script> tags and
         // the theme-init bootstrap is inline; migrating those to a
         // per-request nonce is tracked separately in #225.
-        "Content-Security-Policy": ["default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* http://localhost:*; font-src 'self' data:;"],
+        // GH #250: `frame-src https:` lets the filament detail page embed
+        // an embeddable vendor TDS document in an <iframe>; without it the
+        // load falls back to default-src 'self' and is blocked even after
+        // /api/embed-check confirms the vendor allows framing.
+        "Content-Security-Policy": ["default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws://localhost:* http://localhost:*; font-src 'self' data:; frame-src https:;"],
       },
     });
   });

--- a/next.config.ts
+++ b/next.config.ts
@@ -54,6 +54,13 @@ const nextConfig: NextConfig = {
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",
       "connect-src 'self'",
+      // GH #250 — the filament detail page renders an embeddable vendor
+      // TDS document in an <iframe> once /api/embed-check confirms the
+      // vendor permits framing. Without an explicit frame-src that load
+      // falls back to default-src 'self' and the browser blocks it, so
+      // the "view TDS" feature silently fails. Restrict to https so only
+      // TLS-served documents can be framed.
+      "frame-src https:",
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/src/app/api/tds/route.ts
+++ b/src/app/api/tds/route.ts
@@ -9,19 +9,56 @@ import { errorResponse, getErrorMessage, isClientInputErrorMessage, MAX_UPLOAD_S
 let storedApiKey: string | null = null;
 let storedProvider: AiProvider = "gemini";
 
+const VALID_PROVIDERS: readonly AiProvider[] = ["gemini", "claude", "openai"];
+
+function isValidProvider(p: unknown): p is AiProvider {
+  return typeof p === "string" && (VALID_PROVIDERS as readonly string[]).includes(p);
+}
+
+/** The env API key for a specific provider, if set. */
+function envKeyForProvider(provider: AiProvider): string | undefined {
+  switch (provider) {
+    case "gemini":
+      return process.env.GEMINI_API_KEY;
+    case "claude":
+      return process.env.ANTHROPIC_API_KEY;
+    case "openai":
+      return process.env.OPENAI_API_KEY;
+  }
+}
+
+/** Provider implied by whichever env key is present, in priority order. */
+function providerFromEnv(): AiProvider | null {
+  if (process.env.ANTHROPIC_API_KEY) return "claude";
+  if (process.env.OPENAI_API_KEY) return "openai";
+  if (process.env.GEMINI_API_KEY) return "gemini";
+  return null;
+}
+
+/**
+ * GH #251: single source of truth for which provider a request uses,
+ * shared by GET (config reporting) and POST (extraction) so the UI never
+ * shows one provider while extraction silently runs another.
+ *
+ * Priority:
+ *   1. an explicit, valid provider on the request
+ *   2. the provider saved via PUT (web mode), when a key was stored
+ *   3. the provider implied by whichever env key is present
+ *   4. "gemini" as a last resort
+ */
+function resolveProvider(bodyProvider?: unknown): AiProvider {
+  if (isValidProvider(bodyProvider)) return bodyProvider;
+  if (storedApiKey) return storedProvider;
+  return providerFromEnv() ?? "gemini";
+}
+
 /** GET /api/tds — check if an AI API key is configured */
 export async function GET() {
-  const envKey = process.env.GEMINI_API_KEY || process.env.ANTHROPIC_API_KEY || process.env.OPENAI_API_KEY;
-  const configured = !!(envKey || storedApiKey);
-
-  // Detect provider from env if no stored provider
-  let provider = storedProvider;
-  if (!storedApiKey && envKey) {
-    if (process.env.ANTHROPIC_API_KEY) provider = "claude";
-    else if (process.env.OPENAI_API_KEY) provider = "openai";
-    else provider = "gemini";
-  }
-
+  const provider = resolveProvider();
+  // `configured` reflects whether a key is actually usable for the
+  // *reported* provider — not just "some env key exists" — so the UI
+  // can't claim it's set up when POST would 401.
+  const configured = !!resolveApiKey(undefined, provider);
   return NextResponse.json({ configured, provider });
 }
 
@@ -40,7 +77,7 @@ export async function PUT(request: NextRequest) {
       return errorResponse("API key is required", 400);
     }
 
-    const validProvider = ["gemini", "claude", "openai"].includes(provider) ? provider as AiProvider : "gemini";
+    const validProvider: AiProvider = isValidProvider(provider) ? provider : "gemini";
 
     // Validate the key
     const valid = await validateApiKey(validProvider, apiKey);
@@ -64,24 +101,22 @@ export async function DELETE() {
 }
 
 /**
- * Resolve the API key from various sources.
+ * Resolve the API key for the chosen provider.
+ *   1. an explicit key on the request
+ *   2. the env key for *that* provider
+ *   3. the stored key — but ONLY when it was saved for the same provider.
+ *
+ * GH #251: step 3 used to return `storedApiKey` unconditionally, which
+ * could hand a Gemini key to a Claude/OpenAI endpoint when the request
+ * asked for a different provider than the one the key was saved under.
  */
 function resolveApiKey(bodyKey: string | undefined, provider: AiProvider): string | null {
   if (bodyKey) return bodyKey;
 
-  switch (provider) {
-    case "gemini":
-      if (process.env.GEMINI_API_KEY) return process.env.GEMINI_API_KEY;
-      break;
-    case "claude":
-      if (process.env.ANTHROPIC_API_KEY) return process.env.ANTHROPIC_API_KEY;
-      break;
-    case "openai":
-      if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
-      break;
-  }
+  const envKey = envKeyForProvider(provider);
+  if (envKey) return envKey;
 
-  return storedApiKey;
+  return storedProvider === provider ? storedApiKey : null;
 }
 
 /** POST /api/tds — extract filament data from a TDS URL or uploaded file */
@@ -105,9 +140,7 @@ export async function POST(request: NextRequest) {
         return errorResponse(`File too large (${sizeMB} MB). Maximum is 10 MB.`, 413);
       }
 
-      const provider: AiProvider = (bodyProvider && ["gemini", "claude", "openai"].includes(bodyProvider))
-        ? bodyProvider as AiProvider
-        : storedProvider || "gemini";
+      const provider = resolveProvider(bodyProvider);
 
       const apiKey = resolveApiKey(bodyKey || undefined, provider);
       if (!apiKey) {
@@ -143,8 +176,7 @@ export async function POST(request: NextRequest) {
       return errorResponse("URL is required", 400);
     }
 
-    const provider: AiProvider = (bodyProvider && ["gemini", "claude", "openai"].includes(bodyProvider))
-      ? bodyProvider as AiProvider : storedProvider || "gemini";
+    const provider = resolveProvider(bodyProvider);
     const apiKey = resolveApiKey(bodyKey, provider);
 
     if (!apiKey) {

--- a/tests/tds-csp-and-provider.test.ts
+++ b/tests/tds-csp-and-provider.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * GH #250 — the filament detail page embeds an embeddable vendor TDS
+ * document in an <iframe>. Without an explicit `frame-src` the load falls
+ * back to `default-src 'self'` and the browser blocks it even after
+ * /api/embed-check confirmed the vendor permits framing. This guards that
+ * the app CSP keeps a frame directive.
+ *
+ * GH #251 — provider resolution must be consistent between GET (config
+ * reporting) and POST (extraction). An env-only deploy with only
+ * ANTHROPIC_API_KEY / OPENAI_API_KEY set must extract via that provider,
+ * not silently fall back to Gemini and 401; and a stored key must never
+ * be handed to a provider it was not saved for.
+ */
+
+// ── #250: CSP frame directive ──────────────────────────────────────────
+
+describe("GH #250 — app CSP permits framing external TDS documents", () => {
+  it("next.config.ts CSP includes a frame-src directive", async () => {
+    const { default: nextConfig } = await import("../next.config");
+    const headerGroups = (await nextConfig.headers?.()) ?? [];
+    const csp = headerGroups
+      .flatMap((g) => g.headers)
+      .find((h) => h.key === "Content-Security-Policy")?.value;
+
+    expect(csp).toBeTruthy();
+    // A frame-src must be present, otherwise the iframe falls back to
+    // default-src 'self' and the TDS preview is silently blocked.
+    expect(csp).toMatch(/(?:^|;\s*)frame-src\s+[^;]*https:/);
+  });
+});
+
+// ── #251: provider / key resolution ────────────────────────────────────
+
+const extractFromTds = vi.fn();
+const extractFromTdsContent = vi.fn();
+const validateApiKey = vi.fn();
+
+vi.mock("@/lib/tdsExtractor", () => ({
+  extractFromTds: (...a: unknown[]) => extractFromTds(...a),
+  extractFromTdsContent: (...a: unknown[]) => extractFromTdsContent(...a),
+  validateApiKey: (...a: unknown[]) => validateApiKey(...a),
+}));
+
+const ENV_KEYS = ["GEMINI_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"] as const;
+
+function jsonReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/tds", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * The route keeps the web-mode key/provider in module-level state, so
+ * each test re-imports the module fresh to get a clean store.
+ */
+async function loadRoute() {
+  vi.resetModules();
+  return import("@/app/api/tds/route");
+}
+
+describe("GH #251 — TDS provider/key resolution is consistent and safe", () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (originalEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = originalEnv[k];
+    }
+  });
+
+  it("GET reports the env-detected provider (claude) when only ANTHROPIC_API_KEY is set", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    const { GET } = await loadRoute();
+    const body = await (await GET()).json();
+    expect(body.provider).toBe("claude");
+    expect(body.configured).toBe(true);
+  });
+
+  it("GET reports openai when only OPENAI_API_KEY is set", async () => {
+    process.env.OPENAI_API_KEY = "sk-openai-test";
+    const { GET } = await loadRoute();
+    const body = await (await GET()).json();
+    expect(body.provider).toBe("openai");
+    expect(body.configured).toBe(true);
+  });
+
+  it("GET reports configured:false when no key is available", async () => {
+    const { GET } = await loadRoute();
+    const body = await (await GET()).json();
+    expect(body.configured).toBe(false);
+  });
+
+  it("POST without an explicit provider uses the env-detected provider, not gemini", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    extractFromTds.mockResolvedValue({ success: true, data: {} });
+    const { POST } = await loadRoute();
+    const res = await POST(jsonReq({ url: "https://example.com/tds.pdf" }));
+    expect(res.status).toBe(200);
+    expect(extractFromTds).toHaveBeenCalledWith(
+      "https://example.com/tds.pdf",
+      "sk-ant-test",
+      "claude",
+    );
+  });
+
+  it("POST with an explicit provider that has no matching key returns 401", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    const { POST } = await loadRoute();
+    const res = await POST(
+      jsonReq({ url: "https://example.com/tds.pdf", provider: "openai" }),
+    );
+    expect(res.status).toBe(401);
+    expect(extractFromTds).not.toHaveBeenCalled();
+  });
+
+  it("does not hand a stored key to a provider it was not saved for", async () => {
+    validateApiKey.mockResolvedValue(true);
+    const { PUT, POST } = await loadRoute();
+    // Store a Gemini key via PUT (web mode).
+    const putRes = await PUT(jsonReq({ apiKey: "gemini-stored-key", provider: "gemini" }));
+    expect(putRes.status).toBe(200);
+    // A Claude request with no key must NOT reuse the stored Gemini key.
+    const res = await POST(
+      jsonReq({ url: "https://example.com/tds.pdf", provider: "claude" }),
+    );
+    expect(res.status).toBe(401);
+    expect(extractFromTds).not.toHaveBeenCalled();
+  });
+
+  it("uses the stored key when the request provider matches the stored provider", async () => {
+    validateApiKey.mockResolvedValue(true);
+    extractFromTds.mockResolvedValue({ success: true, data: {} });
+    const { PUT, POST } = await loadRoute();
+    await PUT(jsonReq({ apiKey: "gemini-stored-key", provider: "gemini" }));
+    const res = await POST(
+      jsonReq({ url: "https://example.com/tds.pdf", provider: "gemini" }),
+    );
+    expect(res.status).toBe(200);
+    expect(extractFromTds).toHaveBeenCalledWith(
+      "https://example.com/tds.pdf",
+      "gemini-stored-key",
+      "gemini",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two TDS-feature fixes from the security/code review.

### [#250](https://github.com/hyiger/filament-db/issues/250) — TDS iframe preview blocked by the app CSP
The filament detail page renders an embeddable vendor TDS document in an `<iframe>` once `/api/embed-check` confirms the vendor permits framing. Both the web CSP (`next.config.ts`) and the Electron CSP (`electron/main.ts`) omitted `frame-src`/`child-src`, so with `default-src 'self'` the external `https://` frame was blocked by the app's own policy — "view TDS" silently failed even on allowed URLs.
- Add `frame-src https:` to both CSPs (TLS-served documents only).

### [#251](https://github.com/hyiger/filament-db/issues/251) — TDS POST ignored the env-detected provider
`GET /api/tds` detected the provider from env keys (`ANTHROPIC_API_KEY`→claude, `OPENAI_API_KEY`→openai), but `POST` resolved `provider = bodyProvider || storedProvider`, and `storedProvider` initializes to `"gemini"`. An env-only Docker/web deploy with only `ANTHROPIC_API_KEY` reported `configured:true, provider:"claude"` on GET, then defaulted to gemini on POST and 401'd. `resolveApiKey` also returned the stored key unconditionally, so a Gemini key could be handed to a Claude/OpenAI endpoint.
- New `resolveProvider()` — explicit request provider → stored provider (when a key was saved) → env-implied provider → `gemini` — shared by GET and POST so the UI and extraction can't disagree.
- `resolveApiKey()` only falls back to the stored key when the stored provider matches the requested one.
- `GET`'s `configured` now reflects whether a key is actually usable for the *reported* provider.

## Test plan
- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run electron:compile` succeeds
- [x] New `tests/tds-csp-and-provider.test.ts` — 8 tests (CSP frame-src present; GET/POST provider agreement; no cross-provider stored-key leakage)
- [x] Existing `tds-route-status.test.ts` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)