### PR TITLE
fix(list): resolve inherited values on variant search-result rows (#553)

### DIFF
--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -94,7 +94,29 @@ export async function GET(request: NextRequest) {
           // uses at read time. Without this the list drops inherited
           // multi-color data and the list-row swatch can't render it.
           // (Codex P2 on PR #482.)
-          pipeline: [{ $project: { calibrations: 1, optTags: 1, secondaryColors: 1 } }],
+          //
+          // GH #553: also carry the inheritable scalar fields (temperatures,
+          // cost, density, spoolWeight, netFilamentWeight) so the projection
+          // can resolve them server-side. The list page used to merge these
+          // client-side from the parent row, but a name search returns only
+          // the matching variant (its parent is filtered out by `$match`),
+          // so the variant rendered `—` for inherited Nozzle/Bed in search
+          // results. `$lookup` runs against the full collection regardless of
+          // the search filter, so the parent is always available here.
+          pipeline: [
+            {
+              $project: {
+                calibrations: 1,
+                optTags: 1,
+                secondaryColors: 1,
+                temperatures: 1,
+                cost: 1,
+                density: 1,
+                spoolWeight: 1,
+                netFilamentWeight: 1,
+              },
+            },
+          ],
         },
       },
       // Look up whether any non-deleted filament references this row as
@@ -148,11 +170,30 @@ export async function GET(request: NextRequest) {
               { $ifNull: [{ $arrayElemAt: ["$_parent.secondaryColors", 0] }, []] },
             ],
           },
-          cost: 1,
-          density: 1,
+          // GH #553: resolve inheritable scalars against the parent so a
+          // variant surfaced as a standalone search-result row still shows
+          // its effective cost/density/spool weights (the parent row is
+          // filtered out of search results). `$ifNull` collapses null +
+          // missing, matching resolveFilament's scalar-inheritance rule.
+          // `$_parent` holds 0-or-1 docs; `$arrayElemAt(…, 0)` is null when
+          // there's no parent, so standalones/parents are unaffected.
+          cost: { $ifNull: ["$cost", { $arrayElemAt: ["$_parent.cost", 0] }] },
+          density: {
+            $ifNull: ["$density", { $arrayElemAt: ["$_parent.density", 0] }],
+          },
           parentId: 1,
-          spoolWeight: 1,
-          netFilamentWeight: 1,
+          spoolWeight: {
+            $ifNull: [
+              "$spoolWeight",
+              { $arrayElemAt: ["$_parent.spoolWeight", 0] },
+            ],
+          },
+          netFilamentWeight: {
+            $ifNull: [
+              "$netFilamentWeight",
+              { $arrayElemAt: ["$_parent.netFilamentWeight", 0] },
+            ],
+          },
           totalWeight: 1,
           lowStockThreshold: 1,
           tdsUrl: 1,
@@ -176,8 +217,25 @@ export async function GET(request: NextRequest) {
               { $ifNull: [{ $arrayElemAt: ["$_parent.optTags", 0] }, []] },
             ],
           },
