### PR TITLE
fix(share): add Open link to catalog list (#555) + correct Unpublish button label (#560)

### DIFF
--- a/src/app/share/page.tsx
+++ b/src/app/share/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useToast } from "@/components/Toast";
 import { useConfirm } from "@/components/ConfirmDialog";
 import CopyButton from "@/components/CopyButton";
@@ -103,7 +104,7 @@ export default function ShareManagementPage() {
   };
 
   const handleUnpublish = async (slug: string) => {
-    if (!(await confirm({ message: t("share.unpublishConfirm"), destructive: true, confirmLabel: t("common.delete") }))) return;
+    if (!(await confirm({ message: t("share.unpublishConfirm"), destructive: true, confirmLabel: t("share.unpublish") }))) return;
     const res = await fetch(`/api/share/${slug}`, { method: "DELETE" });
     if (!res.ok) {
       toast(t("share.unpublishError"), "error");
@@ -183,7 +184,12 @@ export default function ShareManagementPage() {
                       <p className="text-xs text-gray-500 mt-1">{c.description}</p>
                     )}
                     <div className="flex items-center gap-2 mt-1 text-xs text-gray-400">
-                      <code className="text-gray-600 dark:text-gray-300">{url}</code>
+                      <Link
+                        href={`/share/${c.slug}`}
+                        className="text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        <code>{url}</code>
+                      </Link>
                       <CopyButton value={url} />
                     </div>
                     <p className="text-xs text-gray-500 mt-1">
@@ -191,13 +197,21 @@ export default function ShareManagementPage() {
                       {formatDate(c.createdAt, locale)}
                     </p>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => handleUnpublish(c.slug)}
-                    className="text-red-500 hover:text-red-700 text-sm"
-                  >
-                    {t("share.unpublish")}
-                  </button>
+                  <div className="flex flex-col items-end gap-2 shrink-0">
+                    <Link
+                      href={`/share/${c.slug}`}
+                      className="text-blue-600 hover:underline dark:text-blue-400 text-sm"
+                    >
+                      {t("share.view")}
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => handleUnpublish(c.slug)}
+                      className="text-red-500 hover:text-red-700 text-sm"
+                    >
+                      {t("share.unpublish")}
+                    </button>
+                  </div>
                 </li>
               );
             })}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -288,6 +288,7 @@
   "share.linkCopied": "Link in Zwischenablage kopiert",
   "share.existingShares": "Deine geteilten Kataloge",
   "share.noShares": "Du hast noch keine Kataloge veröffentlicht.",
+  "share.view": "Öffnen",
   "share.viewCount": "{count} Aufrufe",
   "share.unpublish": "Zurücknehmen",
   "share.unpublished": "Zurückgenommen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -288,6 +288,7 @@
   "share.linkCopied": "Link copied to clipboard",
   "share.existingShares": "Your shared catalogs",
   "share.noShares": "You haven't published any catalogs yet.",
+  "share.view": "Open",
   "share.viewCount": "{count} views",
   "share.unpublish": "Unpublish",
   "share.unpublished": "Unpublished",


### PR DESCRIPTION
## Summary
Two small share-page fixes from the v1.34.5 Electron walkthrough.

### #555 — no obvious open/view link
The shared-catalog list rendered the public URL as plain `<code>` text with only a copy button. Now:
- The URL is a clickable link (in-app navigation to `/share/<slug>`).
- An explicit **Open** link sits in the row's action column next to **Unpublish**.

### #560 — unpublish confirm labeled "Delete"
The unpublish confirmation reused `common.delete` ("Delete"), making an unpublish read like a permanent deletion. The confirm button now uses `share.unpublish` ("Unpublish").

## Changes
- `src/app/share/page.tsx` — clickable URL + Open link; unpublish confirm label.
- `src/i18n/locales/{en,de}.json` — new `share.view` key ("Open" / "Öffnen").

## Testing
- `tests/i18n-key-coverage.test.ts` passes (en/de parity for the new key).
- ESLint clean on the changed file.

Fixes #555
Fixes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)