### PR TITLE
Sync: tolerate concurrent E11000 races + document subdoc-id caveat (#438, #439)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -3,6 +3,25 @@ import { randomUUID } from "crypto";
 import { MongoClient, ObjectId, Document } from "mongodb";
 
 /**
+ * Recognise the MongoDB driver's duplicate-key error so the local-only
+ * push / pull paths can treat a concurrent peer winning the
+ * `syncId`-unique race as a no-op rather than a sync failure
+ * (GH #439). The driver surfaces this as `MongoServerError` with
+ * `code === 11000`; `MongoBulkWriteError` from `insertMany` carries
+ * the same code on its `writeErrors[]` array, but the local-only
+ * paths here use `insertOne`, so just checking the top-level code
+ * is sufficient.
+ */
+export function isDuplicateKeyError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: number }).code === 11000
+  );
+}
+
+/**
  * Extract the database name from a MongoDB connection URI.
  *
  * The DB name is the path segment after the authority:
@@ -98,6 +117,17 @@ interface SyncResult {
  * printer.amsSlots[].spoolId, printhistory.usage[].spoolId — clears that
  * id during cross-side remap. Per-filament gram totals still reconcile;
  * per-spool attribution is dropped pending a spool-syncId migration.
+ *
+ * GH #438: the SAME caveat applies to OTHER subdoc `_id`s — every
+ * `calibrations[]._id` on a Filament and every `amsSlots[]._id` on a
+ * Printer is freshly minted by `insertOne`/`$set` on each cross-side
+ * write because the subdocs don't carry a stable `syncId`. Today nothing
+ * in the codebase references these subdoc ids across sync (URL deep-
+ * links, ledger entries, etc. all key by parent doc + offset), so this
+ * is documented as a constraint on future features rather than fixed
+ * by adding subdoc syncIds. If you add a feature that needs stable
+ * cross-side subdoc identity, the fix is to mint a `syncId` on the
+ * subdoc and preserve it through `stripForTransfer`.
  */
 export class SyncService extends EventEmitter {
   private localUri: string;
@@ -588,17 +618,39 @@ export class SyncService extends EventEmitter {
       const remoteDoc = remoteBySyncId.get(syncId);
 
       if (localDoc && !remoteDoc) {
-        // Local-only: push to remote
+        // Local-only: push to remote.
+        //
+        // GH #439: catch E11000 on `syncId` and treat as a no-op. Two
+        // processes pointed at the same Atlas (desktop client + Docker
+        // instance, two desktops sharing an Atlas) can both pass this
+        // "local-only" branch concurrently when their first sync
+        // cycles overlap. The `syncId` unique index is the right place
+        // to serialize them; the loser of the race just observes the
+        // doc already exists. Without this branch the second insert
+        // bubbled up as a collection-level failure in `trySync` and
+        // the whole sync cycle reported "partial".
         const doc = this.stripForTransfer(localDoc);
         const transformed = transformDoc ? transformDoc(doc, "toRemote") : doc;
-        await remoteCol.insertOne({ ...transformed, _id: new ObjectId() });
-        result.pushed++;
+        try {
+          await remoteCol.insertOne({ ...transformed, _id: new ObjectId() });
+          result.pushed++;
+        } catch (err: unknown) {
+          if (!isDuplicateKeyError(err)) throw err;
+          // Other process won the race — the doc is already there,
+          // future cycles will see it via the existing-on-both branch.
+        }
       } else if (!localDoc && remoteDoc) {
-        // Remote-only: pull to local
+        // Remote-only: pull to local. Same E11000 guard symmetry — a
+        // concurrent sync from another instance could have already
+        // pulled the same doc to a shared local store.
         const doc = this.stripForTransfer(remoteDoc);
         const transformed = transformDoc ? transformDoc(doc, "toLocal") : doc;
-        await localCol.insertOne({ ...transformed, _id: new ObjectId() });
-        result.pulled++;
+        try {
+          await localCol.insertOne({ ...transformed, _id: new ObjectId() });
+          result.pulled++;
+        } catch (err: unknown) {
+          if (!isDuplicateKeyError(err)) throw err;
+        }
       } else if (localDoc && remoteDoc) {
         // Both exist: handle conflicts
         const localDeleted = localDoc._deletedAt != null;

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -3,22 +3,33 @@ import { randomUUID } from "crypto";
 import { MongoClient, ObjectId, Document } from "mongodb";
 
 /**
- * Recognise the MongoDB driver's duplicate-key error so the local-only
- * push / pull paths can treat a concurrent peer winning the
- * `syncId`-unique race as a no-op rather than a sync failure
- * (GH #439). The driver surfaces this as `MongoServerError` with
- * `code === 11000`; `MongoBulkWriteError` from `insertMany` carries
- * the same code on its `writeErrors[]` array, but the local-only
- * paths here use `insertOne`, so just checking the top-level code
- * is sufficient.
+ * Recognise a duplicate-key error specifically on the `syncId` index,
+ * so the local-only push / pull paths can treat a concurrent peer
+ * winning that race as a no-op (GH #439).
+ *
+ * Codex follow-up on PR #464: an earlier version accepted ANY
+ * E11000 and silently swallowed real conflicts. Every synced
+ * collection also has unique indexes on at least one other field
+ * — filament `name` / `instanceId`, nozzle `name`, etc. A real
+ * collision on those would have left the doc unsynced forever
+ * while the cycle still reported success.
+ *
+ * The MongoDB driver decorates the error with:
+ *   - `code: 11000`
+ *   - `keyPattern: { <indexedField>: 1 }`  (which index conflicted)
+ *   - `keyValue`: { <indexedField>: <colliding value> }
+ * Constrain to the `syncId` case by checking `keyPattern.syncId` —
+ * a key in the pattern means the violation involved that index.
+ * Without a keyPattern (some driver versions surface a bare code on
+ * older error shapes), err on the side of NOT swallowing so the
+ * cycle still surfaces the conflict.
  */
 export function isDuplicateKeyError(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code?: number }).code === 11000
-  );
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: number; keyPattern?: Record<string, unknown> };
+  if (e.code !== 11000) return false;
+  if (!e.keyPattern || typeof e.keyPattern !== "object") return false;
+  return Object.prototype.hasOwnProperty.call(e.keyPattern, "syncId");
 }
 
 /**

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { getDbNameFromUri, wrapSyncErrorMessage } from "../electron/sync-service";
+import {
+  getDbNameFromUri,
+  isDuplicateKeyError,
+  wrapSyncErrorMessage,
+} from "../electron/sync-service";
 
 describe("getDbNameFromUri", () => {
   it("extracts db name from a basic mongodb URI with explicit path", () => {
@@ -96,5 +100,37 @@ describe("wrapSyncErrorMessage", () => {
     const wrapped = wrapSyncErrorMessage(err, "filament-db");
     // No rewrite — message passes through (with URI redaction, n/a here)
     expect(wrapped).toBe("network reset while updating filament cache");
+  });
+});
+
+describe("isDuplicateKeyError (GH #439)", () => {
+  // The local-only push / pull paths in `syncCollection` need to treat a
+  // concurrent peer winning the `syncId`-unique race as a no-op rather
+  // than a sync failure. The recogniser keys on `err.code === 11000`
+  // which is the MongoDB driver's universal shape for "unique index
+  // violation" across MongoServerError + write-result subdocs.
+
+  it("returns true for an Error with code 11000", () => {
+    const err = Object.assign(new Error("E11000 duplicate key"), { code: 11000 });
+    expect(isDuplicateKeyError(err)).toBe(true);
+  });
+
+  it("returns true for a plain object with code 11000", () => {
+    expect(isDuplicateKeyError({ code: 11000, message: "dup" })).toBe(true);
+  });
+
+  it("returns false for a different error code (e.g. 121 = document failed validation)", () => {
+    expect(isDuplicateKeyError({ code: 121 })).toBe(false);
+  });
+
+  it("returns false for a bare Error with no code", () => {
+    expect(isDuplicateKeyError(new Error("generic failure"))).toBe(false);
+  });
+
+  it("returns false for non-error inputs", () => {
+    expect(isDuplicateKeyError(null)).toBe(false);
+    expect(isDuplicateKeyError(undefined)).toBe(false);
+    expect(isDuplicateKeyError("E11000 string")).toBe(false);
+    expect(isDuplicateKeyError(11000)).toBe(false);
   });
 });

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -103,31 +103,53 @@ describe("wrapSyncErrorMessage", () => {
   });
 });
 
-describe("isDuplicateKeyError (GH #439)", () => {
-  // The local-only push / pull paths in `syncCollection` need to treat a
-  // concurrent peer winning the `syncId`-unique race as a no-op rather
-  // than a sync failure. The recogniser keys on `err.code === 11000`
-  // which is the MongoDB driver's universal shape for "unique index
-  // violation" across MongoServerError + write-result subdocs.
+describe("isDuplicateKeyError (GH #439, scoped to syncId per Codex on #464)", () => {
+  // The recogniser MUST be scoped to the `syncId` index — every synced
+  // collection also has unique indexes on `name` / `instanceId` /
+  // etc., and silently swallowing those would leave real conflicts
+  // unsynced while the cycle reported success.
 
-  it("returns true for an Error with code 11000", () => {
-    const err = Object.assign(new Error("E11000 duplicate key"), { code: 11000 });
+  it("returns true for an E11000 on the syncId index", () => {
+    const err = Object.assign(new Error("E11000 duplicate key"), {
+      code: 11000,
+      keyPattern: { syncId: 1 },
+      keyValue: { syncId: "abc-123" },
+    });
     expect(isDuplicateKeyError(err)).toBe(true);
   });
 
-  it("returns true for a plain object with code 11000", () => {
-    expect(isDuplicateKeyError({ code: 11000, message: "dup" })).toBe(true);
+  it("returns FALSE for an E11000 on a name index (real conflict to surface)", () => {
+    const err = Object.assign(new Error("E11000 duplicate key"), {
+      code: 11000,
+      keyPattern: { name: 1 },
+      keyValue: { name: "0.4 Brass" },
+    });
+    expect(isDuplicateKeyError(err)).toBe(false);
   });
 
-  it("returns false for a different error code (e.g. 121 = document failed validation)", () => {
-    expect(isDuplicateKeyError({ code: 121 })).toBe(false);
+  it("returns FALSE for an E11000 on instanceId", () => {
+    const err = Object.assign(new Error("E11000 duplicate key"), {
+      code: 11000,
+      keyPattern: { instanceId: 1 },
+      keyValue: { instanceId: "abc-123" },
+    });
+    expect(isDuplicateKeyError(err)).toBe(false);
   });
 
-  it("returns false for a bare Error with no code", () => {
+  it("returns FALSE for a different error code", () => {
+    expect(isDuplicateKeyError({ code: 121, keyPattern: { syncId: 1 } })).toBe(false);
+  });
+
+  it("returns FALSE for a bare Error with no code", () => {
     expect(isDuplicateKeyError(new Error("generic failure"))).toBe(false);
   });
 
-  it("returns false for non-error inputs", () => {
+  it("returns FALSE for an E11000 with no keyPattern (ambiguous — surface it)", () => {
+    expect(isDuplicateKeyError({ code: 11000 })).toBe(false);
+    expect(isDuplicateKeyError(Object.assign(new Error("dup"), { code: 11000 }))).toBe(false);
+  });
+
+  it("returns FALSE for non-error inputs", () => {
     expect(isDuplicateKeyError(null)).toBe(false);
     expect(isDuplicateKeyError(undefined)).toBe(false);
     expect(isDuplicateKeyError("E11000 string")).toBe(false);


### PR DESCRIPTION
## Summary
- **#439** — Local-only push and remote-only pull paths in `syncCollection` now treat a `code: 11000` duplicate-key error as a no-op (concurrent peer won the `syncId` race). New `isDuplicateKeyError` helper, exported for testing.
- **#438** — Extended the SyncService header comment to cover the `calibrations[]._id` / `amsSlots[]._id` cross-side regeneration caveat (today nothing keys off these subdoc ids cross-sync; adding a future feature that does will need a subdoc `syncId` migration).

## Tests
- New unit tests for `isDuplicateKeyError` covering Error-with-code, plain-object-with-code, wrong code, no code, and non-error inputs.
- All 17 sync-service tests pass.

Closes #438
Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)