-          "temperatures.nozzle": 1,
-          "temperatures.bed": 1,
+          // GH #553: same parent-fallback as the scalars above. Built as a
+          // single computed object (not two `temperatures.x: 1` paths) both
+          // because mixing a computed field with dotted sub-paths of the
+          // same root is a projection-path collision, and so the variant
+          // inherits the parent's nozzle/bed temps in search-result rows.
+          temperatures: {
+            nozzle: {
+              $ifNull: [
+                "$temperatures.nozzle",
+                { $arrayElemAt: ["$_parent.temperatures.nozzle", 0] },
+              ],
+            },
+            bed: {
+              $ifNull: [
+                "$temperatures.bed",
+                { $arrayElemAt: ["$_parent.temperatures.bed", 0] },
+              ],
+            },
+          },
           hasCalibrations: {
             $or: [
               { $gt: [{ $size: { $ifNull: ["$calibrations", []] } }, 0] },

--- a/tests/filaments-list-route.test.ts
+++ b/tests/filaments-list-route.test.ts
@@ -331,6 +331,82 @@ describe("GET /api/filaments — projection to FilamentSummary", () => {
     expect(withoutTds.tdsUrl).toBeNull();
   });
 
+  it("resolves inherited scalars on a variant search-result row even when the parent is filtered out (#553)", async () => {
+    // A name search returns only the matching variant; its parent doesn't
+    // match the regex and is dropped by `$match`. The list page used to
+    // merge inherited nozzle/bed/cost/density/spool weights client-side
+    // from the parent row, so when the parent wasn't in the result set the
+    // variant rendered `—` for those columns. The aggregation now resolves
+    // them server-side via the `_parent` lookup, which runs against the
+    // full collection regardless of the search filter.
+    const Filament = (await import("@/models/Filament")).default;
+    const parent = await Filament.create({
+      name: "Galaxy PLA",
+      vendor: "Test",
+      type: "PLA",
+      temperatures: { nozzle: 215, bed: 60 },
+      cost: 25,
+      density: 1.24,
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+    });
+    await Filament.create({
+      name: "Galaxy PLA Red",
+      vendor: "Test",
+      type: "PLA",
+      parentId: parent._id,
+      color: "#ef4444",
+      // no own temperatures/cost/density/weights — must inherit from parent
+    });
+
+    // Search for the variant by name — the parent ("Galaxy PLA") does NOT
+    // match "Red", so it's excluded from the result set.
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments?search=Red"),
+    );
+    const body = await res.json();
+    const variant = body.find((f: { name: string }) => f.name === "Galaxy PLA Red");
+    const parentRow = body.find((f: { name: string }) => f.name === "Galaxy PLA");
+
+    expect(parentRow).toBeUndefined(); // parent filtered out by the search
+    expect(variant).toBeDefined();
+    expect(variant.temperatures.nozzle).toBe(215);
+    expect(variant.temperatures.bed).toBe(60);
+    expect(variant.cost).toBe(25);
+    expect(variant.density).toBe(1.24);
+    expect(variant.spoolWeight).toBe(200);
+    expect(variant.netFilamentWeight).toBe(1000);
+  });
+
+  it("a variant's own scalar values still win over the parent's (#553)", async () => {
+    const Filament = (await import("@/models/Filament")).default;
+    const parent = await Filament.create({
+      name: "Override Galaxy",
+      vendor: "Test",
+      type: "PLA",
+      temperatures: { nozzle: 215, bed: 60 },
+      cost: 25,
+    });
+    await Filament.create({
+      name: "Override Galaxy Blue",
+      vendor: "Test",
+      type: "PLA",
+      parentId: parent._id,
+      color: "#3b82f6",
+      temperatures: { nozzle: 230, bed: 70 },
+      cost: 40,
+    });
+
+    const res = await listFilaments(
+      new NextRequest("http://localhost/api/filaments?search=Blue"),
+    );
+    const body = await res.json();
+    const variant = body.find((f: { name: string }) => f.name === "Override Galaxy Blue");
+    expect(variant.temperatures.nozzle).toBe(230);
+    expect(variant.temperatures.bed).toBe(70);
+    expect(variant.cost).toBe(40);
+  });
+
   it("preserves type/vendor filters across the projection", async () => {
     await seed();
     const res = await listFilaments(


### PR DESCRIPTION
## Summary
When a color variant is shown as its own search-result row on the filament list, inherited values disappeared from the columns — searching `Red` showed `Electron Galaxy PLA Red` with `—` for the **Nozzle** and **Bed** columns, even though the detail page, compare page, and expanded parent/variant view all resolved them correctly (#553).

## Root cause
Search is server-side. A name search returns only the matching variant; its parent doesn't match the regex and is dropped by the aggregation's `$match`. The list page merges inherited scalars (nozzle/bed/cost/density/spool weights) **client-side** from the parent row — but in a search result the parent isn't in the fetched set, so there's nothing to inherit from.

## Fix
Resolve the inheritable scalars server-side in the list aggregation using the existing `_parent` `$lookup` (which runs against the full collection regardless of the search `$match`):
- `temperatures.nozzle` / `temperatures.bed`, `cost`, `density`, `spoolWeight`, `netFilamentWeight` now fall back to the parent via `$ifNull` (collapses null + missing — matches `resolveFilament`'s scalar-inheritance rule).
- Standalones / parents have no `_parent` doc, so `$arrayElemAt(…, 0)` is null and they're unaffected.
- The client-side merge stays as defense in depth.

## Testing
- 2 new cases in `tests/filaments-list-route.test.ts`: a searched variant inherits the parent's scalars when the parent is filtered out; a variant's own values still win.
- Full `filaments-list-route`, `variant-edit-preserves-inheritance`, `filaments-parents-route` suites pass; ESLint + `tsc --noEmit` clean.

Fixes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)