### PR TITLE
feat: colorName typeahead → hex on the filament form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,25 @@ scripts/            CLI tools (read-nfc-tag, seed import, backfill)
 
 - **Spool printer-slot assignment (#242)**: a spool can be assigned to a printer AMS/MMU slot directly from the spool card, distinct from its Location — Location is the spool's semi-permanent "home", the slot is its transient position while loaded in a printer. `src/lib/spoolSlots.ts` is the enforcement point: `findSpoolSlot` (reverse lookup over `Printer.amsSlots[].spoolId`), `assignSpoolToSlot` (clears the spool from every slot, then sets the target — a spool occupies at most one slot, and bad data with a spool in two slots self-heals), `clearSpoolsFromOtherPrinters` (post-save reconciliation wired into the printer PUT/POST so the one-slot invariant holds no matter which form wrote it). New endpoint `GET/PUT/DELETE /api/spools/[spoolId]/assignment` writes only `Printer.amsSlots[].spoolId`, never the spool's `locationId`; PUT rejects retired spools (out of inventory, not loadable). The spool DELETE handler also clears the slot so a deleted spool can't linger. Legacy printer documents predating the `amsSlots` field come back from lean queries without it — all iteration sites guard the missing array. **Hybrid-sync limitation**: `amsSlots[].spoolId` is wiped on cross-side sync remap (spool subdocuments have no stable cross-side id), so slot assignments are reliable only in single-database deployments — the spool card surfaces this caveat.
 
+## Color-name typeahead → hex
+
+`FilamentForm`'s "Color Name" input is a combobox: typing populates a dropdown of suggestions, picking one sets BOTH the color name and the hex color picker. Two suggestion sources, in priority order:
+
+- **From your filaments** — the user's previously-saved `(colorName, color)` pairs, served by a new `GET /api/filaments/colors` endpoint that runs `$group` over non-deleted filaments. Multiple filaments with the same name+hex collapse to one row; different hexes under the same name (e.g. three brands of "Galaxy Black" with slightly different shades) stay separate so the user can pick the right shade.
+- **Standard colors** — the 148 CSS Color Module Level 4 named colors plus the gray/grey + cyan/aqua + fuchsia/magenta + slategray/slategrey synonyms. `src/lib/cssNamedColors.ts` is the source of truth.
+
+Lookup helpers in `src/lib/cssNamedColors.ts`:
+- `lookupCssNamedColor(name)` — case- and whitespace-insensitive. Returns the canonical uppercase hex (`#000080` for any of `navy`, `Navy`, `  NAVY  `) or `null`.
+- `filterColorSuggestions(dbSuggestions, query, maxResults?)` — substring-matches the query against both sources, dedupes by `(lowercase name, uppercase hex)` (DB wins ties), and orders DB entries above CSS entries. Exported because the combobox can't unit-test through it.
+
+Commit-on-write rules in the combobox:
+- **Click / Enter on a dropdown row** sets both `colorName` and `color`.
+- **Tab-out / blur with an exact CSS named-color match** updates the hex even without opening the dropdown — covers users who already know "navy" and just want to type it.
+- **DB-side blur lookup is intentionally NOT auto-applied** — the same name can have multiple legitimate hexes in the DB; the user has to pick which one they meant via the dropdown.
+- **Plain typing never overwrites the hex** — only an explicit commit (click/Enter/exact-CSS-on-blur) changes the color picker, so the user's free-text "I'm naming this whatever I want" path stays uninterrupted.
+
+Translation keys: `form.colorName.section.db` ("From your filaments" / "Aus deinen Filamenten") and `form.colorName.section.css` ("Standard colors" / "Standardfarben") in both `en.json` and `de.json`.
+
 ## Finish indicator on the swatch + name chip
 
 When two filaments share the same color but a different finish (the canonical case: white plain / matte / silk), the inventory list, detail page header, and the color-variants list under a parent now distinguish them visually:

--- a/src/app/api/filaments/colors/route.ts
+++ b/src/app/api/filaments/colors/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import dbConnect from "@/lib/mongodb";
+import Filament from "@/models/Filament";
+
+/**
+ * GET /api/filaments/colors
+ *
+ * Returns the distinct `(colorName, color)` pairs across all
+ * non-deleted filaments — fuel for the colorName typeahead on
+ * `FilamentForm`. Skips entries where `colorName` is empty/null so
+ * the suggestion list doesn't include un-named entries; multiple
+ * filaments sharing the same name with the same hex collapse to one
+ * row (e.g. four spools labelled "Prusa Orange" with hex `#FA6E1C`
+ * give one suggestion, not four).
+ *
+ * Different hexes under the same name are kept as separate
+ * suggestions — that's intentional. The picker shows the swatch
+ * alongside the name so the user can pick the right one even when
+ * their previously-saved "Galaxy Black" differs in shade across
+ * filaments.
+ */
+export async function GET() {
+  try {
+    await dbConnect();
+    // $group on (colorName, color) so a single named hex pair appears
+    // once regardless of how many filaments share it. The filter on
+    // `colorName` keeps non-null, non-empty names only; the same
+    // applies to color (defensive — schema default is "#808080" so
+    // it's normally non-empty, but a malformed import could land null).
+    const docs: Array<{ _id: { name: string; hex: string } }> = await Filament.aggregate([
+      {
+        $match: {
+          _deletedAt: null,
+          colorName: { $exists: true, $nin: [null, ""] },
+          color: { $exists: true, $nin: [null, ""] },
+        },
+      },
+      {
+        $group: {
+          _id: { name: "$colorName", hex: "$color" },
+        },
+      },
+    ]);
+    const pairs = docs
+      .map((d) => ({ name: d._id.name, hex: d._id.hex }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    return NextResponse.json(pairs);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: "Failed to fetch colors", detail: message }, { status: 500 });
+  }
+}

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -6,6 +6,11 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import CollapsibleSection, { expandAndScrollToSection } from "@/components/CollapsibleSection";
 import FormToc, { FormTocMobileButton, type TocEntry } from "@/components/FormToc";
 import FilamentSwatch from "@/components/FilamentSwatch";
+import {
+  filterColorSuggestions,
+  lookupCssNamedColor,
+  type ColorSuggestion,
+} from "@/lib/cssNamedColors";
 
 interface BedTypeTempEntry {
   /** Client-only stable row id for React keys. Stripped before API submission. */
@@ -328,6 +333,16 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
   const [vendorDropdownOpen, setVendorDropdownOpen] = useState(false);
   const [vendorHighlight, setVendorHighlight] = useState(-1);
   const vendorRef = useRef<HTMLDivElement>(null);
+  // colorName typeahead — suggestions come from the user's own
+  // (colorName, color) pairs first ("Prusa Orange" remembers the hex
+  // you saved last time), then the 148 CSS named colors as a fallback
+  // for generic names. Selecting a suggestion sets BOTH the colorName
+  // and the hex `color` field, so the user gets a working swatch
+  // without leaving the keyboard.
+  const [colorNameSuggestions, setColorNameSuggestions] = useState<ColorSuggestion[]>([]);
+  const [colorNameDropdownOpen, setColorNameDropdownOpen] = useState(false);
+  const [colorNameHighlight, setColorNameHighlight] = useState(-1);
+  const colorNameRef = useRef<HTMLDivElement>(null);
   const [fetchErrors, setFetchErrors] = useState<string[]>([]);
 
   const addFetchError = (label: string) =>
@@ -362,6 +377,24 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
     return () => ac.abort();
   }, []);
 
