### PR TITLE
fix: render Spool Tracker on filaments with no spool metadata

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -852,8 +852,16 @@ export default function FilamentDetail() {
         <InfoCard label={t("detail.field.maxVolSpeed")} value={filament.maxVolumetricSpeed ? `${filament.maxVolumetricSpeed} mm³/s` : "—"} inherited={inherited.has("maxVolumetricSpeed")} />
       </div>
 
-      {/* Spool Tracker */}
-      {(filament.spools?.length > 0 || filament.spoolWeight != null || filament.totalWeight != null || filament.netFilamentWeight != null) && (() => {
+      {/* Spool Tracker — always rendered. Pre-fix the outer gate hid the
+          entire section (header + Add Spool button) when the filament had
+          neither spools nor any spool-weight metadata, leaving users with
+          no in-app affordance to add their first spool (e.g. a freshly-
+          imported Siraya Tech PPS-CF row with the OpenPrintTag defaults).
+          Empty state now surfaces an Add Spool CTA via the fallback at
+          the bottom of this block, gated on hasSpools + totalWeight only.
+          (Regression of #346 — that fix covered "no spools but weights
+          set"; the "no spools AND no weights" case still fell through.) */}
+      {(() => {
         const hasSpools = filament.spools?.length > 0;
         const legacyRemaining = !hasSpools ? computeRemaining(filament) : null;
 
@@ -942,10 +950,8 @@ export default function FilamentDetail() {
                       const val = parseFloat(weightInput);
                       // handleNfcWeightUpdate reads a timeout ref internally, but
                       // this arrow is an onClick handler so the ref is accessed
-                      // post-render. The rule can't infer that through a named
-                      // helper, so silence here.
+                      // post-render — outside the render path the rule checks.
                       if (!isNaN(val) && val > 0) {
-                        // eslint-disable-next-line react-hooks/refs
                         handleNfcWeightUpdate(val);
                       } else if (filament.totalWeight != null) {
                         handleNfcWeightUpdate(filament.totalWeight);
@@ -1057,9 +1063,26 @@ export default function FilamentDetail() {
               </div>
             )}
 
-            {/* Add first spool button when no weight data exists yet */}
-            {!hasSpools && filament.totalWeight == null && filament.spoolWeight != null && (
-              addSpoolForm.open ? (
+            {/* Add-first-spool fallback. Pre-fix this was gated on
+                `filament.spoolWeight != null` so the button only appeared
+                after the user had configured an empty-spool weight on the
+                filament. For freshly-created filaments with no weight
+                metadata, the section above this block also rendered
+                nothing — leaving the user with no in-app way to add their
+                first spool. Drop the spoolWeight gate so the CTA appears
+                whenever there are no spools and no legacy
+                totalWeight-based tracking in progress.
+                When NO weights are configured at all, also surface a
+                short hint above the button — otherwise the empty section
+                looks broken rather than awaiting input. */}
+            {!hasSpools && filament.totalWeight == null && (
+              <>
+                {filament.spoolWeight == null && filament.netFilamentWeight == null && !addSpoolForm.open && (
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                    {t("detail.spool.emptyHint")}
+                  </p>
+                )}
+                {addSpoolForm.open ? (
                 <div className="flex flex-wrap gap-2 items-stretch p-3 border border-blue-300 dark:border-blue-700 rounded-lg bg-blue-50/30 dark:bg-blue-950/20">
                   <input
                     type="text"
@@ -1104,7 +1127,8 @@ export default function FilamentDetail() {
                 >
                   + {t("detail.addSpool")}
                 </button>
-              )
+              )}
+              </>
             )}
           </div>
         );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -786,6 +786,7 @@
 
   "detail.spool.added": "Spule hinzugefügt",
   "detail.spool.addFailed": "Spule konnte nicht hinzugefügt werden",
+  "detail.spool.emptyHint": "Noch keine Spulen — füge eine hinzu, um Restgewicht, Trockenzyklen und Verbrauch zu verfolgen.",
   "detail.spool.updated": "Spule aktualisiert",
   "detail.spool.updateFailed": "Spule konnte nicht aktualisiert werden",
   "detail.spool.confirmRemove": "Diese Spule entfernen?",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -786,6 +786,7 @@
 
   "detail.spool.added": "Spool added",
   "detail.spool.addFailed": "Failed to add spool",
+  "detail.spool.emptyHint": "No spools yet — add one to start tracking remaining weight, dry cycles, and usage.",
   "detail.spool.updated": "Spool updated",
   "detail.spool.updateFailed": "Failed to update spool",
   "detail.spool.confirmRemove": "Remove this spool?",


### PR DESCRIPTION
## Summary

The detail page's outer gate at [src/app/filaments/\[id\]/page.tsx:856](src/app/filaments/[id]/page.tsx#L856) short-circuited the entire Spool Tracker section — including the Add Spool button — when the filament had neither spools nor any of `spoolWeight` / `totalWeight` / `netFilamentWeight`. For a freshly-created filament (OpenPrintTag import, fresh sync, manually created with just name + vendor + type), the user had no in-app affordance to add their first spool.

Regression of #346 — that fix covered "no spools but has weight metadata"; the "no spools AND no weight metadata" path still fell through. Hit during a real workflow (user finished a Siraya Tech PPS-CF spool and wanted to add a fresh one on a sparse filament doc).

## Changes

- **Drop the outer gate at line 856** so the section always renders. Inner blocks (info cards, legacy progress, per-spool cards) are already self-gating, so they only render when their inputs exist.
- **Loosen the add-first-spool fallback at ~line 1080** — was gated on `filament.spoolWeight != null`, now gated only on no spools and no in-progress legacy `totalWeight` tracking. Show a short hint above the button when no weight metadata exists at all so the empty section reads as awaiting-input rather than broken.
- Drop a now-dead `eslint-disable-next-line react-hooks/refs` suppression that ESLint flagged as unused (`no problems were reported`) — my edits shifted code such that the rule no longer fires at that callsite.

## i18n

New key `detail.spool.emptyHint` in `en.json` + `de.json` (1200 / 1200 in sync).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 1400 passing
- [x] Verified in preview against an actually-empty filament (Comgrow PLA Red — no spools, no weights): Spool Tracker section + hint text + `+ Add Spool` CTA all render. Pre-fix, nothing rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)