### PR TITLE
feat: prompt to retire spool when remaining weight set to 0

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -410,6 +410,32 @@ export default function FilamentDetail() {
     },
   ) => {
     if (!filament) return;
+
+    // When the user zeroes the remaining weight on a non-retired spool,
+    // offer to retire it in the same write — that's the canonical "I
+    // finished this spool" moment, and retiring preserves the spool's
+    // history (purchase / opened dates, dry cycles, usage log) while
+    // excluding it from inventory totals (see inventoryStats.ts gates on
+    // `retired`). Skipped when:
+    //   - the caller already passed `retired` (don't clobber an explicit
+    //     choice from the SpoolCard's own retire toggle);
+    //   - the spool was already retired (the prompt would be a no-op);
+    //   - the prior weight was already 0 (no real transition to mark).
+    if (data.totalWeight === 0 && data.retired === undefined) {
+      const current = filament.spools?.find(
+        (s: { _id: { toString(): string } }) => s._id.toString() === spoolId,
+      ) as { retired?: boolean; totalWeight?: number | null } | undefined;
+      if (current && !current.retired && current.totalWeight !== 0) {
+        const retire = await confirm({
+          message: t("detail.spool.confirmRetireOnZero"),
+          confirmLabel: t("detail.spool.retire"),
+        });
+        if (retire) {
+          data = { ...data, retired: true };
+        }
+      }
+    }
+
     try {
       const res = await fetch(`/api/filaments/${filament._id}/spools/${spoolId}`, {
         method: "PUT",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -787,6 +787,7 @@
   "detail.spool.added": "Spule hinzugefügt",
   "detail.spool.addFailed": "Spule konnte nicht hinzugefügt werden",
   "detail.spool.emptyHint": "Noch keine Spulen — füge eine hinzu, um Restgewicht, Trockenzyklen und Verbrauch zu verfolgen.",
+  "detail.spool.confirmRetireOnZero": "Restgewicht ist jetzt 0. Diese Spule auch als ausgemustert markieren? Beim Ausmustern bleibt die Historie (Daten, Trockenzyklen, Verbrauch) erhalten, sie wird aber aus den Inventarsummen ausgeschlossen.",
   "detail.spool.updated": "Spule aktualisiert",
   "detail.spool.updateFailed": "Spule konnte nicht aktualisiert werden",
   "detail.spool.confirmRemove": "Diese Spule entfernen?",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -787,6 +787,7 @@
   "detail.spool.added": "Spool added",
   "detail.spool.addFailed": "Failed to add spool",
   "detail.spool.emptyHint": "No spools yet — add one to start tracking remaining weight, dry cycles, and usage.",
+  "detail.spool.confirmRetireOnZero": "Remaining weight is now 0. Also mark this spool as retired? Retiring keeps its history (dates, dry cycles, usage) but excludes it from inventory totals.",
   "detail.spool.updated": "Spool updated",
   "detail.spool.updateFailed": "Failed to update spool",
   "detail.spool.confirmRemove": "Remove this spool?",


### PR DESCRIPTION
## Summary

User feedback after finishing a spool: zeroing remaining weight is the canonical "I finished this spool" moment. Currently the user has to set weight = 0, then separately toggle the retire flag — two clicks for one logical action. This PR offers to also mark the spool retired in the same write.

Retiring (vs. deleting) preserves the spool's history — purchase / opened dates, dry cycles, usage log, location, photo — while excluding it from inventory totals (`inventoryStats.ts` already gates on `retired`). So the user gets clean inventory without losing provenance, and any print-history entries referencing this spool stay attributable.

## How it works

In `handleUpdateSpool`, when `data.totalWeight === 0`:
- **Skip prompt** if the caller already passed `retired` — the SpoolCard's own retire toggle path sets both fields explicitly and shouldn't be second-guessed.
- **Skip prompt** if the spool is already retired (no-op).
- **Skip prompt** if the prior weight was already 0 — no real transition to confirm.
- Otherwise, `await confirm(...)`. If user picks **Retire**, merge `retired: true` into the PUT body; if **Cancel**, just zero the weight as originally requested.

## i18n

One new key `detail.spool.confirmRetireOnZero` (EN + DE, 1200 / 1200 in sync). Reuses existing `detail.spool.retire` for the confirm button label.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 1400 passing
- [x] Verified both branches in preview against a real spool (Overture PLA, 1000g → 0g):
  - Cancel → `totalWeight: 0`, `retired: false`
  - Retire → `totalWeight: 0`, `retired: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)