+  // Fetch the user's previously-saved (colorName, color) pairs so the
+  // colorName typeahead can suggest "Prusa Orange → #FA6E1C" etc.
+  // Falls back to CSS named colors when the DB has no match for what
+  // the user is typing.
+  useEffect(() => {
+    const ac = new AbortController();
+    fetch("/api/filaments/colors", { signal: ac.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error();
+        return r.json();
+      })
+      .then((pairs: { name: string; hex: string }[]) => {
+        setColorNameSuggestions(pairs.map((p) => ({ name: p.name, hex: p.hex, source: "db" })));
+      })
+      .catch(() => { if (!ac.signal.aborted) addFetchError("color suggestions"); });
+    return () => ac.abort();
+  }, []);
+
   // Fetch potential parent filaments
   useEffect(() => {
     const ac = new AbortController();
@@ -388,6 +421,9 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
       }
       if (parentRef.current && !parentRef.current.contains(e.target as Node)) {
         setParentDropdownOpen(false);
+      }
+      if (colorNameRef.current && !colorNameRef.current.contains(e.target as Node)) {
+        setColorNameDropdownOpen(false);
       }
     }
     document.addEventListener("mousedown", handleClick);
@@ -1207,14 +1243,136 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
             />
           </div>
         </div>
-        <div>
-          <label className={labelClass}>{t("form.colorName")}</label>
+        <div ref={colorNameRef} className="relative">
+          <label className={labelClass} id="colorName-label">{t("form.colorName")}</label>
           <input
+            id="filament-colorName"
             className={inputClass}
             value={form.colorName}
-            onChange={(e) => setForm({ ...form, colorName: e.target.value })}
+            role="combobox"
+            aria-expanded={colorNameDropdownOpen}
+            aria-controls="colorName-listbox"
+            aria-labelledby="colorName-label"
+            aria-autocomplete="list"
+            aria-activedescendant={
+              colorNameHighlight >= 0 ? `colorName-opt-${colorNameHighlight}` : undefined
+            }
             placeholder={t("form.placeholder.colorName")}
+            onChange={(e) => {
+              // Typing the colorName never overwrites `color` on its own —
+              // we wait for the user to commit (Enter, click, or exact-
+              // match-then-blur) so we don't churn the hex picker on every
+              // keystroke. The user's free-text "I'm naming this whatever
+              // I want" path stays uninterrupted.
+              setForm({ ...form, colorName: e.target.value });
+              setColorNameDropdownOpen(true);
+              setColorNameHighlight(-1);
+            }}
+            onFocus={() => {
+              setColorNameDropdownOpen(true);
+              setColorNameHighlight(-1);
+            }}
+            onBlur={() => {
+              // Exact (case- and whitespace-insensitive) match on a CSS
+              // named color — populate the hex even though the user
+              // never opened the dropdown. Mirrors how a user expects
+              // the picker to behave after typing "navy" and tabbing.
+              // DB matches are NOT auto-applied on blur because there
+              // can be multiple hexes under the same name (e.g. several
+              // brands of "Galaxy Black"); the user must explicitly
+              // pick which one they meant via the dropdown.
+              const cssHex = lookupCssNamedColor(form.colorName);
+              if (cssHex && form.color.toUpperCase() !== cssHex) {
+                setForm({ ...form, color: cssHex });
+              }
+            }}
+            onKeyDown={(e) => {
+              if (!colorNameDropdownOpen) return;
+              const filtered = filterColorSuggestions(
+                colorNameSuggestions,
+                form.colorName,
+              );
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setColorNameHighlight((h) => Math.min(h + 1, filtered.length - 1));
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setColorNameHighlight((h) => Math.max(h - 1, 0));
+              } else if (
+                e.key === "Enter" &&
+                colorNameHighlight >= 0 &&
+                filtered[colorNameHighlight]
+              ) {
+                e.preventDefault();
+                const s = filtered[colorNameHighlight];
+                setForm({ ...form, colorName: s.name, color: s.hex });
+                setColorNameDropdownOpen(false);
+                setColorNameHighlight(-1);
+              } else if (e.key === "Escape") {
+                setColorNameDropdownOpen(false);
+                setColorNameHighlight(-1);
+              }
+            }}
           />
