### PR TITLE
test(ci): bump vitest testTimeout to 30s for slow Windows x64 runners

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,16 +23,27 @@ export default defineConfig({
         statements: 80,
       },
     },
-    testTimeout: 15000,
-    // Bumped from the 10s default. Several route-level test files use a
-    // beforeEach that dynamically imports Mongoose models and re-registers
-    // them on the connection (setup.ts wipes mongoose.models between
-    // tests). On Windows the cold-import + ESM-resolution path can blow
-    // past 10s on the first iteration of a file, which used to fail the
-    // Windows release build (e.g. tests/locations-route.test.ts beforeEach
-    // timed out in CI but passed locally on macOS / Linux). 30s gives
-    // enough headroom for the slowest Windows runner without masking real
-    // hangs — the testTimeout above still catches stuck tests at 15s.
+    // Bumped from the 15s prior cap. The v1.32.0 release build (run
+    // 26624712937) hit three consecutive Windows x64 failures with
+    // different tests timing out at 15s each time; every failure was a
+    // route-level test running queries against mongodb-memory-server.
+    // Same root cause as `hookTimeout` below (cold-import + ESM-resolve
+    // is slow on Windows runners) — the slowness manifests inside the
+    // test body too, not just the hook, because the first
+    // `Filament.find()` after a model is freshly re-registered triggers
+    // the slow path. 30s matches hookTimeout and still catches genuine
+    // hangs; healthy tests run in <1s so the new ceiling is ~30× their
+    // typical budget. Tests on mac/linux are unaffected — they finish
+    // well under either cap.
+    testTimeout: 30000,
+    // Same root cause as the `testTimeout` above: route-level test files
+    // use a beforeEach that dynamically imports Mongoose models and
+    // re-registers them on the connection (setup.ts wipes
+    // mongoose.models between tests). On Windows the cold-import +
+    // ESM-resolution path can blow past 10s on the first iteration of a
+    // file, which used to fail the Windows release build (e.g.
+    // tests/locations-route.test.ts beforeEach timed out in CI but
+    // passed locally on macOS / Linux).
     hookTimeout: 30000,
     setupFiles: ["./tests/setup.ts"],
   },


### PR DESCRIPTION
## Summary

The v1.32.0 release build ([run 26624712937](https://github.com/hyiger/filament-db/actions/runs/26624712937)) hit three consecutive failures on **Windows x64** with different tests timing out at 15s each time — all route-level tests querying `mongodb-memory-server`. macOS and Linux finished cleanly across the same range.

Same root cause as the existing `hookTimeout: 30000` precedent: cold-import + ESM resolution is slow on Windows runners and triggers the slow path on the first `Filament.find()` after a model is freshly re-registered. The slowness manifests inside the test body too, not only inside the hook.

CLAUDE.md's release-process gotcha for this class of failure: *"When the job fails on that timeout specifically, a re-run usually passes; if it becomes a pattern, bump the timeout."* Three failures is the pattern.

30s matches the existing `hookTimeout`. Healthy tests run in <1s so the new ceiling is ~30× their typical budget — still well within "catches genuine hangs".

## Test plan

- [x] `npm test` — 1455 / 1455 passing locally on macOS (unaffected by the bump)
- [x] No code changes; config-only

Once this lands, **v1.32.1** picks up the timeout fix so the Windows x64 build can complete. v1.32.0 stays as-is (mac + linux + win-arm64 assets shipped; win-x64 absent due to the flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)