### PR TITLE
Security hardening: IPC guard, byte validation, SSRF, dead handler (#506, #523)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1114,8 +1114,18 @@ ipcMain.handle("label-printer-print", async (event, bytes: number[]) => {
   // `ESC i z` media width, `ESC i M`/`K` mode bits, `0x1A`/`0x0C`
   // trailer — and a stray byte in the wrong slot leaves the printer
   // in a wrong-mode / chain-stuck state for the next print.
-  if (!bytes.every((b) => Number.isInteger(b) && b >= 0 && b <= 255)) {
-    throw new Error("bytes must contain only integers in [0, 255]");
+  //
+  // Codex P2 round 1: use an index loop, not Array.prototype.every —
+  // `every` skips sparse-array holes (`new Array(100)` or
+  // `delete arr[5]`), so a hostile renderer could send a 5MB array
+  // with NO actual bytes and the guard would pass. `new Uint8Array`
+  // would then convert every hole to 0x00, reintroducing the silent
+  // coercion this hardening is meant to block.
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i];
+    if (!Number.isInteger(b) || b < 0 || b > 255) {
+      throw new Error("bytes must contain only integers in [0, 255]");
+    }
   }
   const devicePath = (store as Store<Record<string, unknown>>).get(
     "labelPrinterDevicePath",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -865,15 +865,14 @@ ipcMain.handle("test-connection", async (event, uri: string) => {
   }
 });
 
