### PR TITLE
Perf: dashboard projection + AMS slot indexes (#517, partial #525)

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -27,7 +27,33 @@ export async function GET() {
       bedTypeCount,
       recentPrintHistory,
     ] = await Promise.all([
-      Filament.find({ _deletedAt: null }).lean(),
+      // GH #517: project only the fields the dashboard actually reads.
+      // Pre-fix this pulled every Filament with every spool subfield
+      // (incl. base64 photoDataUrl, unbounded usageHistory[], full
+      // calibrations[]/presets[]/settings) — a hot path on cold load
+      // and on every Electron sync-complete event. The fields below
+      // mirror exactly what the handler consumes downstream
+      // (inheritance via parentMap, low-stock math, dry-due loop).
+      Filament.find(
+        { _deletedAt: null },
+        {
+          _id: 1,
+          parentId: 1,
+          name: 1,
+          vendor: 1,
+          color: 1,
+          secondaryColors: 1,
+          optTags: 1,
+          spoolWeight: 1,
+          lowStockThreshold: 1,
+          dryingTemperature: 1,
+          "spools._id": 1,
+          "spools.label": 1,
+          "spools.totalWeight": 1,
+          "spools.retired": 1,
+          "spools.dryCycles.date": 1,
+        },
+      ).lean(),
       Nozzle.countDocuments({ _deletedAt: null }),
       Printer.countDocuments({ _deletedAt: null }),
       BedType.countDocuments({ _deletedAt: null }),

--- a/src/models/Printer.ts
+++ b/src/models/Printer.ts
@@ -91,6 +91,17 @@ PrinterSchema.index(
   { unique: true, partialFilterExpression: { _deletedAt: null } }
 );
 
+// GH #525.3: index the AMS-slot ref fields. spoolSlots.findSpoolSlot,
+// assignSpoolToSlot (clear-everywhere), clearSpoolsFromOtherPrinters,
+// and the sync-engine repair pass all query into amsSlots.spoolId /
+// amsSlots.filamentId on hot paths (every spool DELETE / retire /
+// assignment, every filament DELETE, every Printer save, every sync
+// cycle). Sparse so docs without amsSlots entries don't bloat the
+// index. Personal-use installs have 1-5 printers so the perf delta
+// is small; this is defensive hardening for the maker-space case.
+PrinterSchema.index({ "amsSlots.spoolId": 1 }, { sparse: true });
+PrinterSchema.index({ "amsSlots.filamentId": 1 }, { sparse: true });
+
 const Printer: Model<IPrinter> =
   mongoose.models.Printer || mongoose.model<IPrinter>("Printer", PrinterSchema);
 


### PR DESCRIPTION
## Summary
- **#517** \`/api/dashboard\`'s Filament fetch now projects only the 11 fields the handler reads. Pre-fix every dashboard render (and every Electron sync-complete event) pulled the full spool subdoc tree — base64 photoDataUrl blobs, unbounded usageHistory[], full calibrations[]/presets[]/settings. The sibling \`/api/filaments\` aggregation already did this; the dashboard was the inverse pattern on a hotter path.
- **#525.3** Sparse multi-key indexes on \`Printer.amsSlots.spoolId\` and \`.filamentId\`. Hit on every spool DELETE/retire/assignment, every filament DELETE, and the sync-service repair pass.

**Deferred for follow-up PRs:** #525.1 (spool CSV import N+1 → filament cache) and #525.2 (bulk-delete progress/abort UX) — both bigger design surfaces that benefit from their own review cycles.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] dashboard-route + Printer model tests: 24/24 pass
- [ ] Full CI green
- [ ] Codex review

Fixes #517. Partially addresses #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)