### PR TITLE
docs: fix accuracy drift surfaced by a full audit against the code

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,9 +31,12 @@
 | `GET` | `/api/filaments/:id/calibration` | Get calibration data for a filament and nozzle diameter |
 | `GET` | `/api/filaments/:id/spool-check` | Check if a spool has enough filament for a print job |
 | `POST` | `/api/filaments/:id` | Sync a filament preset back from PrusaSlicer |
+| `GET` | `/api/filaments/:id/prusaslicer` | Download one filament as a PrusaSlicer preset (`.ini`) |
+| `GET` | `/api/filaments/:id/orcaslicer` | Download one filament as an OrcaSlicer preset (`.json`) |
 | `GET` | `/api/filaments/:id/bambustudio` | Download one filament as a Bambu Studio preset (.json) |
 | `POST` | `/api/filaments/:id/bambustudio` | Sync a Bambu Studio preset INTO this filament (pinned by id) |
 | `POST` | `/api/filaments/bambustudio` | Import a Bambu Studio preset by name (upsert + auto-detect calibration) |
+| `GET` | `/api/filaments/colors` | Distinct `(colorName, color)` pairs across non-deleted filaments (backs the color-name typeahead) |
 
 ### Spools
 
@@ -400,7 +403,8 @@ Returns:
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/api/filaments/orcaslicer` | Export filaments as OrcaSlicer-compatible JSON profiles |
+| `GET` | `/api/filaments/orcaslicer` | Export all filaments as OrcaSlicer-compatible JSON profiles (bundle) |
+| `GET` | `/api/filaments/:id/orcaslicer` | Export a single filament as an OrcaSlicer preset (`.json`) |
 | `POST` | `/api/filaments/:name-or-id/orcaslicer` | Sync filament settings back from OrcaSlicer |
 
 ### GET /api/filaments/orcaslicer
@@ -601,14 +605,14 @@ Returns `202 Accepted`:
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/api/openprinttag` | Browse the OpenPrintTag community database (FDM filaments only) |
+| `POST` | `/api/openprinttag` | Force-refresh the cache and re-fetch from GitHub (same-origin guarded) |
 | `POST` | `/api/openprinttag/import` | Import selected materials into Filament DB |
 
 ### GET /api/openprinttag
 
 Fetches the [OpenPrintTag community database](https://github.com/OpenPrintTag/openprinttag-database) from GitHub, parses all material YAML files, filters to FFF (FDM) filaments, and returns them with completeness scores. Results are cached for 1 hour.
 
-Query parameters:
-- `refresh=true` -- force re-fetch from GitHub (clears cache)
+To force a refresh, POST to the same path — the old `GET ?refresh=true` trigger was removed (a cache-busting side effect on a GET violated REST semantics; GH #427).
 
 Returns:
 ```json
@@ -1232,9 +1236,10 @@ All fields optional. Unspecified numeric fields are stored as `null`.
 |--------|----------|-------------|
 | `POST` | `/api/spools/import` | Bulk-create spools from CSV |
 
-Accepts either:
+Accepts any of:
 - `Content-Type: text/csv` with the raw CSV body
 - `Content-Type: application/json` with `{ "csv": "…" }`
+- `Content-Type: multipart/form-data` with the CSV as a `file` field
 
 ### Required columns
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -57,7 +57,7 @@ The packaged app polls GitHub Releases for new versions and surfaces a banner at
 - **Windows**: unsigned NSIS installers auto-install fine. The user sees a SmartScreen warning the next time the app launches.
 - **Linux**: AppImage updates work when the app was launched via AppImageLauncher or a similar integration. `.deb` builds are not auto-updated — use your package manager instead.
 
-**How it finds updates:** the release workflow produces `latest-mac.yml`, `latest-linux.yml`, and `latest-linux-arm64.yml` on every `v*` tag. `electron-updater` reads those manifests from the GitHub release on startup (with a 20-second delay so the UI has time to mount) and every 6 hours while the app is running.
+**How it finds updates:** the release workflow produces the `electron-updater` manifests on every `v*` tag — `latest.yml` (Windows), `latest-mac.yml` / `latest-mac-x64.yml` (macOS), and `latest-linux.yml` / `latest-linux-arm64.yml` (Linux). `electron-updater` reads those manifests from the GitHub release on startup (with a 20-second delay so the UI has time to mount) and every 6 hours while the app is running.
 
 **In dev:** the IPC handlers are always registered but short-circuit to `{ ok: false, error: "dev-mode" }` for mutating actions so the banner never triggers in a packaged-false run.
 
@@ -86,7 +86,7 @@ npm run electron:build
 This runs five steps:
 1. `npm run build` -- builds Next.js in standalone mode
 2. `npm run electron:fixlinks` -- resolves symlinks in the standalone output and copies it with static assets
-3. `npm run electron:rebuild` -- rebuilds native modules (PC/SC) for Electron's Node.js
+3. `npm run electron:rebuild` -- rebuilds the native modules for Electron's Node.js ABI: `@pokusew/pcsclite` (PC/SC, for NFC) and `@serialport/bindings-cpp` (for the Brother label printer)
 4. `npm run electron:compile` -- bundles Electron TypeScript with esbuild
 5. `npm run electron:pack` -- packages everything with electron-builder
 
@@ -107,7 +107,7 @@ Then create a release on GitHub:
 gh release create v1.0.0 --title "v1.0.0" --generate-notes
 ```
 
-The workflow runs builds on macOS, Windows, and Ubuntu runners in parallel (Linux builds both x64 and arm64 via cross-compilation). Each platform's installers are uploaded to the GitHub Release automatically.
+The workflow runs builds on macOS, Windows, and Ubuntu runners in parallel — six jobs in total, since macOS (arm64 + x64), Windows (x64 + arm64), and Linux (x64 + arm64) each build both architectures (the second arch cross-compiled). Each platform's installers are uploaded to the GitHub Release automatically.
 
 ### What the workflow does:
 1. Checks out the code
@@ -154,7 +154,7 @@ The desktop app wraps the Next.js application in Electron:
 │  │ electron/preload.ts                   │  │
 │  │ - Secure IPC bridge (contextBridge)   │  │
 │  │ - Exposes: getConfig, saveConfig,     │  │
-│  │   resetConfig, showMessage,           │  │
+│  │   resetConfig, getRuntimeMode,        │  │
 │  │   nfcGetStatus, nfcReadTag,           │  │
 │  │   nfcWriteTag, sync status/trigger,   │  │
 │  │   event listeners                     │  │

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -57,7 +57,7 @@ The packaged app polls GitHub Releases for new versions and surfaces a banner at
 - **Windows**: unsigned NSIS installers auto-install fine. The user sees a SmartScreen warning the next time the app launches.
 - **Linux**: AppImage updates work when the app was launched via AppImageLauncher or a similar integration. `.deb` builds are not auto-updated — use your package manager instead.
 
-**How it finds updates:** the release workflow produces the `electron-updater` manifests on every `v*` tag — `latest.yml` (Windows), `latest-mac.yml` / `latest-mac-x64.yml` (macOS), and `latest-linux.yml` / `latest-linux-arm64.yml` (Linux). `electron-updater` reads those manifests from the GitHub release on startup (with a 20-second delay so the UI has time to mount) and every 6 hours while the app is running.
+**How it finds updates:** the release workflow produces the `electron-updater` manifests on every `v*` tag — `latest.yml` (Windows), `latest-mac.yml` (macOS — both arches share one manifest; electron-builder only appends an arch suffix for Linux), and `latest-linux.yml` / `latest-linux-arm64.yml` (Linux). `electron-updater` reads those manifests from the GitHub release on startup (with a 20-second delay so the UI has time to mount) and every 6 hours while the app is running.
 
 **In dev:** the IPC handlers are always registered but short-circuit to `{ ok: false, error: "dev-mode" }` for mutating actions so the banner never triggers in a packaged-false run.
 

--- a/docs/importing.md
+++ b/docs/importing.md
@@ -212,7 +212,7 @@ Browse the [OpenPrintTag community database](https://github.com/OpenPrintTag/ope
    - **Identity** -- brand, type, color swatch, UUID
    - **Properties** -- density, temperatures (nozzle, bed, chamber, drying), hardness, transmission distance
    - **Data Quality & Links** -- completeness score bar, photo, product URL
-5. Select materials using checkboxes (or **Select All** / **Clear Selection** in the toolbar)
+5. Select materials using checkboxes (or **Select All** / **Deselect all** in the toolbar)
 6. Click **Import Selected (N)** to import the selected materials
 7. Imported filaments are matched by name and vendor -- existing filaments are updated (only null fields are filled), new filaments are created
 

--- a/docs/nfc.md
+++ b/docs/nfc.md
@@ -191,8 +191,8 @@ CBOR keys below are the actual values from `OPT_KEY` in `src/lib/openprinttag.ts
 | Material type | 9 | PLA, PETG, ABS, etc. |
 | Material name | 10 | Filament name |
 | Brand name | 11 | Vendor name |
-| Net (nominal) full weight | 16 | Net weight, grams |
-| Actual netto full weight | 17 | Measured net weight, grams |
+| Nominal net full weight | 16 | Nominal net filament weight when full, grams |
+| Actual net weight | 17 | Current **remaining** filament, grams (`max(0, totalWeight − spoolWeight)`); the read dialog shows it as "actual remaining" |
 | Empty container weight | 18 | Empty spool weight, grams |
 | Primary color | 19 | RGBA color bytes |
 | Secondary colors | 20–24 | `secondary_color_0..4` (multi-color filaments) |

--- a/docs/nfc.md
+++ b/docs/nfc.md
@@ -188,7 +188,7 @@ CBOR keys below are the actual values from `OPT_KEY` in `src/lib/openprinttag.ts
 
 | Field | CBOR Key | Description |
 |-------|----------|-------------|
-| Material type | 9 | PLA, PETG, ABS, etc. |
+| Material type | 9 | Numeric enum (NOT a string) — the encoder maps names like PLA/PETG/ABS through `MATERIAL_TYPE_MAP` and writes the integer value |
 | Material name | 10 | Filament name |
 | Brand name | 11 | Vendor name |
 | Nominal net full weight | 16 | Nominal net filament weight when full, grams |

--- a/docs/nfc.md
+++ b/docs/nfc.md
@@ -120,11 +120,10 @@ The "Loaded" label persists after the tag-read dialog is dismissed (so you can s
 
 The app communicates with the ACR1552U via PC/SC using `@pokusew/pcsclite`:
 
-- **Connection**: Tries `SCARD_SHARE_SHARED` first (Windows/Linux), falls back to `SCARD_SHARE_DIRECT` (macOS workaround for ISO 15693)
+- **Connection**: Always connects with `SCARD_SHARE_SHARED`. On macOS the built-in `ifd-ccid` driver and Apple's `ifd-acsccid` driver both register an instance of the ACR1552U, but only the ACS driver handles ISO 15693 — the app tries a SHARED connect on each registered reader instance and uses whichever succeeds (it also waits briefly on hot-plug for both driver instances to register).
 - **Tag detection**: Tries MIFARE Classic read first (Bambu); on failure, falls through to ISO 15693 (OpenPrintTag)
 - **OpenPrintTag commands**: ACR1552U Pass Through (`FF FB`) wrapping ISO 15693 Read/Write Single Block commands
 - **Bambu commands**: Standard PC/SC pseudo-APDUs for MIFARE Classic — Get UID (`FF CA`), Load Key (`FF 82`), Authenticate (`FF 86`), Read Binary (`FF B0`)
-- **Fallback**: PCSC 2.0 Part 3 Transparent Exchange (`FF C2 00 01`) via `SCardControl` for DIRECT mode
 
 ### Data Format
 
@@ -136,7 +135,7 @@ The app communicates with the ACR1552U via PC/SC using `@pokusew/pcsclite`:
 **Bambu Lab (MIFARE Classic)**:
 - **Tag**: MIFARE Classic 1K — 16 sectors × 4 blocks × 16 bytes, encrypted with per-sector keys
 - **Key derivation**: HKDF-SHA256 with master key `9a759cf2c4f7caff222cb9769b41bc96`, UID as IKM, info `"RFID-A\0"` → 16 sector keys × 6 bytes
-- **Data layout**: Sectors 0–4 contain filament data (material type, color RGBA, temperatures, weight, diameter, production date, tray UID); sectors 5–9 are empty; sectors 10–15 contain an RSA-2048 signature
+- **Data layout**: The app reads sectors 0–9 as data (filament fields — material type, color RGBA, temperatures, weight, diameter, production date, tray UID — live in sectors 0–4); sectors 10–15 hold an RSA-2048 signature and are skipped
 - **Encoding**: All numbers are little-endian (uint16 LE, float32 LE); strings are null-padded ASCII
 - **Read-only**: Tags are RSA-2048 signed — changing any byte invalidates the signature
 
@@ -185,24 +184,32 @@ The app communicates with the ACR1552U via PC/SC using `@pokusew/pcsclite`:
 
 The following fields are encoded into each NFC tag:
 
+CBOR keys below are the actual values from `OPT_KEY` in `src/lib/openprinttag.ts`.
+
 | Field | CBOR Key | Description |
 |-------|----------|-------------|
-| Material name | 8 | Filament name |
-| Brand name | 9 | Vendor name |
-| Material type | 10 | PLA, PETG, ABS, etc. (numeric enum) |
-| Primary color | 11 | RGB color bytes |
-| Density | 17 | g/cm³ (float16) |
-| Filament diameter | 22 | mm (float16) |
-| Temperatures | 12–16, 18 | Nozzle (min/max), bed (min/max), chamber, preheat |
-| Weights | 19–21 | Net weight, actual weight, empty spool weight |
-| Instance ID | 5 | Brand-specific instance identifier (5-byte hex string, max 16 chars) |
-| Drying temperature | 57 | °C |
-| Drying time | 58 | Minutes |
+| Material type | 9 | PLA, PETG, ABS, etc. |
+| Material name | 10 | Filament name |
+| Brand name | 11 | Vendor name |
+| Net (nominal) full weight | 16 | Net weight, grams |
+| Actual netto full weight | 17 | Measured net weight, grams |
+| Empty container weight | 18 | Empty spool weight, grams |
+| Primary color | 19 | RGBA color bytes |
+| Secondary colors | 20–24 | `secondary_color_0..4` (multi-color filaments) |
 | Transmission distance | 27 | HueForge TD value |
+| Tags | 28 | Flags array (abrasive, soluble, matte, silk, sparkle, coextruded, gradual color change, etc.) |
+| Density | 29 | g/cm³ |
+| Filament diameter | 30 | mm |
 | Shore hardness A | 31 | Flexible materials (TPU/TPE/PEBA) |
 | Shore hardness D | 32 | Rigid materials |
-| Tags | 28 | Flags array (42 supported tags: abrasive, soluble, matte, silk, carbon fiber, high speed, recycled, etc.) |
-| Consumed weight | aux 0 | Tracked in auxiliary region (if set) |
+| Print temperatures | 34–35 | Min / max print (nozzle) temperature |
+| Preheat temperature | 36 | °C |
+| Bed temperatures | 37–38 | Min / max bed temperature |
+| Chamber temperature | 41 | °C |
+| Drying temperature | 57 | °C |
+| Drying time | 58 | Minutes |
+| Instance ID | aux 5 | `brand_specific_instance_id` — 5-byte hex string, max 16 chars |
+| Consumed weight | aux 0 | Tracked in the auxiliary region (if set) |
 
 Instance IDs are auto-generated for each filament (matching Prusament's 5-byte hex format, e.g. `2acc21072a`) and are written as the `brand_specific_instance_id` field per the OpenPrintTag specification.
 
@@ -242,7 +249,7 @@ These are mapped to the same data model as OpenPrintTag fields, so the matching,
 
 - Ensure the tag is centered on the reader and not moving
 - SLIX2 tags have a small antenna -- position matters
-- On macOS, `SCARD_SHARE_SHARED` can be intermittent for ISO 15693; the app falls back to DIRECT mode automatically
+- On macOS, two driver instances claim the ACR1552U but only Apple's `ifd-acsccid` handles ISO 15693; the app tries a SHARED connect on each reader instance and uses whichever works, so a transient failure on one instance is recovered automatically
 
 ### Write fails on last block (SW 640F)
 

--- a/docs/nfc.md
+++ b/docs/nfc.md
@@ -208,8 +208,8 @@ CBOR keys below are the actual values from `OPT_KEY` in `src/lib/openprinttag.ts
 | Chamber temperature | 41 | °C |
 | Drying temperature | 57 | °C |
 | Drying time | 58 | Minutes |
-| Instance ID | aux 5 | `brand_specific_instance_id` — 5-byte hex string, max 16 chars |
-| Consumed weight | aux 0 | Tracked in the auxiliary region (if set) |
+| Instance ID | 5 | `brand_specific_instance_id` (main region) — 5-byte hex string, max 16 chars |
+| Consumed weight | aux 0 | The one auxiliary-region key — tracked consumed weight (if set) |
 
 Instance IDs are auto-generated for each filament (matching Prusament's 5-byte hex format, e.g. `2acc21072a`) and are written as the `brand_specific_instance_id` field per the OpenPrintTag specification.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,7 +58,7 @@ Tests run against Node.js 20 and 22. Coverage reports are uploaded as artifacts 
 
 ### Release Workflow (`.github/workflows/release.yml`)
 
-Runs automatically on version tags (`v*`). Tests are run on all four build configurations (macOS, Windows, Linux x64, Linux arm64) before building the Electron installers. If tests fail, the build is skipped for that platform.
+Runs automatically on version tags (`v*`). Tests are run on all six build configurations (macOS arm64 + x64, Windows x64 + arm64, Linux x64 + arm64) before building the Electron installers. If tests fail, the build is skipped for that platform.
 
 ## Test Setup
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -152,7 +152,7 @@ On the **Add New Filament** page, the **"Populate from"** toolbar offers four bu
 - **Prusament QR** -- enter a spool ID or URL from a Prusament QR code to fetch full specs.
 - **Import from TDS** -- paste a Technical Data Sheet URL and the AI extracts temperatures, density, drying specs, Tg, HDT, shore hardness, and more. Requires an AI API key configured in Settings (see [Step 5b](#step-5b-import-from-a-technical-data-sheet)).
 - **Load from INI** -- upload a PrusaSlicer `.ini` config bundle. If it contains one filament profile, the form fills automatically. If multiple profiles are found, a picker dialog lets you choose which one.
-- **Clone Existing** -- search your library and select a filament. Only identification fields (name with " (copy)" suffix, color, vendor, type) carry over; everything else inherits live from the parent so the new variant tracks the parent's calibrations going forward.
+- **Duplicate Existing** -- search your library and select a filament. Only identification fields (name with " (copy)" suffix, color, vendor, type) carry over; everything else inherits live from the parent so the new variant tracks the parent's calibrations going forward.
 - **NFC Tag** (desktop only, no button — automatic) -- with a reader connected, place a tagged spool on it. The form auto-populates with material, vendor, temps, density, and color from the OpenPrintTag data.
 
 After populating, review and adjust any fields before clicking **Create Filament**.
@@ -292,14 +292,14 @@ Variants share a parent's settings (temperatures, density, retraction, calibrati
 There are two affordances on the detail page. They both produce a new variant, but they pre-fill the form differently:
 
 - **"+ Create variant"** (fuchsia button) — only shown on **root** filaments (i.e. not already a variant). The form opens with the parent linked, **vendor** and **type** pre-filled from the parent, and the parent's other values surfaced as **placeholder text** in each input (not pre-populated). Leaving a field blank keeps the variant inheriting from the parent live; type into a field to override only that one. This is the quickest path when you want a true variant that shares everything except color.
-- **Clone** (amber button) — shown on **every** filament, root or variant. The form opens with **name** (suffixed with " (copy)"), **color**, **colorName**, **vendor**, and **type** copied verbatim from the source filament — a full identity duplicate. The parent relationship is set automatically: cloning a root makes the new filament a variant of that root; cloning a variant makes the new filament a **sibling** under the same parent. Best when you want a starting point you can heavily edit.
+- **Duplicate** (amber button) — shown on **every** filament, root or variant. The form opens with **name** (suffixed with " (copy)"), **color**, **colorName**, **vendor**, and **type** copied verbatim from the source filament — a full identity duplicate. The parent relationship is set automatically: duplicating a root makes the new filament a variant of that root; duplicating a variant makes the new filament a **sibling** under the same parent. Best when you want a starting point you can heavily edit.
 
 Steps:
 
 1. Open a filament's detail page.
-2. Click **"+ Create variant"** (if available) or **Clone**.
+2. Click **"+ Create variant"** (if available) or **Duplicate**.
 3. The form opens pre-filled per the rules above. The fields that aren't pre-filled (or that you don't override) inherit live from the parent — that's the design from GH #106; placeholder text shows what you'll get.
-4. Edit the **name** (Clone only — Create variant leaves it blank for you to type), pick a new **color**, and optionally adjust **colorName**.
+4. Edit the **name** (Duplicate only — Create variant leaves it blank for you to type), pick a new **color**, and optionally adjust **colorName**.
 5. Click **Create Filament**. The new filament is registered as a variant of the parent and any future edits to the parent's calibrations / temperatures / settings flow through automatically to fields you didn't explicitly override.
 
 > **Design rule**: variants-of-variants are not supported. A parent must be a top-level filament. This is why the "+ Create variant" button is hidden on variant pages, and why cloning a variant gives you a sibling instead of nesting.
@@ -573,7 +573,7 @@ Recipients who open the URL see a read-only list. They can multi-select and clic
 
 ## Step 24: Compare Filaments *(v1.11)*
 
-On the filament list, tick the checkbox next to 2–4 rows and click **Compare**. The `/compare` page lays them out side-by-side — temperatures, cost, density, calibrations, and remaining weight — so you can pick the right one for a job.
+Open the **Compare** page (top-nav link, or go to `/compare`). It has a built-in filament picker — search by name/vendor/type and tick up to **8** filaments — then lays them out side-by-side: temperatures, cost, density, calibrations, and remaining weight, so you can pick the right one for a job. You can also deep-link a comparison via `/compare?ids=<id1>,<id2>`.
 
 ## Step 25: Bulk Import Spools from a Spreadsheet *(v1.11)*
 
@@ -591,7 +591,7 @@ Missing locations are auto-created, so you don't need to seed locations in advan
 | Action | Where |
 |--------|-------|
 | Add filament | Home > + Add Filament |
-| Populate from NFC / TDS / INI / Clone | Add Filament > Populate from toolbar |
+| Populate from NFC / TDS / INI / Duplicate | Add Filament > Populate from toolbar |
 | Import from TDS | Add Filament > Import from TDS |
 | Configure AI provider | Settings > AI Features |
 | Import from PrusaSlicer | Home > Import/Export > Import INI |
@@ -605,7 +605,7 @@ Missing locations are auto-created, so you don't need to seed locations in advan
 | Backup database | Settings > Backup & Restore > Download Snapshot |
 | View filament details | Home > click filament name |
 | Edit filament | Detail page > Edit |
-| Add color variant | Detail page > + Add Color |
+| Add color variant | Detail page > Create variant |
 | Manage nozzles | Settings > Nozzles |
 | Manage printers | Settings > Printers |
 | Browse API docs | Settings > API Documentation (or navigate to `/api-docs`) |
@@ -619,7 +619,7 @@ Missing locations are auto-created, so you don't need to seed locations in advan
 | Log a dry cycle | Spool detail > + Log dry cycle |
 | View usage analytics | Top nav > Analytics |
 | Set low-stock threshold | Filament edit > Stock settings |
-| Compare filaments | List > select rows > Compare |
+| Compare filaments | Compare page > pick up to 8 (or /compare?ids=…) |
 | Publish a shared catalog | Top nav > Share > + New |
 | Import spools from CSV | Home > Import > Spools from CSV |
 | Switch theme | Settings > Theme |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ Click any filament name in the table to see its full details:
    - **Import from TDS** to extract properties from a Technical Data Sheet URL using AI (requires API key — see [AI Settings](#ai-settings))
    - **Prusament QR** to fetch specs from a Prusament spool QR code
    - **Load from INI** to pick a profile from a PrusaSlicer config bundle
-   - **Clone Existing** to copy identity fields from another filament and inherit its settings as a variant. (On a filament's detail page, a dedicated **"+ Create variant"** button is also available on root filaments — quicker path when you already know which filament should be the parent.)
+   - **Duplicate Existing** to copy identity fields from another filament and inherit its settings as a variant. (On a filament's detail page, a dedicated **"+ Create variant"** button is also available on root filaments — quicker path when you already know which filament should be the parent.)
 3. Fill in the required fields (name, vendor, type)
 4. Optionally set temperatures, cost, density, color, fan settings, retraction, shrinkage, pressure advance, and other properties
 5. Select compatible nozzles and enter per-nozzle calibration overrides
@@ -438,7 +438,7 @@ Each filament has a unique instance identifier (5-byte hex string, e.g. `2acc210
 
 ---
 
-## Label Printer (Desktop App Only) *(v1.33)*
+## Label Printer (Desktop App Only) *(v1.34)*
 
 Print a 24mm-tape spool label directly from the filament detail page to a **Brother PT-P710BT** (P-touch CUBE) over Bluetooth. The label carries a QR code and the filament name. Two QR payload modes you can pick per print:
 
@@ -506,7 +506,7 @@ Click any material row to expand a detail panel with three columns:
 
 ### Importing Materials
 
-1. Select materials using checkboxes (or use **Select All** / **Clear Selection** in the toolbar)
+1. Select materials using checkboxes (or use **Select All** / **Deselect all** in the toolbar)
 2. Click **"Import Selected (N)"** to import
 3. Materials are matched by name and vendor:
    - **New materials** are created with all available fields
@@ -631,7 +631,7 @@ The **Share** page at `/share` lets you publish a static snapshot of selected fi
 
 ## Filament Comparison *(v1.11)*
 
-The **Compare** page at `/compare` takes up to 8 filaments (pass via query string, or add from the filament list) and renders a side-by-side table of temperatures, cost, density, diameter, calibrations, and current remaining weight. Useful when deciding which of several similar filaments to use for a job. Since v1.34.1 the picker has the same search-as-you-type, material-type filter chips, and "show selected only" toggle as `/share` (only appearing at ≥12 filaments) so picking 4–8 rows out of a large catalog stays quick.
+The **Compare** page at `/compare` takes up to 8 filaments (picked in its built-in picker, or passed via the `?ids=` query string) and renders a side-by-side table of temperatures, cost, density, diameter, calibrations, and current remaining weight. Useful when deciding which of several similar filaments to use for a job. Since v1.34.1 the picker has the same search-as-you-type, material-type filter chips, and "show selected only" toggle as `/share` (only appearing at ≥12 filaments) so picking 4–8 rows out of a large catalog stays quick.
 
 ## Spool Inventory *(v1.32)*
 


### PR DESCRIPTION
A full audit of the documentation against the actual codebase (five parallel readers, each cross-checking a doc group against the code) surfaced a set of inaccuracies. This fixes the English docs.

## HIGH — `docs/nfc.md`
- **OpenPrintTag CBOR-key table was mostly wrong.** Rewrote it against the real `OPT_KEY` map in `src/lib/openprinttag.ts` — e.g. doc said Material name=8 / Primary color=11 / Density=17; actual is 10 / 19 / 29. Added the secondary-color slots (20–24) and corrected temps/weights/instance-id.
- **Removed a fabricated `SCARD_SHARE_DIRECT` / `FF C2` Transparent-Exchange / `SCardControl` fallback** — no such code exists. The reader only uses `SCARD_SHARE_SHARED`; on macOS it tries each driver instance (`ifd-ccid` / `ifd-acsccid`) and uses whichever handles ISO 15693. Fixed the matching troubleshooting line + the sector data-range wording.

## MEDIUM
- `docs/desktop.md`: dropped the removed `showMessage` from the preload-bridge list (replaced with the real `getRuntimeMode`).
- `docs/tutorial.md` / `usage.md`: Compare is reached via the `/compare` picker (cap **8**) or `?ids=`, **not** a "select rows on the list → Compare" control (that control doesn't exist). Detail-page button is **Create variant**, not "+ Add Color".

## LOW
- `Clone` → **Duplicate** rename (#388) across tutorial/usage (button, "Duplicate Existing" toolbar entry, quick-ref rows).
- Label Printer mis-tagged v1.33 → **v1.34**; OPT browser button "Clear Selection" → **Deselect all**.
- `desktop.md` / `testing.md`: corrected the build matrix to **six** jobs and listed the Windows + mac-x64 auto-update manifests; noted `electron:rebuild` also rebuilds serialport.
- `api.md`: documented real-but-missing endpoints — single-filament GET `prusaslicer`/`orcaslicer` exports, `GET /api/filaments/colors`, `POST /api/openprinttag` (cache-refresh; the GET `?refresh` trigger was removed), and the `multipart/form-data` branch of `POST /api/spools/import`.

## Verified accurate (no change)
README.md, CLAUDE.md, AGENTS.md — all paths/commands/ports/versions/feature claims check out.

## Follow-up (not in this PR)
The **German mirror docs** (`docs/de/*`) carry the same drift and need a parallel pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)