### PR TITLE
fix(nfc): friendly empty-tag prompt for blank/unformatted tags (#556)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1281,7 +1281,15 @@ async function initNfc(): Promise<void> {
             }
             // Blank/erased tags have no NDEF data — tell the renderer so it
             // can show an "empty tag" indication instead of silently ignoring.
-            if (err.message?.includes("No NDEF TLV") || err.message?.includes("No NDEF record")) {
+            // Covers an erased NDEF-formatted tag (No NDEF TLV/record) and a
+            // never-formatted blank tag whose all-zero memory has no CC byte
+            // (#556) — both are the friendly "write me to initialize" case,
+            // not a raw error worth surfacing.
+            if (
+              err.message?.includes("No NDEF TLV") ||
+              err.message?.includes("No NDEF record") ||
+              err.message?.includes("Blank or unformatted")
+            ) {
               mainWindow?.webContents.send("nfc-tag-detected", { empty: true });
               return;
             }

--- a/electron/ndef.ts
+++ b/electron/ndef.ts
@@ -250,6 +250,15 @@ export function parseNdefFromTag(raw: Uint8Array): Uint8Array {
 
   // Validate CC
   if (raw[0] !== 0xe1) {
+    // A blank / unformatted tag reads back all-zero memory, so its CC byte
+    // is 0x00. That isn't a wrong-format error the user needs to debug —
+    // it's the "write me to initialize" case (the write path at
+    // nfc-service.ts treats block0[0] === 0x00 as blank too). Throw a
+    // distinguishable message so the caller can surface the friendly
+    // empty-tag UI instead of a raw "Invalid CC magic byte" dump (#556).
+    if (raw[0] === 0x00) {
+      throw new Error("Blank or unformatted NFC tag (no NDEF data)");
+    }
     throw new Error(`Invalid CC magic byte: 0x${raw[0].toString(16)}`);
   }
 

--- a/tests/ndef.test.ts
+++ b/tests/ndef.test.ts
@@ -192,9 +192,21 @@ describe("parseNdefFromTag", () => {
     expect(result[2]).toBe(0xcc);
   });
 
-  it("throws on invalid CC magic byte", () => {
-    const data = new Uint8Array([0x00, 0x40, 0x28, 0x01, 0x03, 0x05, 0xd2, 0x00, 0x00]);
+  it("throws on invalid CC magic byte (wrong-format, non-blank tag)", () => {
+    // A non-zero, non-0xE1 first byte is a genuinely wrong-format tag the
+    // user should see surfaced — distinct from the blank-tag case below.
+    const data = new Uint8Array([0xab, 0x40, 0x28, 0x01, 0x03, 0x05, 0xd2, 0x00, 0x00]);
     expect(() => parseNdefFromTag(data)).toThrow("Invalid CC magic byte");
+  });
+
+  it("throws a distinguishable blank-tag error for an all-zero (unformatted) tag (#556)", () => {
+    // A blank/unformatted tag reads back all-zero memory (CC byte 0x00).
+    // It must NOT surface as a raw "Invalid CC magic byte" dump — the
+    // main-process auto-read routes this distinguishable message to the
+    // friendly empty-tag UI instead.
+    const data = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    expect(() => parseNdefFromTag(data)).toThrow("Blank or unformatted");
+    expect(() => parseNdefFromTag(data)).not.toThrow("Invalid CC magic byte");
   });
 
   it("throws on too-short data", () => {


### PR DESCRIPTION
## Summary
Placing a blank/unformatted NFC tag on the reader surfaced the raw low-level error **`Invalid CC magic byte: 0x0`** in the NFC Read Error dialog (#556).

## Root cause
A blank tag reads back all-zero memory, so its NFC-Forum CC byte is `0x00`. `parseNdefFromTag` threw the generic `Invalid CC magic byte` error for any non-`0xE1` first byte — *before* the no-NDEF check that the main-process auto-read routes to the friendly empty-tag UI.

## Fix
- `electron/ndef.ts` — distinguish the blank case (`raw[0] === 0x00`) with its own message; a genuinely wrong-format tag (non-zero, non-`0xE1` CC byte) still throws `Invalid CC magic byte`.
- `electron/main.ts` — route the blank-tag message, alongside the existing No-NDEF paths, to the renderer's `empty: true` state, which already renders the friendly **"Empty Tag — … write data to it"** dialog (no new copy needed). The `0x00 == blank` convention already matches the write path's guard in `nfc-service.ts`.

## Testing
- `tests/ndef.test.ts`: new case asserts the blank-tag message for all-zero memory; the wrong-format assertion now uses a non-zero CC byte. Full `ndef` / `nfc-roundtrip` / `nfc-binary-parsing` suites pass.

## Note
This is the auto-read path (placing a tag) that produced the reported dialog. The write succeeds afterward as before — this is first-use UX only.

Fixes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)