### PR TITLE
OrcaSlicer round-trip: emit bridge_fan_speed (#508)

### DIFF
--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -165,6 +165,13 @@ export function calibrationToOrcaSlicerKeys(
   }
   set("overhang_fan_speed", calibration.fanMinSpeed);
   set("additional_cooling_fan_speed", calibration.fanMaxSpeed);
+  // GH #508: bridge_fan_speed flows IN via bambuStudioImport
+  // (CALIBRATION_KEYS includes it; calibrationHints.fanBridgeSpeed
+  // persists onto Filament.calibrations[].fanBridgeSpeed) but the
+  // export side was missing it — every export → user-edits-in-Bambu →
+  // re-import → re-export cycle silently dropped the bridge fan speed.
+  // Pinned in the bambuStudioImport round-trip test.
+  set("bridge_fan_speed", calibration.fanBridgeSpeed);
 
   return keys;
 }

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -190,6 +190,11 @@ describe("parseBambuStudioProfile", () => {
       bedTempFirstLayer: 65,
       fanMinSpeed: 50,
       fanMaxSpeed: 100,
+      // GH #508: fanBridgeSpeed must round-trip too. Pre-fix
+      // calibrationToOrcaSlicerKeys never emitted bridge_fan_speed even
+      // though the importer side declared it in CALIBRATION_KEYS, so
+      // every export → calibrate → re-import cycle silently dropped it.
+      fanBridgeSpeed: 70,
     };
     const exported = calibrationToOrcaSlicerKeys(original);
     // Stamp a minimum identifier so the parser accepts the payload.
@@ -203,6 +208,7 @@ describe("parseBambuStudioProfile", () => {
     expect(calibrationHints.retractLift).toBe(original.retractLift);
     expect(calibrationHints.fanMinSpeed).toBe(original.fanMinSpeed);
     expect(calibrationHints.fanMaxSpeed).toBe(original.fanMaxSpeed);
+    expect(calibrationHints.fanBridgeSpeed).toBe(original.fanBridgeSpeed);
   });
 
   it("stashes unknown keys in the settings passthrough bag", () => {


### PR DESCRIPTION
## Summary
\`calibrationToOrcaSlicerKeys\` emitted \`overhang_fan_speed\` + \`additional_cooling_fan_speed\` but never \`bridge_fan_speed\` — even though the importer side declared it in \`CALIBRATION_KEYS\` and the schema field exists. The value flowed IN, persisted, and couldn't flow back OUT. Every export → calibrate → re-import cycle silently lost it.

## Test plan
- [x] \`npm run lint\` clean
- [x] bambuStudioImport round-trip test now pins fanBridgeSpeed alongside every other calibration field
- [x] orcaSlicerBundle + bambuStudioImport: 38/38 pass
- [ ] Full CI green
- [ ] Codex review

Fixes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)