### PR TITLE
fix: reconcile same-name filaments across DBs before hybrid sync

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -353,6 +353,19 @@ export class SyncService extends EventEmitter {
       await this.backfillSyncIds(localDb.collection("filaments"));
       await this.backfillSyncIds(remoteDb.collection("filaments"));
 
+      // Reconcile same-name filaments across DBs before building the
+      // syncId maps. Same first-sync trap as locations + bedtypes — two
+      // sides that independently created "PC Blend" carry distinct
+      // syncIds, so syncCollection's last-write-wins path tries to
+      // updateOne the name into the partial-unique-on-non-deleted
+      // `name` index and E11000s the whole cycle (cascading to
+      // printhistories via the trySync prerequisite chain). Must run
+      // AFTER backfill (reconcileByName trusts existing syncIds when
+      // present and only mints when both sides are missing one) and
+      // BEFORE the maps below so parentId remapping sees the unified
+      // syncId on both sides.
+      await this.reconcileFilamentsByName(localDb, remoteDb);
+
       // Build filament syncId→ID maps for parentId remapping
       const localFilaments = await localDb.collection("filaments").find({}).toArray();
       const remoteFilaments = await remoteDb.collection("filaments").find({}).toArray();
@@ -754,6 +767,24 @@ export class SyncService extends EventEmitter {
     remoteDb: ReturnType<MongoClient["db"]>,
   ): Promise<void> {
     await this.reconcileByName(localDb, remoteDb, "bedtypes");
+  }
+
+  /**
+   * Same name-collision resolver, applied to filaments. Filament has the
+   * partial-unique-on-non-deleted `name` index too, and the same
+   * independent-creation shape ("PC Blend" minted on both desktop and
+   * Atlas before they ever talked) lands as different local syncIds —
+   * syncCollection then treats them as two rows and either insertOne or
+   * updateOne walks into the index and E11000s, aborting the cycle (and
+   * cascading-skipping printhistories via the `trySync` prerequisite
+   * chain added in #369). Unifying the syncIds here turns the pair into
+   * a normal last-write-wins merge.
+   */
+  private async reconcileFilamentsByName(
+    localDb: ReturnType<MongoClient["db"]>,
+    remoteDb: ReturnType<MongoClient["db"]>,
+  ): Promise<void> {
+    await this.reconcileByName(localDb, remoteDb, "filaments");
   }
 
   /**

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -59,6 +59,10 @@ describe("SyncService — v1.12 sync expansion", () => {
         { slug: 1 },
         { unique: true },
       ).catch(() => {});
+      await db.collection("filaments").createIndex(
+        { name: 1 },
+        { unique: true, partialFilterExpression: { _deletedAt: null } },
+      ).catch(() => {});
     }
   }, 120_000);
 
@@ -127,6 +131,50 @@ describe("SyncService — v1.12 sync expansion", () => {
       const remoteRow = await remoteClient.db("filament-db").collection("bedtypes").findOne({ name: "Cool Plate" });
       expect(localRow?.syncId).toBe("local-uuid");
       expect(remoteRow?.syncId).toBe("local-uuid");
+    });
+  });
+
+  // ── filaments name-collision reconciliation ───────────────────────────
+
+  describe("filaments name reconciliation", () => {
+    it("reconciles same-name filaments across DBs without tripping the partial-unique-name index", async () => {
+      // Reproduces the v1.30.x E11000 cycle abort: both sides independently
+      // created "PC Blend" with their own syncIds; without reconcileByName
+      // for filaments, syncCollection's update path walks the new name into
+      // the partial-unique-on-non-deleted `name` index and aborts the cycle.
+      await localClient.db("filament-db").collection("filaments").insertOne({
+        name: "PC Blend", manufacturer: "Local Co", type: "PC",
+        syncId: "local-uuid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+      await remoteClient.db("filament-db").collection("filaments").insertOne({
+        name: "PC Blend", manufacturer: "Remote Co", type: "PC",
+        syncId: "remote-uuid",
+        _deletedAt: null, createdAt: new Date(), updatedAt: new Date(),
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+      const filamentResult = results.find((r) => r.collection === "filaments");
+      expect(filamentResult).toBeDefined();
+      expect(filamentResult?.error).toBeUndefined();
+
+      // Each side still has exactly one active row for the name (no E11000).
+      const localCount = await localClient.db("filament-db").collection("filaments").countDocuments({ name: "PC Blend", _deletedAt: null });
+      const remoteCount = await remoteClient.db("filament-db").collection("filaments").countDocuments({ name: "PC Blend", _deletedAt: null });
+      expect(localCount).toBe(1);
+      expect(remoteCount).toBe(1);
+
+      // syncIds unified — local wins per the tie-break rule in reconcileByName.
+      const localRow = await localClient.db("filament-db").collection("filaments").findOne({ name: "PC Blend" });
+      const remoteRow = await remoteClient.db("filament-db").collection("filaments").findOne({ name: "PC Blend" });
+      expect(localRow?.syncId).toBe("local-uuid");
+      expect(remoteRow?.syncId).toBe("local-uuid");
+
+      // And printhistories (which prerequisite-depend on filaments via trySync)
+      // should not be skip-cascaded with a prerequisite-failed error.
+      const phResult = results.find((r) => r.collection === "printhistories");
+      expect(phResult?.error).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Hybrid sync aborts the whole cycle with `E11000 duplicate key error collection: filament-db.filaments index: name_1 dup key: { name: "PC Blend" }` when a user has independently created the same filament name on desktop and on Atlas before they first synced. Each side has its own local-only `syncId`, so `syncCollection` treats them as two rows and either insertOne or updateOne walks the name into the partial-unique-on-non-deleted `name` index. `printhistories` then cascade-skips via the `trySync` prerequisite chain added in #369.
- Fix mirrors the existing `reconcileLocationsByName` / `reconcileBedTypesByName` pattern: new `reconcileFilamentsByName` wraps the generic `reconcileByName` helper. Called between the syncId backfill and the syncId-map build so parentId remapping sees the unified syncId on both sides. Same last-write-wins tie-break as the other two collections (local syncId wins, both rows re-keyed onto it).
- No other changes — `Nozzle` and `Printer` have the same partial-unique-name index and are vulnerable to the same first-sync trap, but no one has reported hitting them; deferred to a follow-up rather than expanding scope here.

## Test plan
- [x] `npx vitest run tests/sync-service-expansion.test.ts tests/sync-service.test.ts tests/sync-service-locations.test.ts tests/sync-service-error-isolation.test.ts` — 51/51 pass.
- [x] Verified the new regression test fails on `main` with the exact error string from the bug report (`E11000 ... index: name_1 dup key: { name: "PC Blend" }`) and passes with the fix applied.
- [x] Asserted `printhistories` no longer gets `skipped — prerequisite "filaments" failed` in the reproduced scenario.
- [x] `npm run lint` clean.
- [ ] Manual verification on a real desktop ↔ Atlas pair carrying matching-name filaments (the reporter's machine — see the immediate `rm -rf` workaround in the issue thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)