### PR TITLE
Fix #510: stop useUnsavedChanges leaking a history-guard entry per form visit

### DIFF
--- a/src/app/bed-types/[id]/edit/page.tsx
+++ b/src/app/bed-types/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import BedTypeForm from "@/app/bed-types/BedTypeForm";
 import { useToast } from "@/components/Toast";
@@ -11,7 +11,6 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 
 export default function EditBedType() {
   const params = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
   const [bedType, setBedType] = useState(null);
@@ -20,7 +19,7 @@ export default function EditBedType() {
 
   const {
     onDirtyChange, showUnsavedDialog, handleBack,
-    confirmNav, cancelNav, pendingNav,
+    navigate, confirmNav, cancelNav,
   } = useUnsavedChanges("/bed-types");
 
   useEffect(() => {
@@ -44,16 +43,11 @@ export default function EditBedType() {
     });
     if (res.ok) {
       toast(t("bedTypes.updated"));
-      router.push("/bed-types");
+      navigate("/bed-types");
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("bedTypes.updateError"), "error");
     }
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/bed-types");
   };
 
   if (notFound) return (
@@ -81,7 +75,7 @@ export default function EditBedType() {
       <BedTypeForm initialData={bedType} onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/bed-types/new/page.tsx
+++ b/src/app/bed-types/new/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import BedTypeForm from "@/app/bed-types/BedTypeForm";
 import { useToast } from "@/components/Toast";
@@ -9,13 +8,12 @@ import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { useTranslation } from "@/i18n/TranslationProvider";
 
 export default function NewBedType() {
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
 
   const {
     onDirtyChange, showUnsavedDialog, handleBack,
-    confirmNav, cancelNav, pendingNav,
+    navigate, confirmNav, cancelNav,
   } = useUnsavedChanges("/bed-types");
 
   const handleSubmit = async (data: Record<string, unknown>) => {
@@ -26,16 +24,11 @@ export default function NewBedType() {
     });
     if (res.ok) {
       toast(t("bedTypes.created"));
-      router.push("/bed-types");
+      navigate("/bed-types");
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("bedTypes.createError"), "error");
     }
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/bed-types");
   };
 
   return (
@@ -49,7 +42,7 @@ export default function NewBedType() {
       <BedTypeForm onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/filaments/[id]/edit/page.tsx
+++ b/src/app/filaments/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import FilamentForm from "@/app/filaments/FilamentForm";
 import { useToast } from "@/components/Toast";
@@ -11,7 +11,6 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 
 export default function EditFilament() {
   const params = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
   const [filament, setFilament] = useState(null);
@@ -21,7 +20,7 @@ export default function EditFilament() {
   const detailUrl = `/filaments/${params.id}`;
   const {
     onDirtyChange, showUnsavedDialog, handleBack,
-    confirmNav, cancelNav, pendingNav,
+    navigate, confirmNav, cancelNav,
   } = useUnsavedChanges(detailUrl);
 
   useEffect(() => {
@@ -50,16 +49,11 @@ export default function EditFilament() {
     });
     if (res.ok) {
       toast(t("edit.toast.updated"));
-      router.push(detailUrl);
+      navigate(detailUrl);
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("edit.toast.updateFailed"), "error");
     }
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? detailUrl);
   };
 
   if (notFound) return (
@@ -87,7 +81,7 @@ export default function EditFilament() {
       <FilamentForm initialData={filament} onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useEffect, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import FilamentForm from "@/app/filaments/FilamentForm";
 import { useToast } from "@/components/Toast";
@@ -19,7 +19,6 @@ interface FilamentOption {
 }
 
 function NewFilamentContent() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
   const { isElectron, status: nfcStatus, tagReadResult, dismissTagRead } = useNfcContext();
@@ -31,7 +30,7 @@ function NewFilamentContent() {
 
   const {
     dirtyRef, onDirtyChange, showUnsavedDialog, handleBack,
-    guardLink, confirmNav, cancelNav, pendingNav,
+    guardLink, navigate, confirmNav, cancelNav,
   } = useUnsavedChanges("/");
 
   // Pending populate-from action (held while confirmation is shown)
@@ -86,7 +85,7 @@ function NewFilamentContent() {
     if (res.ok) {
       const created = await res.json();
       toast(t("new.toast.created"));
-      router.push(`/filaments/${created._id}`);
+      navigate(`/filaments/${created._id}`);
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("new.toast.createFailed"), "error");
@@ -871,7 +870,7 @@ function NewFilamentContent() {
       {showUnsavedDialog && (
         <UnsavedChangesDialog
           onCancel={cancelNav}
-          onDiscard={() => { confirmNav(); router.push(pendingNav ?? "/"); }}
+          onDiscard={confirmNav}
         />
       )}
 

--- a/src/app/locations/[id]/edit/page.tsx
+++ b/src/app/locations/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import LocationForm from "@/app/locations/LocationForm";
 import { useToast } from "@/components/Toast";
@@ -11,14 +11,13 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 
 export default function EditLocation() {
   const params = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
   const [location, setLocation] = useState(null);
   const [notFound, setNotFound] = useState(false);
   const [fetchError, setFetchError] = useState(false);
 
-  const { onDirtyChange, showUnsavedDialog, handleBack, confirmNav, cancelNav, pendingNav } =
+  const { onDirtyChange, showUnsavedDialog, handleBack, navigate, confirmNav, cancelNav } =
     useUnsavedChanges("/locations");
 
   useEffect(() => {
@@ -52,16 +51,11 @@ export default function EditLocation() {
     });
     if (res.ok) {
       toast(t("locations.updated"));
-      router.push("/locations");
+      navigate("/locations");
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("locations.updateError"), "error");
     }
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/locations");
   };
 
   if (notFound)
@@ -95,7 +89,7 @@ export default function EditLocation() {
       <LocationForm initialData={location} onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/locations/new/page.tsx
+++ b/src/app/locations/new/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import LocationForm from "@/app/locations/LocationForm";
 import { useToast } from "@/components/Toast";
@@ -9,11 +8,10 @@ import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { useTranslation } from "@/i18n/TranslationProvider";
 
 export default function NewLocation() {
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
 
-  const { onDirtyChange, showUnsavedDialog, handleBack, confirmNav, cancelNav, pendingNav } =
+  const { onDirtyChange, showUnsavedDialog, handleBack, navigate, confirmNav, cancelNav } =
     useUnsavedChanges("/locations");
 
   const handleSubmit = async (data: Record<string, unknown>) => {
@@ -24,16 +22,11 @@ export default function NewLocation() {
     });
     if (res.ok) {
       toast(t("locations.created"));
-      router.push("/locations");
+      navigate("/locations");
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("locations.createError"), "error");
     }
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/locations");
   };
 
   return (
@@ -47,7 +40,7 @@ export default function NewLocation() {
       <LocationForm onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/nozzles/[id]/edit/page.tsx
+++ b/src/app/nozzles/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import NozzleForm from "@/app/nozzles/NozzleForm";
 import { useToast } from "@/components/Toast";
@@ -11,7 +11,6 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 
 export default function EditNozzle() {
   const params = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
   const [nozzle, setNozzle] = useState(null);
@@ -20,7 +19,7 @@ export default function EditNozzle() {
 
   const {
     onDirtyChange, showUnsavedDialog, handleBack,
-    confirmNav, cancelNav, pendingNav,
+    navigate, confirmNav, cancelNav,
   } = useUnsavedChanges("/nozzles");
 
   useEffect(() => {
@@ -44,16 +43,11 @@ export default function EditNozzle() {
     });
     if (res.ok) {
       toast(t("nozzles.updated"));
-      router.push("/nozzles");
+      navigate("/nozzles");
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("nozzles.updateError"), "error");
     }
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/nozzles");
   };
 
   if (notFound) return (
@@ -81,7 +75,7 @@ export default function EditNozzle() {
       <NozzleForm initialData={nozzle} onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/nozzles/new/page.tsx
+++ b/src/app/nozzles/new/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import NozzleForm from "@/app/nozzles/NozzleForm";
 import { useToast } from "@/components/Toast";
@@ -9,13 +8,12 @@ import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { useTranslation } from "@/i18n/TranslationProvider";
 
 export default function NewNozzle() {
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
 
   const {
     onDirtyChange, showUnsavedDialog, handleBack,
-    confirmNav, cancelNav, pendingNav,
+    navigate, confirmNav, cancelNav,
   } = useUnsavedChanges("/nozzles");
 
   const handleSubmit = async (data: Record<string, unknown>) => {
@@ -26,16 +24,11 @@ export default function NewNozzle() {
     });
     if (res.ok) {
       toast(t("nozzles.created"));
-      router.push("/nozzles");
+      navigate("/nozzles");
     } else {
       const body = await res.json().catch(() => null);
       toast(body?.error || t("nozzles.createError"), "error");
     }
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/nozzles");
   };
 
   return (
@@ -49,7 +42,7 @@ export default function NewNozzle() {
       <NozzleForm onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/printers/[id]/edit/page.tsx
+++ b/src/app/printers/[id]/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import PrinterForm from "@/app/printers/PrinterForm";
 import { useToast } from "@/components/Toast";
@@ -12,7 +12,6 @@ import { NozzleConflictError, type NozzleConflict } from "@/lib/nozzleConflicts"
 
 export default function EditPrinter() {
   const params = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
   const [printer, setPrinter] = useState(null);
@@ -21,7 +20,7 @@ export default function EditPrinter() {
 
   const {
     onDirtyChange, showUnsavedDialog, handleBack,
-    confirmNav, cancelNav, pendingNav,
+    navigate, confirmNav, cancelNav,
   } = useUnsavedChanges("/printers");
 
   useEffect(() => {
@@ -45,7 +44,7 @@ export default function EditPrinter() {
     });
     if (res.ok) {
       toast(t("printers.updated"));
-      router.push("/printers");
+      navigate("/printers");
       return;
     }
     // GH #232 — see comment in printers/new/page.tsx: 409 means the
@@ -55,11 +54,6 @@ export default function EditPrinter() {
       throw new NozzleConflictError(body.conflicts as NozzleConflict[]);
     }
     toast(body?.error || t("printers.updateError"), "error");
-  };
-
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/printers");
   };
 
   if (notFound) return (
@@ -87,7 +81,7 @@ export default function EditPrinter() {
       <PrinterForm initialData={printer} onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/app/printers/new/page.tsx
+++ b/src/app/printers/new/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import PrinterForm from "@/app/printers/PrinterForm";
 import { useToast } from "@/components/Toast";
@@ -10,13 +9,12 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import { NozzleConflictError, type NozzleConflict } from "@/lib/nozzleConflicts";
 
 export default function NewPrinter() {
-  const router = useRouter();
   const { toast } = useToast();
   const { t } = useTranslation();
 
   const {
     onDirtyChange, showUnsavedDialog, handleBack,
-    confirmNav, cancelNav, pendingNav,
+    navigate, confirmNav, cancelNav,
   } = useUnsavedChanges("/printers");
 
   const handleSubmit = async (data: Record<string, unknown>) => {
@@ -27,7 +25,7 @@ export default function NewPrinter() {
     });
     if (res.ok) {
       toast(t("printers.created"));
-      router.push("/printers");
+      navigate("/printers");
       return;
     }
     // GH #232 — a 409 with `conflicts[]` means one or more of the
@@ -41,11 +39,6 @@ export default function NewPrinter() {
     toast(body?.error || t("printers.createError"), "error");
   };
 
-  const handleDiscard = () => {
-    confirmNav();
-    router.push(pendingNav ?? "/printers");
-  };
-
   return (
     <main id="main-content" className="max-w-2xl mx-auto px-4 py-8">
       <div className="mb-4">
@@ -57,7 +50,7 @@ export default function NewPrinter() {
       <PrinterForm onSubmit={handleSubmit} onDirtyChange={onDirtyChange} />
 
       {showUnsavedDialog && (
-        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={handleDiscard} />
+        <UnsavedChangesDialog onCancel={cancelNav} onDiscard={confirmNav} />
       )}
     </main>
   );

--- a/src/hooks/useUnsavedChanges.ts
+++ b/src/hooks/useUnsavedChanges.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 
 /**
  * Hook to manage unsaved-changes warnings across form pages.
@@ -12,15 +13,43 @@ import { useCallback, useEffect, useRef, useState } from "react";
  *  - setShowUnsavedDialog – setter to open/close the dialog
  *  - pendingNav        – the URL the user was trying to navigate to (null if popstate)
  *  - handleBack        – click handler to attach to back links (e.preventDefault + show dialog)
+ *  - guardLink         – click handler factory for arbitrary guarded links
+ *  - navigate          – programmatic navigation (e.g. after a successful save)
+ *                        that consumes the guard entry first (see below)
  *  - confirmNav        – call this when the user clicks "Discard Changes"
  *  - cancelNav         – call this when the user clicks "Keep Editing"
  *
  * Protects against:
- *  - Back link clicks (via handleBack)
+ *  - Back link clicks (via handleBack / guardLink)
  *  - Browser back/forward buttons (via popstate interception)
+ *
+ * ## History-stack hygiene (GH #510)
+ *
+ * To intercept the browser Back button in the App Router we push one synthetic
+ * "guard" history entry on mount. The original implementation never removed
+ * that entry on the programmatic exit paths (`router.push` after save /
+ * discard), so the guard ended up buried under the destination and a fresh one
+ * was pushed on every form visit — the stack accumulated dead entries across
+ * edits.
+ *
+ * The fix routes EVERY programmatic departure through `navigate()` /
+ * `confirmNav()`, which consume the guard with `history.back()` BEFORE pushing
+ * the destination, so it is never left buried. The unmount cleanup pops the
+ * guard too, but ONLY when it is still the live current entry
+ * (`history.state.unsavedGuard === true`). That guard-the-pop condition is the
+ * crux of the fix: the first attempt popped unconditionally on unmount, which
+ * went back one entry too far whenever the destination was already current
+ * (the exact reason that attempt was reverted).
  */
 export function useUnsavedChanges(fallbackUrl: string) {
+  const router = useRouter();
   const dirtyRef = useRef(false);
+  // True while our synthetic guard entry is live and (as far as we know) the
+  // current top of the history stack.
+  const guardActiveRef = useRef(false);
+  // When set, the next popstate is our own back() consuming the guard ahead of
+  // a programmatic navigation; the handler reads + clears it and pushes.
+  const pendingLeaveRef = useRef<string | null>(null);
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [pendingNav, setPendingNav] = useState<string | null>(null);
 
@@ -28,28 +57,71 @@ export function useUnsavedChanges(fallbackUrl: string) {
     dirtyRef.current = d;
   }, []);
 
-  // Intercept browser back/forward when form is dirty
+  // Consume our guard entry (when it is still live + current) and THEN run the
+  // navigation, so the guard isn't left buried under the destination. Shared
+  // by `navigate()` and the link-click branch of `confirmNav()`.
+  const leave = useCallback(
+    (url: string) => {
+      dirtyRef.current = false;
+      if (guardActiveRef.current && window.history.state?.unsavedGuard) {
+        guardActiveRef.current = false;
+        pendingLeaveRef.current = url;
+        // Pops the guard; the popstate handler below sees pendingLeaveRef and
+        // completes the navigation once the back() settles.
+        window.history.back();
+      } else {
+        router.push(url);
+      }
+    },
+    [router],
+  );
+
+  // Intercept browser back/forward when form is dirty.
   useEffect(() => {
-    // Push a duplicate history entry so we can intercept popstate
+    // Push a duplicate history entry so we can intercept popstate.
     const url = window.location.href;
     window.history.pushState({ unsavedGuard: true }, "", url);
+    guardActiveRef.current = true;
 
     const handlePopState = () => {
+      // A programmatic leave we initiated: complete the navigation now that
+      // our back() has consumed the guard entry.
+      if (pendingLeaveRef.current !== null) {
+        const dest = pendingLeaveRef.current;
+        pendingLeaveRef.current = null;
+        router.push(dest);
+        return;
+      }
       if (dirtyRef.current) {
-        // Re-push to prevent navigation, then show dialog
+        // Re-push to cancel the back press, then show the dialog.
         window.history.pushState({ unsavedGuard: true }, "", url);
+        guardActiveRef.current = true;
         setPendingNav(null); // null = popstate (go back in history)
         setShowUnsavedDialog(true);
+      } else {
+        // Not dirty: the back press consumed our guard entry. Let the browser
+        // proceed normally (the guard shares the form URL, so a subsequent
+        // back leaves the form for real). Mark the guard spent so cleanup
+        // doesn't try to pop a second time.
+        guardActiveRef.current = false;
       }
-      // If not dirty, the browser navigates normally since we consumed
-      // our guard entry and the real history entry is next
     };
 
     window.addEventListener("popstate", handlePopState);
     return () => {
       window.removeEventListener("popstate", handlePopState);
+      // Pop our guard on unmount ONLY if it is still the live current entry
+      // (e.g. React strict-mode double-invoke in dev, or an unexpected unmount
+      // that didn't route through navigate()/confirmNav()). If a router.push
+      // already buried it, history.state is no longer ours and we must NOT pop
+      // — popping there is the original #510 over-pop bug.
+      if (guardActiveRef.current && window.history.state?.unsavedGuard) {
+        guardActiveRef.current = false;
+        window.history.back();
+      }
     };
-  }, []);
+    // router from next/navigation is a stable reference, so this runs once.
+  }, [router]);
 
   /** Attach to onClick of back/navigation links */
   const handleBack = useCallback(
@@ -75,23 +147,40 @@ export function useUnsavedChanges(fallbackUrl: string) {
     [],
   );
 
+  /**
+   * Programmatic navigation away from the form — e.g. after a successful save.
+   * Use this INSTEAD of calling `router.push` directly so the guard entry is
+   * consumed rather than buried (GH #510).
+   */
+  const navigate = useCallback(
+    (url: string) => {
+      setShowUnsavedDialog(false);
+      setPendingNav(null);
+      leave(url);
+    },
+    [leave],
+  );
+
   /** User chose "Discard Changes" */
   const confirmNav = useCallback(() => {
-    dirtyRef.current = false; // prevent popstate handler from re-triggering
     setShowUnsavedDialog(false);
-    if (pendingNav) {
-      // Link-click navigation — let the router handle it
-      // (caller will do router.push)
+    if (pendingNav !== null) {
+      // Link-click navigation — consume the guard then go to the chosen URL.
+      const dest = pendingNav;
+      setPendingNav(null);
+      leave(dest);
     } else {
-      // popstate navigation — go back for real. GH #285: the popstate
-      // handler re-pushed a guard entry to cancel the user's back press,
-      // so history is [...prev, formPage, guard] with `guard` current.
-      // `go(-1)` only reaches `formPage` (same URL as the guard) and
-      // strands the user on the form; `go(-2)` skips past it to the
-      // page they were actually trying to return to.
+      // popstate navigation — go back for real. GH #285: the popstate handler
+      // re-pushed a guard entry to cancel the user's back press, so history is
+      // [...prev, formPage, guard] with `guard` current. `go(-1)` only reaches
+      // `formPage` (same URL as the guard) and strands the user on the form;
+      // `go(-2)` skips past it to the page they were actually trying to return
+      // to.
+      dirtyRef.current = false;
+      guardActiveRef.current = false;
       window.history.go(-2);
     }
-  }, [pendingNav]);
+  }, [pendingNav, leave]);
 
   /** User chose "Keep Editing" */
   const cancelNav = useCallback(() => {
@@ -107,6 +196,7 @@ export function useUnsavedChanges(fallbackUrl: string) {
     pendingNav,
     handleBack,
     guardLink,
+    navigate,
     confirmNav,
     cancelNav,
   };


### PR DESCRIPTION
Closes #510.

## The bug

`useUnsavedChanges` pushes one synthetic **guard** history entry on mount to intercept the browser Back button. But it never consumed that entry on the programmatic exit paths — every consumer did `router.push(dest)` directly after save/discard. So the guard got buried under the destination, and a fresh guard was pushed on the next form visit: **the history stack accumulated dead entries across edits**, and Back from a destination could land on a stale form URL.

## The fix

The hook now owns programmatic navigation:

- New **`navigate(url)`** (and the link-click branch of `confirmNav`) consumes the guard via `history.back()` **before** pushing the destination — so it's never buried. A one-shot `pendingLeaveRef` + the existing `popstate` listener sequence the back→push.
- The unmount cleanup also pops the guard — but **only when it's still the live current entry** (`window.history.state?.unsavedGuard === true`). This guard-the-pop condition is the crux: the earlier reverted attempt (the one Codex flagged as incomplete) popped *unconditionally* on unmount and went back one entry too far whenever the destination was already current (the `router.push` path). Checking that our guard is genuinely current is what makes it safe.
- `guardActiveRef` tracks whether the guard is live, so React strict-mode double-invoke (dev) and unexpected unmounts are handled without leaking.

All 10 form pages (nozzles / printers / locations / bed-types / filaments × new/edit) now route save **and** discard through `navigate` / `confirmNav` instead of calling `router.push` directly. The redundant per-page `useRouter` + `handleDiscard` were removed. The popstate-discard path keeps its existing `go(-2)` behaviour (GH #285). The filaments/new "populate from" dialog is untouched (it's not a navigation).

## On testing

No automated test is added: the repo's vitest environment is `node` with **no jsdom/testing-library harness** (there are zero component/hook tests), and jsdom's history API doesn't faithfully model `pushState`/`back`/`popstate` ordering — a test there would assert the mock, not the behaviour. The logic is documented inline instead. Happy to add one if we stand up a jsdom harness.

## Test plan
- `npm run lint` + `npx tsc --noEmit` — clean
- Manual: dirty a form → Back button prompts; Discard leaves cleanly; Save navigates with no extra history entries accumulating across repeated edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)