### PR TITLE
Multi-color: Bambu second color wiring + correct OPT arrangement tag ids (#501, #507)

### DIFF
--- a/electron/bambu-tag.ts
+++ b/electron/bambu-tag.ts
@@ -188,6 +188,16 @@ export function bambuToDecodedTag(bambu: BambuTagData): DecodedOpenPrintTag {
     materialType,
     materialAbbreviation: bambu.materialVariantId || undefined,
     color: rgbaToHex(bambu.colorRGBA),
+    // GH #501: surface the second color that parseBambuBlocks already
+    // extracts when `formatId === 0x0002 && colorCount >= 2`. The OPT
+    // decoder downstream of this consumes `secondaryColors[]` to render
+    // multi-color swatches (Galaxy line etc.) so the form prefill picks
+    // it up automatically — pre-fix the second color was extracted into
+    // BambuTagData but never wired through, leaving these spools to
+    // scan as single-color.
+    secondaryColors: bambu.secondColorRGBA
+      ? [rgbaToHex(bambu.secondColorRGBA)]
+      : undefined,
     diameter: bambu.filamentDiameter > 0 ? bambu.filamentDiameter : undefined,
     nozzleTemp: bambu.maxHotendTemp > 0 ? bambu.maxHotendTemp : undefined,
     nozzleTempMin: bambu.minHotendTemp > 0 ? bambu.minHotendTemp : undefined,

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -11,14 +11,12 @@ import {
   lookupCssNamedColor,
   type ColorSuggestion,
 } from "@/lib/cssNamedColors";
-import { deriveArrangement, type ColorArrangement } from "@/lib/filamentColors";
-
-/** GH #477: OpenPrintTag tag IDs for color arrangement. Sourced from
- *  the prusa3d/OpenPrintTag `data/tags_enum.yaml` spec file. Constants
- *  rather than magic numbers so the form's tag-toggle logic reads
- *  clearly. */
-const TAG_GRADUAL_COLOR_CHANGE = 28;
-const TAG_COEXTRUDED = 29;
+import {
+  deriveArrangement,
+  arrangementToOptTag,
+  stripArrangementTags,
+  type ColorArrangement,
+} from "@/lib/filamentColors";
 
 interface BedTypeTempEntry {
   /** Client-only stable row id for React keys. Stripped before API submission. */
@@ -2757,36 +2755,61 @@ function MultiColorEditor({
 }) {
   const arrangement: ColorArrangement = deriveArrangement(form.optTags);
 
-  /** Toggle a single arrangement tag on/off in optTags, removing the
-   *  OTHER arrangement tag so the two are always mutually exclusive
-   *  from the UI's perspective. Coextruded + gradient simultaneously
-   *  is theoretically possible per spec but the form only models one
-   *  arrangement at a time — the swatch can't render both. */
+  /** Toggle a single arrangement tag on/off in optTags, removing every
+   *  other arrangement tag so they're always mutually exclusive from
+   *  the UI's perspective.
+   *
+   *  GH #507: arrangement is driven by the canonical OPT_TAG enum —
+   *  27 = gradient, 28 = dual_color, 29 = triple_color. Both 28 and 29
+   *  surface as `"coextruded"` at render time; `arrangementToOptTag`
+   *  picks dual vs triple based on the current secondary-color count
+   *  so toggling the radio writes the right id. `stripArrangementTags`
+   *  removes ALL three so a prior arrangement's tag doesn't survive
+   *  the switch (pre-fix, swapping gradient → coextruded left tag 27
+   *  on the doc and deriveArrangement would then disagree with the
+   *  UI on the next render).
+   *
+   *  Coextruded + gradient simultaneously is theoretically possible per
+   *  spec but the form only models one arrangement at a time. */
   const setArrangement = (next: ColorArrangement) => {
-    const stripped = form.optTags.filter(
-      (id) => id !== TAG_COEXTRUDED && id !== TAG_GRADUAL_COLOR_CHANGE,
-    );
-    if (next === "coextruded") {
-      setForm({ ...form, optTags: [...stripped, TAG_COEXTRUDED] });
-    } else if (next === "gradient") {
-      setForm({ ...form, optTags: [...stripped, TAG_GRADUAL_COLOR_CHANGE] });
-    } else {
-      setForm({ ...form, optTags: stripped });
-    }
+    const stripped = stripArrangementTags(form.optTags);
+    const newTag = arrangementToOptTag(next, form.secondaryColors.length);
+    setForm({
+      ...form,
+      optTags: newTag != null ? [...stripped, newTag] : stripped,
+    });
+  };
+
+  /** GH #507: when the user adds/removes a coextruded secondary slot,
+   *  refresh the arrangement tag so dual→triple (or back) flips on the
+   *  saved doc without the user having to re-click the radio. Gradient
+   *  + solid don't carry a count distinction so they're untouched. */
+  const refreshArrangementTagForCount = (
+    nextSecondaries: string[],
+    optTagsAfter: number[],
+  ): number[] => {
+    if (arrangement !== "coextruded") return optTagsAfter;
+    const stripped = stripArrangementTags(optTagsAfter);
+    const newTag = arrangementToOptTag("coextruded", nextSecondaries.length);
+    return newTag != null ? [...stripped, newTag] : stripped;
   };
 
   const addColor = () => {
     if (form.secondaryColors.length >= 5) return; // spec cap
+    const nextSecondaries = [...form.secondaryColors, "#808080"];
     setForm({
       ...form,
-      secondaryColors: [...form.secondaryColors, "#808080"],
+      secondaryColors: nextSecondaries,
+      optTags: refreshArrangementTagForCount(nextSecondaries, form.optTags),
     });
   };
 
   const removeColor = (idx: number) => {
+    const nextSecondaries = form.secondaryColors.filter((_, i) => i !== idx);
     setForm({
       ...form,
-      secondaryColors: form.secondaryColors.filter((_, i) => i !== idx),
+      secondaryColors: nextSecondaries,
+      optTags: refreshArrangementTagForCount(nextSecondaries, form.optTags),
     });
   };
 

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -737,14 +737,22 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
     try {
       // GH #477: when the user has opted into the "Coextruded"
       // arrangement (auto-toggled via tag 29 in optTags), the
-      // OpenPrintTag spec says primary color SHOULD be null —
-      // "Does not have a primary color, number of colors can be
-      // derived from the defined secondary colors." Submit null so
-      // resolveFilament + every read site honour that semantic. For
+      // OpenPrintTag spec says primary color SHOULD be null for
+      // coextruded — "Does not have a primary color, number of colors
+      // can be derived from the defined secondary colors." Submit null
+      // so resolveFilament + every read site honour that semantic. For
       // gradient and solid arrangements the primary stays as set.
-      const submittedColor = form.optTags.includes(29)
-        ? null
-        : form.color;
+      //
+      // Codex P2 round 1 on PR #533: BOTH the dual_color tag (28) AND
+      // the triple_color tag (29) represent coextruded — pre-fix this
+      // only checked 29, so a dual-color save (the common 2-secondary
+      // shape) kept the primary on the doc and rendered with an extra
+      // unwanted stripe. Use deriveArrangement to stay aligned with
+      // every other render site.
+      const submittedColor =
+        deriveArrangement(form.optTags) === "coextruded"
+          ? null
+          : form.color;
       await onSubmit({
         name: form.name,
         vendor: form.vendor,

--- a/src/lib/filamentColors.ts
+++ b/src/lib/filamentColors.ts
@@ -5,8 +5,10 @@
  * may be null for filaments without a single primary (rainbow,
  * coextruded). Secondary slots (`secondaryColors[]`, spec keys 20–24)
  * carry up to 5 additional colors. Color arrangement is NOT a separate
- * field — it's derived from `optTags` (tag 29 = `coextruded`, tag 28 =
- * `gradual_color_change`), keeping the storage spec-pure.
+ * field — it's derived from `optTags` using the canonical OPT_TAG enum
+ * values: 27 = `gradient`, 28 = `dual_color`, 29 = `triple_color`. Both
+ * 28 and 29 map to the `"coextruded"` arrangement at render time —
+ * the count is already implicit in `secondaryColors.length`.
  *
  * Kept DB-free so this can be unit-tested without mongoose / vitest
  * env config. Every function is pure and takes a minimal subset of the
@@ -14,11 +16,20 @@
  */
 
 /**
- * OpenPrintTag tag IDs that describe color arrangement. Sourced from
- * `data/tags_enum.yaml` in the prusa3d/OpenPrintTag spec repo.
+ * OpenPrintTag tag IDs that describe color arrangement.
+ *
+ * GH #507: pre-fix this file declared TAG_COEXTRUDED = 29 and
+ * TAG_GRADUAL_COLOR_CHANGE = 28 — contradicting the project's
+ * canonical OPT_TAG enum at `src/lib/openprinttag.ts:163-165` AND the
+ * OPT browser importer at `src/lib/openprinttagBrowser.ts:132-134`,
+ * which both encode 27 = gradient, 28 = dual_color, 29 = triple_color
+ * matching the upstream OpenPrintTag YAML. The mismatch made imported
+ * dual-color OPT materials render as a smooth gradient and imported
+ * gradient materials render as solid. Aligned here.
  */
-const TAG_COEXTRUDED = 29;
-const TAG_GRADUAL_COLOR_CHANGE = 28;
+const TAG_GRADIENT = 27;
+const TAG_DUAL_COLOR = 28;
+const TAG_TRIPLE_COLOR = 29;
 
 /** What arrangement the filament's colors are physically in. `"solid"`
  *  is the default for single-color filaments and for multi-color
@@ -43,9 +54,47 @@ export function deriveArrangement(
   optTags: number[] | null | undefined,
 ): ColorArrangement {
   if (!optTags || optTags.length === 0) return "solid";
-  if (optTags.includes(TAG_COEXTRUDED)) return "coextruded";
-  if (optTags.includes(TAG_GRADUAL_COLOR_CHANGE)) return "gradient";
+  if (optTags.includes(TAG_DUAL_COLOR) || optTags.includes(TAG_TRIPLE_COLOR)) {
+    return "coextruded";
+  }
+  if (optTags.includes(TAG_GRADIENT)) return "gradient";
   return "solid";
+}
+
+/**
+ * Inverse of deriveArrangement. The form's arrangement radio needs to
+ * write the right OPT tag for the requested arrangement, with the
+ * caveat that `"coextruded"` actually maps to dual vs triple based on
+ * how many colors are in play. Both forms render identically (striped
+ * coextruded) — only the spec tag id differs.
+ *
+ * Returns the tag id to add, or null when no arrangement tag applies
+ * ("solid").
+ */
+export function arrangementToOptTag(
+  arrangement: ColorArrangement,
+  secondaryColorCount: number,
+): number | null {
+  if (arrangement === "gradient") return TAG_GRADIENT;
+  if (arrangement === "coextruded") {
+    // Color count includes the primary, so secondaryColorCount >= 2
+    // means triple+ (primary + 2 secondaries). One secondary = dual.
+    return secondaryColorCount >= 2 ? TAG_TRIPLE_COLOR : TAG_DUAL_COLOR;
+  }
+  return null;
+}
+
+/**
+ * Strip every arrangement-related tag from an optTags array. Used by
+ * the form when the user switches arrangement, so leftover tags from
+ * the prior arrangement don't survive on the doc and silently override
+ * the next deriveArrangement() call.
+ */
+export function stripArrangementTags(optTags: number[] | null | undefined): number[] {
+  if (!optTags) return [];
+  return optTags.filter(
+    (t) => t !== TAG_GRADIENT && t !== TAG_DUAL_COLOR && t !== TAG_TRIPLE_COLOR,
+  );
 }
 
 /**

--- a/tests/bambu-tag.test.ts
+++ b/tests/bambu-tag.test.ts
@@ -237,6 +237,30 @@ describe("Bambu Tag Decoder", () => {
       expect(result.materialName).toBe("PLA Basic");
     });
 
+    // GH #501: parseBambuBlocks extracts secondColorRGBA when block 16
+    // has formatId === 0x0002 && colorCount >= 2; bambuToDecodedTag now
+    // forwards it as DecodedOpenPrintTag.secondaryColors so the NFC
+    // prefill flow can render dual-color Bambu spools as multi-color
+    // (Galaxy line etc.).
+    it("forwards the parsed second color as secondaryColors", () => {
+      const blocks = buildFullBlocks();
+      // Block 16: format 0x0002, count 2, green secondary
+      blocks[16] = Buffer.alloc(16);
+      blocks[16]!.writeUInt16LE(0x0002, 0);
+      blocks[16]!.writeUInt16LE(2, 2);
+      blocks[16]![4] = 0x00;
+      blocks[16]![5] = 0xff;
+      blocks[16]![6] = 0x00;
+      blocks[16]![7] = 0xff;
+      const result = bambuToDecodedTag(parseBambuBlocks(blocks));
+      expect(result.secondaryColors).toEqual(["#00ff00"]);
+    });
+
+    it("omits secondaryColors when block 16 has no second color", () => {
+      const result = bambuToDecodedTag(makeBambuData());
+      expect(result.secondaryColors).toBeUndefined();
+    });
+
     it("extracts material type from filament type prefix", () => {
       const result = bambuToDecodedTag(makeBambuData());
       expect(result.materialType).toBe("PLA");

--- a/tests/filamentColors.test.ts
+++ b/tests/filamentColors.test.ts
@@ -18,31 +18,38 @@ describe("deriveArrangement", () => {
     expect(deriveArrangement([])).toBe("solid");
   });
 
-  it("returns 'coextruded' when tag 29 is present", () => {
+  // GH #507: canonical OPT_TAG ids — 27 = gradient, 28 = dual_color,
+  // 29 = triple_color. Both dual and triple render as coextruded.
+  it("returns 'coextruded' when tag 28 (dual_color) is present", () => {
+    expect(deriveArrangement([28])).toBe("coextruded");
+    expect(deriveArrangement([16, 28])).toBe("coextruded"); // tag 16 = MATTE
+  });
+
+  it("returns 'coextruded' when tag 29 (triple_color) is present", () => {
     expect(deriveArrangement([29])).toBe("coextruded");
-    expect(deriveArrangement([5, 29])).toBe("coextruded"); // tag 5 = matte
   });
 
-  it("returns 'gradient' when tag 28 is present", () => {
-    expect(deriveArrangement([28])).toBe("gradient");
-    expect(deriveArrangement([3, 28])).toBe("gradient");
+  it("returns 'gradient' when tag 27 (gradient) is present", () => {
+    expect(deriveArrangement([27])).toBe("gradient");
+    expect(deriveArrangement([3, 27])).toBe("gradient");
   });
 
-  it("returns 'coextruded' when BOTH tags are present (coextruded wins)", () => {
+  it("returns 'coextruded' when both coextruded and gradient tags are present (coextruded wins)", () => {
     // A "coextruded gradient" is theoretically possible per OpenPrintTag
     // spec; the rendering UI can only pick one mode, so the more
     // structural property (cross-section) wins over change-over-time.
-    expect(deriveArrangement([28, 29])).toBe("coextruded");
-    expect(deriveArrangement([29, 28])).toBe("coextruded");
+    expect(deriveArrangement([27, 28])).toBe("coextruded");
+    expect(deriveArrangement([29, 27])).toBe("coextruded");
   });
 
   it("returns 'solid' when only non-arrangement tags are present", () => {
-    // Tags 1–5, etc., are finishes (matte/silk/sparkle/glow/transparent).
+    // Tags 1–5 are FOOD_SAFE/BIODEGRADABLE/ABRASIVE/WATER_SOLUBLE/UV_RESISTANT etc;
+    // none of them describe color arrangement.
     expect(deriveArrangement([1, 2, 3, 4, 5])).toBe("solid");
   });
 
   it("type-checks to ColorArrangement", () => {
-    const result: ColorArrangement = deriveArrangement([29]);
+    const result: ColorArrangement = deriveArrangement([28]);
     expect(["solid", "coextruded", "gradient"]).toContain(result);
   });
 });


### PR DESCRIPTION
## Summary

Two v1.33-era multi-color regressions.

- **#501** \`bambuToDecodedTag\` now emits \`secondaryColors\` when \`parseBambuBlocks\` extracted a second color (the \`formatId === 0x0002 && colorCount >= 2\` branch). The decoder side already declares \`DecodedOpenPrintTag.secondaryColors\` and the NFC prefill flow wires it through, so this one missing field lights up Galaxy-line PLA + every dual-color Bambu spool as multi-color on scan. Without it \`BambuTagData.secondColorRGBA\` was dead.
- **#507** \`filamentColors.ts\` declared \`TAG_COEXTRUDED = 29\` and \`TAG_GRADUAL_COLOR_CHANGE = 28\`, contradicting the canonical OPT_TAG enum at \`src/lib/openprinttag.ts\` (27 = GRADIENT, 28 = DUAL_COLOR, 29 = TRIPLE_COLOR — matching the upstream OpenPrintTag YAML the OPT browser at \`openprinttagBrowser.ts\` encodes to). Imported OPT dual-color materials rendered as a smooth gradient; imported gradients rendered as solid. Realigned \`deriveArrangement\`, added \`arrangementToOptTag\`/\`stripArrangementTags\` helpers, and rewrote FilamentForm's MultiColorEditor to use them — the radio writes the right id AND add/remove of secondaries refreshes dual↔triple transitions on the saved doc.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] filamentColors + bambu-tag + openprinttagBrowser: 102/102 pass
- [x] New tests: bambu-tag pins \`secondaryColors\` is populated when block 16 carries a second color and undefined otherwise; filamentColors tests rewritten to the canonical 27/28/29 ids
- [ ] Full CI green
- [ ] Codex review

Fixes #501, #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)