### PR TITLE
fix(api-docs): mount Swagger in its own React root to silence StrictMode dev overlay (#554)

### DIFF
--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,21 +1,60 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import { useEffect, useRef } from "react";
+import type { Root } from "react-dom/client";
 import Link from "next/link";
 import "swagger-ui-react/swagger-ui.css";
 import { useTranslation } from "@/i18n/TranslationProvider";
 
-const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
-
 export default function ApiDocsPage() {
   const { t } = useTranslation();
+  const hostRef = useRef<HTMLDivElement>(null);
 
-  // GH #321: this page used to monkey-patch the global `console.error`
-  // to filter swagger-ui-react's legacy UNSAFE_* lifecycle warnings.
-  // That intercepted *every* console.error app-wide while /api-docs was
-  // open — other components, error boundaries, React's overlay. The
-  // swagger-ui warnings are harmless dev-only noise from a third-party
-  // dependency; we leave them rather than distort global logging.
+  // GH #321 / #554: swagger-ui-react's internal components (ModelCollapse,
+  // OperationContainer, …) still use the legacy UNSAFE_componentWillReceiveProps
+  // lifecycle. Under the app's React StrictMode (Next's default), React logs a
+  // "not recommended in strict mode" warning, and Next's dev overlay then
+  // surfaces it as a blocking "Issue" that makes /api-docs look broken during
+  // local/Electron QA.
+  //
+  // #321 removed the old global console.error monkey-patch (it intercepted ALL
+  // logging app-wide while this page was open) and deliberately left the
+  // warnings. Rather than re-patch console or disable StrictMode app-wide, we
+  // mount SwaggerUI in its OWN React root: a root created here is not a
+  // descendant of the StrictMode that Next wraps the app root in, so swagger's
+  // legacy lifecycles run without the strict-mode warning while the rest of the
+  // app keeps StrictMode. A fresh child node per effect run avoids React's
+  // "container already passed to createRoot" warning under StrictMode's dev
+  // double-invoke, and the unmount is deferred to a microtask to dodge the
+  // "synchronous unmount during render" warning when the effect tears down.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const mount = document.createElement("div");
+    host.appendChild(mount);
+
+    let root: Root | null = null;
+    let cancelled = false;
+
+    Promise.all([import("react-dom/client"), import("swagger-ui-react")]).then(
+      ([{ createRoot }, { default: SwaggerUI }]) => {
+        if (cancelled) return;
+        root = createRoot(mount);
+        root.render(<SwaggerUI url="/api/openapi" />);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      const r = root;
+      root = null;
+      Promise.resolve().then(() => {
+        r?.unmount();
+        mount.remove();
+      });
+    };
+  }, []);
+
   return (
     <div className="min-h-screen">
       <div className="max-w-7xl mx-auto px-4 pt-6 pb-2">
@@ -25,9 +64,7 @@ export default function ApiDocsPage() {
           </Link>
         </div>
       </div>
-      <div className="swagger-wrapper">
-        <SwaggerUI url="/api/openapi" />
-      </div>
+      <div className="swagger-wrapper" ref={hostRef} />
       <style jsx global>{`
         .swagger-wrapper .swagger-ui .wrapper {
           max-width: 1400px;


### PR DESCRIPTION
## Summary
Opening `/api-docs` in Electron dev mode tripped the Next.js dev "Issues" overlay with a legacy React lifecycle warning (`Using UNSAFE_componentWillReceiveProps in strict mode is not recommended … ModelCollapse`), making the page feel broken during local QA (#554).

## Root cause
`swagger-ui-react`'s internal components still use the legacy `UNSAFE_componentWillReceiveProps` lifecycle. Under the app's React StrictMode (Next's default), React logs the warning and the dev overlay surfaces it as a blocking issue.

## Why not the obvious fixes
- **#321 already removed** a global `console.error` monkey-patch (it intercepted *all* logging app-wide) and deliberately left the warnings — so re-patching console is out.
- Disabling `reactStrictMode` app-wide would drop StrictMode's dev checks everywhere — a real regression for a P3 third-party warning.

## Fix
Mount `SwaggerUI` in its **own React root** (`createRoot` in an effect). A root created here is not a descendant of the StrictMode that Next wraps the app root in, so swagger's legacy lifecycles run warning-free while the rest of the app keeps StrictMode. Details:
- A fresh child node per effect run avoids the "container already passed to createRoot" warning under StrictMode's dev double-invoke.
- The unmount is deferred to a microtask to dodge the "synchronous unmount during render" warning on teardown.
- No new dependency, no CSP change, no console patching. CSS/UI unchanged (`<style jsx global>` rules are global and still match).

## Verification (manual, `next dev`)
- `/api-docs` renders all **95** operations, title `Filament DB API 1.34.5 OAS 3.0`.
- Console: **no warnings/errors** (previously the UNSAFE lifecycle warning fired and tripped the overlay).
- Exactly one `.swagger-ui` node after StrictMode's double-invoke — no orphaned root.

Fixes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)