### PR TITLE
fix(detail): refresh printer slots after retiring a loaded spool (#558)

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -515,6 +515,15 @@ function FilamentDetail() {
     }
   };
 
+  // Re-pull printers so every spool card's *derived* AMS-slot assignment
+  // (read off amsSlots[].spoolId, not stored on the spool) reflects the
+  // latest server state. Used after any write that the server may have
+  // reconciled slots for — slot assign/clear and spool retire (#558).
+  const refreshPrinters = async () => {
+    const pr = await fetch("/api/printers");
+    if (pr.ok) setPrinters(await pr.json());
+  };
+
   const handleUpdateSpool = async (
     spoolId: string,
     data: {
@@ -561,6 +570,13 @@ function FilamentDetail() {
       if (res.ok) {
         const updated = await res.json();
         setFilament(prev => prev ? { ...prev, spools: updated.spools } : prev);
+        // #558: retiring a loaded spool clears it from its printer AMS slot
+        // server-side (the PUT handler calls assignSpoolToSlot(..., null)).
+        // The card's slot text is derived from `printers`, so refresh it or
+        // the stale "Printer slot: <printer> · <slot>" lingers until reload.
+        if (data.retired === true) {
+          await refreshPrinters();
+        }
         toast(t("detail.spool.updated"));
       } else {
         toast(t("detail.spool.updateFailed"), "error");
@@ -585,8 +601,7 @@ function FilamentDetail() {
         body: target ? JSON.stringify(target) : undefined,
       });
       if (res.ok) {
-        const pr = await fetch("/api/printers");
-        if (pr.ok) setPrinters(await pr.json());
+        await refreshPrinters();
         toast(t(target ? "detail.spool.slotAssigned" : "detail.spool.slotCleared"));
       } else {
         toast(t(target ? "detail.spool.slotAssignFailed" : "detail.spool.slotClearFailed"), "error");


### PR DESCRIPTION
## Summary
Retiring a spool that's loaded in a printer AMS slot clears the assignment server-side, but the filament detail card kept showing the stale `Printer slot: <printer> · <slot>` text (and its clear action) until a manual refresh. Unretiring then carried the stale text forward even though the backend assignment stayed cleared (#558).

## Root cause
The spool PUT handler already clears the slot on retire (`assignSpoolToSlot(Printer, spoolId, null)`), and `GET /api/spools/:spoolId/assignment` returns `null` afterward. But the card's slot text is **derived client-side** from the `printers` state, and `handleUpdateSpool` only refreshed `filament.spools` — never `printers`.

## Fix
`src/app/filaments/[id]/page.tsx`:
- Re-pull printers after a successful retire (`data.retired === true`) so the derived slot text matches the server.
- Extracted the existing `fetch("/api/printers")` + `setPrinters` into a `refreshPrinters` helper, now shared with `handleAssignSlot`.

## Testing
- ESLint + `tsc --noEmit` clean.
- The backend slot-clear-on-retire is already covered by `tests/spool-slots.test.ts`; this PR is the client-side refresh that surfaces that cleared state. The new path mirrors the existing `handleAssignSlot` refresh.

Fixes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)