+          {colorNameDropdownOpen && (() => {
+            const filtered = filterColorSuggestions(colorNameSuggestions, form.colorName);
+            if (filtered.length === 0) return null;
+            // Section boundaries — render a small "From your filaments"
+            // / "Standard colors" header before each source group.
+            // Pre-computing the first-of-each-source flag avoids an
+            // extra pass during render.
+            let lastSource: "db" | "css" | null = null;
+            return (
+              <ul
+                id="colorName-listbox"
+                role="listbox"
+                aria-labelledby="colorName-label"
+                className="absolute z-50 w-full mt-1 max-h-64 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg"
+              >
+                {filtered.map((s, i) => {
+                  const showHeader = s.source !== lastSource;
+                  lastSource = s.source;
+                  return (
+                    <span key={`${s.source}-${s.name}-${s.hex}`}>
+                      {showHeader && (
+                        <li
+                          aria-hidden="true"
+                          className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-400 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700"
+                        >
+                          {s.source === "db"
+                            ? t("form.colorName.section.db")
+                            : t("form.colorName.section.css")}
+                        </li>
+                      )}
+                      <li
+                        id={`colorName-opt-${i}`}
+                        role="option"
+                        aria-selected={i === colorNameHighlight}
+                        className={`px-3 py-1.5 cursor-pointer text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2 ${i === colorNameHighlight ? "bg-gray-100 dark:bg-gray-600" : ""}`}
+                        onMouseDown={(e) => {
+                          // mousedown beats blur — without preventDefault the
+                          // input's onBlur fires first and the dropdown closes
+                          // before the click registers.
+                          e.preventDefault();
+                          setForm({ ...form, colorName: s.name, color: s.hex });
+                          setColorNameDropdownOpen(false);
+                          setColorNameHighlight(-1);
+                        }}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="inline-block w-4 h-4 rounded-full border border-gray-300 dark:border-gray-500 flex-shrink-0"
+                          style={{ backgroundColor: s.hex }}
+                        />
+                        <span className="flex-1 truncate">{s.name}</span>
+                        <span className="text-xs font-mono text-gray-400">{s.hex.toUpperCase()}</span>
+                      </li>
+                    </span>
+                  );
+                })}
+              </ul>
+            );
+          })()}
         </div>
         <div>
           <label className={labelClass}>{t("form.cost", { symbol: currencySymbol })}</label>

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -239,9 +239,21 @@ function NewFilamentContent() {
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
-  // Handle NFC tag read while on this page
+  // Handle NFC tag read while on this page.
+  //
+  // NfcProvider intentionally keeps `tagReadResult` alive after the tag
+  // is lifted off the reader — the scan-match dialog's action buttons
+  // (View Filament / Create New / candidates) need to remain usable
+  // after the user dismisses the modal. That design is fine for the
+  // dialog; it's wrong for this page, which has no concept of "stale
+  // result vs. fresh scan." Without the `tagPresent` gate, clicking
+  // "+ Add Filament" any time after a scan-and-lift sequence would
+  // pre-fill the form with whatever was last scanned — even when the
+  // user has clearly moved on. Match the user's mental model: if the
+  // tag isn't on the reader RIGHT NOW, do nothing.
   useEffect(() => {
     if (!tagReadResult?.data) return;
+    if (!nfcStatus.tagPresent) return;
     const data = tagReadResult.data;
     // Syncing NFC tag payload into form initial data — same pattern as above.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -268,7 +280,7 @@ function NewFilamentContent() {
     setFormKey((k) => k + 1);
     dismissTagRead();
     toast(t("new.toast.populatedFromNfc"));
-  }, [tagReadResult, dismissTagRead, toast, t]);
+  }, [tagReadResult, nfcStatus.tagPresent, dismissTagRead, toast, t]);
 
   // Handle INI file selection
   const handleIniFile = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -249,14 +249,28 @@ function NewFilamentContent() {
   // result vs. fresh scan." Without the `tagPresent` gate, clicking
   // "+ Add Filament" any time after a scan-and-lift sequence would
   // pre-fill the form with whatever was last scanned — even when the
-  // user has clearly moved on. Match the user's mental model: if the
-  // tag isn't on the reader RIGHT NOW, do nothing.
+  // user has clearly moved on.
+  //
+  // `tagPresent` is read through a ref rather than the deps array
+  // (codex round-1 P1 on PR #354). The naive form — listing
+  // `nfcStatus.tagPresent` as a dep — re-runs this effect on every
+  // present↔absent transition with whatever `tagReadResult` is
+  // currently in scope. `electron/main.ts` emits `nfc-status-changed`
+  // immediately when a tag is detected, BEFORE the async tag read
+  // completes; during that window the effect would re-fire with
+  // `tagPresent=true` and the PREVIOUS tag's `tagReadResult`, prefilling
+  // the form from stale data. Routing the read through a ref means the
+  // prefill effect only runs when `tagReadResult` itself changes, but
+  // can still consult the latest tag-presence state at that moment.
+  const tagPresentRef = useRef(nfcStatus.tagPresent);
+  useEffect(() => {
+    tagPresentRef.current = nfcStatus.tagPresent;
+  }, [nfcStatus.tagPresent]);
   useEffect(() => {
     if (!tagReadResult?.data) return;
-    if (!nfcStatus.tagPresent) return;
+    if (!tagPresentRef.current) return;
     const data = tagReadResult.data;
     // Syncing NFC tag payload into form initial data — same pattern as above.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setInitialData({
       name: data.materialName || "",
       vendor: data.brandName || "",
@@ -280,7 +294,9 @@ function NewFilamentContent() {
     setFormKey((k) => k + 1);
     dismissTagRead();
     toast(t("new.toast.populatedFromNfc"));
-  }, [tagReadResult, nfcStatus.tagPresent, dismissTagRead, toast, t]);
+    // `nfcStatus.tagPresent` is read via `tagPresentRef` (see the block
+    // above) and intentionally omitted from this dep array.
+  }, [tagReadResult, dismissTagRead, toast, t]);
 
   // Handle INI file selection
   const handleIniFile = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -901,6 +901,8 @@
   "form.type": "Typ",
   "form.color": "Farbe",
   "form.colorName": "Farbname",
