### PR TITLE
docs: refresh user guides for v1.26-v1.30 UX changes

### DIFF
--- a/docs/importing.md
+++ b/docs/importing.md
@@ -137,7 +137,16 @@ You can restore a previously exported snapshot to import core app data: filament
 
 ## CSV / XLSX Export
 
-Open the **Import/Export** dropdown on the home page and click **"Export CSV"** or **"Export XLSX"** to download all filaments. Exports include name, vendor, type, color, color name, temperatures (nozzle, bed, first layer, ranges, standby), cost, density, weights, instance ID, drying settings, transmission distance, glass transition (Tg), heat deflection (HDT), shore hardness (A/D), print speed ranges, and spool type.
+Open the **Import/Export** dropdown on the home page and click **"Export CSV"** or **"Export XLSX"** to download all filaments. Exports include name, vendor, type, color, color name, temperatures (nozzle, bed, first layer, ranges, standby), cost, density, weights, instance ID, drying settings, transmission distance, glass transition (Tg), heat deflection (HDT), shore hardness (A/D), print speed ranges, spool type, and (as of v1.30.3) two columns surfacing the parent/variant relationship:
+
+- **Parent** — name of the parent filament when this row is a variant; empty for roots and standalones.
+- **Variant Count** — number of variants this filament has (>0 only for parents with variants).
+
+Variants still inherit their parent's print values (those are flattened into each variant's row), so the new columns are the *only* way to reconstruct the parent/variant tree from an export.
+
+The spool CSV export (`/api/spools/export-csv`) mirrors these two columns at the spool level.
+
+> Slicer-bound exports (PrusaSlicer .ini / OrcaSlicer .json / Bambu Studio .json) intentionally stay flat — slicers have no concept of variants and need every preset to stand alone.
 
 ---
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -289,20 +289,20 @@ You can also click the **Edit** button directly from the home page table row.
 
 Variants share a parent's settings (temperatures, density, retraction, calibrations) and only store what's different: name, color, and cost.
 
-There are two affordances on the detail page that lead to the same result:
+There are two affordances on the detail page. They both produce a new variant, but they pre-fill the form differently:
 
-- **"+ Create variant"** (fuchsia button) — only shown on **root** filaments (i.e. not already a variant). Quickest path when you're on the intended parent and just want to add a color under it.
-- **Clone** (amber button) — shown on **every** filament, root or variant. When you Clone a root, the new filament becomes a variant of that root. When you Clone a variant, the new filament becomes a sibling variant under the same parent.
+- **"+ Create variant"** (fuchsia button) — only shown on **root** filaments (i.e. not already a variant). The form opens with the parent linked, **vendor** and **type** pre-filled from the parent, and the parent's other values surfaced as **placeholder text** in each input (not pre-populated). Leaving a field blank keeps the variant inheriting from the parent live; type into a field to override only that one. This is the quickest path when you want a true variant that shares everything except color.
+- **Clone** (amber button) — shown on **every** filament, root or variant. The form opens with **name** (suffixed with " (copy)"), **color**, **colorName**, **vendor**, and **type** copied verbatim from the source filament — a full identity duplicate. The parent relationship is set automatically: cloning a root makes the new filament a variant of that root; cloning a variant makes the new filament a **sibling** under the same parent. Best when you want a starting point you can heavily edit.
 
-Steps with either button:
+Steps:
 
 1. Open a filament's detail page.
-2. Click **Clone** or **"+ Create variant"**.
-3. The form opens with the parent's **name** (suffixed with " (copy)"), **color**, **colorName**, **vendor**, and **type** pre-filled. All other fields are blank — they inherit live from the parent. Inherited values appear as placeholder text in each input so you can see what you'll get without typing.
-4. Edit the **name**, pick a new **color**, and optionally adjust **colorName**.
-5. Click **Create Filament**. The new filament is registered as a variant of the parent and any future edits to the parent's calibrations / temperatures / settings will flow through automatically.
+2. Click **"+ Create variant"** (if available) or **Clone**.
+3. The form opens pre-filled per the rules above. The fields that aren't pre-filled (or that you don't override) inherit live from the parent — that's the design from GH #106; placeholder text shows what you'll get.
+4. Edit the **name** (Clone only — Create variant leaves it blank for you to type), pick a new **color**, and optionally adjust **colorName**.
+5. Click **Create Filament**. The new filament is registered as a variant of the parent and any future edits to the parent's calibrations / temperatures / settings flow through automatically to fields you didn't explicitly override.
 