-ipcMain.handle("show-message", async (_event, options: { type: string; title: string; message: string }) => {
-  if (mainWindow) {
-    await dialog.showMessageBox(mainWindow, {
-      type: options.type as "info" | "error" | "warning",
-      title: options.title,
-      message: options.message,
-    });
-  }
-});
+// GH #523: the `show-message` IPC handler that lived here was unguarded
+// (no assertTrustedSender) AND dead code (zero renderer callers — see
+// `grep -rn showMessage\|show-message src electron` before reintroducing).
+// It rendered an OS-native dialog parented to the main window from
+// renderer-controlled type/title/message strings — perfect material for
+// UI-spoofing / credential-phishing prompts if a sub-frame is ever
+// compromised. If a future feature needs it, re-add with
+// assertTrustedSender and a constrained payload allowlist.
 
 // Sync
 ipcMain.handle("get-sync-status", () => {
@@ -905,7 +904,13 @@ ipcMain.handle("trigger-sync", async (event) => {
   return { results };
 });
 
-ipcMain.handle("check-atlas-connectivity", async () => {
+// GH #506: same sub-frame attack surface as #432's trigger-sync — this
+// handler opens a real MongoClient to Atlas (per call when syncService
+// is null; per-cycle thereafter) and is polled by SyncStatusIndicator.
+// A compromised sub-frame can weaponise it for connection-pool / billing
+// exhaustion against the user's Atlas tier.
+ipcMain.handle("check-atlas-connectivity", async (event) => {
+  assertTrustedSender(event, "check-atlas-connectivity");
   if (!syncService) {
     // Try a direct check
     const atlasUri = store.get("atlasUri") as string;
@@ -1101,6 +1106,16 @@ ipcMain.handle("label-printer-print", async (event, bytes: number[]) => {
     // is well past any legitimate single-label print and ensures a
     // misbehaving renderer can't lock the printer indefinitely.
     throw new Error(`bytes array too large (${bytes.length} bytes)`);
+  }
+  // GH #523: per-byte validation mirroring nfc-write-tag (#278). Without
+  // this, `new Uint8Array(bytes)` silently coerces floats to truncated
+  // ints, NaN/Infinity/strings/objects/null to 0, and out-of-range
+  // values mod-256 wrap. Brother's raster protocol is positional —
+  // `ESC i z` media width, `ESC i M`/`K` mode bits, `0x1A`/`0x0C`
+  // trailer — and a stray byte in the wrong slot leaves the printer
+  // in a wrong-mode / chain-stuck state for the next print.
+  if (!bytes.every((b) => Number.isInteger(b) && b >= 0 && b <= 255)) {
+    throw new Error("bytes must contain only integers in [0, 255]");
   }
   const devicePath = (store as Store<Record<string, unknown>>).get(
     "labelPrinterDevicePath",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -36,8 +36,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("save-config", config),
   resetConfig: () => ipcRenderer.invoke("reset-config"),
   testConnection: (uri: string) => ipcRenderer.invoke("test-connection", uri),
-  showMessage: (options: { type: string; title: string; message: string }) =>
-    ipcRenderer.invoke("show-message", options),
+  // GH #523: showMessage bridge removed — see corresponding comment in
+  // electron/main.ts. Re-add only with assertTrustedSender + payload
+  // allowlist if a future feature needs it.
 
   // Sync
   getSyncStatus: () => ipcRenderer.invoke("get-sync-status"),

--- a/src/app/api/prusament/route.ts
+++ b/src/app/api/prusament/route.ts
@@ -1,11 +1,55 @@
 import { NextRequest, NextResponse } from "next/server";
 import { extractSpoolData } from "@/lib/prusament";
-import { readBodyCapped } from "@/lib/externalUrlGuard";
+import {
+  assertExternalUrl,
+  readBodyCapped,
+  ssrfDispatcher,
+} from "@/lib/externalUrlGuard";
 
 /** GH #258: cap the Prusament HTML page. A real spool page is well under
  * 1 MB; the cap stops a hostile/compromised response from buffering an
  * unbounded body into memory before the regex/JSON.parse step. */
 const MAX_PRUSAMENT_HTML_BYTES = 4 * 1024 * 1024;
+
+/** GH #523: cap on redirect hops, matching tdsExtractor / embed-check. */
+const MAX_REDIRECTS = 5;
+
+/**
+ * Manually-followed fetch with per-hop SSRF revalidation. Same pattern as
+ * `src/lib/tdsExtractor.ts` and `src/app/api/embed-check/route.ts`. Without
+ * this, undici's automatic `redirect: "follow"` would silently chase a
+ * 3xx Location into RFC1918 / loopback / cloud-metadata space without
+ * re-checking the target. The risk on prusament.com specifically is low
+ * (hardcoded host) but the asymmetry breaks the invariant that every
+ * outbound fetch goes through the SSRF dispatcher.
+ */
+async function fetchWithSsrfGuard(
+  initialUrl: string,
+  init: RequestInit,
+): Promise<Response> {
+  let currentUrl = initialUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    await assertExternalUrl(currentUrl);
+    const res = await fetch(currentUrl, {
+      ...init,
+      redirect: "manual",
+      dispatcher: ssrfDispatcher,
+    } as RequestInit & { dispatcher?: typeof ssrfDispatcher });
+    const isRedirect = res.status >= 300 && res.status < 400 && res.status !== 304;
+    if (!isRedirect) return res;
+    const loc = res.headers.get("location");
+    res.body?.cancel().catch(() => {});
+    if (!loc) {
+      throw new Error(`Prusament fetch: HTTP ${res.status} with no Location header`);
+    }
+    if (hop === MAX_REDIRECTS) {
+      throw new Error(`Prusament fetch: too many redirects (>${MAX_REDIRECTS})`);
+    }
+    currentUrl = new URL(loc, currentUrl).toString();
+  }
+  // Unreachable — the loop either returns or throws.
+  throw new Error("Prusament fetch: redirect loop exited unexpectedly");
+}
 
 /** Shape of the spoolData JSON embedded in the Prusament spool page. */
 interface PrusamentSpoolData {
@@ -98,7 +142,7 @@ export async function GET(request: NextRequest) {
 
     let html: string;
     try {
-      const res = await fetch(pageUrl, {
+      const res = await fetchWithSsrfGuard(pageUrl, {
         headers: { "User-Agent": "FilamentDB/1.0" },
         signal: AbortSignal.timeout(10_000),
       });

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -4,7 +4,6 @@ interface ElectronAPI {
   saveConfig: (config: { mongodbUri?: string; connectionMode?: string; atlasUri?: string; geminiApiKey?: string; aiApiKey?: string; aiProvider?: string; currency?: string; customCurrencies?: string; locale?: string }) => Promise<{ success: boolean }>;
   resetConfig: () => Promise<{ success: boolean }>;
   testConnection: (uri: string) => Promise<{ success: boolean; error?: string }>;
-  showMessage: (options: { type: string; title: string; message: string }) => Promise<void>;
 
   // Sync
   getSyncStatus: () => Promise<{


### PR DESCRIPTION
## Summary
- **#506** `check-atlas-connectivity` now requires `assertTrustedSender` — same sub-frame attack surface that #432 closed on `trigger-sync`. Polled by `SyncStatusIndicator`, so a compromised sub-frame could exhaust Atlas connection-pool slots / billable connections.
- **#523.1** `label-printer-print` per-byte validation that bytes are integers in [0, 255]. Without it, `new Uint8Array(bytes)` silently coerces floats/NaN/Infinity/strings/null to 0 and wraps out-of-range mod 256 — Brother's positional raster protocol leaves the printer in a wrong-mode / chain-stuck state for the next print. Mirrors #278's nfc-write-tag pattern.
- **#523.2** `/api/prusament` now does manual hop-by-hop fetch with `assertExternalUrl` on every redirect target + `ssrfDispatcher` pinning the socket to the SSRF-validated IP. Same pattern `tdsExtractor` and `embed-check` already use. Risk on hardcoded prusament.com was low; this restores the "all outbound fetch goes through the dispatcher" invariant.
- **#523.3** Dead `show-message` IPC handler + preload bridge + type declaration deleted. Was unguarded AND had zero renderer callers — perfect material for UI-spoofing prompts parented to the trusted main window if any code in the renderer is ever compromised.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/prusament.test.ts` — 8/8 pass
- [ ] CI green
- [ ] Codex review

Fixes #506, #523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)