### PR TITLE
TDS extractor: drop unsupported bedRangeMin/bedRangeMax (#518)

### DIFF
--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -420,7 +420,14 @@ function NewFilamentContent() {
         nozzleRangeMin: d.temperatures?.nozzleRangeMin ?? null,
         nozzleRangeMax: d.temperatures?.nozzleRangeMax ?? null,
         bed: d.temperatures?.bed ?? null,
-        bedFirstLayer: d.temperatures?.bedRangeMin ?? d.temperatures?.bed ?? null,
+        // GH #518: the AI used to be prompted for bedRangeMin (since
+        // dropped — the schema doesn't store bed ranges). The fallback
+        // here was also semantically wrong: the AI's "minimum
+        // operating bed temp" was being routed to "first-layer bed
+        // temp", but first-layer is typically the HIGHER value (better
+        // adhesion), not the lower. Fall back to the recommended bed
+        // temp only.
+        bedFirstLayer: d.temperatures?.bed ?? null,
       },
       dryingTemperature: d.dryingTemperature ?? null,
       dryingTime: d.dryingTime ?? null,

--- a/src/lib/tdsExtractor.ts
+++ b/src/lib/tdsExtractor.ts
@@ -35,8 +35,6 @@ export interface TdsExtractedData {
     nozzleRangeMax?: number;
     bed?: number;
     bedFirstLayer?: number;
-    bedRangeMin?: number;
-    bedRangeMax?: number;
     standby?: number;
   };
   dryingTemperature?: number;
@@ -77,9 +75,7 @@ Return ONLY a JSON object with the following fields. Use null for any field not 
     "nozzle": "Recommended nozzle temperature in °C (use the typical/middle value if a range is given)",
     "nozzleRangeMin": "Minimum recommended nozzle temperature in °C",
     "nozzleRangeMax": "Maximum recommended nozzle temperature in °C",
-    "bed": "Recommended bed/platform temperature in °C (use the typical/middle value if a range is given)",
-    "bedRangeMin": "Minimum recommended bed temperature in °C",
-    "bedRangeMax": "Maximum recommended bed temperature in °C"
+    "bed": "Recommended bed/platform temperature in °C (use the typical/middle value if a range is given)"
   },
   "dryingTemperature": "Recommended drying temperature in °C",
   "dryingTime": "Recommended drying time in MINUTES (e.g. 480 for 8 hours — convert any TDS-quoted hours to minutes by multiplying by 60)",
@@ -96,7 +92,7 @@ Return ONLY a JSON object with the following fields. Use null for any field not 
 
 Important:
 - Temperature ranges like "210-230°C" should be split: nozzleRangeMin=210, nozzleRangeMax=230, nozzle=220 (midpoint)
-- For bed temperature ranges, do the same split
+- For bed temperature ranges, use the midpoint as 'bed' (the schema only stores a single bed temp, not a range)
 - Density is typically in g/cm³ (e.g. 1.24, not 1240 kg/m³ — convert if needed)
 - Drying time MUST be returned in minutes (multiply hours by 60 — e.g. "8 hours" → 480, "30 minutes" → 30). The downstream filament schema stores minutes.
 - Only include fields you can confidently extract from the document


### PR DESCRIPTION
## Summary
- The TDS extraction prompt asked the AI for \`bedRangeMin\` / \`bedRangeMax\` and the interface declared them — but \`Filament.temperatures\` only models \`bed\` + \`bedFirstLayer\` (no bed range, unlike nozzle). Every bedRange value the AI returned was silently dropped after we paid for it.
- The one fallback that used the dropped field (\`new/page.tsx:423\`) was also semantically off: it routed the AI's "minimum operating bed temp" to the form's first-layer bed temp, which is typically the HIGHER value (better adhesion), not the lower.
- Option (a) from the issue: dropped bedRangeMin/Max from the interface + prompt, fixed the misleading fallback to use \`bed\` instead. Prompt now tells the AI to use the midpoint for the single \`bed\` field when a range is given.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] tdsExtractor tests: 33/33 pass
- [ ] Full CI green
- [ ] Codex review

Fixes #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)