-> **Design rule**: variants-of-variants are not supported. A parent must be a top-level filament. This is why the "+ Create variant" button is hidden on variant pages.
+> **Design rule**: variants-of-variants are not supported. A parent must be a top-level filament. This is why the "+ Create variant" button is hidden on variant pages, and why cloning a variant gives you a sibling instead of nesting.
 
 To turn an existing standalone filament into a variant:
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -289,11 +289,20 @@ You can also click the **Edit** button directly from the home page table row.
 
 Variants share a parent's settings (temperatures, density, retraction, calibrations) and only store what's different: name, color, and cost.
 
+There are two affordances on the detail page that lead to the same result:
+
+- **"+ Create variant"** (fuchsia button) — only shown on **root** filaments (i.e. not already a variant). Quickest path when you're on the intended parent and just want to add a color under it.
+- **Clone** (amber button) — shown on **every** filament, root or variant. When you Clone a root, the new filament becomes a variant of that root. When you Clone a variant, the new filament becomes a sibling variant under the same parent.
+
+Steps with either button:
+
 1. Open a filament's detail page.
-2. Click **Clone** (amber button — visible only on parent filaments, not on existing variants).
-3. The form opens with the parent's **name** (suffixed with " (copy)"), **color**, **colorName**, **vendor**, and **type** pre-filled. All other fields are blank — they inherit live from the parent.
+2. Click **Clone** or **"+ Create variant"**.
+3. The form opens with the parent's **name** (suffixed with " (copy)"), **color**, **colorName**, **vendor**, and **type** pre-filled. All other fields are blank — they inherit live from the parent. Inherited values appear as placeholder text in each input so you can see what you'll get without typing.
 4. Edit the **name**, pick a new **color**, and optionally adjust **colorName**.
 5. Click **Create Filament**. The new filament is registered as a variant of the parent and any future edits to the parent's calibrations / temperatures / settings will flow through automatically.
+
+> **Design rule**: variants-of-variants are not supported. A parent must be a top-level filament. This is why the "+ Create variant" button is hidden on variant pages.
 
 To turn an existing standalone filament into a variant:
 
@@ -442,13 +451,15 @@ Even in pure **Atlas mode**, if Atlas is unreachable when the app starts, it aut
 
 Each filament can track multiple physical spools with individual weights.
 
-1. On a filament's detail page, scroll to the **Spool Tracker** section.
+1. On a filament's detail page, find the **Spool Tracker** section. As of v1.30.3 it always renders — on a brand-new filament with no weight metadata it shows a short "No spools yet" hint above the **"+ Add Spool"** button.
 2. Click **"+ Add Spool"** to add a new spool with an optional label and weight.
 3. Each spool shows its label, total weight, and a delete button.
 4. The tracker aggregates stats across all spools (total weight, computed length from density and diameter).
 5. Each spool can also be assigned a **Location** (its storage home) and a **Printer slot** (the AMS/MMU position it is currently loaded in — a spool occupies one slot at a time).
 
 If a filament has a single `totalWeight` but no spools yet, click **"Migrate to spool tracking"** to convert it.
+
+When you finish a spool and set its remaining weight to **0**, the app prompts to also mark it **retired** in the same write — that's the canonical "I finished this spool" workflow. Retiring preserves the spool's full history (dates, dry cycles, usage log) but excludes it from inventory totals, so your remaining-weight numbers stay clean without losing provenance.
 
 ---
 
@@ -497,13 +508,14 @@ Without the fork, sync manually:
 
 ## Step 18: Delete a Filament
 
-1. On the home page, tick the checkbox at the start of any filament row (or the header checkbox to select every row).
-2. A red bulk-action bar appears above the table showing the number selected.
-3. Click **Delete N** in that bar and confirm.
+Two paths, same result:
+
+- **Bulk** — on the home page, tick the checkbox at the start of any filament row (or the header checkbox to select every row). A red bulk-action bar appears above the table showing the number selected. Click **Delete N** in that bar and confirm.
+- **Single (v1.29)** — on the filament detail page, click the red **Delete** button in the top-right action row. Faster when you've already opened the filament.
 
 **Note**: Parent filaments with color variants cannot be deleted — delete the variants first. Failed deletions surface in a per-row error toast and the rest of the batch still completes.
 
