### PR TITLE
Harden Electron security: CSP + IPC sender guards (#408, #409, #410, #432, #434)

### DIFF
--- a/electron/auto-updater.ts
+++ b/electron/auto-updater.ts
@@ -77,7 +77,14 @@ export function initAutoUpdater(win: BrowserWindow) {
   // electron-updater refuses to run when app.isPackaged is false.
   ipcMain.handle("update-get-status", () => currentState);
 
-  ipcMain.handle("update-check", async () => {
+  // GH #434: update-check and update-download were gated only on
+  // `app.isPackaged`. In a release build a sub-frame could drive
+  // both unconditionally — checking is free but `update-download`
+  // pulls the full installer payload, which is bandwidth abuse
+  // against the user. Defence-in-depth: trust only the top-level
+  // app frame, same as the install handler.
+  ipcMain.handle("update-check", async (event) => {
+    assertTrustedSender(event, "update-check");
     if (!app.isPackaged) return { ok: false, error: "dev-mode" };
     try {
       await autoUpdater.checkForUpdates();
@@ -89,7 +96,8 @@ export function initAutoUpdater(win: BrowserWindow) {
     }
   });
 
-  ipcMain.handle("update-download", async () => {
+  ipcMain.handle("update-download", async (event) => {
+    assertTrustedSender(event, "update-download");
     if (!app.isPackaged) return { ok: false, error: "dev-mode" };
     if (currentState.state !== "available") return { ok: false, error: "No update available" };
     try {
@@ -154,7 +162,12 @@ export function initAutoUpdater(win: BrowserWindow) {
 
   // Opens the GitHub release page — useful for macOS where unsigned auto-
   // install is blocked by Gatekeeper and the user has to download manually.
-  ipcMain.handle("update-open-release-page", async () => {
+  // GH #434: shell.openExternal opens the user's default browser. The URL
+  // is built from a server-supplied version string (`currentState.version`)
+  // so injection risk is low, but a sub-frame triggering arbitrary tab
+  // opens is still a phishing surface — gate on the top-level frame.
+  ipcMain.handle("update-open-release-page", async (event) => {
+    assertTrustedSender(event, "update-open-release-page");
     const version = currentState.version;
     const url = version
       ? `https://github.com/hyiger/filament-db/releases/tag/v${version}`

--- a/electron/csp-scope.ts
+++ b/electron/csp-scope.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helper extracted so the "should this response receive the
+ * app CSP?" decision can be unit-tested in isolation. Lives in its
+ * own module because `electron/main.ts` is excluded from tsconfig
+ * and not directly importable from `tests/`.
+ *
+ * Background (Codex P1 on PR #462): the `onHeadersReceived` handler
+ * runs for EVERY response in the default session — including the
+ * vendor TDS document loaded inside the `<iframe>` (the
+ * `frame-src https:` flow added in GH #250). The app CSP carries
+ * `frame-ancestors 'none'`, which on a vendor response tells
+ * Chromium the document may not be embedded by ANY parent. Without
+ * scoping the CSP write to app responses only, every vendor TDS
+ * preview is broken in desktop builds.
+ *
+ * Pin the decision by origin match: if the response URL's origin
+ * matches the embedded Next server's origin, apply the app CSP;
+ * otherwise leave the response's own CSP untouched.
+ */
+export function shouldApplyAppCsp(
+  responseUrl: string,
+  appOrigin: string,
+): boolean {
+  try {
+    return new URL(responseUrl).origin === appOrigin;
+  } catch {
+    // Malformed URL → don't touch the headers. Better to fall
+    // through than to apply the app CSP to something we can't
+    // reason about.
+    return false;
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,7 @@ import { startLocalMongo, stopLocalMongo } from "./local-mongo";
 import { SyncService, SyncStatus, getDbNameFromUri } from "./sync-service";
 import { initAutoUpdater } from "./auto-updater";
 import { assertTrustedSender, validateMongoUri } from "./ipc-security";
+import { shouldApplyAppCsp } from "./csp-scope";
 
 // ── Diagnostic log ──
 // Writes lifecycle and crash events to a file in userData so users on
@@ -1129,13 +1130,13 @@ app.whenReady().then(async () => {
   // Gate on the response URL's origin matching the app origin.
   const APP_ORIGIN = `http://localhost:${PORT}`;
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-    let requestOrigin: string | null = null;
-    try {
-      requestOrigin = new URL(details.url).origin;
-    } catch {
-      // Malformed URL — fall through and don't touch the headers.
-    }
-    if (requestOrigin !== APP_ORIGIN) {
+    // Critical: shouldApplyAppCsp returns false for vendor TDS iframe
+    // responses (origin !== APP_ORIGIN). Without that early-out, the
+    // `frame-ancestors 'none'` directive below would land on the
+    // vendor document and Chromium would refuse to embed it. See
+    // `electron/csp-scope.ts` for the rationale and the dedicated
+    // unit test that pins this contract.
+    if (!shouldApplyAppCsp(details.url, APP_ORIGIN)) {
       callback({ responseHeaders: details.responseHeaders });
       return;
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1119,7 +1119,26 @@ app.whenReady().then(async () => {
   const scriptSrc = app.isPackaged
     ? "script-src 'self' 'unsafe-inline'"
     : "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
+  // CSP header rewrite, scoped to the embedded Next app's own
+  // responses. Codex flagged a P1 on PR #462: an unfiltered handler
+  // would also rewrite the CSP on the vendor TDS document loaded
+  // inside the `<iframe>` (the `frame-src https:` flow), and setting
+  // `frame-ancestors 'none'` on the vendor doc's response tells
+  // Chromium it can't be embedded by ANY parent — Chromium would
+  // block the frame even though the vendor's own CSP allowed it.
+  // Gate on the response URL's origin matching the app origin.
+  const APP_ORIGIN = `http://localhost:${PORT}`;
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    let requestOrigin: string | null = null;
+    try {
+      requestOrigin = new URL(details.url).origin;
+    } catch {
+      // Malformed URL — fall through and don't touch the headers.
+    }
+    if (requestOrigin !== APP_ORIGIN) {
+      callback({ responseHeaders: details.responseHeaders });
+      return;
+    }
     callback({
       responseHeaders: {
         ...details.responseHeaders,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -124,6 +124,43 @@ app.on("second-instance", () => {
   }
 });
 
+// GH #410: per-window guards on `mainWindow.webContents` (will-navigate,
+// setWindowOpenHandler) protect only the top-level frame. A new
+// BrowserWindow, an embedded <iframe> whose target becomes a separate
+// WebContents, or a stray <webview> tag would inherit nothing. The
+// global `web-contents-created` listener applies the same http(s)-only
+// filter to EVERY WebContents the app ever creates — defence in depth
+// against future code paths that spin up additional browser surfaces.
+app.on("web-contents-created", (_event, contents) => {
+  contents.setWindowOpenHandler(({ url }) => {
+    try {
+      const proto = new URL(url).protocol;
+      if (proto === "http:" || proto === "https:") {
+        shell.openExternal(url);
+      } else {
+        console.warn(
+          `[web-contents-created] Refused external URL scheme: ${proto}`,
+        );
+      }
+    } catch {
+      console.warn(
+        `[web-contents-created] Refused malformed external URL: ${url}`,
+      );
+    }
+    return { action: "deny" };
+  });
+
+  contents.on("will-navigate", (event, url) => {
+    const appUrl = getAppURL();
+    if (!url.startsWith(appUrl)) event.preventDefault();
+  });
+
+  // `<webview>` is denied at the BrowserWindow level via
+  // `webPreferences.webviewTag: false`, but a child WebContents
+  // could still try to attach one. Deny at the contents level too.
+  contents.on("will-attach-webview", (event) => event.preventDefault());
+});
+
 function getAppURL(urlPath = "/") {
   return `http://localhost:${PORT}${urlPath}`;
 }
@@ -164,6 +201,12 @@ function createWindow(urlPath = "/") {
       // DB content / TDS-extracted HTML so it can't reach beyond the
       // renderer process.
       sandbox: true,
+      // GH #410: explicit defence-in-depth. `<webview>` tags load a
+      // distinct WebContents that doesn't inherit the renderer's
+      // sandbox settings. The app doesn't use them anywhere; deny
+      // them so a future stray <webview> can't be a privileged
+      // escape hatch.
+      webviewTag: false,
     },
   });
 
@@ -635,7 +678,16 @@ function initSyncService(localUri: string, atlasUri: string) {
 // ── IPC handlers ──
 
 // Config
-ipcMain.handle("get-config", () => {
+//
+// GH #409: returns the Atlas URI + AI API keys + Mongo URI. Without a
+// sender guard, a sub-frame (embedded TDS, an XSS payload in a
+// user-supplied filament field) could read the full credential blob
+// and exfiltrate it through `img-src https:`-permitted beaconing.
+// The siblings (`save-config`, `test-connection`, `reset-config`) all
+// gate on `assertTrustedSender` already — this read path was the
+// asymmetric hole.
+ipcMain.handle("get-config", (event) => {
+  assertTrustedSender(event, "get-config");
   return {
     mongodbUri: store.get("mongodbUri") as string,
     connectionMode: store.get("connectionMode") as string,
@@ -817,7 +869,13 @@ ipcMain.handle("get-sync-status", () => {
   };
 });
 
-ipcMain.handle("trigger-sync", async () => {
+// GH #432: trigger-sync was reachable from any sub-frame. The
+// `this.syncing` guard in SyncService makes the SECOND call cheap
+// but the FIRST opens a real MongoClient connection to Atlas, which
+// a compromised sub-frame could weaponise for timing attacks or
+// bandwidth abuse against the user's Atlas tier.
+ipcMain.handle("trigger-sync", async (event) => {
+  assertTrustedSender(event, "trigger-sync");
   if (!syncService) {
     return { error: "Sync not available in current mode" };
   }
@@ -858,7 +916,12 @@ ipcMain.handle("nfc-get-status", () => {
   };
 });
 
-ipcMain.handle("nfc-read-tag", async () => {
+// GH #432 follow-up: nfc-read-tag can move tag state (reads consume
+// a slot in the reader's pipeline) and a sub-frame racing the
+// legitimate auto-read could mask a real scan. Gate on the same
+// trusted-sender check the write/format handlers already use.
+ipcMain.handle("nfc-read-tag", async (event) => {
+  assertTrustedSender(event, "nfc-read-tag");
   if (!nfcService) throw new Error("NFC not initialized");
   return withIpcTimeout(() => nfcService!.readTag(), "nfc-read-tag");
 });
@@ -1079,7 +1142,17 @@ app.whenReady().then(async () => {
         // so anything missing on this side is silently dropped in desktop.
         // `connect-src` intentionally diverges: Electron adds localhost
         // ws/http for the embedded Next server; everything else mirrors web.
-        "Content-Security-Policy": [`default-src 'self'; ${scriptSrc}; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' ws://localhost:* http://localhost:*; font-src 'self' data:; frame-src https:;`],
+        //
+        // GH #408: four hardening directives the web CSP has been carrying
+        // were silently absent on desktop — `frame-ancestors 'none'`
+        // (prevents clickjacking by blocking framing of the renderer),
+        // `base-uri 'self'` (prevents <base href> injection redirecting all
+        // relative URLs), `form-action 'self'` (blocks credential-stealing
+        // form exfil), `object-src 'none'` (blocks plugin-based code
+        // execution). Drop-in addition since the Electron CSP REPLACES the
+        // Next-sent header, every directive on the web side has to be
+        // mirrored explicitly here.
+        "Content-Security-Policy": [`default-src 'self'; ${scriptSrc}; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' ws://localhost:* http://localhost:*; font-src 'self' data:; frame-src https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none';`],
       },
     });
   });

--- a/tests/csp-parity.test.ts
+++ b/tests/csp-parity.test.ts
@@ -55,16 +55,36 @@ const KNOWN_DIRECTIVES = [
   "child-src",
 ] as const;
 
+/**
+ * Strip JS / TS comments before scanning for directives. Codex
+ * follow-up on PR #462 round 2: the regex matches directive names
+ * followed by a CSP value token, but the source file contains
+ * COMMENTS that quote real CSP fragments verbatim (e.g.
+ * `// 'base-uri 'self'' (prevents <base> injection)`). Those
+ * comment mentions would falsely satisfy the parity assertion.
+ *
+ * Doesn't try to be a full TS parser — the only comment shapes in
+ * this repo are `// line` and `/* block *​/`, so a tiny regex pass
+ * is enough. The negative lookbehind on `//` (preceding char not
+ * `:`) keeps `https://` / `mongodb://` URLs in code from being
+ * misread as line comments.
+ */
+function stripComments(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
 function readDirectives(filePath: string): Set<string> {
-  const text = readFileSync(resolve(REPO_ROOT, filePath), "utf8");
+  const raw = readFileSync(resolve(REPO_ROOT, filePath), "utf8");
+  const text = stripComments(raw);
   const seen = new Set<string>();
   for (const name of KNOWN_DIRECTIVES) {
     // Match the directive name preceded by a non-word-char boundary
     // (so `style-src` doesn't accidentally match inside `frame-style-src`)
     // and followed by whitespace + a value that starts with a CSP value
     // token (`'self'`, `'none'`, `https:`, `data:`, `blob:`, `*`, `ws:`,
-    // or a hostname-like character). That filters out prose mentions
-    // and comment text.
+    // or a hostname-like character).
     const pattern = new RegExp(
       String.raw`(?:^|[^a-z\-])` +
         name.replace(/-/g, "\\-") +

--- a/tests/csp-parity.test.ts
+++ b/tests/csp-parity.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * GH #408 — Electron CSP parity guard.
+ *
+ * The Electron renderer's `onHeadersReceived` overrides whatever CSP
+ * the embedded Next.js server sends, so any directive present in the
+ * web CSP (`next.config.ts`) but absent from the Electron header
+ * (`electron/main.ts`) silently drops in desktop builds. v1.25.1 +
+ * v1.30.3 both shipped with that exact drift; this test fails fast
+ * when a future change touches one side and forgets the other.
+ *
+ * The ONE intentional asymmetry is `connect-src` — Electron adds
+ * `ws://localhost:* http://localhost:*` for the embedded server.
+ * `script-src` ALSO carries a dev-vs-packaged variance (Turbopack
+ * needs `unsafe-eval` in dev), so we just verify both files declare
+ * the directive and don't compare its tokens.
+ */
+const REPO_ROOT = resolve(__dirname, "..");
+
+function readDirectives(filePath: string): Set<string> {
+  const text = readFileSync(resolve(REPO_ROOT, filePath), "utf8");
+  // Match every CSP directive name (the token right after `;` or at the
+  // start of a CSP string literal, before the value). We grep across the
+  // whole file rather than parse it so the test doesn't depend on the
+  // exact line layout.
+  const seen = new Set<string>();
+  for (const match of text.matchAll(/(?:^|;\s*)([a-z\-]+)\s+[^;'"]*?(?=[;'"])/g)) {
+    const name = match[1];
+    // Filter to real CSP directive names — there are only ~15 of them
+    // and we don't want to pick up arbitrary CSS-like tokens.
+    if (
+      [
+        "default-src",
+        "script-src",
+        "style-src",
+        "img-src",
+        "font-src",
+        "connect-src",
+        "frame-src",
+        "frame-ancestors",
+        "base-uri",
+        "form-action",
+        "object-src",
+        "media-src",
+        "worker-src",
+        "manifest-src",
+        "child-src",
+      ].includes(name)
+    ) {
+      seen.add(name);
+    }
+  }
+  return seen;
+}
+
+describe("CSP parity — web (next.config.ts) vs Electron (electron/main.ts)", () => {
+  it("every directive on the web side is also present on the Electron side", () => {
+    const web = readDirectives("next.config.ts");
+    const electron = readDirectives("electron/main.ts");
+    const missing = [...web].filter((d) => !electron.has(d));
+    expect(missing).toEqual([]);
+  });
+
+  it("Electron CSP carries the four hardening directives added in #408", () => {
+    const electron = readDirectives("electron/main.ts");
+    expect(electron.has("frame-ancestors")).toBe(true);
+    expect(electron.has("base-uri")).toBe(true);
+    expect(electron.has("form-action")).toBe(true);
+    expect(electron.has("object-src")).toBe(true);
+  });
+});

--- a/tests/csp-parity.test.ts
+++ b/tests/csp-parity.test.ts
@@ -20,36 +20,58 @@ import { resolve } from "node:path";
  */
 const REPO_ROOT = resolve(__dirname, "..");
 
+/**
+ * Codex feedback on PR #462: the earlier regex required the directive
+ * name to follow `;` or start-of-file, which never matches the web CSP
+ * where each directive lives in its own JS string literal like
+ * `"default-src 'self'"`. The directive name there is right after a
+ * `"` — not after a `;`.
+ *
+ * Replace the position-anchored regex with one that finds each known
+ * CSP directive name preceded by ANY non-word boundary (`;`, `"`, `'`,
+ * `\``, whitespace, BOL) and followed by whitespace + a value. This
+ * matches both:
+ *   - one big template literal: `"… ;${scriptSrc}; style-src 'self'…"`
+ *   - per-line quoted strings: `"default-src 'self'"`, `"style-src…"`
+ * Comments in the file (the prose mentioning a directive name) won't
+ * match because they're not followed by whitespace + a CSP value
+ * unless the test ALSO accepts a comma / period, which we don't.
+ */
+const KNOWN_DIRECTIVES = [
+  "default-src",
+  "script-src",
+  "style-src",
+  "img-src",
+  "font-src",
+  "connect-src",
+  "frame-src",
+  "frame-ancestors",
+  "base-uri",
+  "form-action",
+  "object-src",
+  "media-src",
+  "worker-src",
+  "manifest-src",
+  "child-src",
+] as const;
+
 function readDirectives(filePath: string): Set<string> {
   const text = readFileSync(resolve(REPO_ROOT, filePath), "utf8");
-  // Match every CSP directive name (the token right after `;` or at the
-  // start of a CSP string literal, before the value). We grep across the
-  // whole file rather than parse it so the test doesn't depend on the
-  // exact line layout.
   const seen = new Set<string>();
-  for (const match of text.matchAll(/(?:^|;\s*)([a-z\-]+)\s+[^;'"]*?(?=[;'"])/g)) {
-    const name = match[1];
-    // Filter to real CSP directive names — there are only ~15 of them
-    // and we don't want to pick up arbitrary CSS-like tokens.
-    if (
-      [
-        "default-src",
-        "script-src",
-        "style-src",
-        "img-src",
-        "font-src",
-        "connect-src",
-        "frame-src",
-        "frame-ancestors",
-        "base-uri",
-        "form-action",
-        "object-src",
-        "media-src",
-        "worker-src",
-        "manifest-src",
-        "child-src",
-      ].includes(name)
-    ) {
+  for (const name of KNOWN_DIRECTIVES) {
+    // Match the directive name preceded by a non-word-char boundary
+    // (so `style-src` doesn't accidentally match inside `frame-style-src`)
+    // and followed by whitespace + a value that starts with a CSP value
+    // token (`'self'`, `'none'`, `https:`, `data:`, `blob:`, `*`, `ws:`,
+    // or a hostname-like character). That filters out prose mentions
+    // and comment text.
+    const pattern = new RegExp(
+      String.raw`(?:^|[^a-z\-])` +
+        name.replace(/-/g, "\\-") +
+        String.raw`\s+(?:'(?:self|none|unsafe-(?:inline|eval))'|https?:|wss?:|data:|blob:|\*|[a-z0-9.\-]+)`,
+      "i",
+    );
+    if (pattern.test(text)) {
       seen.add(name);
     }
   }

--- a/tests/csp-scope.test.ts
+++ b/tests/csp-scope.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { shouldApplyAppCsp } from "../electron/csp-scope";
+
+/**
+ * Pin the Electron CSP scope: the app-CSP rewrite MUST NOT touch
+ * responses from external origins (the most important being a vendor
+ * TDS document loaded inside the renderer's `<iframe>` — GH #250's
+ * `frame-src https:` flow). Codex flagged this as a P1 on PR #462
+ * twice; this test exists so any future tweak to the scope helper
+ * fails CI before it can regress the TDS preview again.
+ */
+const APP_ORIGIN = "http://localhost:3456";
+
+describe("shouldApplyAppCsp", () => {
+  it("applies the app CSP to top-level app responses", () => {
+    expect(shouldApplyAppCsp("http://localhost:3456/", APP_ORIGIN)).toBe(true);
+    expect(
+      shouldApplyAppCsp("http://localhost:3456/filaments/abc", APP_ORIGIN),
+    ).toBe(true);
+  });
+
+  it("applies the app CSP to app API responses", () => {
+    expect(
+      shouldApplyAppCsp("http://localhost:3456/api/filaments", APP_ORIGIN),
+    ).toBe(true);
+  });
+
+  it("does NOT apply the app CSP to vendor TDS documents (the critical case)", () => {
+    // The exact failure mode Codex P1'd: a vendor TDS fetched into an
+    // iframe must keep its OWN CSP — applying our `frame-ancestors
+    // 'none'` would make Chromium refuse to embed it.
+    expect(
+      shouldApplyAppCsp("https://prusament.com/tds/PLA.pdf", APP_ORIGIN),
+    ).toBe(false);
+    expect(
+      shouldApplyAppCsp("https://www.polymaker.com/tds/PETG.html", APP_ORIGIN),
+    ).toBe(false);
+  });
+
+  it("does NOT apply the app CSP to image/font/data responses from other origins", () => {
+    expect(
+      shouldApplyAppCsp("https://cdn.example.com/image.png", APP_ORIGIN),
+    ).toBe(false);
+  });
+
+  it("distinguishes by port (a different port is a different origin)", () => {
+    // The embedded Next server pins to a specific port; CSP must not
+    // leak to a different localhost service the user happens to run.
+    expect(shouldApplyAppCsp("http://localhost:8080/", APP_ORIGIN)).toBe(false);
+    expect(shouldApplyAppCsp("http://localhost:5173/", APP_ORIGIN)).toBe(false);
+  });
+
+  it("distinguishes by scheme (http vs https)", () => {
+    expect(shouldApplyAppCsp("https://localhost:3456/", APP_ORIGIN)).toBe(false);
+  });
+
+  it("returns false for malformed URLs (safe default)", () => {
+    expect(shouldApplyAppCsp("not-a-url", APP_ORIGIN)).toBe(false);
+    expect(shouldApplyAppCsp("", APP_ORIGIN)).toBe(false);
+  });
+
+  it("respects custom app origins (PORT env override)", () => {
+    const custom = "http://localhost:9999";
+    expect(shouldApplyAppCsp("http://localhost:9999/api/x", custom)).toBe(true);
+    expect(shouldApplyAppCsp("http://localhost:3456/", custom)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Five Electron security fixes filed during the full-codebase audit.

- **#408** — Add `frame-ancestors 'none' / base-uri 'self' / form-action 'self' / object-src 'none'` to the Electron CSP (the web CSP had them; Electron's onHeadersReceived replaces the Next-sent header so missing directives silently drop on desktop). Added a parity test.
- **#409** — `get-config` IPC now `assertTrustedSender` (was leaking Atlas URI + AI keys to sub-frames).
- **#410** — Global `app.on("web-contents-created", ...)` applies http(s)-only filter to every WebContents; `webviewTag: false` + `will-attach-webview` denier.
- **#432** — `trigger-sync` + `nfc-read-tag` IPCs gated.
- **#434** — `update-check` / `update-download` / `update-open-release-page` gated.

## Tests
- New `tests/csp-parity.test.ts` — fails if any CSP directive present in `next.config.ts` is absent from `electron/main.ts`.
- `npm run lint` clean
- `npx tsc --noEmit` clean

Closes #408
Closes #409
Closes #410
Closes #432
Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)