### PR TITLE
Multi-color phase 1: schema + resolver + helpers (#477)

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -7,6 +7,7 @@ import BedType from "@/models/BedType";
 import PrintHistory from "@/models/PrintHistory";
 import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
 import { resolveFilament } from "@/lib/resolveFilament";
+import { displayColor } from "@/lib/filamentColors";
 
 /**
  * GET /api/dashboard — aggregate summary for the dashboard page.
@@ -95,11 +96,13 @@ export async function GET() {
           _id: String(f._id),
           name: f.name,
           vendor: f.vendor,
-          // GH #477: primary `color` is now nullable per OpenPrintTag
-          // spec. Dashboard's low-stock row swatch only renders a
-          // single color, so fall back to the gray sentinel (matches
-          // every pre-#477 row's behavior).
-          color: f.color ?? "#808080",
+          // GH #477 (Codex P2 on PR #482): primary `color` is nullable
+          // per OpenPrintTag spec. For coextruded / rainbow filaments
+          // the primary IS null and the user's intended representative
+          // color lives in `secondaryColors[0]`. Use `displayColor()`
+          // so the dashboard swatch shows secondaryColors[0] in that
+          // case instead of a misleading gray dot.
+          color: displayColor(f),
           remainingGrams: remaining,
           threshold: f.lowStockThreshold,
         });

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -95,7 +95,11 @@ export async function GET() {
           _id: String(f._id),
           name: f.name,
           vendor: f.vendor,
-          color: f.color,
+          // GH #477: primary `color` is now nullable per OpenPrintTag
+          // spec. Dashboard's low-stock row swatch only renders a
+          // single color, so fall back to the gray sentinel (matches
+          // every pre-#477 row's behavior).
+          color: f.color ?? "#808080",
           remainingGrams: remaining,
           threshold: f.lowStockThreshold,
         });

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -116,10 +116,22 @@ export async function GET(
       .select("name color secondaryColors cost optTags")
       .sort({ name: 1 })
       .lean();
+    // GH #477 (Codex P2 on PR #482 r2): apply the same array-fallback
+    // resolution to `secondaryColors` that we apply to `optTags` —
+    // otherwise a variant that inherits its parent's multi-color slots
+    // (empty own array) renders single-color on the parent's variant
+    // chips while the same variant resolves correctly everywhere else.
+    // Mirrors resolveFilament's secondaryColors block + the list
+    // aggregation's $project ternary.
     const parentOptTags = (filament.optTags ?? []) as number[];
+    const parentSecondaryColors = (filament.secondaryColors ?? []) as string[];
     const variants = rawVariants.map((v) => ({
       ...v,
       optTags: v.optTags && v.optTags.length > 0 ? v.optTags : parentOptTags,
+      secondaryColors:
+        v.secondaryColors && v.secondaryColors.length > 0
+          ? v.secondaryColors
+          : parentSecondaryColors,
     }));
 
     if (parentSummary) {

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -80,7 +80,7 @@ export async function GET(
     if (filament.parentId) {
       if (raw) {
         parentSummary = (await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
-          .select("_id name vendor type color cost density diameter")
+          .select("_id name vendor type color secondaryColors cost density diameter")
           .lean()) as typeof parentSummary;
       } else {
         const parentDoc = (await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
@@ -111,7 +111,9 @@ export async function GET(
     // detail page shows it (that path goes through resolveFilament).
     // Codex round-1 P2 on PR #353.
     const rawVariants = await Filament.find({ parentId: id, _deletedAt: null })
-      .select("name color cost optTags")
+      // GH #477: secondaryColors so the parent's color-variants chips can
+      // render multi-color swatches without a follow-up fetch per variant.
+      .select("name color secondaryColors cost optTags")
       .sort({ name: 1 })
       .lean();
     const parentOptTags = (filament.optTags ?? []) as number[];

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -52,7 +52,13 @@ export async function GET(request: NextRequest) {
           localField: "parentId",
           foreignField: "_id",
           as: "_parent",
-          pipeline: [{ $project: { calibrations: 1, optTags: 1 } }],
+          // GH #477: include `secondaryColors` so the effective projection
+          // below can merge a variant's empty array with the parent's full
+          // array — same array-fallback inheritance pattern resolveFilament
+          // uses at read time. Without this the list drops inherited
+          // multi-color data and the list-row swatch can't render it.
+          // (Codex P2 on PR #482.)
+          pipeline: [{ $project: { calibrations: 1, optTags: 1, secondaryColors: 1 } }],
         },
       },
       // Look up whether any non-deleted filament references this row as
@@ -91,8 +97,21 @@ export async function GET(request: NextRequest) {
           color: 1,
           // GH #477: secondaryColors rides the list so a multi-color
           // filament renders its full swatch in the list view without a
-          // follow-up fetch. Cheap (≤5 short hex strings per row).
-          secondaryColors: 1,
+          // follow-up fetch. Same effective-array merge as `optTags`
+          // below — variants with an empty secondaryColors inherit the
+          // parent's array per resolveFilament's array-fallback rule.
+          // Without this merge, a variant whose parent is a tri-color
+          // coextruded but whose own secondaryColors is `[]` would
+          // render single-color on the list / parent's color-variant
+          // chips despite the detail page showing the full set.
+          // (Codex P2 on PR #482.)
+          secondaryColors: {
+            $cond: [
+              { $gt: [{ $size: { $ifNull: ["$secondaryColors", []] } }, 0] },
+              "$secondaryColors",
+              { $ifNull: [{ $arrayElemAt: ["$_parent.secondaryColors", 0] }, []] },
+            ],
+          },
           cost: 1,
           density: 1,
           parentId: 1,

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -89,6 +89,10 @@ export async function GET(request: NextRequest) {
           vendor: 1,
           type: 1,
           color: 1,
+          // GH #477: secondaryColors rides the list so a multi-color
+          // filament renders its full swatch in the list view without a
+          // follow-up fetch. Cheap (≤5 short hex strings per row).
+          secondaryColors: 1,
           cost: 1,
           density: 1,
           parentId: 1,

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -345,7 +345,9 @@ function FilamentDetail() {
         materialName: filament.name,
         brandName: filament.vendor,
         materialType: filament.type,
-        color: filament.color,
+        // GH #477: nullable color → omit key 19 from CBOR. Phase 3
+        // will surface secondaryColors on the tag too.
+        color: filament.color ?? undefined,
         density: filament.density,
         diameter: filament.diameter,
         nozzleTemp: filament.temperatures?.nozzle,
@@ -398,7 +400,9 @@ function FilamentDetail() {
         materialName: filament.name,
         brandName: filament.vendor,
         materialType: filament.type,
-        color: filament.color,
+        // GH #477: nullable color → omit key 19 from CBOR. Phase 3
+        // will surface secondaryColors on the tag too.
+        color: filament.color ?? undefined,
         density: filament.density,
         diameter: filament.diameter,
         nozzleTemp: filament.temperatures?.nozzle,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -553,7 +553,7 @@ export default function Home() {
             isParent={!isVariant && f.hasVariants === true}
             finish={deriveFinish(f.optTags)}
             size={isVariant ? 20 : 24}
-            title={f.color}
+            title={f.color ?? undefined}
           />
         </div>
       </td>
@@ -669,7 +669,7 @@ export default function Home() {
                 color={f.color}
                 isParent
                 size={24}
-                title={f.color}
+                title={f.color ?? undefined}
               />
             </div>
           </td>

--- a/src/lib/filamentColors.ts
+++ b/src/lib/filamentColors.ts
@@ -1,0 +1,119 @@
+/**
+ * GH #477 — multi-color filament helpers.
+ *
+ * Mirrors the OpenPrintTag spec 1:1: primary color (`color`, spec key 19)
+ * may be null for filaments without a single primary (rainbow,
+ * coextruded). Secondary slots (`secondaryColors[]`, spec keys 20–24)
+ * carry up to 5 additional colors. Color arrangement is NOT a separate
+ * field — it's derived from `optTags` (tag 29 = `coextruded`, tag 28 =
+ * `gradual_color_change`), keeping the storage spec-pure.
+ *
+ * Kept DB-free so this can be unit-tested without mongoose / vitest
+ * env config. Every function is pure and takes a minimal subset of the
+ * filament shape.
+ */
+
+/**
+ * OpenPrintTag tag IDs that describe color arrangement. Sourced from
+ * `data/tags_enum.yaml` in the prusa3d/OpenPrintTag spec repo.
+ */
+const TAG_COEXTRUDED = 29;
+const TAG_GRADUAL_COLOR_CHANGE = 28;
+
+/** What arrangement the filament's colors are physically in. `"solid"`
+ *  is the default for single-color filaments and for multi-color
+ *  filaments where neither arrangement tag is set (a misconfigured
+ *  state we render the same as solid — primary color only). */
+export type ColorArrangement = "solid" | "coextruded" | "gradient";
+
+/**
+ * Derive the arrangement from an `optTags` array.
+ *
+ * Priority order if both tags are present:
+ *   coextruded > gradient
+ *
+ * Rationale: coextruded is the more structural property (about the
+ * physical cross-section of the strand), while gradient describes
+ * change-over-time. A "coextruded gradient" — where the strand has
+ * multiple parallel colors AND those colors change along the length —
+ * is theoretically possible per spec, but the rendering UI can only
+ * pick one mode, so coextruded wins.
+ */
+export function deriveArrangement(
+  optTags: number[] | null | undefined,
+): ColorArrangement {
+  if (!optTags || optTags.length === 0) return "solid";
+  if (optTags.includes(TAG_COEXTRUDED)) return "coextruded";
+  if (optTags.includes(TAG_GRADUAL_COLOR_CHANGE)) return "gradient";
+  return "solid";
+}
+
+/**
+ * Pick the single hex string a UI should render when forced to show
+ * just one color (the filament-list color dot, parent-picker chip,
+ * etc.).
+ *
+ * Fallback order:
+ *   1. `color` if non-null (the primary color)
+ *   2. `secondaryColors[0]` if any (the spec convention for coextruded
+ *      filaments is to leave `color` null and put colors in secondaries)
+ *   3. `"#808080"` (gray) as a last-resort sentinel — should never be
+ *      reached for any DB-stored row, but cheap to be defensive
+ */
+export function displayColor(
+  filament: {
+    color?: string | null;
+    secondaryColors?: string[] | null;
+  } | null | undefined,
+): string {
+  if (!filament) return "#808080";
+  if (filament.color != null && filament.color !== "") return filament.color;
+  if (filament.secondaryColors && filament.secondaryColors.length > 0) {
+    return filament.secondaryColors[0];
+  }
+  return "#808080";
+}
+
+/**
+ * Return every color the filament carries, primary first, in the order
+ * a coextruded swatch should render them. Filters out the empty / null
+ * primary so consumers don't have to.
+ *
+ * Used by `<FilamentSwatch>` (Phase 2) to lay out the stripes /
+ * gradient stops without each call-site re-implementing the same
+ * concat-and-filter dance.
+ */
+export function allColors(
+  filament: {
+    color?: string | null;
+    secondaryColors?: string[] | null;
+  } | null | undefined,
+): string[] {
+  if (!filament) return [];
+  const out: string[] = [];
+  if (filament.color != null && filament.color !== "") out.push(filament.color);
+  if (filament.secondaryColors) {
+    for (const c of filament.secondaryColors) {
+      if (c != null && c !== "") out.push(c);
+    }
+  }
+  return out;
+}
+
+/**
+ * True if the filament should render as multi-color (i.e. it has at
+ * least one secondary color OR an arrangement tag is set). Useful for
+ * gating "the slicer export will drop secondaries" notices and the
+ * arrangement radio on the form.
+ */
+export function isMultiColor(
+  filament: {
+    color?: string | null;
+    secondaryColors?: string[] | null;
+    optTags?: number[] | null;
+  } | null | undefined,
+): boolean {
+  if (!filament) return false;
+  if (filament.secondaryColors && filament.secondaryColors.length > 0) return true;
+  return deriveArrangement(filament.optTags) !== "solid";
+}

--- a/src/lib/resolveFilament.ts
+++ b/src/lib/resolveFilament.ts
@@ -129,6 +129,21 @@ export function resolveFilament(
     }
   }
 