-In hybrid mode, deletions are synced to Atlas on the next sync cycle. Deleted filaments are soft-deleted internally (marked with a timestamp) so the deletion propagates correctly across devices.
+Both paths soft-delete: the filament is marked with a `_deletedAt` timestamp and moves to the trash. The deletion propagates correctly across devices in hybrid mode on the next sync cycle. From the trash you can either restore or permanently delete it; permanent deletes also propagate via a `_purged` tombstone so they don't get resurrected by a peer's sync.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ Click any filament name in the table to see its full details:
    - **Import from TDS** to extract properties from a Technical Data Sheet URL using AI (requires API key — see [AI Settings](#ai-settings))
    - **Prusament QR** to fetch specs from a Prusament spool QR code
    - **Load from INI** to pick a profile from a PrusaSlicer config bundle
-   - **Clone Existing** to copy identity fields from another filament and inherit its settings as a variant
+   - **Clone Existing** to copy identity fields from another filament and inherit its settings as a variant. (On a filament's detail page, a dedicated **"+ Create variant"** button is also available on root filaments — quicker path when you already know which filament should be the parent.)
 3. Fill in the required fields (name, vendor, type)
 4. Optionally set temperatures, cost, density, color, fan settings, retraction, shrinkage, pressure advance, and other properties
 5. Select compatible nozzles and enter per-nozzle calibration overrides
@@ -326,7 +326,7 @@ Each filament can track multiple physical spools with individual weights.
 
 ### Adding Spools
 
-On a filament's detail page, the **Spool Tracker** section appears when weight data exists. Click **"+ Add Spool"** to add a new spool entry with an optional label and weight.
+On a filament's detail page, the **Spool Tracker** section always renders (as of v1.30.3 / #380). When there are no spools and no weight metadata configured yet, the section shows a short "No spools yet" hint above the **"+ Add Spool"** button — click it to add a new spool entry with an optional label and weight.
 
 ### Managing Spools
 
@@ -502,7 +502,7 @@ Separate from its **Location** (its storage "home"), a spool can be assigned to 
 Each spool now has three additional ledgers accessible from its detail panel:
 
 - **Photo** — upload a JPEG/PNG (SVG is rejected for security). The file is downsampled to 1200px and compressed client-side to ~200KB before being stored inline on the spool subdocument, so there's no file-upload endpoint.
-- **Retired** — toggle to remove a spool from inventory totals, the PrusaSlicer spool-check endpoint, and the main spool list. History is preserved.
+- **Retired** — toggle to remove a spool from inventory totals, the PrusaSlicer spool-check endpoint, and the main spool list. History is preserved. As of v1.30.3 (#381), setting a spool's remaining weight to **0** triggers a prompt offering to also mark it retired in the same write — the canonical "I finished this spool" moment, one click instead of two.
 - **Dry cycles** — log each drying session with optional temperature (°C), duration (minutes), and notes. The dashboard's "needs drying" warning reads from this log.
 - **Usage history** — each manual weight decrement (or slicer-driven print job) appends an entry tagged with its source (`manual`, `slicer`, `job`, `nfc`).
 


### PR DESCRIPTION
## Summary

User-facing docs were missing seven UX/feature changes from v1.26 through v1.30.3. This refresh brings them in. Text-only — no screenshots re-shot. The Smart Filament Workflow guide is untouched (its top-of-file disclaimer already acknowledges the v1.25.1 version it was written against).

## Changes

| File | Change |
|---|---|
| `docs/importing.md` | Document the new **Parent** + **Variant Count** export columns from v1.30.3 (#378); note that slicer-bound exports intentionally stay flat. Also flag the matching spool CSV columns. |
| `docs/usage.md` | "Spool Tracker appears when weight data exists" → always renders, mention the empty-state hint (v1.30.3 #380). Update the **Clone Existing** toolbar entry to also point at the dedicated **"+ Create variant"** button (v1.26). Note the retire-on-zero prompt under the **Retired** bullet (v1.30.3 #381). |
| `docs/tutorial.md` | Step 10: drop the stale "Clone visible only on parent filaments" claim (v1.30.2 #377 made it universal); explain Clone vs + Create variant. Step 15: note Spool Tracker always renders and the retire-on-zero prompt. Step 18: add the v1.29 detail-page Delete button as the second deletion path; explain `_purged` propagation. |

## Out of scope

- Smart Filament Workflow guide (`docs/smart-filament-workflow-guide.md`): version-locked to v1.25.1 with screenshots; a real refresh needs re-shooting, not text edits. Disclaimer at the top covers the drift for now.
- Re-import side for the Parent column on CSV import — tracked as #379, intentionally not in this PR.

## Test plan

Doc-only change — no code touched, no tests need to run. Markdown structure verified (no broken headings, all i18n version refs match CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)