### PR TITLE
Guard inventory + add-spool actions against double-submit (#404, #440)

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -100,6 +100,13 @@ export default function FilamentDetail() {
   const [addSpoolForm, setAddSpoolForm] = useState<
     { open: boolean; label: string; totalWeight: string }
   >({ open: false, label: "", totalWeight: "" });
+  // GH #440: double-submit guard for the Add Spool Create button.
+  // Pre-fix both inline Add Spool buttons `await`-ed handleAddSpool
+  // without disabling, so a second click during the POST created a
+  // duplicate spool. Lifts to component-level state because BOTH
+  // create buttons (the regular flow and the empty-state fallback)
+  // need to share the same in-flight flag.
+  const [addSpoolSubmitting, setAddSpoolSubmitting] = useState(false);
   const { isElectron, status: nfcStatus, writing: nfcWriting, writeTag, notifyTagWritten } = useNfcContext();
   const [nfcWriteSuccess, setNfcWriteSuccess] = useState<boolean | null>(null);
   const nfcWriteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1121,22 +1128,30 @@ export default function FilamentDetail() {
                       className="w-32 px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-transparent"
                     />
                     <button
+                      disabled={addSpoolSubmitting}
                       onClick={async () => {
+                        if (addSpoolSubmitting) return;
                         const weight = addSpoolForm.totalWeight
                           ? Number(addSpoolForm.totalWeight)
                           : null;
-                        await handleAddSpool(addSpoolForm.label.trim(), weight);
-                        setAddSpoolForm({ open: false, label: "", totalWeight: "" });
+                        setAddSpoolSubmitting(true);
+                        try {
+                          await handleAddSpool(addSpoolForm.label.trim(), weight);
+                          setAddSpoolForm({ open: false, label: "", totalWeight: "" });
+                        } finally {
+                          setAddSpoolSubmitting(false);
+                        }
                       }}
-                      className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700"
+                      className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {t("detail.spool.addCreate")}
                     </button>
                     <button
+                      disabled={addSpoolSubmitting}
                       onClick={() =>
                         setAddSpoolForm({ open: false, label: "", totalWeight: "" })
                       }
-                      className="px-4 py-1.5 border border-gray-300 dark:border-gray-700 rounded text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
+                      className="px-4 py-1.5 border border-gray-300 dark:border-gray-700 rounded text-sm hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
                     >
                       {t("common.cancel")}
                     </button>
@@ -1200,20 +1215,28 @@ export default function FilamentDetail() {
                     className="w-32 px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-transparent"
                   />
                   <button
+                    disabled={addSpoolSubmitting}
                     onClick={async () => {
+                      if (addSpoolSubmitting) return;
                       const weight = addSpoolForm.totalWeight
                         ? Number(addSpoolForm.totalWeight)
                         : null;
-                      await handleAddSpool(addSpoolForm.label.trim(), weight);
-                      setAddSpoolForm({ open: false, label: "", totalWeight: "" });
+                      setAddSpoolSubmitting(true);
+                      try {
+                        await handleAddSpool(addSpoolForm.label.trim(), weight);
+                        setAddSpoolForm({ open: false, label: "", totalWeight: "" });
+                      } finally {
+                        setAddSpoolSubmitting(false);
+                      }
                     }}
-                    className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700"
+                    className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {t("detail.spool.addCreate")}
                   </button>
                   <button
+                    disabled={addSpoolSubmitting}
                     onClick={() => setAddSpoolForm({ open: false, label: "", totalWeight: "" })}
-                    className="px-4 py-1.5 border border-gray-300 dark:border-gray-700 rounded text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
+                    className="px-4 py-1.5 border border-gray-300 dark:border-gray-700 rounded text-sm hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
                   >
                     {t("common.cancel")}
                   </button>

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -461,12 +461,29 @@ function SpoolEditRow({ row, locations, updateSpool, confirmRetire, onChanged }:
     }
   };
 
+  // GH #404: the move-to <select> and retire button used to fire
+  // PUTs without a busy guard. On a slow LAN (Pi-hosted instance,
+  // etc.) a second click would race the first PUT; on retire toggle
+  // the response order could end in the wrong state. Per-handler
+  // saving flags disable the matching control until the round-trip
+  // completes. The weight editor already did this via its own
+  // `saving` state.
+  const [movePending, setMovePending] = useState(false);
+  const [retirePending, setRetirePending] = useState(false);
+
   const moveTo = async (locId: string) => {
-    const ok = await updateSpool(row, { locationId: locId || null });
-    if (ok) onChanged();
+    if (movePending) return;
+    setMovePending(true);
+    try {
+      const ok = await updateSpool(row, { locationId: locId || null });
+      if (ok) onChanged();
+    } finally {
+      setMovePending(false);
+    }
   };
 
   const toggleRetire = async () => {
+    if (retirePending) return;
     if (!row.retired) {
       // Retiring removes the spool from inventory totals — confirm
       // because it's the kind of action a click can fire by mistake.
@@ -475,8 +492,13 @@ function SpoolEditRow({ row, locations, updateSpool, confirmRetire, onChanged }:
         confirmLabel: t("inventory.retire"),
       }))) return;
     }
-    const ok = await updateSpool(row, { retired: !row.retired });
-    if (ok) onChanged();
+    setRetirePending(true);
+    try {
+      const ok = await updateSpool(row, { retired: !row.retired });
+      if (ok) onChanged();
+    } finally {
+      setRetirePending(false);
+    }
   };
 
   return (
@@ -599,6 +621,7 @@ function SpoolEditRow({ row, locations, updateSpool, confirmRetire, onChanged }:
         <div className="inline-flex items-center gap-1">
           <select
             value=""
+            disabled={movePending}
             onChange={(e) => {
               const v = e.target.value;
               if (v === "__none") moveTo("");
@@ -607,7 +630,7 @@ function SpoolEditRow({ row, locations, updateSpool, confirmRetire, onChanged }:
             }}
             aria-label={t("inventory.moveTo")}
             title={t("inventory.moveTo")}
-            className="text-xs px-1 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-transparent"
+            className="text-xs px-1 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-transparent disabled:opacity-50"
           >
             <option value="">{t("inventory.moveTo")}</option>
             <option value="__none">{t("inventory.noLocation")}</option>
@@ -620,7 +643,8 @@ function SpoolEditRow({ row, locations, updateSpool, confirmRetire, onChanged }:
           <button
             type="button"
             onClick={toggleRetire}
-            className={`text-xs px-2 py-0.5 rounded ${
+            disabled={retirePending}
+            className={`text-xs px-2 py-0.5 rounded disabled:opacity-50 ${
               row.retired
                 ? "border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800"
                 : "text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-950"


### PR DESCRIPTION
## Summary
- **#404**: `/inventory` move-to and retire actions now use per-action `movePending` / `retirePending` flags. Select + retire button `disabled` through the PUT; handlers short-circuit on re-entry.
- **#440**: Both Add Spool Create buttons on filament detail share one `addSpoolSubmitting` flag, gating their `disabled` through the POST.

## Out of scope (separate PRs)
- #403 (Bambu inheritance), #406 (FilamentForm negatives) — handled in follow-up PRs to keep this one tight.
- #458 — the visible Save/Cancel buttons the issue requests already exist in both targets (inventory weight editor + Add Spool form). Will close with that note.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [ ] Manual: throttle network on `/inventory`, rapid-click move-to / retire, verify single PUT
- [ ] Manual: throttle network on filament detail, rapid-click Add Spool Create, verify single POST

Closes #404
Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)