+  "form.colorName.section.db": "Aus deinen Filamenten",
+  "form.colorName.section.css": "Standardfarben",
   "form.cost": "Preis ({symbol}/kg)",
   "form.density": "Dichte (g/cm³)",
   "form.diameter": "Durchmesser (mm)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -901,6 +901,8 @@
   "form.type": "Type",
   "form.color": "Color",
   "form.colorName": "Color Name",
+  "form.colorName.section.db": "From your filaments",
+  "form.colorName.section.css": "Standard colors",
   "form.cost": "Cost ({symbol}/kg)",
   "form.density": "Density (g/cm³)",
   "form.diameter": "Diameter (mm)",

--- a/src/lib/cssNamedColors.ts
+++ b/src/lib/cssNamedColors.ts
@@ -1,0 +1,247 @@
+/**
+ * CSS Color Module Level 4 named colors → 6-digit hex.
+ *
+ * Used by `FilamentForm`'s colorName typeahead so typing a recognised
+ * color name auto-populates the hex picker. Stored as a flat literal
+ * rather than a Map so it's static (no init cost, tree-shakes cleanly,
+ * trivially type-checked).
+ *
+ * All names are lowercase here; lookups are case-insensitive via
+ * `lookupCssNamedColor`. The list is the 148 named colors from
+ * https://www.w3.org/TR/css-color-4/#named-colors plus the 9 system
+ * shorthand synonyms (cyan/aqua, magenta/fuchsia, etc.) that the spec
+ * lists as aliases.
+ */
+
+const CSS_NAMED_COLORS: Record<string, string> = {
+  aliceblue: "#F0F8FF",
+  antiquewhite: "#FAEBD7",
+  aqua: "#00FFFF",
+  aquamarine: "#7FFFD4",
+  azure: "#F0FFFF",
+  beige: "#F5F5DC",
+  bisque: "#FFE4C4",
+  black: "#000000",
+  blanchedalmond: "#FFEBCD",
+  blue: "#0000FF",
+  blueviolet: "#8A2BE2",
+  brown: "#A52A2A",
+  burlywood: "#DEB887",
+  cadetblue: "#5F9EA0",
+  chartreuse: "#7FFF00",
+  chocolate: "#D2691E",
+  coral: "#FF7F50",
+  cornflowerblue: "#6495ED",
+  cornsilk: "#FFF8DC",
+  crimson: "#DC143C",
+  cyan: "#00FFFF",
+  darkblue: "#00008B",
+  darkcyan: "#008B8B",
+  darkgoldenrod: "#B8860B",
+  darkgray: "#A9A9A9",
+  darkgreen: "#006400",
+  darkgrey: "#A9A9A9",
+  darkkhaki: "#BDB76B",
+  darkmagenta: "#8B008B",
+  darkolivegreen: "#556B2F",
+  darkorange: "#FF8C00",
+  darkorchid: "#9932CC",
+  darkred: "#8B0000",
+  darksalmon: "#E9967A",
+  darkseagreen: "#8FBC8F",
+  darkslateblue: "#483D8B",
+  darkslategray: "#2F4F4F",
+  darkslategrey: "#2F4F4F",
+  darkturquoise: "#00CED1",
+  darkviolet: "#9400D3",
+  deeppink: "#FF1493",
+  deepskyblue: "#00BFFF",
+  dimgray: "#696969",
+  dimgrey: "#696969",
+  dodgerblue: "#1E90FF",
+  firebrick: "#B22222",
+  floralwhite: "#FFFAF0",
+  forestgreen: "#228B22",
+  fuchsia: "#FF00FF",
+  gainsboro: "#DCDCDC",
+  ghostwhite: "#F8F8FF",
+  gold: "#FFD700",
+  goldenrod: "#DAA520",
+  gray: "#808080",
+  green: "#008000",
+  greenyellow: "#ADFF2F",
+  grey: "#808080",
+  honeydew: "#F0FFF0",
+  hotpink: "#FF69B4",
+  indianred: "#CD5C5C",
+  indigo: "#4B0082",
+  ivory: "#FFFFF0",
+  khaki: "#F0E68C",
+  lavender: "#E6E6FA",
+  lavenderblush: "#FFF0F5",
+  lawngreen: "#7CFC00",
+  lemonchiffon: "#FFFACD",
+  lightblue: "#ADD8E6",
+  lightcoral: "#F08080",
+  lightcyan: "#E0FFFF",
+  lightgoldenrodyellow: "#FAFAD2",
+  lightgray: "#D3D3D3",
+  lightgreen: "#90EE90",
+  lightgrey: "#D3D3D3",
+  lightpink: "#FFB6C1",
+  lightsalmon: "#FFA07A",
+  lightseagreen: "#20B2AA",
+  lightskyblue: "#87CEFA",
+  lightslategray: "#778899",
+  lightslategrey: "#778899",
+  lightsteelblue: "#B0C4DE",
+  lightyellow: "#FFFFE0",
+  lime: "#00FF00",
+  limegreen: "#32CD32",
+  linen: "#FAF0E6",
+  magenta: "#FF00FF",
+  maroon: "#800000",
+  mediumaquamarine: "#66CDAA",
+  mediumblue: "#0000CD",
+  mediumorchid: "#BA55D3",
+  mediumpurple: "#9370DB",
+  mediumseagreen: "#3CB371",
+  mediumslateblue: "#7B68EE",
+  mediumspringgreen: "#00FA9A",
+  mediumturquoise: "#48D1CC",
+  mediumvioletred: "#C71585",
+  midnightblue: "#191970",
+  mintcream: "#F5FFFA",
+  mistyrose: "#FFE4E1",
+  moccasin: "#FFE4B5",
+  navajowhite: "#FFDEAD",
+  navy: "#000080",
+  oldlace: "#FDF5E6",
+  olive: "#808000",
+  olivedrab: "#6B8E23",
+  orange: "#FFA500",
+  orangered: "#FF4500",
+  orchid: "#DA70D6",
+  palegoldenrod: "#EEE8AA",
+  palegreen: "#98FB98",
+  paleturquoise: "#AFEEEE",
+  palevioletred: "#DB7093",
+  papayawhip: "#FFEFD5",
+  peachpuff: "#FFDAB9",
+  peru: "#CD853F",
+  pink: "#FFC0CB",
+  plum: "#DDA0DD",
+  powderblue: "#B0E0E6",
+  purple: "#800080",
+  rebeccapurple: "#663399",
+  red: "#FF0000",
+  rosybrown: "#BC8F8F",
+  royalblue: "#4169E1",
+  saddlebrown: "#8B4513",
+  salmon: "#FA8072",
+  sandybrown: "#F4A460",
+  seagreen: "#2E8B57",
+  seashell: "#FFF5EE",
+  sienna: "#A0522D",
+  silver: "#C0C0C0",
+  skyblue: "#87CEEB",
+  slateblue: "#6A5ACD",
+  slategray: "#708090",
+  slategrey: "#708090",
+  snow: "#FFFAFA",
+  springgreen: "#00FF7F",
+  steelblue: "#4682B4",
+  tan: "#D2B48C",
+  teal: "#008080",
+  thistle: "#D8BFD8",
+  tomato: "#FF6347",
+  turquoise: "#40E0D0",
+  violet: "#EE82EE",
+  wheat: "#F5DEB3",
+  white: "#FFFFFF",
+  whitesmoke: "#F5F5F5",
+  yellow: "#FFFF00",
+  yellowgreen: "#9ACD32",
+};
+
+/**
+ * Look up a CSS named color by name. Case- and whitespace-insensitive
+ * (callers can pass "Dark Slate Gray", " navy ", or "NAVY" — all
+ * resolve). Returns the uppercase 6-digit hex, or `null` for unknown
+ * names. Callers that need to differentiate "no match" from "fall back
+ * to another source" should check for null explicitly.
+ */
+export function lookupCssNamedColor(name: string): string | null {
+  const key = name.replace(/\s+/g, "").toLowerCase();
+  return CSS_NAMED_COLORS[key] ?? null;
+}
+
+/**
+ * All CSS named colors as `{ name, hex }` pairs, sorted alphabetically.
+ * Used by the colorName typeahead to render the "Standard colors"
+ * suggestion section. The display name preserves the canonical CSS
+ * spelling (lowercase, no spaces) so the suggestion text matches what
+ * the user can type to get back to the same entry.
+ */
+export const CSS_NAMED_COLOR_LIST: ReadonlyArray<{ name: string; hex: string }> = Object.entries(
+  CSS_NAMED_COLORS,
+)
+  .map(([name, hex]) => ({ name, hex }))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+/**
+ * Single entry in the colorName typeahead dropdown. `source` drives the
+ * section header — DB suggestions ("From your filaments") render above
+ * the CSS named-color group ("Standard colors").
+ */
+export interface ColorSuggestion {
+  name: string;
+  hex: string;
+  source: "db" | "css";
+}
+
+/**
+ * Merge the user's previously-saved (colorName, color) pairs with the
+ * CSS named-color list and substring-filter by a query string. Returns
+ * a deduped, ordered list ready to render in the dropdown.
+ *
+ * Ordering:
+ *   1. DB matches first (the user's own naming wins — same hex they
+ *      reached for last time is the most relevant suggestion).
+ *   2. CSS named colors second.
+ * Within each source, entries preserve the order they came in
+ * (suggestions arrive sorted alphabetically from the API; the CSS
+ * list is sorted alphabetically at module load).
+ *
+ * Dedup key is `(lowercase name, uppercase hex)` — a DB row with the
+ * exact same name+hex as a CSS entry is rendered once, with DB
+ * winning. Different hexes under the same name are kept as separate
+ * suggestions (intentional — different brands of "Galaxy Black"
+ * legitimately have different shades).
+ */
+export function filterColorSuggestions(
+  dbSuggestions: readonly ColorSuggestion[],
+  query: string,
+  maxResults = 30,
+): ColorSuggestion[] {
+  const q = query.replace(/\s+/g, "").toLowerCase();
+  const matchesQuery = (s: ColorSuggestion) =>
+    !q || s.name.replace(/\s+/g, "").toLowerCase().includes(q);
+  const cssMatches: ColorSuggestion[] = CSS_NAMED_COLOR_LIST.filter((c) =>
+    !q || c.name.toLowerCase().includes(q),
+  ).map((c) => ({ name: c.name, hex: c.hex, source: "css" }));
+  const dbMatches = dbSuggestions.filter(matchesQuery);
+
+  const seen = new Set<string>();
+  const key = (s: ColorSuggestion) =>
+    `${s.name.replace(/\s+/g, "").toLowerCase()}::${s.hex.toUpperCase()}`;
+  const merged: ColorSuggestion[] = [];
+  for (const s of [...dbMatches, ...cssMatches]) {
+    const k = key(s);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    merged.push(s);
+    if (merged.length >= maxResults) break;
+  }
+  return merged;
+}

