### PR TITLE
Loading skeletons for inventory / dashboard / analytics (#449)

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useCurrency } from "@/hooks/useCurrency";
+import { Skeleton, SkeletonRegion } from "@/components/Skeleton";
 
 interface AnalyticsData {
   since: string;
@@ -99,7 +100,30 @@ export default function AnalyticsPage() {
         </div>
       </div>
 
-      {loading && !data && <p className="text-sm text-gray-500">{t("common.loading")}</p>}
+      {loading && !data && (
+        // GH #449: skeleton placeholders — totals row + chart area +
+        // 4-row table — so the layout doesn't reflow when the
+        // analytics fetch lands.
+        <SkeletonRegion label={t("common.loading")} className="space-y-6">
+          <div className="grid grid-cols-3 gap-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="border border-gray-200 dark:border-gray-800 rounded-lg p-4 space-y-2"
+              >
+                <Skeleton className="h-3 w-20 rounded" />
+                <Skeleton className="h-7 w-16 rounded" />
+              </div>
+            ))}
+          </div>
+          <Skeleton className="h-48 w-full rounded" />
+          <div className="border border-gray-200 dark:border-gray-800 rounded-lg p-4 space-y-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-5 w-full rounded" />
+            ))}
+          </div>
+        </SkeletonRegion>
+      )}
 
       {error && !loading && (
         <div className="border border-gray-200 dark:border-gray-800 rounded p-6 text-center">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { formatDate, formatDateTime } from "@/lib/dateFormat";
 import { useCurrency } from "@/hooks/useCurrency";
+import { Skeleton, SkeletonRegion } from "@/components/Skeleton";
 
 interface DashboardData {
   counts: {
@@ -104,9 +105,36 @@ export default function DashboardPage() {
   }
 
   if (!data) {
+    // GH #449: skeleton placeholders — 6 metric tiles + a couple of
+    // section blocks — so the layout doesn't reflow when content
+    // lands. Matches the shape that comes back from /api/dashboard.
     return (
       <main id="main-content" className="w-full px-4 py-8">
-        <p className="text-sm text-gray-500">{t("common.loading")}</p>
+        <SkeletonRegion label={t("common.loading")} className="space-y-6">
+          <Skeleton className="h-9 w-48 rounded" />
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="border border-gray-200 dark:border-gray-800 rounded-lg p-4 space-y-2"
+              >
+                <Skeleton className="h-3 w-20 rounded" />
+                <Skeleton className="h-7 w-16 rounded" />
+              </div>
+            ))}
+          </div>
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div
+              key={i}
+              className="border border-gray-200 dark:border-gray-800 rounded-lg p-4 space-y-2"
+            >
+              <Skeleton className="h-5 w-40 rounded" />
+              {Array.from({ length: 3 }).map((__, j) => (
+                <Skeleton key={j} className="h-4 w-full rounded" />
+              ))}
+            </div>
+          ))}
+        </SkeletonRegion>
       </main>
     );
   }

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/Toast";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { formatDate } from "@/lib/dateFormat";
+import { Skeleton, SkeletonRegion } from "@/components/Skeleton";
 
 /**
  * GH #389 — Spool Inventory page.
@@ -348,7 +349,22 @@ export default function InventoryPage() {
 
       {/* Groups */}
       {loading ? (
-        <p className="text-gray-500">{t("inventory.loading")}</p>
+        // GH #449: skeleton placeholders instead of a single "Loading…"
+        // line. Three card-shaped blocks mirror the group cards that
+        // arrive once the fetch completes, so the layout doesn't
+        // reflow when content lands.
+        <SkeletonRegion label={t("inventory.loading")} className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="border border-gray-200 dark:border-gray-800 rounded-lg p-4 space-y-3"
+            >
+              <Skeleton className="h-5 w-48 rounded" />
+              <Skeleton className="h-4 w-full rounded" />
+              <Skeleton className="h-4 w-3/4 rounded" />
+            </div>
+          ))}
+        </SkeletonRegion>
       ) : filteredGroups.length === 0 ? (
         <div className="text-center py-12 border border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
           <p className="text-gray-500 mb-3">{t("inventory.empty")}</p>

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,67 @@
+/**
+ * GH #449 — animated skeleton placeholders for data-heavy pages.
+ *
+ * Used by the inventory / dashboard / analytics pages during their
+ * initial fetch so the layout doesn't reflow when content arrives.
+ * Single class string (`animate-pulse bg-gray-200 dark:bg-gray-800`)
+ * — kept here so a future tweak to the skeleton look only needs one
+ * edit.
+ */
+
+import { CSSProperties } from "react";
+
+/**
+ * A single animated placeholder block. Pass `className` for sizing
+ * (`h-4 w-32 rounded`, etc.) and an optional inline `style` for
+ * exact-pixel widths the Tailwind scale doesn't cover.
+ */
+export function Skeleton({
+  className = "h-4 w-full rounded",
+  style,
+  ariaLabel,
+}: {
+  className?: string;
+  style?: CSSProperties;
+  /** Provide for the wrapper region; individual blocks usually inherit
+   *  the wrapper's `aria-live="polite"` and stay decorative. */
+  ariaLabel?: string;
+}) {
+  return (
+    <span
+      className={`block animate-pulse bg-gray-200 dark:bg-gray-800 ${className}`}
+      style={style}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : "true"}
+    />
+  );
+}
+
+/**
+ * A wrapper that announces a loading region to screen readers
+ * (`role="status"` + polite) and renders skeleton children visually.
+ * Use this around the page's skeleton block so AT users hear "loading"
+ * once instead of every individual block claiming to be a separate
+ * region.
+ */
+export function SkeletonRegion({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={label}
+      className={className}
+    >
+      {children}
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `Skeleton` + `SkeletonRegion` components — animated grey block + a11y wrapper with `role="status"` / `aria-live="polite"`.
- Applied placeholders that mirror each page's actual content shape: inventory (3 group cards), dashboard (title + 6 metric tiles + 2 sections), analytics (3 totals tiles + chart area + 4-row table).

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)