### PR TITLE
fix: Windows-arm64 mongodb timeout + stale-NFC prefill on /filaments/new (v1.27.1)

### DIFF
--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -239,9 +239,21 @@ function NewFilamentContent() {
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  // Handle NFC tag read while on this page
+  // Handle NFC tag read while on this page.
+  //
+  // NfcProvider intentionally keeps `tagReadResult` alive after the tag
+  // is lifted off the reader — the scan-match dialog's action buttons
+  // (View Filament / Create New / candidates) need to remain usable
+  // after the user dismisses the modal. That design is fine for the
+  // dialog; it's wrong for this page, which has no concept of "stale
+  // result vs. fresh scan." Without the `tagPresent` gate, clicking
+  // "+ Add Filament" any time after a scan-and-lift sequence would
+  // pre-fill the form with whatever was last scanned — even when the
+  // user has clearly moved on. Match the user's mental model: if the
+  // tag isn't on the reader RIGHT NOW, do nothing.
   useEffect(() => {
     if (!tagReadResult?.data) return;
+    if (!nfcStatus.tagPresent) return;
     const data = tagReadResult.data;
     // Syncing NFC tag payload into form initial data — same pattern as above.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -268,7 +280,7 @@ function NewFilamentContent() {
     setFormKey((k) => k + 1);
     dismissTagRead();
     toast(t("new.toast.populatedFromNfc"));
-  }, [tagReadResult, dismissTagRead, toast, t]);
+  }, [tagReadResult, nfcStatus.tagPresent, dismissTagRead, toast, t]);
 
   // Handle INI file selection
   const handleIniFile = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -249,14 +249,28 @@ function NewFilamentContent() {
   // result vs. fresh scan." Without the `tagPresent` gate, clicking
   // "+ Add Filament" any time after a scan-and-lift sequence would
   // pre-fill the form with whatever was last scanned — even when the
-  // user has clearly moved on. Match the user's mental model: if the
-  // tag isn't on the reader RIGHT NOW, do nothing.
+  // user has clearly moved on.
+  //
+  // `tagPresent` is read through a ref rather than the deps array
+  // (codex round-1 P1 on PR #354). The naive form — listing
+  // `nfcStatus.tagPresent` as a dep — re-runs this effect on every
+  // present↔absent transition with whatever `tagReadResult` is
+  // currently in scope. `electron/main.ts` emits `nfc-status-changed`
+  // immediately when a tag is detected, BEFORE the async tag read
+  // completes; during that window the effect would re-fire with
+  // `tagPresent=true` and the PREVIOUS tag's `tagReadResult`, prefilling
+  // the form from stale data. Routing the read through a ref means the
+  // prefill effect only runs when `tagReadResult` itself changes, but
+  // can still consult the latest tag-presence state at that moment.
+  const tagPresentRef = useRef(nfcStatus.tagPresent);
+  useEffect(() => {
+    tagPresentRef.current = nfcStatus.tagPresent;
+  }, [nfcStatus.tagPresent]);
   useEffect(() => {
     if (!tagReadResult?.data) return;
-    if (!nfcStatus.tagPresent) return;
+    if (!tagPresentRef.current) return;
     const data = tagReadResult.data;
     // Syncing NFC tag payload into form initial data — same pattern as above.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setInitialData({
       name: data.materialName || "",
       vendor: data.brandName || "",
@@ -280,7 +294,9 @@ function NewFilamentContent() {
     setFormKey((k) => k + 1);
     dismissTagRead();
     toast(t("new.toast.populatedFromNfc"));
-  }, [tagReadResult, nfcStatus.tagPresent, dismissTagRead, toast, t]);
+    // `nfcStatus.tagPresent` is read via `tagPresentRef` (see the block
+    // above) and intentionally omitted from this dep array.
+  }, [tagReadResult, dismissTagRead, toast, t]);
 
   // Handle INI file selection
   const handleIniFile = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,10 +8,26 @@ import { beforeAll, afterAll, afterEach } from "vitest";
 // whole suite collapsing on a cold cache.
 const MONGO_START_TIMEOUT_MS = 120_000;
 