--- a/tests/cssNamedColors.test.ts
+++ b/tests/cssNamedColors.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  CSS_NAMED_COLOR_LIST,
+  filterColorSuggestions,
+  lookupCssNamedColor,
+  type ColorSuggestion,
+} from "@/lib/cssNamedColors";
+
+/**
+ * The CSS named-color module powers `FilamentForm`'s colorName
+ * typeahead. Two invariants:
+ *   1. `lookupCssNamedColor` is case- and whitespace-insensitive so the
+ *      input's onBlur "exact match → hex" path doesn't fail on "NAVY",
+ *      "Dark Slate Gray", or padded strings.
+ *   2. `filterColorSuggestions` merges the user's DB suggestions with
+ *      the CSS named-color list, dedupes by (name, hex), and keeps DB
+ *      entries ahead of CSS ones when both qualify.
+ */
+describe("lookupCssNamedColor", () => {
+  it("returns the canonical hex for a known lowercase name", () => {
+    expect(lookupCssNamedColor("red")).toBe("#FF0000");
+    expect(lookupCssNamedColor("navy")).toBe("#000080");
+    expect(lookupCssNamedColor("rebeccapurple")).toBe("#663399");
+  });
+
+  it("is case-insensitive", () => {
+    expect(lookupCssNamedColor("NAVY")).toBe("#000080");
+    expect(lookupCssNamedColor("Navy")).toBe("#000080");
+  });
+
+  it("ignores whitespace within the name", () => {
+    expect(lookupCssNamedColor("Dark Slate Gray")).toBe("#2F4F4F");
+    expect(lookupCssNamedColor("  navy  ")).toBe("#000080");
+    expect(lookupCssNamedColor("light Sea green")).toBe("#20B2AA");
+  });
+
+  it("returns null for unknown names", () => {
+    expect(lookupCssNamedColor("galaxy black")).toBeNull();
+    expect(lookupCssNamedColor("prusa orange")).toBeNull();
+    expect(lookupCssNamedColor("")).toBeNull();
+  });
+
+  it("handles the gray/grey synonyms", () => {
+    expect(lookupCssNamedColor("gray")).toBe("#808080");
+    expect(lookupCssNamedColor("grey")).toBe("#808080");
+    expect(lookupCssNamedColor("darkgray")).toBe("#A9A9A9");
+    expect(lookupCssNamedColor("darkgrey")).toBe("#A9A9A9");
+  });
+});
+
+describe("CSS_NAMED_COLOR_LIST", () => {
+  it("is sorted alphabetically by name", () => {
+    for (let i = 1; i < CSS_NAMED_COLOR_LIST.length; i++) {
+      expect(
+        CSS_NAMED_COLOR_LIST[i - 1].name.localeCompare(CSS_NAMED_COLOR_LIST[i].name),
+      ).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it("includes the full CSS Color Module Level 4 set", () => {
+    // Spot-check a handful of distinctive entries to catch accidental
+    // truncation of the static map.
+    const names = new Set(CSS_NAMED_COLOR_LIST.map((c) => c.name));
+    for (const expected of [
+      "aliceblue",
+      "blueviolet",
+      "cornflowerblue",
+      "darkslategrey",
+      "rebeccapurple",
+      "yellowgreen",
+    ]) {
+      expect(names.has(expected)).toBe(true);
+    }
+    // 148 named + 9 synonyms (the spec lists aqua/cyan, fuchsia/magenta,
+    // dark/lightgray-grey, dim/slategray-grey as aliases). Don't pin the
+    // exact count — bump-resistant.
+    expect(CSS_NAMED_COLOR_LIST.length).toBeGreaterThanOrEqual(140);
+  });
+});
+
+describe("filterColorSuggestions", () => {
+  const dbPrusaOrange: ColorSuggestion = { name: "Prusa Orange", hex: "#FA6E1C", source: "db" };
+  const dbGalaxyBlack: ColorSuggestion = { name: "Galaxy Black", hex: "#0D0D14", source: "db" };
+
+  it("returns CSS-only suggestions when DB is empty and query is empty", () => {
+    const result = filterColorSuggestions([], "", 5);
+    expect(result.length).toBe(5);
+    for (const r of result) {
+      expect(r.source).toBe("css");
+    }
+  });
+
+  it("places DB matches before CSS matches", () => {
+    const result = filterColorSuggestions([dbPrusaOrange, dbGalaxyBlack], "", 30);
+    // First two should be DB; rest should be CSS
+    expect(result[0].source).toBe("db");
+    expect(result[1].source).toBe("db");
+    expect(result[2].source).toBe("css");
+  });
+
+  it("substring-matches case- and whitespace-insensitively", () => {
+    const result = filterColorSuggestions([dbPrusaOrange], "ORANGE");
+    const names = result.map((r) => r.name.toLowerCase());
+    expect(names).toContain("prusa orange");
+    expect(names).toContain("orange"); // CSS
+    expect(names).toContain("darkorange"); // CSS
+  });
+
+  it("dedupes a DB row with the same (name, hex) as a CSS entry — DB wins", () => {
+    // Pretend the user once named a filament "navy" with the canonical CSS hex.
+    const dup: ColorSuggestion = { name: "navy", hex: "#000080", source: "db" };
+    const result = filterColorSuggestions([dup], "navy", 30);
+    const navyEntries = result.filter((r) => r.name.toLowerCase() === "navy");
+    expect(navyEntries.length).toBe(1);
+    expect(navyEntries[0].source).toBe("db");
+  });
+
+  it("keeps different hexes under the same name as separate suggestions", () => {
+    const a: ColorSuggestion = { name: "Galaxy Black", hex: "#0D0D14", source: "db" };
+    const b: ColorSuggestion = { name: "Galaxy Black", hex: "#1A1A2E", source: "db" };
+    const result = filterColorSuggestions([a, b], "galaxy");
+    const galaxy = result.filter((r) => r.name === "Galaxy Black");
+    expect(galaxy.length).toBe(2);
+    expect(galaxy.map((g) => g.hex.toUpperCase()).sort()).toEqual(["#0D0D14", "#1A1A2E"]);
+  });
+
+  it("respects the maxResults cap", () => {
+    const result = filterColorSuggestions([], "", 3);
+    expect(result.length).toBe(3);
+  });
+
+  it("returns an empty list when nothing matches a non-empty query", () => {
+    const result = filterColorSuggestions([], "thiscolordoesnotexistanywhere");
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/filaments-colors-route.test.ts
+++ b/tests/filaments-colors-route.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { GET as listColors } from "@/app/api/filaments/colors/route";
+
+/**
+ * `/api/filaments/colors` feeds the colorName typeahead in
+ * FilamentForm. The contract: distinct (colorName, color) pairs from
+ * non-deleted filaments, sorted alphabetically, with empty/null
+ * names filtered out. Multiple filaments sharing one name+hex collapse
+ * to one entry; different hexes under the same name stay separate.
+ */
+describe("GET /api/filaments/colors", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const mod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) {
+      mongoose.model("Filament", mod.default.schema);
+    }
+    Filament = mongoose.models.Filament;
+  });
+
+  it("returns distinct (colorName, color) pairs, alphabetically sorted", async () => {
+    await Filament.create({
+      name: "A",
+      vendor: "v",
+      type: "PLA",
+      color: "#FA6E1C",
+      colorName: "Prusa Orange",
+    });
+    await Filament.create({
+      name: "B",
+      vendor: "v",
+      type: "PLA",
+      color: "#0D0D14",
+      colorName: "Galaxy Black",
+    });
+    await Filament.create({
+      name: "C",
+      vendor: "v",
+      type: "PLA",
+      color: "#FA6E1C",
+      colorName: "Prusa Orange", // duplicate of A — should collapse
+    });
+
+    const res = await listColors();
+    const body = (await res.json()) as Array<{ name: string; hex: string }>;
+    expect(body).toHaveLength(2);
+    expect(body[0]).toEqual({ name: "Galaxy Black", hex: "#0D0D14" });
+    expect(body[1]).toEqual({ name: "Prusa Orange", hex: "#FA6E1C" });
+  });
+
+  it("keeps different hexes under the same name as separate rows", async () => {
+    await Filament.create({
+      name: "A",
+      vendor: "v",
+      type: "PLA",
+      color: "#0D0D14",
+      colorName: "Galaxy Black",
+    });
+    await Filament.create({
+      name: "B",
+      vendor: "v",
+      type: "PLA",
+      color: "#1A1A2E",
+      colorName: "Galaxy Black",
+    });
+
+    const res = await listColors();
+    const body = (await res.json()) as Array<{ name: string; hex: string }>;
+    const galaxy = body.filter((r) => r.name === "Galaxy Black");
+    expect(galaxy.length).toBe(2);
+    expect(galaxy.map((g) => g.hex).sort()).toEqual(["#0D0D14", "#1A1A2E"]);
+  });
+
+  it("filters out rows with null/empty colorName", async () => {
+    await Filament.create({
+      name: "Named",
+      vendor: "v",
+      type: "PLA",
+      color: "#FFFFFF",
+      colorName: "Pearl",
+    });
+    await Filament.create({
+      name: "Unnamed",
+      vendor: "v",
+      type: "PLA",
+      color: "#000000",
+      // colorName intentionally omitted — defaults to null per the schema
+    });
+    await Filament.create({
+      name: "Blank-Named",
+      vendor: "v",
+      type: "PLA",
+      color: "#888888",
+      colorName: "",
+    });
+
+    const res = await listColors();
+    const body = (await res.json()) as Array<{ name: string; hex: string }>;
+    expect(body).toEqual([{ name: "Pearl", hex: "#FFFFFF" }]);
+  });
+
+  it("ignores soft-deleted filaments", async () => {
+    await Filament.create({
+      name: "Live",
+      vendor: "v",
+      type: "PLA",
+      color: "#FFFFFF",
+      colorName: "Snow",
+    });
+    await Filament.create({
+      name: "Trashed",
+      vendor: "v",
+      type: "PLA",
+      color: "#000000",
+      colorName: "Coal",
+      _deletedAt: new Date(),
+    });
+
+    const res = await listColors();
+    const body = (await res.json()) as Array<{ name: string; hex: string }>;
+    expect(body).toEqual([{ name: "Snow", hex: "#FFFFFF" }]);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,10 +8,26 @@ import { beforeAll, afterAll, afterEach } from "vitest";
 // whole suite collapsing on a cold cache.
 const MONGO_START_TIMEOUT_MS = 120_000;
 
+// Per-instance launch timeout for `MongoMemoryServer.create()` — the
+// mongodb-memory-server-core internal default is 10 seconds and that's
+// not enough on the Windows-arm64 release runner, which executes the
+// suite under x64 emulation. v1.27.0 shipped without Windows-arm64
+// assets because both the initial build and the re-run hit
+// `GenericMMSError: Instance failed to start within 10000ms` on the
+// first `MongoMemoryServer.create()`. Two consecutive failures is the
+// "becoming a pattern" trigger CLAUDE.md's release-process gotcha
+// section already calls out — bumping the start timeout is the
+// recommended durable fix. 60s gives the emulated runner ~6× the
+// headroom of the default; faster runners (mac/linux native) only
+// spend their typical ~1–2s and remain unaffected.
+const MONGO_INSTANCE_LAUNCH_TIMEOUT_MS = 60_000;
+
 let mongoServer: MongoMemoryServer | null = null;
 
 beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create();
+  mongoServer = await MongoMemoryServer.create({
+    instance: { launchTimeout: MONGO_INSTANCE_LAUNCH_TIMEOUT_MS },
+  });
   const uri = mongoServer.getUri();
   process.env.MONGODB_URI = uri;
   await mongoose.connect(uri);


### PR DESCRIPTION
Bundles the v1.28 colorName→hex typeahead with the two v1.27.1 bug fixes that were originally on PR #354 (closed and folded into this branch). All three landings are independent and ship together.

---

### 1. colorName → hex typeahead

Typing in the **Color Name** input now suggests matching colors with their hex code and populates the picker when you commit. Two suggestion sources, in priority order:

1. **From your filaments** — distinct `(colorName, color)` pairs from your own previously-saved filaments. "Prusa Orange" remembers the hex you reached for last time. Different hexes under the same name (e.g. three brands of "Galaxy Black" with slightly different shades) stay as separate rows.
2. **Standard colors** — the 148 CSS Color Module Level 4 named colors plus the gray/grey, cyan/aqua, fuchsia/magenta, slategray/slategrey synonyms.

**How it commits**:
- **Click or Enter on a dropdown row** → sets BOTH `colorName` and the hex `color` field.
- **Tab out with an exact CSS named-color match** (case- and whitespace-insensitive — "Dark Slate Gray", " navy ", "NAVY" all work) → updates the hex even if you never opened the dropdown.
- **DB-side blur lookup is intentionally NOT auto-applied** — same name can have multiple hexes in the DB; you pick which one you meant via the dropdown.
- **Plain typing never overwrites the hex** — free-text "I'm naming this whatever I want" stays uninterrupted.

**Files**: `src/lib/cssNamedColors.ts` (static map + `lookupCssNamedColor` + `filterColorSuggestions`); `src/app/api/filaments/colors/route.ts` (distinct pair endpoint); `src/app/filaments/FilamentForm.tsx` (combobox); en + de i18n keys.

---

### 2. Bump `mongodb-memory-server` launchTimeout to 60s

v1.27.0 shipped without Windows-arm64 desktop assets. Both the initial build and the re-run hit `GenericMMSError: Instance failed to start within 10000ms`. The mongodb-memory-server-core default of 10s isn't enough on the Windows-arm64 release runner (which executes the vitest suite under x64 emulation). 60s gives ~6× the headroom; native runners stay unaffected. Documented gotcha in `CLAUDE.md` § Release-process gotchas, with this exact remediation.

**Files**: `tests/setup.ts` — pass `instance: { launchTimeout: 60_000 }` to `MongoMemoryServer.create()`.

---

### 3. Clear NFC prefill on `/filaments/new` when no tag is on the reader

**Repro** (user-reported): scan a tag that matches an existing filament, dismiss the scan-match dialog, lift the tag off the reader, navigate to inventory, click **+ Add Filament**. The new-filament form opens titled "New Filament from NFC Tag" with every field pre-filled from the tag that's no longer on the reader.

**Cause**: `NfcProvider` intentionally keeps `tagReadResult` alive after the tag is lifted so the scan-match dialog's action buttons stay usable post-dismiss. That's fine for the dialog — but the new-filament page was reading `tagReadResult` unconditionally and treating any non-null value as "user just scanned this."

**Fix**: gate the prefill `useEffect` on `tagPresent`, BUT route the gate through a `tagPresentRef` rather than the dep array. The naive form (listing `nfcStatus.tagPresent` in deps — what the first commit did) re-runs the effect on every present↔absent transition, which can fire with the previous tag's still-cached `tagReadResult` during the window between `nfc-status-changed` (instant) and the async `nfc-tag-detected` read completion. Route through a ref → the prefill effect only re-runs when `tagReadResult` itself changes, but still consults the latest tag-presence state at that moment. Both stale-mount AND tag-swap races are closed.

**Files**: `src/app/filaments/new/page.tsx`.

---

## Tests + lint

- `npm test` — **1363 passed (1363)**.
- `npm run lint` — clean.

## Verified in dev preview

- Typeahead: typed "bl" → "FROM YOUR FILAMENTS" header with 7 black-related DB entries with distinct hex codes; typed "navy" → "STANDARD COLORS" header with the single CSS entry; click + ArrowDown+Enter both commit a row.
- The mongodb-memory-server change is a CI-only knob — verified by the local test suite still passing.
- The NFC fix requires Electron + PC/SC reader to reproduce end-to-end; verified locally that `/filaments/new` still loads cleanly with the default title.

## Test plan (post-merge)

- [ ] Windows-arm64 CI succeeds on the next tagged release (the whole point of fix #2).
- [ ] In the packaged desktop app: scan a tag → match dialog shows → dismiss → lift tag → navigate to inventory → click "+ Add Filament" → form opens blank with "Add New Filament" title (no NFC prefill).
- [ ] Tag swap A→B while on `/filaments/new` doesn't briefly flash the previous tag's data.
- [ ] Typeahead: typing a CSS name and tabbing out populates the hex; typing a DB-only name doesn't auto-populate (must pick from dropdown).

## Backports the Windows-arm64 desktop assets

Cutting the next minor (v1.28.0) after merge will rebuild the full desktop matrix with the bumped timeout. v1.27.0 stays as-is; v1.28.0 supersedes it as the recommended download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)