### PR TITLE
_purged tombstones for PrintHistory + SharedCatalog (#524.5)

### DIFF
--- a/src/app/api/print-history/[id]/route.ts
+++ b/src/app/api/print-history/[id]/route.ts
@@ -170,6 +170,31 @@ export async function DELETE(
   try {
     await dbConnect();
     const { id } = await params;
+
+    // GH #524.5: ?permanent=true sets the `_purged` tombstone, mirroring
+    // the Filament permanent-delete path. Gated on the row ALREADY being
+    // soft-deleted (`_deletedAt != null`) so an accidental
+    // DELETE?permanent=true on an active entry can't skip the refund +
+    // soft-delete step. Idempotent — a second purge on an already-purged
+    // row returns 404 (filtered on `_purged: { $ne: true }`). No refund
+    // here: the spool weight was already refunded on the soft delete.
+    const permanent = request.nextUrl.searchParams.get("permanent") === "true";
+    if (permanent) {
+      const trashed = await PrintHistory.findOne({
+        _id: id,
+        _deletedAt: { $ne: null },
+        _purged: { $ne: true },
+      });
+      if (!trashed) {
+        return errorResponse(
+          "Not found, or not in trash (permanent delete requires the entry to be soft-deleted first)",
+          404,
+        );
+      }
+      await PrintHistory.updateOne({ _id: id }, { $set: { _purged: true } });
+      return NextResponse.json({ message: "Permanently deleted" });
+    }
+
     // Filter on _deletedAt: null so a retry / double-click / client-retry
     // after a timeout doesn't re-run the refund loop on an already
     // tombstoned entry. Without this, each repeat call would refund the

--- a/src/app/api/share/[slug]/route.ts
+++ b/src/app/api/share/[slug]/route.ts
@@ -83,6 +83,26 @@ export async function DELETE(
   try {
     await dbConnect();
     const { slug } = await params;
+
+    // GH #524.5: ?permanent=true sets the `_purged` tombstone, mirroring
+    // Filament. Gated on the catalog ALREADY being unpublished
+    // (`_deletedAt != null`) so a permanent delete can't skip the
+    // unpublish step. Idempotent — a second purge returns 404.
+    const permanent = request.nextUrl.searchParams.get("permanent") === "true";
+    if (permanent) {
+      const res = await SharedCatalog.updateOne(
+        { slug, _deletedAt: { $ne: null }, _purged: { $ne: true } },
+        { $set: { _purged: true } },
+      );
+      if (res.matchedCount === 0) {
+        return errorResponse(
+          "Not found, or not unpublished (permanent delete requires the catalog to be unpublished first)",
+          404,
+        );
+      }
+      return NextResponse.json({ message: "Permanently deleted" });
+    }
+
     // Soft-delete instead of hard `deleteOne` so the unpublish actually
     // sticks across peers. syncCollection treats a missing row as
     // "pull/push back" rather than "propagate the delete" — without a

--- a/src/models/PrintHistory.ts
+++ b/src/models/PrintHistory.ts
@@ -40,6 +40,13 @@ export interface IPrintHistory extends Document {
   /** Optional notes — success/fail, material issues, etc. */
   notes: string;
   _deletedAt: Date | null;
+  /** GH #524.5: "delete forever" tombstone, mirroring Filament. A
+   * permanent purge marker that the hybrid-sync engine's generic
+   * `_purged` branch propagates to the peer so the row stays gone on
+   * both sides. Physically deleting instead would let the sync engine
+   * treat "remote has it, local doesn't" as a fresh insert and
+   * resurrect it. */
+  _purged: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -71,6 +78,7 @@ const PrintHistorySchema = new Schema<IPrintHistory>(
     },
     notes: { type: String, default: "" },
     _deletedAt: { type: Date, default: null },
+    _purged: { type: Boolean, default: false, index: true },
   },
   { timestamps: true }
 );

--- a/src/models/SharedCatalog.ts
+++ b/src/models/SharedCatalog.ts
@@ -34,6 +34,10 @@ export interface ISharedCatalog extends Document {
   /** Soft-delete tombstone so a hard-delete on one peer doesn't get
    * resurrected by the next sync cycle from the other peer. */
   _deletedAt: Date | null;
+  /** GH #524.5: "delete forever" tombstone, mirroring Filament — the
+   * hybrid-sync engine's generic `_purged` branch propagates it so the
+   * row stays gone on both sides without resurrection. */
+  _purged: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -60,6 +64,7 @@ const SharedCatalogSchema = new Schema<ISharedCatalog>(
     expiresAt: { type: Date, default: null, index: true },
     viewCount: { type: Number, default: 0, min: 0 },
     _deletedAt: { type: Date, default: null },
+    _purged: { type: Boolean, default: false, index: true },
   },
   { timestamps: true }
 );

--- a/tests/print-history.test.ts
+++ b/tests/print-history.test.ts
@@ -270,6 +270,13 @@ describe("print-history DELETE (undo)", () => {
     return new NextRequest(`http://localhost/api/print-history/${id}`, { method: "DELETE" });
   }
 
+  function purgeReq(id: string) {
+    return new NextRequest(
+      `http://localhost/api/print-history/${id}?permanent=true`,
+      { method: "DELETE" },
+    );
+  }
+
   it("refunds spool weight and removes the matching usageHistory entry", async () => {
     const f = await Filament.create({
       name: "Refund Basic",
@@ -469,6 +476,47 @@ describe("print-history DELETE (undo)", () => {
     // Refund still happened
     const refunded = await Filament.findById(f._id);
     expect(refunded.spools[0].totalWeight).toBe(1000);
+  });
+
+  // GH #524.5: ?permanent=true sets the _purged tombstone, but ONLY on a
+  // row that's already soft-deleted (mirrors Filament's trash→purge gate).
+  it("permanent delete sets _purged on a soft-deleted row; rejects an active row", async () => {
+    const f = await Filament.create({
+      name: "Purge Check",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    const job = await postJob(f, "purge-me", 100);
+
+    // Permanent delete on an ACTIVE (not-yet-trashed) entry is refused —
+    // can't skip the refund + soft-delete step.
+    const earlyPurge = await deletePrintHistory(purgeReq(job._id), {
+      params: Promise.resolve({ id: job._id }),
+    });
+    expect(earlyPurge.status).toBe(404);
+
+    // Soft-delete first (refund happens), then purge.
+    const soft = await deletePrintHistory(delReq(job._id), {
+      params: Promise.resolve({ id: job._id }),
+    });
+    expect(soft.status).toBe(200);
+
+    const purge = await deletePrintHistory(purgeReq(job._id), {
+      params: Promise.resolve({ id: job._id }),
+    });
+    expect(purge.status).toBe(200);
+    const purged = await PrintHistory.findById(job._id);
+    expect(purged._purged).toBe(true);
+    expect(purged._deletedAt).toBeInstanceOf(Date); // _deletedAt untouched
+
+    // Idempotent — a second purge is a 404 no-op.
+    const again = await deletePrintHistory(purgeReq(job._id), {
+      params: Promise.resolve({ id: job._id }),
+    });
+    expect(again.status).toBe(404);
   });
 
   // GH #228 + Codex P1 review on PR #229: refund clamps at the spool's

--- a/tests/share-route.test.ts
+++ b/tests/share-route.test.ts
@@ -355,5 +355,40 @@ describe("/api/share", () => {
       );
       expect(res.status).toBe(404);
     });
+
+    // GH #524.5: ?permanent=true sets _purged on an already-unpublished
+    // catalog (mirrors Filament's trash→purge gate).
+    it("permanent delete sets _purged on an unpublished catalog; rejects an active one", async () => {
+      const catalog = await SharedCatalog.create({
+        title: "Purge Me",
+        payload: { version: 1, createdAt: new Date().toISOString(), filaments: [], nozzles: [], printers: [], bedTypes: [] },
+      });
+      const purgeReq = (slug: string) =>
+        new NextRequest(`http://localhost/api/share/${slug}?permanent=true`, { method: "DELETE" });
+
+      // Active (not unpublished) → refused.
+      const early = await deleteShare(purgeReq(catalog.slug), {
+        params: Promise.resolve({ slug: catalog.slug }),
+      });
+      expect(early.status).toBe(404);
+
+      // Unpublish, then purge.
+      await deleteShare(new NextRequest(`http://localhost/api/share/${catalog.slug}`), {
+        params: Promise.resolve({ slug: catalog.slug }),
+      });
+      const purge = await deleteShare(purgeReq(catalog.slug), {
+        params: Promise.resolve({ slug: catalog.slug }),
+      });
+      expect(purge.status).toBe(200);
+      const purged = await SharedCatalog.findOne({ slug: catalog.slug });
+      expect(purged?._purged).toBe(true);
+      expect(purged?._deletedAt).toBeInstanceOf(Date);
+
+      // Idempotent.
+      const again = await deleteShare(purgeReq(catalog.slug), {
+        params: Promise.resolve({ slug: catalog.slug }),
+      });
+      expect(again.status).toBe(404);
+    });
   });
 });


### PR DESCRIPTION
## Summary
The last sub-item of #524 — PrintHistory and SharedCatalog had only `_deletedAt`, no `_purged` permanent-delete tombstone like Filament, and no purge path.

- Both models gain an indexed `_purged: Boolean`. The hybrid-sync engine's generic `_purged` branch already propagates it — adding the field is all that's needed.
- `DELETE …?permanent=true` on both routes sets the tombstone, gated on the row already being soft-deleted/unpublished (mirrors Filament's trash→purge gate). Idempotent.
- Read paths unchanged: a `_purged` row always has `_deletedAt` set, so existing `_deletedAt: null` filters hide it. Snapshot round-trips it automatically.

**Scope note:** this brings parity with Filament + a callable purge path. Physically pruning converged tombstones to shrink the per-cycle sync fetch (issue option b) is a larger lazy-prune design Filament itself doesn't solve — left for a follow-up.

## Test plan
- [x] `npm run lint` + `npx tsc --noEmit` clean
- [x] New tests: permanent-delete gating + idempotence for both routes (print-history + share)
- [x] print-history + share-route + sync-service-expansion: pass
- [ ] Full CI green
- [ ] Codex review

Partially addresses #524 (sub-item 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)