### PR TITLE
fix(settings): accept displayed DELETE token in danger-zone confirm (#559)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1003,7 +1003,7 @@ export default function SettingsPage() {
                     setDeleteInput("");
                   }
                 }}
-                disabled={deleteInput !== "delete" || deleting}
+                disabled={deleteInput.trim() !== "DELETE" || deleting}
                 className="px-4 py-1.5 bg-red-700 text-white rounded text-sm hover:bg-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               >
                 {deleting ? t("settings.deleting") : t("settings.confirmDelete")}


### PR DESCRIPTION
## Summary
The **Delete All Data** confirmation tells the user to type `DELETE` (both `settings.deleteTypeConfirm` and the `settings.deleteTypePlaceholder` show `DELETE`), but the **Delete Everything** button only enabled on lowercase `delete`. Typing the displayed uppercase token left the button disabled — the confirmation UI looked broken right where users need clarity, and the dangerous action was effectively gated on guessing the wrong case.

## Fix
Compare the input against the displayed token `DELETE` (trimmed) so the instruction, placeholder, and the enable-gate all agree.

`src/app/settings/page.tsx` — one-line change to the disabled predicate.

## Testing
- ESLint clean.
- No test pinned the old lowercase behavior.

Fixes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)