### PR TITLE
Resolve moderate npm audit findings + restore audit CI gate (#253)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,13 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
+      # GH #253: this step previously ended in `|| true`, which swallowed
+      # the audit exit code so moderate+ advisories never failed CI. The
+      # known findings are now resolved (brace-expansion bumped; uuid
+      # pinned >=11.1.1 via an exceljs override), so the audit is a real
+      # gate again — a new moderate+ advisory will fail the workflow.
       - name: Security audit
-        run: npm audit --audit-level=moderate || true
+        run: npm audit --audit-level=moderate
 
       - name: Build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -5750,9 +5750,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -14635,12 +14635,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/verror": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "yaml": "^2.8.3"
   },
   "overrides": {
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "exceljs": {
+      "uuid": "^11.1.1"
+    }
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",


### PR DESCRIPTION
## Summary

CI ran `npm audit --audit-level=moderate || true` — the `|| true` swallowed the exit code, so moderate+ advisories never failed the workflow. `npm audit` reported 3 moderate findings; all are now resolved and the gate is real again.

### Findings resolved
- **`brace-expansion`** ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)) — reachable through `electron-builder` (dev dependency). Fixed by `npm audit fix`: `5.0.5 → 5.0.6`.
- **`uuid <11.1.1`** ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)) — reachable only through `exceljs@4.4.0`, which declares `uuid ^8.3.0`. The advisory is a missing buffer bounds check in `v3`/`v5`/`v6` **when a `buf` arg is passed**; exceljs calls `uuid.v4()` with no args (`lib/xlsx/xform/sheet/cf-ext/cf-rule-ext-xform.js`), so it isn't actually reachable. Pinned anyway via an `exceljs → uuid ^11.1.1` override so `npm audit` goes fully clean — avoids the breaking `exceljs@3.4.0` downgrade that `npm audit fix --force` would apply.

### CI gate restored
With `npm audit` now reporting **0 vulnerabilities**, the `|| true` is dropped — a new moderate+ advisory will fail the workflow instead of silently passing.

## Test plan
- [x] `npm audit --audit-level=moderate` → `found 0 vulnerabilities` (exit 0)
- [x] exceljs write→read round-trip verified against `uuid@11.1.1` (`uuid.v4()` resolves via CJS `require`)
- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] `package.json` / `package-lock.json` in sync (`npm ci`-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)