### PR TITLE
feat: round-trip Parent column on filament CSV/XLSX import (closes #379)

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1397,7 +1397,7 @@
       "post": {
         "tags": ["Filaments"],
         "summary": "Import filaments from CSV",
-        "description": "Upload a CSV file with header row. Requires Name, Vendor, Type columns. Only fields present are updated.",
+        "description": "Upload a CSV file with header row. Requires Name, Vendor, Type columns. Only fields present are updated. The optional `Parent` column (matching the filament CSV export) attaches a newly-created filament as a variant of the named parent — honoured on create/resurrect only; ignored on update. The parent must exist among active filaments and must not itself be a variant. `Variant Count` is read-only and ignored on import.",
         "requestBody": {
           "required": true,
           "content": {
@@ -1426,7 +1426,7 @@
       "post": {
         "tags": ["Filaments"],
         "summary": "Import filaments from XLSX",
-        "description": "Upload an XLSX file with header row. Same column mapping as CSV import.",
+        "description": "Upload an XLSX file with header row. Same column mapping as CSV import, including the optional `Parent` column for round-tripping variant relationships.",
         "requestBody": {
           "required": true,
           "content": {

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -33,6 +33,15 @@ export interface ImportRow {
   standbyTemp?: number | null;
   tdsUrl?: string | null;
   instanceId?: string | null;
+  /**
+   * GH #379: optional parent-filament name surfaced as the `Parent` column
+   * in the filament CSV/XLSX export (see EXPORT_COLUMNS in
+   * `src/lib/exportFilaments.ts`). Only honoured on CREATE/RESURRECT — for
+   * an existing active filament we ignore it, because silently re-parenting
+   * a row from a re-imported edit is a surprising user experience and the
+   * "Create variant" / Clone-from-parent UI already covers the manual case.
+   */
+  parentName?: string | null;
 }
 
 /** Map header text (case-insensitive) to ImportRow keys */
@@ -106,6 +115,15 @@ const HEADER_MAP: Record<string, keyof ImportRow | undefined> = {
   "nozzle range max (°c)": "nozzleRangeMax",
   "standby temp": "standbyTemp",
   "standby temp (°c)": "standbyTemp",
+  // GH #379: round-trip the filament-level export's parent/variant columns.
+  // "Parent" carries the parent filament's name (string); "Variant Count"
+  // is derived/read-only and explicitly skipped so a re-import doesn't try
+  // to set it as a field.
+  parent: "parentName",
+  "parent name": "parentName",
+  parentname: "parentName",
+  "variant count": undefined,
+  variantcount: undefined,
 };
 
 const NUM_FIELDS = new Set<keyof ImportRow>([
@@ -188,25 +206,48 @@ export async function upsertImportRows(
   let skipped = 0;
   const skippedRows: SkippedRow[] = [];
 
-  // Batch-load all existing filaments by name to avoid N+1 queries
-  const validNames = rows
-    .filter((r) => r.name && r.vendor && r.type)
-    .map((r) => r.name!);
-
-  const allExisting = await Filament.find({ name: { $in: validNames } }).lean();
-
-  // Build lookup maps: name → active doc, name → soft-deleted doc
-  const activeByName = new Map<string, { _id: mongoose.Types.ObjectId }>();
-  const deletedByName = new Map<string, { _id: mongoose.Types.ObjectId }>();
-  for (const doc of allExisting) {
-    if (doc._deletedAt == null) {
-      activeByName.set(doc.name, doc);
-    } else if (!deletedByName.has(doc.name)) {
-      deletedByName.set(doc.name, doc);
+  // Batch-load all existing filaments by name to avoid N+1 queries.
+  // GH #379: also include every Parent value, because a variant row's
+  // parent may not itself appear as an import row (i.e. only the variant
+  // is being imported, against an already-active parent in the DB). Also
+  // project `parentId` so the parent-validity check below can reject a
+  // parentName pointing at a row that's itself a variant.
+  const namesToLoad = new Set<string>();
+  for (const r of rows) {
+    if (r.name && r.vendor && r.type) namesToLoad.add(r.name);
+    if (r.parentName) {
+      const trimmed = r.parentName.trim();
+      if (trimmed) namesToLoad.add(trimmed);
     }
   }
 
-  for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
+  const allExisting = await Filament.find({ name: { $in: [...namesToLoad] } })
+    .select("_id name parentId _deletedAt")
+    .lean();
+
+  // The same map carries existing rows AND filaments created earlier in
+  // this same import batch — pass-2 (variant rows) resolves the `Parent`
+  // column against it, so an export → reimport works even when the parent
+  // row only exists because pass 1 just created it.
+  type IndexEntry = {
+    _id: mongoose.Types.ObjectId;
+    parentId: mongoose.Types.ObjectId | null;
+  };
+  const activeByName = new Map<string, IndexEntry>();
+  const deletedByName = new Map<string, IndexEntry>();
+  for (const doc of allExisting) {
+    const entry: IndexEntry = {
+      _id: doc._id,
+      parentId: doc.parentId ?? null,
+    };
+    if (doc._deletedAt == null) {
+      activeByName.set(doc.name, entry);
+    } else if (!deletedByName.has(doc.name)) {
+      deletedByName.set(doc.name, entry);
+    }
+  }
+
+  async function processRow(rowIdx: number): Promise<void> {
     const row = rows[rowIdx];
     if (!row.name || !row.vendor || !row.type) {
       const missing = [
@@ -216,7 +257,50 @@ export async function upsertImportRows(
       ].filter(Boolean).join(", ");
       skippedRows.push({ row: rowIdx + 2, name: row.name, reason: `Missing required field(s): ${missing}` });
       skipped++;
-      continue;
+      return;
+    }
+
+    const existing = activeByName.get(row.name);
+    const softDeleted = !existing ? deletedByName.get(row.name) : undefined;
+
+    // GH #379: resolve the optional Parent column. Honoured ONLY when this
+    // row will produce a new active filament (create or resurrect); for an
+    // already-active row we silently ignore it, because re-parenting an
+    // existing filament via a re-imported CSV is a surprising UX and the
+    // app already exposes the relationship explicitly via "Create variant"
+    // and Clone-from-parent. Self-references are blocked outright.
+    let resolvedParentId: mongoose.Types.ObjectId | null = null;
+    const parentName = row.parentName ? row.parentName.trim() : "";
+    if (parentName && !existing) {
+      if (parentName === row.name) {
+        skippedRows.push({
+          row: rowIdx + 2,
+          name: row.name,
+          reason: `Parent cannot reference self`,
+        });
+        skipped++;
+        return;
+      }
+      const parentEntry = activeByName.get(parentName);
+      if (!parentEntry) {
+        skippedRows.push({
+          row: rowIdx + 2,
+          name: row.name,
+          reason: `Parent "${parentName}" not found among active filaments`,
+        });
+        skipped++;
+        return;
+      }
+      if (parentEntry.parentId) {
+        skippedRows.push({
+          row: rowIdx + 2,
+          name: row.name,
+          reason: `Parent "${parentName}" is itself a variant — variants-of-variants are not allowed`,
+        });
+        skipped++;
+        return;
+      }
+      resolvedParentId = parentEntry._id;
     }
 
     // Build the update doc using only fields that were actually present in the
@@ -274,7 +358,6 @@ export async function upsertImportRows(
     if (row.nozzleRangeMax !== undefined) temps.nozzleRangeMax = row.nozzleRangeMax ?? null;
     if (row.standbyTemp !== undefined) temps.standby = row.standbyTemp ?? null;
 
-    const existing = activeByName.get(row.name);
     if (existing) {
       // For updates, use dot-notation for temperatures to avoid overwriting
       // sub-fields that weren't in the import
@@ -294,7 +377,6 @@ export async function upsertImportRows(
       );
       updated++;
     } else {
-      const softDeleted = deletedByName.get(row.name);
       // For creates/resurrections, include temperatures as a nested object
       if (Object.keys(temps).length > 0) {
         doc.temperatures = {
@@ -307,6 +389,7 @@ export async function upsertImportRows(
           standby: temps.standby ?? null,
         };
       }
+      if (resolvedParentId) doc.parentId = resolvedParentId;
       if (softDeleted) {
         // GH #228: the resurrect path was the only Filament write in the
         // codebase running `updateOne` without `runValidators`. The pre-
@@ -321,13 +404,41 @@ export async function upsertImportRows(
           { ...doc, _deletedAt: null },
           { runValidators: true, context: "query" },
         );
+        // GH #379: re-promote into activeByName so a later pass-2 row
+        // referencing this name as Parent resolves correctly. The
+        // effective parentId after resurrect is `resolvedParentId ??
+        // softDeleted.parentId` because we only include `parentId` in
+        // `doc` when a Parent column was provided — without it the
+        // soft-deleted row's prior parentId survives unchanged, and a
+        // pass-2 row that tried to point its Parent at this resurrected
+        // row would otherwise wrongly skip the variant-of-variant guard.
+        const effectiveParentId = resolvedParentId ?? softDeleted.parentId;
+        activeByName.set(row.name, { _id: softDeleted._id, parentId: effectiveParentId });
+        deletedByName.delete(row.name);
         updated++;
       } else {
-        await Filament.create(doc);
+        const newDoc = await Filament.create(doc);
+        // GH #379: seed activeByName with the freshly-created row so a
+        // later pass-2 row referencing it as Parent can resolve in-batch
+        // (the round-trip case: parent and variant rows in the same CSV).
+        activeByName.set(row.name, { _id: newDoc._id, parentId: resolvedParentId });
         created++;
       }
     }
   }
+
+  // GH #379: two-pass driver. Rows without a Parent column run first so
+  // any new top-level filaments are present in `activeByName` by the time
+  // pass-2 (variant rows) tries to resolve them. The skipped report is
+  // sorted at the end to preserve original-row order even though we
+  // visited rows out of order.
+  for (let i = 0; i < rows.length; i++) {
+    if (!rows[i].parentName) await processRow(i);
+  }
+  for (let i = 0; i < rows.length; i++) {
+    if (rows[i].parentName) await processRow(i);
+  }
+  skippedRows.sort((a, b) => a.row - b.row);
 
   return { total: rows.length, created, updated, skipped, skippedRows };
 }

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -247,6 +247,16 @@ export async function upsertImportRows(
     }
   }
 
+  // GH #379 (Codex P2 follow-up): share one trim between the two-pass
+  // router and processRow. If routing used raw `row.parentName` while
+  // processRow trimmed before checking, a whitespace-only Parent cell
+  // would be routed to pass 2 (delaying processing of a row that's
+  // really a standalone), and any variant referencing that row's name
+  // would skip with a misleading "Parent not found".
+  function trimmedParentName(row: ImportRow): string {
+    return row.parentName ? row.parentName.trim() : "";
+  }
+
   async function processRow(rowIdx: number): Promise<void> {
     const row = rows[rowIdx];
     if (!row.name || !row.vendor || !row.type) {
@@ -270,7 +280,7 @@ export async function upsertImportRows(
     // app already exposes the relationship explicitly via "Create variant"
     // and Clone-from-parent. Self-references are blocked outright.
     let resolvedParentId: mongoose.Types.ObjectId | null = null;
-    const parentName = row.parentName ? row.parentName.trim() : "";
+    const parentName = trimmedParentName(row);
     if (parentName && !existing) {
       if (parentName === row.name) {
         skippedRows.push({
@@ -429,14 +439,16 @@ export async function upsertImportRows(
 
   // GH #379: two-pass driver. Rows without a Parent column run first so
   // any new top-level filaments are present in `activeByName` by the time
-  // pass-2 (variant rows) tries to resolve them. The skipped report is
+  // pass-2 (variant rows) tries to resolve them. Use the same trimmed
+  // view of the cell that processRow does so a whitespace-only Parent
+  // resolves to pass 1 (treated as a standalone). The skipped report is
   // sorted at the end to preserve original-row order even though we
   // visited rows out of order.
   for (let i = 0; i < rows.length; i++) {
-    if (!rows[i].parentName) await processRow(i);
+    if (!trimmedParentName(rows[i])) await processRow(i);
   }
   for (let i = 0; i < rows.length; i++) {
-    if (rows[i].parentName) await processRow(i);
+    if (trimmedParentName(rows[i])) await processRow(i);
   }
   skippedRows.sort((a, b) => a.row - b.row);
 

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -46,6 +46,13 @@ describe("mapHeaders", () => {
     expect(result).toEqual(["name", null, "vendor"]);
   });
 
+  it("maps the Parent column for round-trip variant import (GH #379)", () => {
+    const headers = ["Name", "Vendor", "Type", "Parent", "Variant Count"];
+    const result = mapHeaders(headers);
+    // Parent → parentName, "Variant Count" is derived/read-only and skipped.
+    expect(result).toEqual(["name", "vendor", "type", "parentName", null]);
+  });
+
   it("handles headers with extra whitespace", () => {
     const headers = ["  Name  ", " Vendor ", "  Type  "];
     const result = mapHeaders(headers);
@@ -339,5 +346,211 @@ describe("upsertImportRows", () => {
     expect(doc!.temperatures.standby).toBe(140);
     expect(doc!.temperatures.nozzle).toBe(200);
     expect(doc!.temperatures.bed).toBe(55);
+  });
+});
+
+/**
+ * GH #379: Parent-column round-trip on the filament importer.
+ *
+ * The filament CSV/XLSX export added a `Parent` column in #378 so the
+ * variant relationship is visible. The re-import side now reads it so the
+ * round-trip preserves the cluster (parent + its variants), instead of
+ * flattening every row to a standalone filament.
+ *
+ * Rules under test:
+ *   - CREATE path: parentName resolves against existing + in-batch active
+ *     filaments. Missing / variant / self-referential Parent → skip with
+ *     named reason.
+ *   - UPDATE path: parentName is silently ignored (re-parenting via
+ *     re-import is too lossy a UX).
+ */
+describe("upsertImportRows — Parent column (GH #379)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+  });
+
+  it("creates a variant with the correct parentId when Parent references an existing active filament", async () => {
+    const parent = await Filament.create({
+      name: "Universal PLA",
+      vendor: "Generic",
+      type: "PLA",
+    });
+
+    const result = await upsertImportRows([
+      {
+        name: "Galaxy Black PLA",
+        vendor: "Sunlu",
+        type: "PLA",
+        color: "#000000",
+        parentName: "Universal PLA",
+      },
+    ]);
+
+    expect(result.created).toBe(1);
+    expect(result.skipped).toBe(0);
+    const variant = await Filament.findOne({ name: "Galaxy Black PLA" });
+    expect(variant.parentId?.toString()).toBe(parent._id.toString());
+  });
+
+  it("creates a parent + variant in the same batch when the variant row comes BEFORE the parent row", async () => {
+    // Real exports sort by name, so "Galaxy Black PLA" lands before
+    // "Universal PLA" alphabetically — the two-pass driver must still
+    // resolve the in-batch parent.
+    const result = await upsertImportRows([
+      {
+        name: "Galaxy Black PLA",
+        vendor: "Sunlu",
+        type: "PLA",
+        parentName: "Universal PLA",
+      },
+      {
+        name: "Universal PLA",
+        vendor: "Generic",
+        type: "PLA",
+      },
+    ]);
+
+    expect(result.created).toBe(2);
+    expect(result.skipped).toBe(0);
+    const parent = await Filament.findOne({ name: "Universal PLA" });
+    const variant = await Filament.findOne({ name: "Galaxy Black PLA" });
+    expect(parent.parentId).toBeFalsy();
+    expect(variant.parentId.toString()).toBe(parent._id.toString());
+  });
+
+  it("skips a row whose Parent does not exist among active filaments", async () => {
+    const result = await upsertImportRows([
+      {
+        name: "Orphan Variant",
+        vendor: "V",
+        type: "PLA",
+        parentName: "Does Not Exist",
+      },
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.skippedRows[0].name).toBe("Orphan Variant");
+    expect(result.skippedRows[0].reason).toContain("Does Not Exist");
+    expect(result.skippedRows[0].reason).toContain("not found");
+  });
+
+  it("skips a row whose Parent is itself a variant (variants-of-variants forbidden)", async () => {
+    const grandparent = await Filament.create({
+      name: "Top PLA",
+      vendor: "V",
+      type: "PLA",
+    });
+    await Filament.create({
+      name: "Middle PLA",
+      vendor: "V",
+      type: "PLA",
+      parentId: grandparent._id,
+    });
+
+    const result = await upsertImportRows([
+      {
+        name: "Leaf PLA",
+        vendor: "V",
+        type: "PLA",
+        parentName: "Middle PLA",
+      },
+    ]);
+
+    expect(result.skipped).toBe(1);
+    expect(result.skippedRows[0].reason).toContain("Middle PLA");
+    expect(result.skippedRows[0].reason).toContain("itself a variant");
+
+    const leaf = await Filament.findOne({ name: "Leaf PLA" });
+    expect(leaf).toBeNull();
+  });
+
+  it("skips a row that references its own name as Parent", async () => {
+    const result = await upsertImportRows([
+      {
+        name: "Self-Parent",
+        vendor: "V",
+        type: "PLA",
+        parentName: "Self-Parent",
+      },
+    ]);
+
+    expect(result.skipped).toBe(1);
+    expect(result.skippedRows[0].reason).toContain("self");
+  });
+
+  it("ignores the Parent column when updating an existing active filament", async () => {
+    // Active sibling that could appear to be the Parent — but updates
+    // never re-parent, per the issue's design.
+    const sibling = await Filament.create({
+      name: "Existing Parent",
+      vendor: "V",
+      type: "PLA",
+    });
+    const target = await Filament.create({
+      name: "Already Active",
+      vendor: "V",
+      type: "PLA",
+    });
+    expect(target.parentId).toBeFalsy();
+
+    const result = await upsertImportRows([
+      {
+        name: "Already Active",
+        vendor: "V",
+        type: "PLA",
+        cost: 19.99,
+        parentName: "Existing Parent",
+      },
+    ]);
+
+    expect(result.updated).toBe(1);
+    expect(result.skipped).toBe(0);
+    const fresh = await Filament.findById(target._id);
+    expect(fresh.cost).toBe(19.99);
+    expect(fresh.parentId).toBeFalsy();
+    // The sibling stays a top-level filament too.
+    const stillSibling = await Filament.findById(sibling._id);
+    expect(stillSibling.parentId).toBeFalsy();
+  });
+
+  it("round-trips a parent + its variants through a single import batch", async () => {
+    // Simulates an export of (parent + 2 variants) being re-imported into
+    // an empty DB. After the import, the cluster shape is preserved:
+    // one root with two children.
+    const result = await upsertImportRows([
+      { name: "Galaxy Black PLA", vendor: "Sunlu", type: "PLA", parentName: "Universal PLA" },
+      { name: "Universal PLA", vendor: "Generic", type: "PLA" },
+      { name: "Galaxy Gold PLA", vendor: "Sunlu", type: "PLA", parentName: "Universal PLA" },
+    ]);
+
+    expect(result.created).toBe(3);
+    expect(result.skipped).toBe(0);
+
+    const parent = await Filament.findOne({ name: "Universal PLA" });
+    expect(parent.parentId).toBeFalsy();
+    const children = await Filament.find({ parentId: parent._id });
+    expect(children).toHaveLength(2);
+    const names = children.map((c: { name: string }) => c.name).sort();
+    expect(names).toEqual(["Galaxy Black PLA", "Galaxy Gold PLA"]);
+  });
+
+  it("treats a Variant Count cell as read-only — does not blow up or persist anything", async () => {
+    // `rowToImport` would already filter the column out via mapHeaders, so
+    // an ImportRow built normally never carries `variantCount`. This test
+    // just guards the surface — a stray field on a hand-built row is
+    // ignored, not crashing.
+    const result = await upsertImportRows([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { name: "Plain Row", vendor: "V", type: "PLA", variantCount: 5 } as any,
+    ]);
+
+    expect(result.created).toBe(1);
+    const doc = await Filament.findOne({ name: "Plain Row" });
+    // No spurious `variantCount` field landed on the model.
+    expect("variantCount" in (doc.toObject?.() ?? {})).toBe(false);
   });
 });

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -538,6 +538,31 @@ describe("upsertImportRows — Parent column (GH #379)", () => {
     expect(names).toEqual(["Galaxy Black PLA", "Galaxy Gold PLA"]);
   });
 
+  it("routes a whitespace-only Parent cell to pass 1 so it can serve as an in-batch parent (Codex P2)", async () => {
+    // Whitespace-only `Parent` is semantically empty (processRow trims
+    // before resolving). Pre-fix the router compared raw `row.parentName`,
+    // so a row with parentName="   " landed in pass 2 even though it had
+    // no parent — and any earlier variant referencing it as Parent then
+    // skipped with a misleading "not found" because pass 2's order of
+    // operations meant the parent row wasn't processed yet.
+    //
+    // Ordering this test like the original failure: variant first, then
+    // the whitespace-parent row. Both should now end up in their
+    // semantically-correct passes (variant in pass 2, parent in pass 1).
+    const result = await upsertImportRows([
+      { name: "Variant", vendor: "V", type: "PLA", parentName: "Real Parent" },
+      // Whitespace-only Parent column — semantically a standalone.
+      { name: "Real Parent", vendor: "V", type: "PLA", parentName: "   " },
+    ]);
+
+    expect(result.created).toBe(2);
+    expect(result.skipped).toBe(0);
+    const realParent = await Filament.findOne({ name: "Real Parent" });
+    const variant = await Filament.findOne({ name: "Variant" });
+    expect(realParent.parentId).toBeFalsy();
+    expect(variant.parentId.toString()).toBe(realParent._id.toString());
+  });
+
   it("treats a Variant Count cell as read-only — does not blow up or persist anything", async () => {
     // `rowToImport` would already filter the column out via mapHeaders, so
     // an ImportRow built normally never carries `variantCount`. This test


### PR DESCRIPTION
## Summary

- Follow-up to [#378](https://github.com/hyiger/filament-db/pull/378), which added `Parent` and `Variant Count` columns to the filament-level export. The re-import path didn't read them, so a round-trip flattened every variant into a standalone filament — [#379](https://github.com/hyiger/filament-db/issues/379).
- Shared filament importer (`src/lib/importFilaments.ts`, used by both `/api/filaments/import-csv` and `/import-xlsx`) now recognises the `Parent` column. Honoured **only on create/resurrect**; silently ignored on update because re-parenting via re-import is a surprising UX. `Variant Count` is read-only and ignored.
- Two-pass driver: rows without `Parent` go first, so an in-batch parent is present in the lookup map by the time the variant rows resolve. Works regardless of CSV row order (real exports sort by name, so variants often precede their parents alphabetically).
- Parent must be active and must not itself be a variant. Self-references are rejected. All failure modes land in `skippedRows` with a named reason.

## Scope note

Issue title says "Spool CSV importer" but the substantive round-trip described is filament-level (export filaments → reimport → cluster preserved). The spool importer requires filaments to exist already and doesn't create them, so the fix belongs in the filament importer. Spool importer is unchanged — extra `parentName` columns in a spool CSV are silently ignored as they were before.

## Test plan

- [x] `npm test` — 1410 tests pass (8 new in `tests/importFilaments.test.ts` covering header mapping, in-batch round-trip in either row order, missing/variant/self-referential parent, and the update-ignores-Parent rule)
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] Manual: export filaments with variants → delete all → re-import → confirm cluster preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)