### PR TITLE
feat: surface parent/variant relationship in CSV + XLSX exports

### DIFF
--- a/src/lib/exportFilaments.ts
+++ b/src/lib/exportFilaments.ts
@@ -34,6 +34,21 @@ export interface ExportRow {
   standbyTemp: number | null;
   tdsUrl: string | null;
   instanceId: string;
+  /**
+   * Parent/variant relationship surfaced for round-trip clarity (Codex /
+   * user feedback on the v1.30 export): `parentName` is the name of the
+   * parent filament when this row is a variant (empty for roots/parents),
+   * and `variantCount` is how many variants this row has (>0 only for
+   * parents). The export already inherits-flattens variant values via
+   * resolveFilament, so without these two columns the relationship is
+   * invisible in CSV/XLSX even though the app uses it heavily.
+   *
+   * Slicer-bound exports (PrusaSlicer / OrcaSlicer / Bambu) intentionally
+   * don't include these — slicers have no concept of variants and need
+   * every row to stand alone.
+   */
+  parentName: string | null;
+  variantCount: number;
 }
 
 export const EXPORT_COLUMNS: { key: keyof ExportRow; header: string }[] = [
@@ -68,6 +83,11 @@ export const EXPORT_COLUMNS: { key: keyof ExportRow; header: string }[] = [
   { key: "standbyTemp", header: "Standby Temp (°C)" },
   { key: "tdsUrl", header: "TDS URL" },
   { key: "instanceId", header: "Instance ID" },
+  // Parent/variant relationship — empty for roots, populated for variants
+  // (Parent) and parents (Variant Count). Placed at the end so existing
+  // consumers that read columns by header index keep working.
+  { key: "parentName", header: "Parent" },
+  { key: "variantCount", header: "Variant Count" },
 ];
 
 export async function getExportRows(): Promise<ExportRow[]> {
@@ -85,9 +105,23 @@ export async function getExportRows(): Promise<ExportRow[]> {
     }
   }
 
+  // Count variants per parent for the Variant Count column. A separate map
+  // because parentMap above only indexes roots/parents; we need to count
+  // how many filaments reference each id as their parentId.
+  const variantCountByParent = new Map<string, number>();
+  for (const f of filaments) {
+    if (f.parentId) {
+      const key = f.parentId.toString();
+      variantCountByParent.set(key, (variantCountByParent.get(key) ?? 0) + 1);
+    }
+  }
+
   return filaments.map((filament) => {
+    const parentDoc = filament.parentId
+      ? parentMap.get(filament.parentId.toString())
+      : undefined;
     const resolved = filament.parentId
-      ? resolveFilament(filament, parentMap.get(filament.parentId.toString()))
+      ? resolveFilament(filament, parentDoc)
       : filament;
 
     return {
@@ -122,6 +156,12 @@ export async function getExportRows(): Promise<ExportRow[]> {
       standbyTemp: resolved.temperatures?.standby ?? null,
       tdsUrl: resolved.tdsUrl ?? null,
       instanceId: filament.instanceId ?? "",
+      // Read parentName from the source `filament` (not `resolved`) because
+      // resolveFilament doesn't mutate name fields. The variant count
+      // applies to whatever this row's _id is — variants always 0, roots
+      // are 0 unless they have variants pointing at them.
+      parentName: parentDoc?.name ?? null,
+      variantCount: variantCountByParent.get(filament._id.toString()) ?? 0,
     };
   });
 }

--- a/src/lib/exportSpools.ts
+++ b/src/lib/exportSpools.ts
@@ -45,6 +45,16 @@ export interface SpoolExportRow {
   instanceId: string;
   filamentId: string;
   spoolId: string;
+  /**
+   * Parent/variant relationship surfaced for export clarity — matches the
+   * filament-level export columns (see exportFilaments.ts). `parentName`
+   * is the parent filament's name when the spool belongs to a variant
+   * (empty for roots/standalones); `variantCount` is how many variants
+   * the spool's filament has (>0 only when the spool belongs to a parent
+   * with variants).
+   */
+  parentName: string | null;
+  variantCount: number;
 }
 
 export const SPOOL_EXPORT_COLUMNS: { key: keyof SpoolExportRow; header: string }[] = [
@@ -70,6 +80,9 @@ export const SPOOL_EXPORT_COLUMNS: { key: keyof SpoolExportRow; header: string }
   { key: "instanceId", header: "instanceId" },
   { key: "filamentId", header: "filamentId" },
   { key: "spoolId", header: "spoolId" },
+  // Parent/variant context — matches the filament-level export columns.
+  { key: "parentName", header: "parentName" },
+  { key: "variantCount", header: "variantCount" },
 ];
 
 function isoDateOnly(d: Date | string | null | undefined): string | null {
@@ -104,6 +117,17 @@ export async function getSpoolExportRows(): Promise<SpoolExportRow[]> {
     }
   }
 
+  // Count variants per parent for the variantCount column. A spool belonging
+  // to a parent that has variants gets the count; variants and standalones
+  // get 0. Built once and looked up by filament id below.
+  const variantCountByParent = new Map<string, number>();
+  for (const f of filaments) {
+    if (f.parentId) {
+      const key = f.parentId.toString();
+      variantCountByParent.set(key, (variantCountByParent.get(key) ?? 0) + 1);
+    }
+  }
+
   const locationNameById = new Map<string, string>();
   for (const l of locations) {
     locationNameById.set(l._id.toString(), l.name as string);
@@ -111,8 +135,11 @@ export async function getSpoolExportRows(): Promise<SpoolExportRow[]> {
 
   const rows: SpoolExportRow[] = [];
   for (const filament of filaments) {
+    const parentDoc = filament.parentId
+      ? parentMap.get(filament.parentId.toString())
+      : undefined;
     const resolved = filament.parentId
-      ? resolveFilament(filament, parentMap.get(filament.parentId.toString()))
+      ? resolveFilament(filament, parentDoc)
       : filament;
 
     for (const spool of filament.spools || []) {
@@ -160,6 +187,9 @@ export async function getSpoolExportRows(): Promise<SpoolExportRow[]> {
         instanceId: filament.instanceId ?? "",
         filamentId: filament._id.toString(),
         spoolId: spool._id ? spool._id.toString() : "",
+        parentName: parentDoc?.name ?? null,
+        variantCount:
+          variantCountByParent.get(filament._id.toString()) ?? 0,
       });
     }
   }

--- a/tests/exportFilaments.test.ts
+++ b/tests/exportFilaments.test.ts
@@ -215,4 +215,67 @@ describe("getExportRows", () => {
     expect(legacy!.spoolCount).toBe(1);
     expect(none!.spoolCount).toBe(0);
   });
+
+  // User feedback on v1.30.x: the CSV/XLSX exports flattened variant
+  // values via resolveFilament but dropped the relationship itself —
+  // a "Overture PETG Red" row showed inherited print temps but no hint
+  // that it was a variant of "Overture PETG". Surface parent name +
+  // variant count so the export round-trips relationship info too.
+  describe("parent/variant columns", () => {
+    it("declares the new columns in EXPORT_COLUMNS", () => {
+      const keys = EXPORT_COLUMNS.map((c) => c.key);
+      expect(keys).toContain("parentName");
+      expect(keys).toContain("variantCount");
+    });
+
+    it("emits parent name on variants, variant count on parents, both empty on standalones", async () => {
+      const parent = await Filament.create({
+        name: "Overture PETG",
+        vendor: "Overture",
+        type: "PETG",
+        temperatures: { nozzle: 240, bed: 80 },
+        density: 1.27,
+      });
+      await Filament.create({
+        name: "Overture PETG Red",
+        vendor: "Overture",
+        type: "PETG",
+        color: "#ff0000",
+        parentId: parent._id,
+      });
+      await Filament.create({
+        name: "Overture PETG Black",
+        vendor: "Overture",
+        type: "PETG",
+        color: "#000000",
+        parentId: parent._id,
+      });
+      await Filament.create({
+        name: "Standalone TPU",
+        vendor: "X",
+        type: "TPU",
+      });
+
+      const rows = await getExportRows();
+      const byName = new Map(rows.map((r) => [r.name, r]));
+
+      // Parent: empty parentName, variant count = 2.
+      expect(byName.get("Overture PETG")!.parentName).toBeNull();
+      expect(byName.get("Overture PETG")!.variantCount).toBe(2);
+
+      // Variant: parentName is the parent's name; variant count = 0 (a
+      // variant is never a parent — variants-of-variants aren't supported).
+      expect(byName.get("Overture PETG Red")!.parentName).toBe("Overture PETG");
+      expect(byName.get("Overture PETG Red")!.variantCount).toBe(0);
+      expect(byName.get("Overture PETG Black")!.parentName).toBe("Overture PETG");
+
+      // Variants still inherit print values (sanity check this didn't regress).
+      expect(byName.get("Overture PETG Red")!.nozzleTemp).toBe(240);
+      expect(byName.get("Overture PETG Red")!.density).toBe(1.27);
+
+      // Standalone: both empty / zero.
+      expect(byName.get("Standalone TPU")!.parentName).toBeNull();
+      expect(byName.get("Standalone TPU")!.variantCount).toBe(0);
+    });
+  });
 });

