### PR TITLE
fix(bed-types): block delete when a filament names the surface in bedTypeTemps (#557)

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2719,7 +2719,7 @@
             }
           },
           "400": {
-            "description": "Bed type is still referenced",
+            "description": "Bed type is still referenced by a filament calibration, a printer's installed bed types, or a filament's per-bed-type temperatures",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/app/api/bed-types/[id]/route.ts
+++ b/src/app/api/bed-types/[id]/route.ts
@@ -74,6 +74,14 @@ export async function DELETE(
     await dbConnect();
     const { id } = await params;
 
+    // Load the target up front: we need its name to match against the
+    // free-text `bedTypeTemps[].bedType` keys below, and a clean 404 when
+    // it's already gone.
+    const bedType = await BedType.findOne({ _id: id, _deletedAt: null }).lean();
+    if (!bedType) {
+      return errorResponse("Not found", 404);
+    }
+
     // Prevent deleting a bed type that is referenced by any filament calibration
     const referencingCount = await Filament.countDocuments({
       _deletedAt: null,
@@ -103,12 +111,32 @@ export async function DELETE(
       );
     }
 
-    const bedType = await BedType.findOneAndUpdate(
+    // GH #557: filaments also name a bed surface by NAME via the free-text
+    // `bedTypeTemps[].bedType` key — a slicer surface string that is
+    // deliberately NOT a BedType ObjectId ref (see the docblock in
+    // src/models/Filament.ts). Without this guard, deleting a catalog bed
+    // type whose name a filament's per-surface temperature table still uses
+    // silently removes a selectable surface that existing filament data
+    // depends on, leaving the user unable to re-pick it. Match by name to
+    // mirror the calibration/printer guards above and the nozzle/location
+    // delete guards elsewhere.
+    const bedTempCount = await Filament.countDocuments({
+      _deletedAt: null,
+      "bedTypeTemps.bedType": bedType.name,
+    });
+    if (bedTempCount > 0) {
+      return errorResponse(
+        `Cannot delete this bed type — ${bedTempCount} filament${bedTempCount !== 1 ? "s" : ""} reference${bedTempCount === 1 ? "s" : ""} "${bedType.name}" in per-bed-type temperatures. Remove it from those filaments first.`,
+        400,
+      );
+    }
+
+    const deleted = await BedType.findOneAndUpdate(
       { _id: id, _deletedAt: null },
       { _deletedAt: new Date() },
       { returnDocument: "after" }
     ).lean();
-    if (!bedType) {
+    if (!deleted) {
       return errorResponse("Not found", 404);
     }
     return NextResponse.json({ message: "Deleted" });

--- a/tests/bed-types-route.test.ts
+++ b/tests/bed-types-route.test.ts
@@ -217,6 +217,59 @@ describe("/api/bed-types", () => {
       expect(res.status).toBe(200);
     });
 
+    it("refuses if an active filament names it in bedTypeTemps (#557)", async () => {
+      // `bedTypeTemps[].bedType` is a free-text slicer surface key, not a
+      // BedType ObjectId ref — but deleting a catalog bed type whose name a
+      // filament's per-surface temperature table still uses would silently
+      // remove a selectable surface that existing data depends on. The
+      // guard matches by name.
+      const bed = await BedType.create({ name: "Textured PEI", material: "PEI" });
+      await Filament.create({
+        name: "PETG",
+        vendor: "T",
+        type: "PETG",
+        bedTypeTemps: [{ bedType: "Textured PEI", temperature: 80 }],
+      });
+
+      const res = await deleteBedType(
+        new NextRequest(`http://localhost/api/bed-types/${bed._id}`, { method: "DELETE" }),
+        { params: Promise.resolve({ id: String(bed._id) }) },
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/per-bed-type temperatures/i);
+      // The bed type was not soft-deleted.
+      const after = await BedType.findById(bed._id);
+      expect(after._deletedAt).toBeNull();
+    });
+
+    it("ignores soft-deleted filaments and unrelated surface names in the bedTypeTemps check (#557)", async () => {
+      const bed = await BedType.create({ name: "Smooth PEI", material: "PEI" });
+      // Soft-deleted filament that names it — must not block.
+      await Filament.create({
+        name: "Trashed PETG",
+        vendor: "T",
+        type: "PETG",
+        bedTypeTemps: [{ bedType: "Smooth PEI", temperature: 70 }],
+        _deletedAt: new Date(),
+      });
+      // Active filament that names a DIFFERENT surface — must not block.
+      await Filament.create({
+        name: "Other PETG",
+        vendor: "T",
+        type: "PETG",
+        bedTypeTemps: [{ bedType: "Glass", temperature: 70 }],
+      });
+
+      const res = await deleteBedType(
+        new NextRequest(`http://localhost/api/bed-types/${bed._id}`, { method: "DELETE" }),
+        { params: Promise.resolve({ id: String(bed._id) }) },
+      );
+      expect(res.status).toBe(200);
+      const after = await BedType.findById(bed._id);
+      expect(after._deletedAt).not.toBeNull();
+    });
+
     it("soft-deletes a bed type with no references", async () => {
       const bed = await BedType.create({ name: "Standalone", material: "Glass" });
       const res = await deleteBedType(


### PR DESCRIPTION
## Summary
Deleting a bed type was blocked when it was installed on printers or used by calibrations, but it succeeded while active filaments referenced it in their per-bed-type temperature table — leaving data that names a now-deleted surface (#557).

## Context
`bedTypeTemps[].bedType` is a **free-text slicer surface key**, deliberately *not* a `BedType` ObjectId ref (see the docblock in `src/models/Filament.ts`). So there's no FK to follow — but a user who created a bed type "Textured PEI", named it in a filament's per-surface temps, then deleted the catalog entry, silently loses a selectable surface their data still depends on, with none of the guard errors the parallel nozzle/printer/location deletes give.

## Fix
`src/app/api/bed-types/[id]/route.ts`:
- Load the target bed type up front (needed for the name match + a clean 404).
- Add a third guard: block the delete with a 400 when any **active** filament names the bed type (by name) in `bedTypeTemps[].bedType`, mirroring the existing calibration/printer guards.

`public/openapi.json` — 400 description broadened to name all three reference paths.

## Testing
- New tests: refuses when an active filament names it (and isn't soft-deleted); ignores soft-deleted filaments + unrelated surface names. Full `bed-types-route` suite passes.
- ESLint + `tsc --noEmit` clean.

Fixes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)