### PR TITLE
fix(list): keep parents with their own spool under the Has spools filter (#552)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -330,27 +330,41 @@ export default function Home() {
     };
     for (const f of inventoryFilaments) {
       if (isLowStock(f)) counts.lowStock++;
-      if ((f.spools?.length ?? 0) > 0) counts.hasSpools++;
       if (!f.hasCalibrations) counts.noCalibration++;
     }
+    // #552: "Has spools" is a presence check, not an inventory aggregate.
+    // A parent is excluded from `inventoryFilaments` because its gram/spool
+    // totals live on its variants — but a parent can still carry its OWN
+    // spool, and that roll is real. Count every filament with its own
+    // spool, parents included, so the chip badge matches the rows the
+    // filter renders (see the matching source switch in `visibleFilaments`).
+    counts.hasSpools = filaments.filter(
+      (f) => (f.spools?.length ?? 0) > 0,
+    ).length;
     return counts;
-  }, [inventoryFilaments]);
+  }, [filaments, inventoryFilaments]);
 
   const visibleFilaments = useMemo(() => {
     // The "all" view keeps parents in the dataset so the list renders
-    // them as grouping headers above their color variants. Every other
-    // filter resolves against `inventoryFilaments` instead — otherwise
-    // the chip badge (derived from `inventoryFilaments`, see
+    // them as grouping headers above their color variants.
+    if (quickFilter === "all") return filaments;
+    // #552: "Has spools" resolves against the full list (parents
+    // included) because a parent carrying its own spool genuinely has
+    // one — see the matching note in `quickFilterCounts`. Dropping it
+    // here is what made the filter return no rows for a parent whose
+    // only spool sat on the parent itself.
+    if (quickFilter === "hasSpools") {
+      return filaments.filter((f) => (f.spools?.length ?? 0) > 0);
+    }
+    // Every other filter resolves against `inventoryFilaments` instead —
+    // otherwise the chip badge (derived from `inventoryFilaments`, see
     // `quickFilterCounts` above) disagrees with the rendered row count
     // whenever a parent happens to match the filter criterion.
-    // `noCalibration` is the obvious case: a parent without
-    // calibrations would otherwise appear in the list even though the
-    // badge excluded it from the count. Codex round-1 P2 on PR #356.
-    const source = quickFilter === "all" ? filaments : inventoryFilaments;
-    if (quickFilter === "all") return source;
-    return source.filter((f) => {
+    // `noCalibration` is the obvious case: a parent without calibrations
+    // would otherwise appear in the list even though the badge excluded
+    // it from the count. Codex round-1 P2 on PR #356.
+    return inventoryFilaments.filter((f) => {
       if (quickFilter === "lowStock") return isLowStock(f);
-      if (quickFilter === "hasSpools") return (f.spools?.length ?? 0) > 0;
       if (quickFilter === "noCalibration") return !f.hasCalibrations;
       return true;
     });


### PR DESCRIPTION
## Summary
The **Has spools** quick filter on the filament list returned an empty table even when an active spool was visible on the same list — reported in the v1.34.5 walkthrough (`Electron Galaxy PLA`, one active spool, 53% remaining).

## Root cause
The filter and its chip count both resolve against `inventoryFilaments`, which excludes every parent (`!f.hasVariants`). Parent exclusion exists so a parent's gram/spool totals don't double-count its variants' inventory. But when the parent carries **its own** spool, that roll is real — and the presence filter dropped it.

## Fix
`src/app/page.tsx`:
- "Has spools" now resolves against the full filament list and counts the same way (`(f.spools?.length ?? 0) > 0`), so a parent with its own spool stays findable and the chip badge still matches the rendered rows.
- `lowStock` / `noCalibration` keep resolving against `inventoryFilaments` (unchanged) — a parent that "matches" those by virtue of exclusion must not appear, per the prior Codex P2 on #356.

## Testing
- ESLint + `tsc --noEmit` clean.

Fixes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)