+// Per-instance launch timeout for `MongoMemoryServer.create()` — the
+// mongodb-memory-server-core internal default is 10 seconds and that's
+// not enough on the Windows-arm64 release runner, which executes the
+// suite under x64 emulation. v1.27.0 shipped without Windows-arm64
+// assets because both the initial build and the re-run hit
+// `GenericMMSError: Instance failed to start within 10000ms` on the
+// first `MongoMemoryServer.create()`. Two consecutive failures is the
+// "becoming a pattern" trigger CLAUDE.md's release-process gotcha
+// section already calls out — bumping the start timeout is the
+// recommended durable fix. 60s gives the emulated runner ~6× the
+// headroom of the default; faster runners (mac/linux native) only
+// spend their typical ~1–2s and remain unaffected.
+const MONGO_INSTANCE_LAUNCH_TIMEOUT_MS = 60_000;
+
 let mongoServer: MongoMemoryServer | null = null;
 
 beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
+  mongoServer = await MongoMemoryServer.create({
+    instance: { launchTimeout: MONGO_INSTANCE_LAUNCH_TIMEOUT_MS },
+  });
   const uri = mongoServer.getUri();
   process.env.MONGODB_URI = uri;
   await mongoose.connect(uri);


### PR DESCRIPTION
Two independent patch-level fixes bundled for v1.27.1.

---

### 1. Bump `mongodb-memory-server` launchTimeout to 60s

**Why**: v1.27.0 shipped without Windows-arm64 desktop assets. Both the initial build and the re-run hit the same error during the test step:

```
GenericMMSError: Instance failed to start within 10000ms
```

The mongodb-memory-server-core internal default of 10s for `MongoInstance.launchTimeout` isn't enough on the Windows-arm64 release runner, which executes the vitest suite under x64 emulation. Two consecutive failures is the "becoming a pattern" trigger CLAUDE.md's `### Release-process gotchas` section already calls out, with this exact remediation:

> When the job fails on that timeout specifically, a re-run usually passes; if it becomes a pattern, bump the `mongodb-memory-server` start timeout in `tests/setup.ts` or skip the affected test on the cross runner.

60s gives the emulated runner ~6× the headroom of the default; faster runners (mac/linux native, Windows x64) typically spend ~1–2s on `MongoMemoryServer.create()` and remain unaffected.

**Change**: `tests/setup.ts` — pass `instance: { launchTimeout: 60_000 }` to `MongoMemoryServer.create()`.

---

### 2. Clear NFC prefill on `/filaments/new` when no tag is on the reader

**Repro** (user-reported):
1. Scan a tag that matches an existing filament; dismiss the scan-match dialog.
2. Lift the tag off the reader.
3. Navigate to the inventory page; click **+ Add Filament**.
4. The new-filament form opens titled **"New Filament from NFC Tag"** with every field pre-filled from the tag that's no longer on the reader.

**Cause**: `NfcProvider` intentionally keeps `tagReadResult` alive after the tag is lifted so the scan-match dialog's action buttons (View Filament / Create New / candidate suggestions) stay usable post-dismiss. That design is fine for the dialog — but the new-filament page was reading `tagReadResult` unconditionally and treating any non-null value as *"user just scanned this."* On a stale navigation any time after the lift, it would pre-fill from data the user thought was gone.

**Fix**: gate the prefill `useEffect` on `nfcStatus.tagPresent` being true. If the tag isn't on the reader RIGHT NOW, the page does nothing — matches the user's mental model. The dialog's action buttons remain unaffected; `tagReadResult` still lingers globally for them. Subsequent scans while on the page still prefill correctly because both `tagPresent` and `tagReadResult` flip on tag placement, and `nfcStatus.tagPresent` is added to the effect's dependency array.

**Verification**: cannot reproduce the bug end-to-end in the browser dev preview (the bug requires the Electron renderer + PC/SC reader to produce real `tagReadResult` values). Confirmed the fix doesn't regress page load (`/filaments/new` opens with the default "Add New Filament" title, no console errors), full test suite still passes, lint clean.

---

## Tests + lint

- `npm test` — **1345 passed (1345)**.
- `npm run lint` — clean.

## Backports the Windows-arm64 desktop assets

After this merges, cutting v1.27.1 will rebuild the full desktop matrix with the new timeout. The v1.27.0 release page stays as-is (no force-pushing the tag); v1.27.1 supersedes it as the recommended download.

## Test plan

- [ ] CI green on Node 20 + Node 22.
- [ ] Windows-arm64 CI succeeds on the v1.27.1 tag (the whole point of fix #1).
- [ ] On the desktop app from a v1.27.1 build:
  - [ ] Scan a tag → match dialog shows → dismiss → lift tag → navigate to inventory → click "+ Add Filament" → form opens blank with "Add New Filament" title (no NFC prefill).
  - [ ] Place a tag while on `/filaments/new` → form prefills with the tag's data (existing scan-while-on-page flow still works).
  - [ ] Scan-match dialog's "Create New" button still works (the global `tagReadResult` is still readable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)