### PR TITLE
Cap scan-stream SSE concurrent subscribers (#428)

### DIFF
--- a/src/app/api/scan/stream/route.ts
+++ b/src/app/api/scan/stream/route.ts
@@ -29,6 +29,23 @@ export const dynamic = "force-dynamic";
 const HEARTBEAT_MS = 25_000;
 const encoder = new TextEncoder();
 
+/**
+ * GH #428 — concurrent-subscriber cap. The bus uses
+ * `EventEmitter.setMaxListeners(0)` to suppress Node's leak warning,
+ * which means there's no upper bound on how many sub-processes can
+ * attach. A misbehaving / hostile client on the LAN could open
+ * thousands of long-lived SSE connections, each holding open a heart-
+ * beat interval and a scan listener for the process lifetime.
+ *
+ * 100 concurrent is generously above any real workload — a typical
+ * PrusaSlicer + Bambu Studio + browser-tab setup hits 3-5. Beyond
+ * that we 429 the new connections; the existing ones keep working.
+ * Cap is per-process (module-level counter), so this is local-only
+ * mitigation; a multi-process deployment would need a shared limit.
+ */
+const MAX_CONCURRENT_SUBSCRIBERS = 100;
+let activeSubscribers = 0;
+
 function formatEvent(eventType: string, data: ScanEvent): Uint8Array {
   return encoder.encode(
     `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`,
@@ -36,15 +53,38 @@ function formatEvent(eventType: string, data: ScanEvent): Uint8Array {
 }
 
 export async function GET(request: NextRequest) {
+  // GH #428: enforce the concurrent-subscriber cap before allocating
+  // any per-connection resources (listener, interval, ReadableStream).
+  // 429 with a Retry-After signals the standard "back off, try again"
+  // shape to EventSource consumers.
+  if (activeSubscribers >= MAX_CONCURRENT_SUBSCRIBERS) {
+    console.warn(
+      `[scan/stream] Rejected SSE connection: ${activeSubscribers} active subscribers (cap=${MAX_CONCURRENT_SUBSCRIBERS})`,
+    );
+    return new Response("Too many active SSE subscribers", {
+      status: 429,
+      headers: { "retry-after": "60" },
+    });
+  }
+
   const replayParam = request.nextUrl.searchParams.get("replay");
   const replay = replayParam !== "0";
 
   let unsubscribe: (() => void) | null = null;
   let heartbeat: ReturnType<typeof setInterval> | null = null;
   let aborted = false;
+  let counted = false;
+  const release = () => {
+    if (counted) {
+      counted = false;
+      activeSubscribers--;
+    }
+  };
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
+      counted = true;
+      activeSubscribers++;
       const safeEnqueue = (chunk: Uint8Array) => {
         if (aborted) return;
         try {
@@ -77,6 +117,7 @@ export async function GET(request: NextRequest) {
         aborted = true;
         if (heartbeat) clearInterval(heartbeat);
         if (unsubscribe) unsubscribe();
+        release();
         try {
           controller.close();
         } catch {
@@ -88,6 +129,7 @@ export async function GET(request: NextRequest) {
       aborted = true;
       if (heartbeat) clearInterval(heartbeat);
       if (unsubscribe) unsubscribe();
+      release();
     },
   });
 

--- a/tests/scan-stream-route.test.ts
+++ b/tests/scan-stream-route.test.ts
@@ -117,6 +117,30 @@ describe("GET /api/scan/stream", () => {
     await reader.cancel();
   });
 
+  it("returns 429 when the concurrent-subscriber cap is exceeded (GH #428)", async () => {
+    // Open subscriptions up to the cap and verify the next one is
+    // rejected. 100 connections is the in-module cap; we just verify
+    // the 101st gets the 429 + Retry-After contract.
+    const readers: ReadableStreamDefaultReader<Uint8Array>[] = [];
+    try {
+      for (let i = 0; i < 100; i++) {
+        const res = await stream(streamReq("?replay=0"));
+        expect(res.status).toBe(200);
+        readers.push(res.body!.getReader());
+      }
+      const denied = await stream(streamReq("?replay=0"));
+      expect(denied.status).toBe(429);
+      expect(denied.headers.get("retry-after")).toBe("60");
+    } finally {
+      for (const r of readers) await r.cancel().catch(() => {});
+    }
+    // After cancelling all opened streams, a fresh connection should
+    // pass again — the cap is per-active-subscriber, not lifetime.
+    const fresh = await stream(streamReq("?replay=0"));
+    expect(fresh.status).toBe(200);
+    await fresh.body!.getReader().cancel();
+  });
+
   it("unsubscribes from the bus when the stream is cancelled", async () => {
     const res = await stream(streamReq("?replay=0"));
     const reader = res.body!.getReader();


### PR DESCRIPTION
## Summary
Adds a 100-subscriber concurrent cap on the `/api/scan/stream` SSE endpoint, returning 429 + `Retry-After: 60` when exceeded. The endpoint is intentionally non-origin-guarded so PrusaSlicer / Bambu Studio can subscribe over the LAN, but the underlying `scanBus` sets `maxListeners(0)` — so a misbehaving / hostile client could open thousands of long-lived connections.

## Tests
- New regression test: open 100 connections, verify 101st returns 429 with `Retry-After: 60`, verify slot frees on cancel.
- All 7 scan-stream tests pass.

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)