### PR TITLE
Multi-color phase 4: slicer export policy + UX notice (#477)

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -846,7 +846,17 @@ function FilamentDetail() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </summary>
-            <div className="absolute right-0 z-20 mt-1 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg py-1">
+            <div className="absolute right-0 z-20 mt-1 w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg py-1">
+              {/* GH #477 Phase 4: warn the user that slicer presets only
+                  carry one color so secondary colors won't make it into
+                  the exported file. Surfaces ONLY when the filament has
+                  multi-color data — single-color exports show the menu
+                  with no extra chrome. */}
+              {(filament.secondaryColors && filament.secondaryColors.length > 0) && (
+                <p className="px-3 py-2 mb-1 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 border-b border-amber-200 dark:border-amber-800">
+                  {t("detail.slicerExport.multiColorNotice")}
+                </p>
+              )}
               {([
                 ["prusaslicer", t("detail.slicerExport.prusa"), ".ini"],
                 ["orcaslicer", t("detail.slicerExport.orca"), ".json"],

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -755,6 +755,7 @@
   "detail.slicerExport.prusa": "PrusaSlicer-Konfigurationspaket",
   "detail.slicerExport.orca": "OrcaSlicer-Filamentvorlage",
   "detail.slicerExport.bambu": "Bambu Studio-Filamentvorlage",
+  "detail.slicerExport.multiColorNotice": "Slicer-Voreinstellungen unterstützen nur eine Farbe. Die Primärfarbe wird exportiert; Sekundärfarben werden verworfen.",
   "detail.addSpool": "Spule hinzufügen",
   "detail.spool.addLabelPlaceholder": "Bezeichnung (z. B. Spule 2, Trockenbox A)",
   "detail.spool.addWeightPlaceholder": "Anfangsgewicht (g)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -755,6 +755,7 @@
   "detail.slicerExport.prusa": "PrusaSlicer config bundle",
   "detail.slicerExport.orca": "OrcaSlicer filament preset",
   "detail.slicerExport.bambu": "Bambu Studio filament preset",
+  "detail.slicerExport.multiColorNotice": "Slicer presets only support one color. The primary will be exported; secondaries are dropped.",
   "detail.addSpool": "Add Spool",
   "detail.spool.addLabelPlaceholder": "Label (e.g. Spool 2, Drybox A)",
   "detail.spool.addWeightPlaceholder": "Initial weight (g)",

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -16,10 +16,24 @@
  * when the printer/nozzle/plate context changes — they are NOT baked into the profiles.
  */
 
-import { displayColor } from "@/lib/filamentColors";
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FilamentDoc = Record<string, any>;
+
+/**
+ * The single hex string a slicer preset should carry for a multi-color
+ * filament. When neither a primary nor a secondary exists this returns
+ * `null` so the `set()` helper skips the key entirely and OrcaSlicer
+ * falls back to its own default — rather than emitting a forced
+ * `#808080` gray the user never picked (Codex P2 on PR #485).
+ */
+function slicerExportColor(filament: FilamentDoc): string | null {
+  if (filament.color != null && filament.color !== "") return filament.color;
+  if (Array.isArray(filament.secondaryColors) && filament.secondaryColors.length > 0) {
+    const first = filament.secondaryColors[0];
+    if (first != null && first !== "") return first;
+  }
+  return null;
+}
 
 /**
  * OrcaSlicer bed-type name → config key prefix mapping.
@@ -65,10 +79,13 @@ export function filamentToOrcaSlicerKeys(
   set("filament_vendor", filament.vendor);
   // Slicer presets are single-color — coextruded / multi-color filaments
   // surface their primary, falling back to the first secondary when the
-  // primary is null (the spec-aligned "coextruded" shape). Secondary
-  // colors beyond the primary are intentionally dropped; the detail
-  // page's slicer-export menu warns the user about this trade-off.
-  set("filament_colour", displayColor(filament));
+  // primary is null (the spec-aligned "coextruded" shape). When NEITHER
+  // a primary nor a secondary exists `slicerExportColor` returns null so
+  // `set` is a no-op and OrcaSlicer uses its own default — we never
+  // invent a gray the user did not pick. Secondary colors beyond the
+  // primary are intentionally dropped; the detail page's slicer-export
+  // menu warns the user about this trade-off.
+  set("filament_colour", slicerExportColor(filament));
   set("filament_diameter", filament.diameter);
   set("filament_density", filament.density);
   set("filament_cost", filament.cost);

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -16,6 +16,8 @@
  * when the printer/nozzle/plate context changes — they are NOT baked into the profiles.
  */
 
+import { displayColor } from "@/lib/filamentColors";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FilamentDoc = Record<string, any>;
 
@@ -61,7 +63,12 @@ export function filamentToOrcaSlicerKeys(
   // Core identification
   set("filament_type", filament.type);
   set("filament_vendor", filament.vendor);
-  set("filament_colour", filament.color);
+  // Slicer presets are single-color — coextruded / multi-color filaments
+  // surface their primary, falling back to the first secondary when the
+  // primary is null (the spec-aligned "coextruded" shape). Secondary
+  // colors beyond the primary are intentionally dropped; the detail
+  // page's slicer-export menu warns the user about this trade-off.
+  set("filament_colour", displayColor(filament));
   set("filament_diameter", filament.diameter);
   set("filament_density", filament.density);
   set("filament_cost", filament.cost);

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -20,10 +20,25 @@
  * Filament DB doesn't model (e.g. filament_ramming_parameters, start_filament_gcode).
  */
 
-import { displayColor } from "@/lib/filamentColors";
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FilamentDoc = Record<string, any>;
+
+/**
+ * The single hex string a slicer preset should carry for a multi-color
+ * filament. Differs from `displayColor()` in one important way: when
+ * neither a primary nor a secondary exists, this returns `null` so the
+ * `set()` helper skips the key entirely and the slicer falls back to its
+ * own default — rather than emitting a forced `#808080` gray the user
+ * never picked (Codex P2 on PR #485).
+ */
+function slicerExportColor(filament: FilamentDoc): string | null {
+  if (filament.color != null && filament.color !== "") return filament.color;
+  if (Array.isArray(filament.secondaryColors) && filament.secondaryColors.length > 0) {
+    const first = filament.secondaryColors[0];
+    if (first != null && first !== "") return first;
+  }
+  return null;
+}
 
 /**
  * Map a resolved Filament DB document to PrusaSlicer INI key-value pairs.
@@ -57,10 +72,13 @@ export function filamentToSlicerKeys(
   set("filament_vendor", filament.vendor);
   // Slicer presets are single-color — coextruded / multi-color filaments
   // surface their primary, falling back to the first secondary when the
-  // primary is null (the spec-aligned "coextruded" shape). Secondary
-  // colors beyond the primary are intentionally dropped; the detail
-  // page's slicer-export menu warns the user about this trade-off.
-  set("filament_colour", displayColor(filament));
+  // primary is null (the spec-aligned "coextruded" shape). When NEITHER
+  // a primary nor a secondary exists `slicerExportColor` returns null so
+  // `set` is a no-op and the slicer uses its own default — we never
+  // invent a gray the user did not pick. Secondary colors beyond the
+  // primary are intentionally dropped; the detail page's slicer-export
+  // menu warns the user about this trade-off.
+  set("filament_colour", slicerExportColor(filament));
   set("filament_diameter", filament.diameter);
   set("filament_density", filament.density);
   set("filament_cost", filament.cost);

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -20,6 +20,8 @@
  * Filament DB doesn't model (e.g. filament_ramming_parameters, start_filament_gcode).
  */
 
+import { displayColor } from "@/lib/filamentColors";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FilamentDoc = Record<string, any>;
 
@@ -53,7 +55,12 @@ export function filamentToSlicerKeys(
   // Core identification
   set("filament_type", filament.type);
   set("filament_vendor", filament.vendor);
-  set("filament_colour", filament.color);
+  // Slicer presets are single-color — coextruded / multi-color filaments
+  // surface their primary, falling back to the first secondary when the
+  // primary is null (the spec-aligned "coextruded" shape). Secondary
+  // colors beyond the primary are intentionally dropped; the detail
+  // page's slicer-export menu warns the user about this trade-off.
+  set("filament_colour", displayColor(filament));
   set("filament_diameter", filament.diameter);
   set("filament_density", filament.density);
   set("filament_cost", filament.cost);

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -77,6 +77,45 @@ describe("filamentToOrcaSlicerKeys", () => {
     expect(keys.textured_cool_plate_temp_initial_layer).toEqual(["50"]);
   });
 
+  it("multi-color filament exports only the primary; secondaries are dropped", () => {
+    const filament = {
+      name: "Multi Solid",
+      vendor: "Test",
+      type: "PLA",
+      color: "#FF0000",
+      secondaryColors: ["#00FF00", "#0000FF"],
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+    };
+
+    const keys = filamentToOrcaSlicerKeys(filament);
+
+    expect(keys.filament_colour).toEqual(["#FF0000"]);
+    // No secondary-color values are ever emitted — OrcaSlicer presets
+    // are single-color and the detail page warns the user about this.
+    expect(JSON.stringify(keys)).not.toContain("#00FF00");
+    expect(JSON.stringify(keys)).not.toContain("#0000FF");
+  });
+
+  it("coextruded filament (null primary) falls back to the first secondary", () => {
+    const filament = {
+      name: "Coextruded",
+      vendor: "Test",
+      type: "PLA",
+      color: null,
+      secondaryColors: ["#3366CC", "#CC3366"],
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+    };
+
+    const keys = filamentToOrcaSlicerKeys(filament);
+
+    expect(keys.filament_colour).toEqual(["#3366CC"]);
+    expect(JSON.stringify(keys)).not.toContain("#CC3366");
+  });
+
   it("preserves settings bag keys as arrays", () => {
     const filament = {
       name: "Test",

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -116,6 +116,28 @@ describe("filamentToOrcaSlicerKeys", () => {
     expect(JSON.stringify(keys)).not.toContain("#CC3366");
   });
 
+  it("coextruded filament with NO secondaries omits filament_colour entirely", () => {
+    // Reachable state: user picked "coextruded" in the form (clears
+    // primary to null) and saved before adding any secondary slots.
+    // We must NOT fall back to displayColor()'s gray sentinel — that
+    // would force a #808080 the user never picked. (Codex P2 on PR #485.)
+    const filament = {
+      name: "Coextruded Empty",
+      vendor: "Test",
+      type: "PLA",
+      color: null,
+      secondaryColors: [],
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+    };
+
+    const keys = filamentToOrcaSlicerKeys(filament);
+
+    expect(keys).not.toHaveProperty("filament_colour");
+    expect(JSON.stringify(keys)).not.toContain("#808080");
+  });
+
   it("preserves settings bag keys as arrays", () => {
     const filament = {
       name: "Test",

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -258,6 +258,47 @@ describe("filamentToSlicerKeys", () => {
     expect(keys.filament_settings_id).toBe("Original Slicer ID");
   });
 
+  it("multi-color filament exports only the primary; secondaries are dropped", () => {
+    const filament = {
+      name: "Multi Solid",
+      vendor: "Test",
+      type: "PLA",
+      color: "#FF0000",
+      secondaryColors: ["#00FF00", "#0000FF"],
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+    };
+
+    const keys = filamentToSlicerKeys(filament);
+
+    expect(keys.filament_colour).toBe("#FF0000");
+    // No secondary-color keys are ever emitted — slicer presets are
+    // single-color and the detail page warns the user about this.
+    expect(JSON.stringify(keys)).not.toContain("#00FF00");
+    expect(JSON.stringify(keys)).not.toContain("#0000FF");
+  });
+
+  it("coextruded filament (null primary) falls back to the first secondary", () => {
+    const filament = {
+      name: "Coextruded",
+      vendor: "Test",
+      type: "PLA",
+      color: null, // coextruded: no single primary
+      secondaryColors: ["#3366CC", "#CC3366"],
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+    };
+
+    const keys = filamentToSlicerKeys(filament);
+
+    // Primary is null but displayColor() promotes the first secondary so
+    // the slicer at least sees a valid color rather than its bare default.
+    expect(keys.filament_colour).toBe("#3366CC");
+    expect(JSON.stringify(keys)).not.toContain("#CC3366");
+  });
+
   it("null structured fields must not emit nil; settings bag nil is preserved", () => {
     const filament = {
       name: "Nil Test",

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -293,10 +293,34 @@ describe("filamentToSlicerKeys", () => {
 
     const keys = filamentToSlicerKeys(filament);
 
-    // Primary is null but displayColor() promotes the first secondary so
-    // the slicer at least sees a valid color rather than its bare default.
+    // Primary is null but the slicer-export fallback promotes the first
+    // secondary so the slicer sees a valid color rather than its bare
+    // default.
     expect(keys.filament_colour).toBe("#3366CC");
     expect(JSON.stringify(keys)).not.toContain("#CC3366");
+  });
+
+  it("coextruded filament with NO secondaries omits filament_colour entirely", () => {
+    // Reachable state: user picked "coextruded" in the form (clears
+    // primary to null) and saved before adding any secondary slots.
+    // We must NOT fall back to displayColor()'s gray sentinel — that
+    // would force a #808080 the user never picked. Better to omit the
+    // key and let the slicer use its own default. (Codex P2 on PR #485.)
+    const filament = {
+      name: "Coextruded Empty",
+      vendor: "Test",
+      type: "PLA",
+      color: null,
+      secondaryColors: [],
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+    };
+
+    const keys = filamentToSlicerKeys(filament);
+
+    expect(keys).not.toHaveProperty("filament_colour");
+    expect(JSON.stringify(keys)).not.toContain("#808080");
   });
 
   it("null structured fields must not emit nil; settings bag nil is preserved", () => {


### PR DESCRIPTION
## Summary
- Slicer presets are single-color. Route `filament_colour` for both PrusaSlicer and OrcaSlicer bundle generators through `displayColor()` so a coextruded filament (null primary, secondary list) falls back to the first secondary instead of emitting no color at all. Otherwise the slicer renders its bare default for coextruded materials, which loses every color the user picked.
- Amber notice on the filament detail page's "Export for slicer" disclosure menu — fires only when `secondaryColors[]` is non-empty, so single-color users see no extra chrome.
- New i18n key `detail.slicerExport.multiColorNotice` in EN + DE (1275/1275 parity).
- Pinning tests on `filamentToSlicerKeys` + `filamentToOrcaSlicerKeys`: solid multi-color → primary only, coextruded with null primary → first-secondary fallback, secondaries never appear anywhere else in the keyset.

Tracks #477 phase 4 of 5.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` — 1599 passing
- [ ] Manual: filament with secondaries → detail page → "Export for slicer" dropdown → notice visible above the three export buttons
- [ ] Manual: coextruded filament → PrusaSlicer / OrcaSlicer export → `filament_colour` = first secondary

🤖 Generated with [Claude Code](https://claude.com/claude-code)