--- a/tests/exportSpools.test.ts
+++ b/tests/exportSpools.test.ts
@@ -209,4 +209,55 @@ describe("getSpoolExportRows", () => {
     expect(row.instanceId).toBe(filament.instanceId);
     expect(row.instanceId.length).toBeGreaterThan(0);
   });
+
+  // Matches the parent/variant exposure added to exportFilaments — the spool
+  // export now also surfaces the relationship so a spool's row tells you
+  // whether its filament is a variant (and of what).
+  describe("parent/variant columns", () => {
+    it("declares the new columns in SPOOL_EXPORT_COLUMNS", () => {
+      const keys = SPOOL_EXPORT_COLUMNS.map((c) => c.key);
+      expect(keys).toContain("parentName");
+      expect(keys).toContain("variantCount");
+    });
+
+    it("populates parentName for spools on variants and variantCount for spools on parents", async () => {
+      const parent = await Filament.create({
+        name: "Overture PETG",
+        vendor: "Overture",
+        type: "PETG",
+        spoolWeight: 230,
+        netFilamentWeight: 1000,
+        spools: [{ label: "Parent's own spool", totalWeight: 980 }],
+      });
+      await Filament.create({
+        name: "Overture PETG Red",
+        vendor: "Overture",
+        type: "PETG",
+        color: "#ff0000",
+        parentId: parent._id,
+        spools: [{ label: "Variant spool", totalWeight: 850 }],
+      });
+      await Filament.create({
+        name: "Standalone TPU",
+        vendor: "X",
+        type: "TPU",
+        spools: [{ label: "Standalone spool", totalWeight: 500 }],
+      });
+
+      const rows = await getSpoolExportRows();
+      const byLabel = new Map(rows.map((r) => [r.label, r]));
+
+      // Parent's own spool: variant count 1 (has the variant below), no parent.
+      expect(byLabel.get("Parent's own spool")!.parentName).toBeNull();
+      expect(byLabel.get("Parent's own spool")!.variantCount).toBe(1);
+
+      // Variant spool: parentName = the parent, variant count 0.
+      expect(byLabel.get("Variant spool")!.parentName).toBe("Overture PETG");
+      expect(byLabel.get("Variant spool")!.variantCount).toBe(0);
+
+      // Standalone: both empty / zero.
+      expect(byLabel.get("Standalone spool")!.parentName).toBeNull();
+      expect(byLabel.get("Standalone spool")!.variantCount).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The CSV and XLSX exports of filaments and spools used `resolveFilament` to flatten variant values (so a `Overture PETG Red` row inherited its parent's print temps and density correctly), but **dropped the parent/variant relationship itself**. Looking at an exported xlsx there was no way to tell which rows were variants or what they were variants of — found this auditing a real user's export.

Two new columns on both exports:

| Column | Value |
|---|---|
| **Parent** | Parent filament's name if this row is a variant, else empty |
| **Variant Count** | Number of variants this row has (>0 only for parents) |

## Scope

Applied to:
- `/api/filaments/export-csv` (uses `EXPORT_COLUMNS`)
- `/api/filaments/export-xlsx` (uses `EXPORT_COLUMNS` — auto picks up)
- `/api/spools/export-csv` (uses `SPOOL_EXPORT_COLUMNS`)

**Not applied to** slicer-bound exports (PrusaSlicer / OrcaSlicer / Bambu Studio) — slicers have no concept of variants and need every preset to stand alone. Snapshot export already preserves `parentId` for full backups.

## Out of scope

Re-import doesn't yet reconstitute relationships from the `Parent` column. Tracked as a follow-up — this PR is export-only per the user's preference for a focused first pass.

## Test plan
- [x] `npm run lint` — clean
- [x] 23 tests pass across `exportFilaments.test.ts` and `exportSpools.test.ts` (+4 new, covering parent w/ variants, variant w/ parent, standalone w/ neither, and the spool-side mirror of those)
- [x] Live curl against `/api/filaments/export-csv` confirms `Parent` and `Variant Count` appear in the header row

🤖 Generated with [Claude Code](https://claude.com/claude-code)