+  // GH #477: secondaryColors inherits as a whole array (same pattern as
+  // optTags above). Per-slot inheritance would let a variant override slot
+  // 2 only and create a Frankenfilament whose effective colors come from
+  // two different filaments — that ambiguity isn't worth the flexibility.
+  // Variant declares its own non-empty array to override; otherwise it
+  // inherits the parent's full array.
+  if (filament.secondaryColors && filament.secondaryColors.length > 0) {
+    resolved.secondaryColors = filament.secondaryColors;
+  } else {
+    resolved.secondaryColors = parent.secondaryColors || [];
+    if (parent.secondaryColors?.length > 0) {
+      inherited.push("secondaryColors");
+    }
+  }
+
   if (filament.bedTypeTemps && filament.bedTypeTemps.length > 0) {
     resolved.bedTypeTemps = filament.bedTypeTemps;
   } else {

--- a/src/models/Filament.ts
+++ b/src/models/Filament.ts
@@ -96,7 +96,19 @@ export interface IFilament extends Document {
   instanceId: string;
   vendor: string;
   type: string;
-  color: string;
+  /** Primary color hex (#RRGGBB). GH #477: per OpenPrintTag spec key 19
+   *  this MAY be null for filaments without a single primary color
+   *  (coextruded, rainbow). Existing rows keep their "#808080" default —
+   *  null is only ever written when the user explicitly toggles the
+   *  multi-color "Coextruded" arrangement in the form. Most UI surfaces
+   *  use `displayColor()` from src/lib/filamentColors.ts to fall back
+   *  to secondaryColors[0] when this is null. */
+  color: string | null;
+  /** GH #477: additional color slots for multi-color filaments, mirroring
+   *  OpenPrintTag spec keys 20–24 (`secondary_color_0..4`). Max 5 entries,
+   *  each `#RRGGBB`. Empty array on every single-color filament (default).
+   *  Treated as an array-fallback inheritable field by `resolveFilament`. */
+  secondaryColors: string[];
   colorName: string | null;
   cost: number | null;
   density: number | null;
@@ -201,7 +213,33 @@ const FilamentSchema = new Schema<IFilament>(
     instanceId: { type: String, default: generateInstanceId },
     vendor: { type: String, required: true, index: true },
     type: { type: String, required: true, index: true },
+    // GH #477: `color` is the OpenPrintTag spec's `primary_color` (key 19),
+    // which the spec explicitly allows to be null for coextruded / rainbow
+    // filaments where there's no single primary. Default stays "#808080"
+    // so existing rows + every single-color filament keep current behavior;
+    // null is only written when the user opts into the multi-color
+    // "Coextruded" arrangement. Hex shape is validated on writes via the
+    // route handlers (matches the existing posture for free-form strings).
     color: { type: String, default: "#808080" },
+    // GH #477: spec keys 20–24 (`secondary_color_0..4`). Hex validation
+    // applied per-entry; max-5 cap matches the spec exactly. Defaulting
+    // to an empty array (vs undefined) so the read path never needs a
+    // null guard.
+    secondaryColors: {
+      type: [String],
+      default: () => [],
+      validate: [
+        {
+          validator: (arr: string[]) => Array.isArray(arr) && arr.length <= 5,
+          message: "secondaryColors may not exceed 5 entries (OpenPrintTag spec limit)",
+        },
+        {
+          validator: (arr: string[]) =>
+            arr.every((c) => typeof c === "string" && /^#[0-9A-Fa-f]{6}$/.test(c)),
+          message: "Each secondaryColors entry must be a #RRGGBB hex string",
+        },
+      ],
+    },
     colorName: { type: String, default: null },
     // GH #337: physically nonsensical values (negative diameter / density /
     // cost, out-of-range temperatures) used to be silently accepted and

--- a/src/types/filament.ts
+++ b/src/types/filament.ts
@@ -6,7 +6,17 @@
 export interface FilamentVariant {
   _id: string;
   name: string;
-  color: string;
+  /** GH #477: primary color hex. May be `null` per OpenPrintTag spec key
+   *  19 — coextruded / rainbow filaments don't have a single primary,
+   *  and the form's "Coextruded" arrangement toggle writes `null` here.
+   *  UI sites that need a single representative color should call
+   *  `displayColor()` from `src/lib/filamentColors.ts` to fall back to
+   *  `secondaryColors[0]`. */
+  color: string | null;
+  /** GH #477: up to 5 additional color hexes, mirroring OpenPrintTag
+   *  spec keys 20–24. Inherits as a whole array from parent when this
+   *  variant's array is empty. */
+  secondaryColors?: string[];
   cost: number | null;
   /** Tag IDs that drive the finish-derived swatch texture + chip when
    * this variant is rendered under its parent on the detail page. The
@@ -92,7 +102,10 @@ export interface FilamentDetail {
   instanceId?: string;
   vendor: string;
   type: string;
-  color: string;
+  /** GH #477: nullable per OpenPrintTag spec. See FilamentVariant.color. */
+  color: string | null;
+  /** GH #477: spec keys 20–24, up to 5 secondary color hexes. */
+  secondaryColors?: string[];
   cost: number | null;
   density: number | null;
   diameter: number;
@@ -136,7 +149,10 @@ export interface FilamentSummary {
   name: string;
   vendor: string;
   type: string;
-  color: string;
+  /** GH #477: nullable per OpenPrintTag spec. See FilamentVariant.color. */
+  color: string | null;
+  /** GH #477: spec keys 20–24, up to 5 secondary color hexes. */
+  secondaryColors?: string[];
   cost: number | null;
   density: number | null;
   parentId: string | null;

--- a/tests/Filament.test.ts
+++ b/tests/Filament.test.ts
@@ -883,4 +883,93 @@ describe("Filament Model — v1.11 spool fields", () => {
       }),
     ).rejects.toThrow();
   });
+
+  // GH #477: multi-color filament schema. Mirrors OpenPrintTag spec
+  // (primary key 19 may be null; up to 5 secondary slots in keys 20–24).
+  describe("multi-color support (#477)", () => {
+    it("defaults secondaryColors to an empty array", async () => {
+      const f = await Filament.create({
+        name: "Default Secondary Colors",
+        vendor: "Test",
+        type: "PLA",
+      });
+      expect(Array.isArray(f.secondaryColors)).toBe(true);
+      expect(f.secondaryColors).toHaveLength(0);
+    });
+
+    it("accepts null color (OpenPrintTag spec — coextruded filament)", async () => {
+      // Spec key 19: "If a material doesn't have a single primary
+      // color (for example rainbow or coextruded filaments), this
+      // field can be null."
+      const f = await Filament.create({
+        name: "Coextruded Tri",
+        vendor: "Test",
+        type: "PLA",
+        color: null,
+        secondaryColors: ["#FF0000", "#00FF00", "#0000FF"],
+      });
+      expect(f.color).toBeNull();
+      expect(f.secondaryColors).toEqual(["#FF0000", "#00FF00", "#0000FF"]);
+    });
+
+    it("stores up to 5 secondaryColors", async () => {
+      const f = await Filament.create({
+        name: "Max Secondary",
+        vendor: "Test",
+        type: "PLA",
+        color: "#FF0000",
+        secondaryColors: ["#FF8800", "#FFFF00", "#00FF00", "#0000FF", "#8800FF"],
+      });
+      expect(f.secondaryColors).toHaveLength(5);
+    });
+
+    it("rejects more than 5 secondaryColors (OpenPrintTag spec ceiling)", async () => {
+      await expect(
+        Filament.create({
+          name: "Too Many Secondary",
+          vendor: "Test",
+          type: "PLA",
+          secondaryColors: [
+            "#FF0000", "#FF8800", "#FFFF00", "#00FF00", "#0000FF", "#8800FF",
+          ],
+        }),
+      ).rejects.toThrow(/may not exceed 5/);
+    });
+
+    it("rejects invalid hex strings in secondaryColors", async () => {
+      await expect(
+        Filament.create({
+          name: "Bad Hex",
+          vendor: "Test",
+          type: "PLA",
+          secondaryColors: ["red", "#GGG"],
+        }),
+      ).rejects.toThrow(/#RRGGBB hex string/);
+    });
+
+    it("rejects 8-char hex (alpha channel) in secondaryColors — not yet supported", async () => {
+      // OpenPrintTag spec's color_rgba can be 3 or 4 bytes. We don't
+      // carry alpha (translucency is handled by finish tags); reject
+      // alpha hex strings explicitly rather than silently dropping
+      // the alpha byte. Documented gap in CLAUDE.md.
+      await expect(
+        Filament.create({
+          name: "Alpha Hex",
+          vendor: "Test",
+          type: "PLA",
+          secondaryColors: ["#FF000080"],
+        }),
+      ).rejects.toThrow(/#RRGGBB hex string/);
+    });
+
+    it("preserves existing single-color behavior — color default is gray, secondaryColors is empty", async () => {
+      const f = await Filament.create({
+        name: "Plain Single Color",
+        vendor: "Test",
+        type: "PLA",
+      });
+      expect(f.color).toBe("#808080");
+      expect(f.secondaryColors).toEqual([]);
+    });
+  });
 });

--- a/tests/filamentColors.test.ts
+++ b/tests/filamentColors.test.ts
@@ -1,0 +1,160 @@
+/**
+ * GH #477 — Phase 1 unit tests for the multi-color helpers in
+ * src/lib/filamentColors.ts. Pure functions, no DB / DOM env required.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  deriveArrangement,
+  displayColor,
+  allColors,
+  isMultiColor,
+  type ColorArrangement,
+} from "@/lib/filamentColors";
+
+describe("deriveArrangement", () => {
+  it("returns 'solid' for null/undefined/empty optTags", () => {
+    expect(deriveArrangement(null)).toBe("solid");
+    expect(deriveArrangement(undefined)).toBe("solid");
+    expect(deriveArrangement([])).toBe("solid");
+  });
+
+  it("returns 'coextruded' when tag 29 is present", () => {
+    expect(deriveArrangement([29])).toBe("coextruded");
+    expect(deriveArrangement([5, 29])).toBe("coextruded"); // tag 5 = matte
+  });
+
+  it("returns 'gradient' when tag 28 is present", () => {
+    expect(deriveArrangement([28])).toBe("gradient");
+    expect(deriveArrangement([3, 28])).toBe("gradient");
+  });
+
+  it("returns 'coextruded' when BOTH tags are present (coextruded wins)", () => {
+    // A "coextruded gradient" is theoretically possible per OpenPrintTag
+    // spec; the rendering UI can only pick one mode, so the more
+    // structural property (cross-section) wins over change-over-time.
+    expect(deriveArrangement([28, 29])).toBe("coextruded");
+    expect(deriveArrangement([29, 28])).toBe("coextruded");
+  });
+
+  it("returns 'solid' when only non-arrangement tags are present", () => {
+    // Tags 1–5, etc., are finishes (matte/silk/sparkle/glow/transparent).
+    expect(deriveArrangement([1, 2, 3, 4, 5])).toBe("solid");
+  });
+
+  it("type-checks to ColorArrangement", () => {
+    const result: ColorArrangement = deriveArrangement([29]);
+    expect(["solid", "coextruded", "gradient"]).toContain(result);
+  });
+});
+
+describe("displayColor", () => {
+  it("returns gray sentinel for null/undefined input", () => {
+    expect(displayColor(null)).toBe("#808080");
+    expect(displayColor(undefined)).toBe("#808080");
+  });
+
+  it("returns the primary color when it's set", () => {
+    expect(displayColor({ color: "#FF0000" })).toBe("#FF0000");
+    expect(
+      displayColor({ color: "#FF0000", secondaryColors: ["#00FF00"] }),
+    ).toBe("#FF0000");
+  });
+
+  it("falls back to secondaryColors[0] when primary is null (coextruded case)", () => {
+    expect(
+      displayColor({ color: null, secondaryColors: ["#00FF00", "#0000FF"] }),
+    ).toBe("#00FF00");
+  });
+
+  it("falls back to secondaryColors[0] when primary is empty string", () => {
+    expect(
+      displayColor({ color: "", secondaryColors: ["#00FF00"] }),
+    ).toBe("#00FF00");
+  });
+
+  it("returns gray sentinel when both primary and secondaryColors are absent", () => {
+    expect(displayColor({})).toBe("#808080");
+    expect(displayColor({ color: null })).toBe("#808080");
+    expect(displayColor({ color: null, secondaryColors: [] })).toBe("#808080");
+  });
+});
+
+describe("allColors", () => {
+  it("returns empty array for null/undefined input", () => {
+    expect(allColors(null)).toEqual([]);
+    expect(allColors(undefined)).toEqual([]);
+  });
+
+  it("returns primary first, then each secondary in order", () => {
+    expect(
+      allColors({
+        color: "#FF0000",
+        secondaryColors: ["#00FF00", "#0000FF"],
+      }),
+    ).toEqual(["#FF0000", "#00FF00", "#0000FF"]);
+  });
+
+  it("skips null/empty primary so the array starts with secondaryColors[0]", () => {
+    expect(
+      allColors({
+        color: null,
+        secondaryColors: ["#00FF00", "#0000FF"],
+      }),
+    ).toEqual(["#00FF00", "#0000FF"]);
+    expect(
+      allColors({ color: "", secondaryColors: ["#00FF00"] }),
+    ).toEqual(["#00FF00"]);
+  });
+
+  it("skips null/empty secondary entries (defensive — schema validates but lean reads might surface them)", () => {
+    expect(
+      allColors({
+        color: "#FF0000",
+        secondaryColors: ["#00FF00", null as unknown as string, "#0000FF", ""],
+      }),
+    ).toEqual(["#FF0000", "#00FF00", "#0000FF"]);
+  });
+
+  it("returns empty when no usable colors at all", () => {
+    expect(allColors({})).toEqual([]);
+    expect(allColors({ color: null, secondaryColors: [] })).toEqual([]);
+    expect(allColors({ color: "", secondaryColors: ["", null as unknown as string] })).toEqual([]);
+  });
+});
+
+describe("isMultiColor", () => {
+  it("returns false for null/undefined input", () => {
+    expect(isMultiColor(null)).toBe(false);
+    expect(isMultiColor(undefined)).toBe(false);
+  });
+
+  it("returns false for plain single-color filament", () => {
+    expect(isMultiColor({ color: "#FF0000" })).toBe(false);
+    expect(isMultiColor({ color: "#FF0000", secondaryColors: [] })).toBe(false);
+    expect(isMultiColor({ color: "#FF0000", optTags: [5] })).toBe(false); // matte, not arrangement
+  });
+
+  it("returns true when secondaryColors has at least one entry", () => {
+    expect(
+      isMultiColor({ color: "#FF0000", secondaryColors: ["#00FF00"] }),
+    ).toBe(true);
+  });
+
+  it("returns true when an arrangement tag is set (even with no secondary colors)", () => {
+    // Edge case: a misconfigured filament with the coextruded tag but no
+    // secondary colors yet. Still "multi-color" in intent — the form
+    // should show the arrangement radio so the user can add slots.
+    expect(isMultiColor({ color: "#FF0000", optTags: [29] })).toBe(true);
+    expect(isMultiColor({ color: "#FF0000", optTags: [28] })).toBe(true);
+  });
+
+  it("returns true when both arrangement tag AND secondaryColors are set", () => {
+    expect(
+      isMultiColor({
+        color: "#FF0000",
+        secondaryColors: ["#00FF00"],
+        optTags: [29],
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/resolveFilament.test.ts
+++ b/tests/resolveFilament.test.ts
@@ -408,6 +408,51 @@ describe("resolveFilament", () => {
     expect(result.compatibleNozzles).toEqual(["nozzle-3"]);
     expect(result._inherited).not.toContain("compatibleNozzles");
   });
+
+  // GH #477: secondaryColors uses the same array-fallback inheritance
+  // pattern as optTags / compatibleNozzles. Tested separately because
+  // it's the first nullable-primary-aware field — null variant color
+  // must NOT trigger inheritance (color is VARIANT_ONLY_FIELDS), while
+  // empty secondaryColors DOES trigger inheritance.
+  describe("secondaryColors inheritance (#477)", () => {
+    it("inherits parent's secondaryColors when variant's is empty", () => {
+      const parent = makeParent({ secondaryColors: ["#FF0000", "#00FF00"] });
+      const variant = makeVariant({ secondaryColors: [] });
+      const result = resolveFilament(variant, parent);
+      expect(result.secondaryColors).toEqual(["#FF0000", "#00FF00"]);
+      expect(result._inherited).toContain("secondaryColors");
+    });
+
+    it("uses variant's secondaryColors when non-empty (overrides parent)", () => {
+      const parent = makeParent({ secondaryColors: ["#FF0000", "#00FF00"] });
+      const variant = makeVariant({ secondaryColors: ["#0000FF"] });
+      const result = resolveFilament(variant, parent);
+      expect(result.secondaryColors).toEqual(["#0000FF"]);
+      expect(result._inherited).not.toContain("secondaryColors");
+    });
+
+    it("returns empty array (not undefined) when neither variant nor parent has any", () => {
+      const parent = makeParent({});
+      const variant = makeVariant({});
+      const result = resolveFilament(variant, parent);
+      expect(result.secondaryColors).toEqual([]);
+      expect(result._inherited).not.toContain("secondaryColors");
+    });
+
+    it("preserves variant's null color even when parent has a color (no inheritance)", () => {
+      // Coextruded variants opt into null primary; that null must NOT
+      // be replaced by the parent's color. `color` is in
+      // VARIANT_ONLY_FIELDS so this is structural, not coincidental.
+      const parent = makeParent({ color: "#FF0000" });
+      const variant = makeVariant({
+        color: null,
+        secondaryColors: ["#00FF00", "#0000FF"],
+      });
+      const result = resolveFilament(variant, parent);
+      expect(result.color).toBeNull();
+      expect(result.secondaryColors).toEqual(["#00FF00", "#0000FF"]);
+    });
+  });
 });
 
 describe("hasVariants", () => {


### PR DESCRIPTION
## Summary

First of 5 phases for multi-color filament support (GH #477). **Foundation only — no UI changes.** Data model now mirrors the OpenPrintTag spec 1:1 (nullable primary color + up to 5 secondary slots + arrangement derived from existing `optTags`). Phase 2 is the first user-visible release.

## Spec alignment

| OpenPrintTag concept | Our model |
|---|---|
| `primary_color` (key 19, may be null) | `color: string \| null` |
| `secondary_color_0..4` (keys 20-24) | `secondaryColors: [String]` (max 5) |
| `coextruded` tag (key 29) | `optTags` contains 29 |
| `gradual_color_change` tag (key 28) | `optTags` contains 28 |

## Changes

- **Schema** (`Filament.ts`): `color` nullable, `secondaryColors[]` with max-5 + per-entry hex validators
- **Resolver** (`resolveFilament.ts`): `secondaryColors` joins the array-fallback inheritance block; null `color` on variants is preserved (already `VARIANT_ONLY_FIELDS`)
- **Helpers** (`src/lib/filamentColors.ts`, DB-free): `deriveArrangement`, `displayColor`, `allColors`, `isMultiColor`
- **API projections**: list aggregation + detail + variants + parent summary all carry `secondaryColors`
- **Types**: `FilamentSummary` / `FilamentDetail` / `FilamentVariant` updated
- **Null-color consumer fixes** at 5 sites (dashboard, NFC writes, swatch titles)

## Tests

- **+32 new** (21 helper, 7 schema, 4 resolver)
- Full suite: **1582/1582 pass** (was 1550)
- Lint + tsc clean

## What this PR does NOT do

- No UI changes — `<FilamentSwatch>` still renders the single primary color
- No NFC encode/decode for secondaries — that's Phase 3
- No slicer export reduction — that's Phase 4
- No docs — that's Phase 5

## Phase tracking

See [#477](https://github.com/hyiger/filament-db/issues/477) for the full phase checklist. This PR ticks Phase 1.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` 1582/1582
- [ ] @codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)