### PR TITLE
Write-path validation: dates, color hex, refs, VersionError, races (#502, #503, #504, #519, partial #524)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -3,9 +3,9 @@ import dbConnect from "@/lib/mongodb";
 import Filament, { IFilament } from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
-import "@/models/BedType";
+import BedType from "@/models/BedType";
 import { resolveFilament, hasVariants } from "@/lib/resolveFilament";
-import { errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught, handleDuplicateKeyError, assertActiveRefs } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
 import { assignSpoolToSlot } from "@/lib/spoolSlots";
@@ -215,6 +215,35 @@ export async function PUT(
       if (variantCount > 0) {
         return errorResponse("Cannot set parent on a filament that has variants — remove variants first", 400);
       }
+    }
+
+    // GH #519: same cross-collection ref existence check the POST handler
+    // runs (Nozzle / Printer / BedType from compatibleNozzles +
+    // calibrations[]). Without this, a PUT could attach phantom refs the
+    // GET handler's .populate() then silently drops, leaving the slicer
+    // / compare UI looking at calibrations that point at nothing.
+    {
+      const nozzleRefs = new Set<string>();
+      const printerRefs = new Set<string>();
+      const bedRefs = new Set<string>();
+      if (Array.isArray(body.compatibleNozzles)) {
+        for (const refId of body.compatibleNozzles) {
+          if (typeof refId === "string") nozzleRefs.add(refId);
+        }
+      }
+      if (Array.isArray(body.calibrations)) {
+        for (const cal of body.calibrations as Array<Record<string, unknown>>) {
+          if (typeof cal?.nozzle === "string") nozzleRefs.add(cal.nozzle);
+          if (typeof cal?.printer === "string") printerRefs.add(cal.printer);
+          if (typeof cal?.bedType === "string") bedRefs.add(cal.bedType);
+        }
+      }
+      const nozzleGuard = await assertActiveRefs(Nozzle, Array.from(nozzleRefs), "referenced nozzles");
+      if (nozzleGuard) return nozzleGuard;
+      const printerGuard = await assertActiveRefs(Printer, Array.from(printerRefs), "referenced printers");
+      if (printerGuard) return printerGuard;
+      const bedGuard = await assertActiveRefs(BedType, Array.from(bedRefs), "referenced bed types");
+      if (bedGuard) return bedGuard;
     }
 
     const filament = await Filament.findOneAndUpdate(

--- a/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/dry-cycles/route.ts
@@ -43,8 +43,38 @@ export async function POST(
     return errorResponse("notes must be 1000 characters or fewer", 400);
   }
 
+  // GH #502.1: mirror the print-history POST guard (#306) so an Invalid
+  // Date can't reach the doc. Without this, /api/dashboard later 500s
+  // when `new Date(invalidDate).toISOString()` throws RangeError.
+  const cycleDate = body?.date ? new Date(body.date) : new Date();
+  if (Number.isNaN(cycleDate.getTime())) {
+    return errorResponse("date is not a valid date", 400);
+  }
+
+  // GH #502.2: the schema declares `tempC { min: 0, max: 300 }` and
+  // `durationMin { min: 0 }`, but `findOneAndUpdate(..., { $push })`
+  // below intentionally omits `runValidators: true` to keep the
+  // atomic $slice cap (#304). Enforce the same bounds explicitly here
+  // so negatives / out-of-range values can't corrupt the row.
+  if (body?.tempC != null) {
+    if (typeof body.tempC !== "number" || !Number.isFinite(body.tempC)) {
+      return errorResponse("tempC must be a finite number", 400);
+    }
+    if (body.tempC < 0 || body.tempC > 300) {
+      return errorResponse("tempC must be between 0 and 300", 400);
+    }
+  }
+  if (body?.durationMin != null) {
+    if (typeof body.durationMin !== "number" || !Number.isFinite(body.durationMin)) {
+      return errorResponse("durationMin must be a finite number", 400);
+    }
+    if (body.durationMin < 0) {
+      return errorResponse("durationMin must be non-negative", 400);
+    }
+  }
+
   const entry: Record<string, unknown> = {
-    date: body?.date ? new Date(body.date) : new Date(),
+    date: cycleDate,
     tempC:
       typeof body?.tempC === "number" && Number.isFinite(body.tempC) ? body.tempC : null,
     durationMin:

--- a/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
-import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught, handleVersionError } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 
 /** GH #304: hard cap on a spool's embedded usageHistory array. Far
@@ -88,6 +88,11 @@ export async function POST(
     await filament.save();
     return NextResponse.json(filament.toObject(), { status: 201 });
   } catch (err) {
+    // GH #504: surface optimistic-concurrency conflicts as 409 with a
+    // retry hint so a SpoolCard logging usage while a slicer concurrently
+    // posts print-history doesn't see a misleading 500.
+    const conflict = handleVersionError(err);
+    if (conflict) return conflict;
     return errorResponseFromCaught(err, "Failed to log usage");
   }
 }

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -1,8 +1,44 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
-import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
+import Nozzle from "@/models/Nozzle";
+import Printer from "@/models/Printer";
+import BedType from "@/models/BedType";
+import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError, assertActiveRefs } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
+
+/**
+ * GH #519: collect every cross-collection ref carried by a filament body and
+ * verify each id resolves to an active doc. Mirrors the printer-route shape
+ * (`assertActiveRefs(model, ids, label)`). Calibration refs are pulled out
+ * per-collection so the error message names the right field; null/missing
+ * refs in calibration entries are passed through (the schema marks
+ * `nozzle` required and handles it at validation time).
+ */
+async function assertFilamentBodyRefs(
+  body: Record<string, unknown>,
+): Promise<Response | null> {
+  const compatibleNozzles = Array.isArray(body.compatibleNozzles)
+    ? (body.compatibleNozzles as unknown[]).filter((id): id is string => typeof id === "string")
+    : [];
+  const nozzleRefs = new Set<string>(compatibleNozzles);
+  const printerRefs = new Set<string>();
+  const bedRefs = new Set<string>();
+  if (Array.isArray(body.calibrations)) {
+    for (const cal of body.calibrations as Array<Record<string, unknown>>) {
+      if (typeof cal?.nozzle === "string") nozzleRefs.add(cal.nozzle);
+      if (typeof cal?.printer === "string") printerRefs.add(cal.printer);
+      if (typeof cal?.bedType === "string") bedRefs.add(cal.bedType);
+    }
+  }
+  const nozzleGuard = await assertActiveRefs(Nozzle, Array.from(nozzleRefs), "referenced nozzles");
+  if (nozzleGuard) return nozzleGuard;
+  const printerGuard = await assertActiveRefs(Printer, Array.from(printerRefs), "referenced printers");
+  if (printerGuard) return printerGuard;
+  const bedGuard = await assertActiveRefs(BedType, Array.from(bedRefs), "referenced bed types");
+  if (bedGuard) return bedGuard;
+  return null;
+}
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -264,6 +300,9 @@ export async function POST(request: NextRequest) {
         body.diameter = null;
       }
     }
+
+    const refGuard = await assertFilamentBodyRefs(body);
+    if (refGuard) return refGuard;
 
     const filament = await Filament.create(body);
     return NextResponse.json(filament, { status: 201 });

--- a/src/app/api/openprinttag/import/route.ts
+++ b/src/app/api/openprinttag/import/route.ts
@@ -6,6 +6,7 @@ import {
   mapToFilamentPayload,
 } from "@/lib/openprinttagBrowser";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
+import { isDuplicateKeyError } from "@/lib/apiErrorHandler";
 
 /**
  * POST /api/openprinttag/import
@@ -176,8 +177,39 @@ export async function POST(request: NextRequest) {
             );
             continue;
           }
-          await Filament.create(payload);
-          created++;
+          // GH #524.1: between the nameCollision check above and the
+          // create below, a concurrent POST can win the race and the
+          // loser's create throws E11000 with the raw MongoServerError
+          // text that used to leak into errors[]. Mirror the three-phase
+          // recovery the bambustudio / filament-import / prusament
+          // importers all use: on a duplicate-key error, re-fetch the
+          // winner and treat it as an update.
+          try {
+            await Filament.create(payload);
+            created++;
+          } catch (createErr) {
+            if (!isDuplicateKeyError(createErr)) throw createErr;
+            const winner = await Filament.findOneAndUpdate(
+              { name, vendor, _deletedAt: null },
+              { $set: optUpdateFields },
+              { returnDocument: "after" },
+            );
+            if (winner) {
+              updated++;
+            } else {
+              // The race winner is in a different vendor — same shape as
+              // the pre-create nameCollision branch above.
+              const racedCollision = await Filament.findOne({ name, _deletedAt: null }).lean();
+              if (racedCollision) {
+                errors.push(
+                  `${material.name}: skipped — a filament named "${name}" already exists under vendor "${racedCollision.vendor}"`,
+                );
+              } else {
+                // Shouldn't happen — but don't leak the raw E11000.
+                errors.push(`${material.name}: write conflict, please retry`);
+              }
+            }
+          }
         }
       } catch (err) {
         errors.push(`${material.name}: ${String(err)}`);

--- a/src/app/api/openprinttag/import/route.ts
+++ b/src/app/api/openprinttag/import/route.ts
@@ -118,6 +118,58 @@ export async function POST(request: NextRequest) {
         if (payload.shoreHardnessD != null)
           conditionalDefaults.shoreHardnessD = payload.shoreHardnessD;
 
+        /** Apply conditional defaults (only set if currently null) to a
+         *  row — used by both the normal existing-row path AND the
+         *  duplicate-key race-recovery path (Codex P2 round 1 on
+         *  PR #531). Without this shared helper, a doc that's created
+         *  by a concurrent caller between the existing-lookup and the
+         *  create below would land with ONLY the optUpdateFields set —
+         *  density/color/drying/etc. would never get backfilled from
+         *  the OPT material the user explicitly chose to import. */
+        const applyConditionalDefaults = async (
+          row: { _id: unknown; density?: number | null; color?: string | null; secondaryColors?: string[] | null; transmissionDistance?: number | null; dryingTemperature?: number | null; dryingTime?: number | null; shoreHardnessD?: number | null },
+        ): Promise<void> => {
+          const conditionalSet: Record<string, unknown> = {};
+          if (conditionalDefaults.density != null && row.density == null)
+            conditionalSet.density = conditionalDefaults.density;
+          if (conditionalDefaults.color && row.color === "#808080")
+            conditionalSet.color = conditionalDefaults.color;
+          // GH #477: only adopt the OPT db's secondaryColors when the
+          // existing row has none. Don't overwrite user-set arrays.
+          if (
+            conditionalDefaults.secondaryColors &&
+            (!row.secondaryColors || row.secondaryColors.length === 0)
+          ) {
+            conditionalSet.secondaryColors = conditionalDefaults.secondaryColors;
+            // GH #477 (Codex P2 on PR #484 r3): when the OPT material
+            // is coextruded (payload.color === null, secondaryColors
+            // populated) AND the row still has the gray sentinel
+            // "#808080", clear it to null so we don't end up with the
+            // gray+secondaries state the spec doesn't permit for
+            // coextruded materials. mapToFilamentPayload already emits
+            // null for this case so payload.color is null here, but the
+            // conditionalDefaults.color branch above only fires when
+            // payload.color is truthy — leaving the sentinel in place.
+            // This explicit clear closes the gap. Matches the create
+            // branch which gets null directly via mapToFilamentPayload.
+            if (payload.color === null && row.color === "#808080") {
+              conditionalSet.color = null;
+            }
+          }
+          if (conditionalDefaults.transmissionDistance != null && row.transmissionDistance == null)
+            conditionalSet.transmissionDistance = conditionalDefaults.transmissionDistance;
+          if (conditionalDefaults.dryingTemperature != null && row.dryingTemperature == null)
+            conditionalSet.dryingTemperature = conditionalDefaults.dryingTemperature;
+          if (conditionalDefaults.dryingTime != null && row.dryingTime == null)
+            conditionalSet.dryingTime = conditionalDefaults.dryingTime;
+          if (conditionalDefaults.shoreHardnessD != null && row.shoreHardnessD == null)
+            conditionalSet.shoreHardnessD = conditionalDefaults.shoreHardnessD;
+
+          if (Object.keys(conditionalSet).length > 0) {
+            await Filament.findByIdAndUpdate(row._id, { $set: conditionalSet });
+          }
+        };
+
         const existing = await Filament.findOneAndUpdate(
           { name, _deletedAt: null, vendor },
           { $set: optUpdateFields },
@@ -125,48 +177,7 @@ export async function POST(request: NextRequest) {
         );
 
         if (existing) {
-          // Apply conditional defaults (only set if currently null) in a
-          // second update — $set alone cannot express "set if null".
-          const conditionalSet: Record<string, unknown> = {};
-          if (conditionalDefaults.density != null && existing.density == null)
-            conditionalSet.density = conditionalDefaults.density;
-          if (conditionalDefaults.color && existing.color === "#808080")
-            conditionalSet.color = conditionalDefaults.color;
-          // GH #477: only adopt the OPT db's secondaryColors when the
-          // existing row has none. Don't overwrite user-set arrays.
-          if (
-            conditionalDefaults.secondaryColors &&
-            (!existing.secondaryColors || existing.secondaryColors.length === 0)
-          ) {
-            conditionalSet.secondaryColors = conditionalDefaults.secondaryColors;
-            // GH #477 (Codex P2 on PR #484 r3): when the OPT material
-            // is coextruded (payload.color === null, secondaryColors
-            // populated) AND the existing row still has the gray
-            // sentinel "#808080", clear it to null so we don't end up
-            // with the gray+secondaries state the spec doesn't permit
-            // for coextruded materials. mapToFilamentPayload already
-            // emits null for this case so payload.color is null here,
-            // but the conditionalDefaults.color branch above only
-            // fires when payload.color is truthy — leaving the
-            // sentinel in place. This explicit clear closes the gap.
-            // Matches the create branch which gets null directly via
-            // mapToFilamentPayload.
-            if (payload.color === null && existing.color === "#808080") {
-              conditionalSet.color = null;
-            }
-          }
-          if (conditionalDefaults.transmissionDistance != null && existing.transmissionDistance == null)
-            conditionalSet.transmissionDistance = conditionalDefaults.transmissionDistance;
-          if (conditionalDefaults.dryingTemperature != null && existing.dryingTemperature == null)
-            conditionalSet.dryingTemperature = conditionalDefaults.dryingTemperature;
-          if (conditionalDefaults.dryingTime != null && existing.dryingTime == null)
-            conditionalSet.dryingTime = conditionalDefaults.dryingTime;
-          if (conditionalDefaults.shoreHardnessD != null && existing.shoreHardnessD == null)
-            conditionalSet.shoreHardnessD = conditionalDefaults.shoreHardnessD;
-
-          if (Object.keys(conditionalSet).length > 0) {
-            await Filament.findByIdAndUpdate(existing._id, { $set: conditionalSet });
-          }
+          await applyConditionalDefaults(existing);
           updated++;
         } else {
           // Check if a filament exists with a different vendor (name collision)
@@ -195,6 +206,12 @@ export async function POST(request: NextRequest) {
               { returnDocument: "after" },
             );
             if (winner) {
+              // Codex P2 round 1: same conditional-default backfill the
+              // normal existing-row path applies — without this the
+              // duplicate-recovery branch would report "updated" while
+              // leaving the OPT material's density/color/drying-temp
+              // unset on the raced-in row.
+              await applyConditionalDefaults(winner);
               updated++;
             } else {
               // The race winner is in a different vendor — same shape as

--- a/src/app/api/print-history/[id]/route.ts
+++ b/src/app/api/print-history/[id]/route.ts
@@ -4,7 +4,7 @@ import dbConnect from "@/lib/mongodb";
 import PrintHistory from "@/models/PrintHistory";
 import Filament from "@/models/Filament";
 import Printer from "@/models/Printer";
-import { errorResponseFromCaught, getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
+import { errorResponseFromCaught, getErrorMessage, errorResponse, handleVersionError } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 
 /**
@@ -271,6 +271,12 @@ export async function DELETE(
     );
     return NextResponse.json({ message: "Deleted and refunded" });
   } catch (err) {
+    // GH #504: same concurrent-edit pattern. DELETE refunds spool weight
+    // via filament.save(); if that races a slicer POST or another DELETE
+    // on the same filament, surface as 409 so the caller can retry
+    // instead of seeing a generic 500 toast.
+    const conflict = handleVersionError(err);
+    if (conflict) return conflict;
     return errorResponse("Failed to delete print history", 500, getErrorMessage(err));
   }
 }

--- a/src/app/api/printers/[id]/route.ts
+++ b/src/app/api/printers/[id]/route.ts
@@ -55,6 +55,14 @@ export async function PUT(
     delete body.instanceId;
     delete body.syncId;
 
+    // GH #524.4: see parallel comment in POST handler.
+    if (Array.isArray(body.installedNozzles)) {
+      body.installedNozzles = Array.from(new Set(body.installedNozzles.map(String)));
+    }
+    if (Array.isArray(body.installedBedTypes)) {
+      body.installedBedTypes = Array.from(new Set(body.installedBedTypes.map(String)));
+    }
+
     // Validate that all referenced nozzle IDs exist and are active
     if (body.installedNozzles?.length > 0) {
       const activeCount = await Nozzle.countDocuments({

--- a/src/app/api/printers/route.ts
+++ b/src/app/api/printers/route.ts
@@ -59,6 +59,16 @@ export async function POST(request: NextRequest) {
   delete body.instanceId;
   delete body.syncId;
 
+  // GH #524.4: dedupe ref arrays at entry so a body with the same valid id
+  // twice doesn't trip the `activeCount !== body.installedNozzles.length`
+  // comparison and 400 with the misleading "no longer exist." message.
+  if (Array.isArray(body.installedNozzles)) {
+    body.installedNozzles = Array.from(new Set(body.installedNozzles.map(String)));
+  }
+  if (Array.isArray(body.installedBedTypes)) {
+    body.installedBedTypes = Array.from(new Set(body.installedBedTypes.map(String)));
+  }
+
   try {
     // Validate that all referenced nozzle IDs exist and are active
     if (body.installedNozzles?.length > 0) {

--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -111,6 +111,79 @@ export function errorResponseFromCaught(
   return errorResponse(fallbackMessage, fallbackStatus, getErrorMessage(err));
 }
 
+/**
+ * GH #504: Mongoose `Error.VersionError` is the optimistic-concurrency
+ * signal — two writers raced the same document version. Surface it as
+ * 409 so the caller can re-fetch and retry against the fresh state
+ * (instead of seeing a generic 500). `print-history`'s POST handler
+ * has had this branch since GH #224; this helper lifts the pattern so
+ * every `.save()` site can share it without duplicating message copy.
+ *
+ * Pass the caught error AND an optional context label for the message.
+ * Returns the 409 NextResponse on a VersionError, or null when the
+ * caller should fall through to its existing generic-error branch.
+ *
+ * Usage:
+ *   } catch (err) {
+ *     const conflict = handleVersionError(err);
+ *     if (conflict) return conflict;
+ *     return errorResponseFromCaught(err, "Failed to ...");
+ *   }
+ */
+export function handleVersionError(err: unknown): NextResponse | null {
+  // Use a runtime instanceof check — but lazy-import to avoid pulling
+  // mongoose into edge-runtime callers. Mongoose's VersionError extends
+  // Error with name "VersionError"; matching on the name is portable
+  // and survives across the framework-internal subclass.
+  if (
+    err instanceof Error &&
+    (err.name === "VersionError" || err.constructor?.name === "VersionError")
+  ) {
+    return errorResponse(
+      "This record was modified by another request. Please retry.",
+      409,
+    );
+  }
+  return null;
+}
+
+/**
+ * GH #519: assert every id in `ids` corresponds to an active (non-trashed)
+ * document in `model`. Returns null when every id resolves; returns a 400
+ * NextResponse naming the offending field when any are missing. Same shape
+ * as the printer-route existence checks so error messages stay consistent.
+ *
+ * The check ignores order and duplicates (`countDocuments` is on the
+ * deduped `$in` set) — combine with a `Array.from(new Set(ids))` at the
+ * route entry to make the per-route message match the deduped count
+ * (see GH #524.4).
+ */
+interface CountableModel {
+  countDocuments(filter: Record<string, unknown>): Promise<number> | { exec(): Promise<number> };
+}
+
+export async function assertActiveRefs(
+  model: CountableModel,
+  ids: string[] | undefined,
+  fieldLabel: string,
+): Promise<NextResponse | null> {
+  if (!ids || ids.length === 0) return null;
+  const deduped = Array.from(new Set(ids.map(String)));
+  const result = model.countDocuments({
+    _id: { $in: deduped },
+    _deletedAt: null,
+  });
+  // Both Mongoose Query and a plain Promise resolve to a number — handle
+  // either so route-level mocks don't have to fake the .exec() shape.
+  const activeCount = await (typeof (result as { exec?: () => Promise<number> }).exec === "function"
+    ? (result as { exec(): Promise<number> }).exec()
+    : (result as Promise<number>));
+  if (activeCount !== deduped.length) {
+    return errorResponse(`One or more ${fieldLabel} no longer exist.`, 400);
+  }
+  return null;
+}
+
 /** Maximum upload file size (10 MB) */
 export const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
 

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -340,6 +340,20 @@ export async function upsertImportRows(
       type: row.type,
     };
     if (row.color !== undefined && row.color !== "" && row.color !== null) {
+      // GH #503: drop bad-hex rows into skippedRows the same way the
+      // route-level validators reject them on direct API calls. Without
+      // this per-row guard the new schema validator on `color` would
+      // throw on the bulk save() and we'd lose the WHOLE batch's
+      // accounting rather than the one bad row.
+      if (!/^#[0-9A-Fa-f]{6}$/.test(String(row.color))) {
+        skippedRows.push({
+          row: rowIdx + 2,
+          name: row.name,
+          reason: `Invalid color hex "${row.color}" (expected #RRGGBB)`,
+        });
+        skipped++;
+        return;
+      }
       doc.color = row.color;
     }
     // GH #477: parse the comma-separated "Secondary Colors" column,

--- a/src/lib/inventoryStats.ts
+++ b/src/lib/inventoryStats.ts
@@ -43,19 +43,27 @@ export function getSpoolCount(f: InventoryFilament): number {
  * set but `netFilamentWeight` blank, so the guard checks only the inputs
  * the calculation actually uses. */
 export function getRemainingGrams(f: InventoryFilament): number | null {
-  if (!f.spools || f.spools.length === 0 || f.spoolWeight == null) {
-    return null;
-  }
-  let grams = 0;
-  let any = false;
-  for (const s of f.spools) {
-    if (s.retired) continue;
-    if (s.totalWeight != null) {
-      grams += Math.max(0, s.totalWeight - f.spoolWeight);
-      any = true;
+  if (f.spools && f.spools.length > 0) {
+    if (f.spoolWeight == null) return null;
+    let grams = 0;
+    let any = false;
+    for (const s of f.spools) {
+      if (s.retired) continue;
+      if (s.totalWeight != null) {
+        grams += Math.max(0, s.totalWeight - f.spoolWeight);
+        any = true;
+      }
     }
+    return any ? grams : null;
   }
-  return any ? grams : null;
+  // GH #524.3: legacy single-spool fallback — same shape getSpoolCount
+  // and getRemainingPct already honour. Without this branch, the home
+  // page's isLowStock helper (which calls getRemainingGrams and treats
+  // null as "not low") never lights up the badge for a pre-migration
+  // filament with a top-level `totalWeight`, even though the same row's
+  // remaining-% bar renders correctly via getRemainingPct's legacy path.
+  if (f.totalWeight == null || f.spoolWeight == null) return null;
+  return Math.max(0, f.totalWeight - f.spoolWeight);
 }
 
 /** Percentage remaining (0-100, integer). Excludes retired spools so

--- a/src/lib/validateSpoolBody.ts
+++ b/src/lib/validateSpoolBody.ts
@@ -79,6 +79,16 @@ export function isValidIsoDateString(s: string): boolean {
   // If a time portion is present, also confirm the whole string parses
   // (catches bad hours/minutes/offsets like "T25:00Z").
   if (s.length > 10 && isNaN(new Date(s).getTime())) return false;
+  // GH #524.2: ECMA-262 allows `T24:00` and `T24:00:00` as aliases for
+  // 00:00 of the following day, so `new Date('2025-01-01T24:00:00Z')`
+  // returns 2025-01-02 instead of failing. That's a silent +1-day shift
+  // a user wouldn't expect. Parse the hour component out of the regex
+  // capture and reject 24+ explicitly (every other invalid hour like 25
+  // is already caught by the `isNaN` check above).
+  if (m[4]) {
+    const hourMatch = /^T(\d{2}):/.exec(m[4]);
+    if (hourMatch && Number(hourMatch[1]) >= 24) return false;
+  }
   return true;
 }
 

--- a/src/models/Filament.ts
+++ b/src/models/Filament.ts
@@ -218,9 +218,26 @@ const FilamentSchema = new Schema<IFilament>(
     // filaments where there's no single primary. Default stays "#808080"
     // so existing rows + every single-color filament keep current behavior;
     // null is only written when the user opts into the multi-color
-    // "Coextruded" arrangement. Hex shape is validated on writes via the
-    // route handlers (matches the existing posture for free-form strings).
-    color: { type: String, default: "#808080" },
+    // "Coextruded" arrangement.
+    //
+    // GH #503: schema-level hex validator (matching the per-entry
+    // validator on `secondaryColors` immediately below). The previous
+    // posture relied on "validated on writes via the route handlers"
+    // — that claim wasn't true: the POST handler called `Filament.create`
+    // without inspecting `color`, the PUT used `runValidators: true`
+    // against a no-op validator, the CSV importer wrote `row.color`
+    // straight through, and the round-trip ate garbage on OpenPrintTag
+    // / slicer exports. Allow null per the spec; otherwise enforce
+    // `#RRGGBB`.
+    color: {
+      type: String,
+      default: "#808080",
+      validate: {
+        validator: (v: string | null | undefined) =>
+          v == null || (typeof v === "string" && /^#[0-9A-Fa-f]{6}$/.test(v)),
+        message: "color must be a #RRGGBB hex string or null",
+      },
+    },
     // GH #477: spec keys 20–24 (`secondary_color_0..4`). Hex validation
     // applied per-entry; max-5 cap matches the spec exactly. Defaulting
     // to an empty array (vs undefined) so the read path never needs a

--- a/tests/compare-route-spoolweight.test.ts
+++ b/tests/compare-route-spoolweight.test.ts
@@ -76,7 +76,7 @@ describe("/api/filaments/compare — inherited spoolWeight (Codex P2 PR #190)", 
       name: "Override-Variant",
       vendor: "V",
       type: "PLA",
-      color: "#fff",
+      color: "#ffffff",
       parentId: parent._id,
       spoolWeight: 300,
     });
@@ -104,7 +104,7 @@ describe("/api/filaments/compare — inherited spoolWeight (Codex P2 PR #190)", 
       name: "VNP",
       vendor: "V",
       type: "PLA",
-      color: "#fff",
+      color: "#ffffff",
       parentId: parent._id,
     });
     const res = await compareFilaments(req([String(variant._id)]));

--- a/tests/compare-route.test.ts
+++ b/tests/compare-route.test.ts
@@ -140,7 +140,7 @@ describe("/api/filaments/compare — variant inheritance (GH #184)", () => {
       name: "Mixed Variant",
       vendor: "V",
       type: "PETG",
-      color: "#fff",
+      color: "#ffffff",
       parentId: parent._id,
     });
     const solo = await Filament.create({

--- a/tests/dashboard-route.test.ts
+++ b/tests/dashboard-route.test.ts
@@ -323,7 +323,7 @@ describe("/api/dashboard — totalGrams + low-stock subtract empty-spool mass (G
       name: "LS Variant",
       vendor: "Test",
       type: "PLA",
-      color: "#fff",
+      color: "#ffffff",
       parentId: parent._id,
       lowStockThreshold: 200,
       // 600 - inherited 500 = 100 remaining → below threshold 200.

--- a/tests/locations-route.test.ts
+++ b/tests/locations-route.test.ts
@@ -193,7 +193,7 @@ describe("/api/locations", () => {
         name: "Inherit Variant",
         vendor: "Test",
         type: "PLA",
-        color: "#abc",
+        color: "#aabbcc",
         parentId: parent._id,
         // spoolWeight intentionally omitted — inherit.
         spools: [

--- a/tests/scan-publish-route.test.ts
+++ b/tests/scan-publish-route.test.ts
@@ -33,7 +33,7 @@ describe("POST /api/scan/publish", () => {
           name: "Prusament PLA Galaxy Black",
           vendor: "Prusament",
           type: "PLA",
-          color: "#000",
+          color: "#000000",
         },
         candidates: [],
         decoded: {
@@ -93,7 +93,7 @@ describe("POST /api/scan/publish", () => {
           name: "n",
           vendor: "v",
           type: "t",
-          color: "#fff",
+          color: "#ffffff",
           // Unknown field — must be dropped by the route's allow-list pick.
           maliciousScript: "<script>",
         },
@@ -117,7 +117,7 @@ describe("POST /api/scan/publish", () => {
       name: "n",
       vendor: "v",
       type: "t",
-      color: "#fff",
+      color: "#ffffff",
     });
     expect(event.candidates).toHaveLength(1);
     expect(event.candidates[0]!._id).toBe("y");

--- a/tests/scan-stream-route.test.ts
+++ b/tests/scan-stream-route.test.ts
@@ -20,7 +20,7 @@ function sampleEvent(over: Partial<ScanEvent> = {}): ScanEvent {
       name: "Prusament PLA Galaxy Black",
       vendor: "Prusament",
       type: "PLA",
-      color: "#000",
+      color: "#000000",
     },
     candidates: [],
     decoded: { materialName: "Prusament PLA Galaxy Black" },

--- a/tests/scanMatchHandler.test.ts
+++ b/tests/scanMatchHandler.test.ts
@@ -58,7 +58,7 @@ function decoded(name: string): DecodedOpenPrintTag {
 }
 
 function matchFor(id: string, name: string): FilamentMatch {
-  return { _id: id, name, vendor: "Test Vendor", type: "PLA", color: "#000" };
+  return { _id: id, name, vendor: "Test Vendor", type: "PLA", color: "#000000" };
 }
 
 describe("createScanMatchHandler", () => {

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -252,7 +252,7 @@ describe("SyncService — v1.12 sync expansion", () => {
       const localFilId = new ObjectId();
       const remoteFilId = new ObjectId();
       const filDoc = {
-        name: "AMS PLA", vendor: "Test", type: "PLA", color: "#000",
+        name: "AMS PLA", vendor: "Test", type: "PLA", color: "#000000",
         diameter: 1.75, temperatures: {}, bedTypeTemps: [],
         compatibleNozzles: [], calibrations: [], spools: [], optTags: [], settings: {},
         syncId: "ams-fil",
@@ -339,7 +339,7 @@ describe("SyncService — v1.12 sync expansion", () => {
       const localFilId = new ObjectId();
       const remoteFilId = new ObjectId();
       const filDoc = {
-        name: "Used PLA", vendor: "Test", type: "PLA", color: "#fff",
+        name: "Used PLA", vendor: "Test", type: "PLA", color: "#ffffff",
         diameter: 1.75, temperatures: {}, bedTypeTemps: [],
         compatibleNozzles: [], calibrations: [], spools: [], optTags: [], settings: {},
         syncId: "f-syncid",


### PR DESCRIPTION
## Summary
Eight cross-cutting write-path correctness fixes. Adds two shared helpers in `src/lib/apiErrorHandler.ts` (`handleVersionError`, `assertActiveRefs`).

- **#502** Dry-cycle POST guards `Invalid Date` (mirror of #306's print-history fix) and enforces `tempC` 0-300 / `durationMin >= 0` explicitly. The `$push` at `/dry-cycles` intentionally skips `runValidators` to keep the atomic `$slice` cap from #304, so the schema bounds were dead. Stopped `/api/dashboard` from RangeError-500ing on bad dates.
- **#503** Schema-level hex validator on `Filament.color` that mirrors `secondaryColors` (null per OPT spec, otherwise `#RRGGBB`). `importFilaments` skips bad-hex rows into `skippedRows`.
- **#504** `handleVersionError` applied to spool-usage POST and print-history DELETE — concurrent-edit conflicts now surface as 409 + retry hint instead of 500.
- **#519** Filament POST/PUT verify every cross-collection ref via `assertActiveRefs` (mirrors printer-route pattern).
- **#524.1** OpenPrintTag import wrapped in the three-phase race-recovery pattern bambustudio / filament-import / prusament already use. No more leaked raw E11000 strings.
- **#524.2** `isValidIsoDateString` rejects ECMA-262's `T24:00` midnight-of-next-day alias.
- **#524.3** `getRemainingGrams` gains the legacy single-spool fallback the sibling helpers already carry.
- **#524.4** Printer POST/PUT dedupe `installedNozzles` / `installedBedTypes` at entry.

**Deferred:** #524.5 (tombstone purge / sync filtering) — the issue's `_deletedAt: null` filter at fetch would break tombstone propagation. Needs a `_purged` field + endpoint design, separate PR.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] Targeted 242-test sweep: Filament, api-route-correctness, api-validation-and-semantics, validateSpoolBody, importFilaments, inventoryStats, dry-cycles-route, printers-route, print-history, openprinttagBrowser — all pass
- [ ] Full CI green
- [ ] Codex review

Fixes #502, #503, #504, #519. Partially addresses #524 (sub-items 1–4; #524.5 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)