### PR TITLE
docs: fix accuracy drift surfaced by an audit against the code (en + de)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -815,7 +815,7 @@ Soft-delete a printer by ID (sets `_deletedAt` timestamp). Cannot delete a print
 | `POST` | `/api/bed-types` | Create a new bed type |
 | `GET` | `/api/bed-types/:id` | Get a single bed type by ID |
 | `PUT` | `/api/bed-types/:id` | Update a bed type by ID |
-| `DELETE` | `/api/bed-types/:id` | Soft-delete a bed type (blocked if referenced by filament calibrations) |
+| `DELETE` | `/api/bed-types/:id` | Soft-delete a bed type (blocked if referenced by a filament calibration, installed on a printer, or named in a filament's per-bed-type temperatures) |
 
 ### GET /api/bed-types
 
@@ -833,7 +833,7 @@ Update a bed type. Send a JSON body with the fields to update.
 
 ### DELETE /api/bed-types/:id
 
-Soft-delete a bed type by ID (sets `_deletedAt` timestamp). Cannot delete a bed type that is referenced by filament calibrations. Returns `{ message: "Deleted" }`.
+Soft-delete a bed type by ID (sets `_deletedAt` timestamp). Returns `400` when the bed type is still in use — by any active filament's `calibrations[].bedType`, by any printer's `installedBedTypes`, or by name in any active filament's per-bed-type temperature table (`bedTypeTemps[].bedType`); the error message names what's blocking the delete. On success returns `{ message: "Deleted" }`.
 
 ---
 
@@ -1269,7 +1269,7 @@ A single request is capped at 10,000 rows by `parseCsv`; beyond that the request
 
 Mirror of `GET /api/filaments/export-csv` for spool inventory. Streams every active spool from every active filament as a single CSV with one row per spool. Columns include `filament`, `vendor`, `label`, `totalWeight`, `lotNumber`, `purchaseDate`, `openedDate`, `location`, and `retired`. Soft-deleted filaments and retired-only spools are excluded by default. Suitable for round-tripping through `POST /api/spools/import` when migrating between instances.
 
-Response headers: `Content-Type: text/csv` and `Content-Disposition: attachment; filename="spools-YYYY-MM-DD.csv"`.
+Response headers: `Content-Type: text/csv` and `Content-Disposition: attachment; filename="spools.csv"`.
 
 ---
 

--- a/docs/de/api.md
+++ b/docs/de/api.md
@@ -803,7 +803,7 @@ Soft-Delete eines Druckers per ID (setzt den Zeitstempel `_deletedAt`). Ein Druc
 | `POST` | `/api/bed-types` | Legt einen neuen Druckbett-Typ an |
 | `GET` | `/api/bed-types/:id` | Ruft einen einzelnen Druckbett-Typ per ID ab |
 | `PUT` | `/api/bed-types/:id` | Aktualisiert einen Druckbett-Typ per ID |
-| `DELETE` | `/api/bed-types/:id` | Soft-Delete eines Druckbett-Typs (blockiert, wenn von Filament-Kalibrierungen referenziert) |
+| `DELETE` | `/api/bed-types/:id` | Soft-Delete eines Druckbett-Typs (blockiert, wenn von einer Filament-Kalibrierung referenziert, auf einem Drucker installiert oder in einer Filament-Pro-Druckbett-Typ-Temperaturtabelle genannt) |
 
 ### GET /api/bed-types
 
@@ -821,7 +821,7 @@ Aktualisiert einen Druckbett-Typ. Sende einen JSON-Body mit den zu aktualisieren
 
 ### DELETE /api/bed-types/:id
 
-Soft-Delete eines Druckbett-Typs per ID (setzt den Zeitstempel `_deletedAt`). Ein Druckbett-Typ, der von Filament-Kalibrierungen referenziert wird, kann nicht gelöscht werden. Liefert `{ message: "Deleted" }`.
+Soft-Delete eines Druckbett-Typs per ID (setzt den Zeitstempel `_deletedAt`). Liefert `400`, wenn der Druckbett-Typ noch in Verwendung ist — durch `calibrations[].bedType` eines aktiven Filaments, durch `installedBedTypes` eines Druckers oder namentlich durch die Pro-Druckbett-Typ-Temperaturtabelle eines aktiven Filaments (`bedTypeTemps[].bedType`); die Fehlermeldung zeigt, was das Löschen blockiert. Bei Erfolg liefert er `{ message: "Deleted" }`.
 
 ---
 
@@ -1257,7 +1257,7 @@ Eine einzelne Anfrage ist von `parseCsv` auf 10.000 Zeilen gedeckelt; darüber w
 
 Pendant zu `GET /api/filaments/export-csv` für das Spulen-Inventar. Streamt jede aktive Spule aus jedem aktiven Filament als eine einzelne CSV mit einer Zeile pro Spule. Spalten umfassen `filament`, `vendor`, `label`, `totalWeight`, `lotNumber`, `purchaseDate`, `openedDate`, `location` und `retired`. Soft-gelöschte Filamente und ausschließlich ausgemusterte Spulen werden standardmäßig ausgeschlossen. Geeignet für Round-Trip über `POST /api/spools/import` bei der Migration zwischen Instanzen.
 
-Response-Header: `Content-Type: text/csv` und `Content-Disposition: attachment; filename="spools-YYYY-MM-DD.csv"`.
+Response-Header: `Content-Type: text/csv` und `Content-Disposition: attachment; filename="spools.csv"`.
 
 ---
 

--- a/docs/de/setup.md
+++ b/docs/de/setup.md
@@ -224,7 +224,7 @@ npm run dev                   # Entwicklung unter http://localhost:3456
 npm run build && npm start    # Produktion unter http://localhost:3000 (setze PORT=3456 für gleichen Port wie dev)
 ```
 
-`npm start` startet den Standalone-Server-Eintrittspunkt (`node .next/standalone/server.js`) — `next start` ist nicht mit dem `output: "standalone"`-Build-Modus kompatibel, den das Projekt für Docker- und Electron-Paketierung verwendet.
+`npm start` führt zuerst `start:prep` aus (kopiert `.next/static` und `public/` in die Standalone-Ausgabe) und startet dann den Standalone-Server-Eintrittspunkt (`node .next/standalone/server.js`) — `next start` ist nicht mit dem `output: "standalone"`-Build-Modus kompatibel, den das Projekt für Docker- und Electron-Paketierung verwendet.
 
 #### Desktop-App (aus Quellen)
 

--- a/docs/de/smart-filament-workflow-guide.md
+++ b/docs/de/smart-filament-workflow-guide.md
@@ -312,10 +312,12 @@ Notizen.
 
 **Schritt 21 — Einen NFC-Tag für eine Spule schreiben.** Um eine physische Spule „smart" zu machen,
 öffne die Detailseite dieses Filaments in Filament DB, lege einen leeren NFC-V-Tag auf den ACR1552U
-und nutze **OPT exportieren** (OpenPrintTag), um die Eigenschaften des Filaments auf den Tag zu
-schreiben. Ziehe den Tag ab und klebe ihn auf die Spule — von da an kann jede OpenPrintTag-
-kompatible App oder jeder kompatible Drucker ihn sofort lesen. Der Spulen-Tracker auf derselben
-Seite erfasst Gewicht und Restprozent; wiege eine Spule jederzeit neu, um sie aktuell zu halten.
+(die Status-Pille wird grün) und klicke **NFC beschreiben**, um die Eigenschaften des Filaments auf
+den Tag zu schreiben. (Die separate Aktion **OPT exportieren** lädt stattdessen eine OpenPrintTag-
+`.bin`-Datei für externe Tag-Schreibsoftware herunter — sie schreibt nicht auf den Reader.) Ziehe den
+Tag ab und klebe ihn auf die Spule — von da an kann jede OpenPrintTag-kompatible App oder jeder
+kompatible Drucker ihn sofort lesen. Der Spulen-Tracker auf derselben Seite erfasst Gewicht und
+Restprozent; wiege eine Spule jederzeit neu, um sie aktuell zu halten.
 
 **Schritt 22 — Tag nutzen und die Schleife schließen.** Der Tag reist mit der Spule. Tippe ihn auf
 den Reader (oder einen kompatiblen Drucker), und das Filament wird sofort identifiziert. Wenn eine

--- a/docs/de/tutorial.md
+++ b/docs/de/tutorial.md
@@ -348,7 +348,7 @@ Gehe zu **Einstellungen** und klicke auf **Druckbett-Typen**.
 
 - **Erstellen** — klicke „+ Druckbett-Typ hinzufügen", um eine Druckbett-Oberfläche zu definieren (z. B. „Smooth PEI", „Textured PEI", „G10/FR4").
 - **Bearbeiten** — klicke „Bearbeiten" neben einem Druckbett-Typ, um Name, Material oder Notizen zu ändern.
-- **Löschen** — klicke „Löschen", um einen Druckbett-Typ zu entfernen. Referenzieren Filament-Kalibrierungen ihn, wird das Löschen blockiert.
+- **Löschen** — klicke „Löschen", um einen Druckbett-Typ zu entfernen. Das Löschen wird blockiert, wenn eine Filament-Kalibrierung ihn referenziert, er auf einem Drucker installiert ist oder eine Filament-Pro-Druckbett-Typ-Temperaturtabelle ihn namentlich nennt.
 
 Sobald Druckbett-Typen definiert sind, zeigt der Kalibrierungs-Abschnitt im Filament-Formular einen Druckbett-Typ-Selektor, sodass du pro Druckbett-Typ Overrides für Temperaturen, Lüftereinstellungen und Kalibrierungswerte hinterlegen kannst.
 
@@ -565,9 +565,9 @@ Die **Trocknen nötig**-Liste des Dashboards zeigt Spulen, deren letzter Zyklus 
 Möchtest du einem Freund deinen exakten PLA- + PETG-Setup schicken?
 
 1. Navigiere zu **Teilen** (`/share`)
-2. Klicke auf **+ Neuen Shared Catalog**
-3. Wähle Filamente (Multi-Select), setze einen Titel, optional eine Beschreibung, optional Ablaufdatum
-4. Klicke auf **Veröffentlichen** — du bekommst eine Kurz-URL
+2. Gib unter **Neuen geteilten Katalog veröffentlichen** einen Titel ein (und optional eine Beschreibung)
+3. Wähle Filamente (Multi-Select)
+4. Klicke auf **Veröffentlichen** — du bekommst eine Kurz-URL (automatisch in die Zwischenablage kopiert) plus einen **Öffnen**-Link in der Katalogzeile
 
 Empfänger, die die URL öffnen, sehen eine schreibgeschützte Liste. Sie können per Multi-Select **Auswahl importieren** klicken, um die Filamente (plus referenzierte Düsen/Drucker/Druckbett-Typen) in ihre eigene Instanz zu ziehen. Gleichnamige Datensätze am Zielort werden wiederverwendet, sodass nichts doppelt entsteht.
 

--- a/docs/de/usage.md
+++ b/docs/de/usage.md
@@ -49,11 +49,10 @@ Klicke einen Filamentnamen in der Tabelle, um alle Details zu sehen:
 
 ## Filament löschen
 
-Löschen läuft über die Bulk-Aktionsleiste:
+Es gibt zwei Wege zu löschen:
 
-1. Hake eine oder mehrere Checkboxen neben Zeilen in der Filament-Liste an.
-2. Eine rote Auswahlleiste über der Tabelle erscheint mit **„{Anzahl} löschen"**.
-3. Klicke und bestätige.
+- **Aus der Filament-Liste** — hake eine oder mehrere Checkboxen neben Zeilen an. Eine rote Auswahlleiste über der Tabelle erscheint mit **„{Anzahl} löschen"**; klicke sie an und bestätige.
+- **Von der Detailseite** — klicke den roten **Löschen**-Button in der Aktionsleiste oben rechts (seit v1.29). Er löst dasselbe Soft-Delete aus und ist schneller, wenn das Filament bereits geöffnet ist.
 
 Das Löschen ist **soft** — Filamente landen im **Papierkorb**, statt endgültig zu verschwinden. Die Auswahlleiste enthält einen kleinen „Papierkorb öffnen"-Link, sodass das Ziel beim Löschen sichtbar ist.
 
@@ -214,7 +213,7 @@ Jeder Druckbett-Typ hat:
 - **Material** — die Oberflächenmaterial-Art (PEI, Textured PEI, Federstahl, Glas, G10/FR4, BuildTak, PEX, Polypropylen, Sonstiges)
 - **Notizen**
 
-Druckbett-Typen werden in Kalibrierungen verwendet, um Pro-Drucker-Pro-Düse-Pro-Druckbett-Typ-Override-Werte zu speichern. Sie können nicht gelöscht werden, wenn Filament-Kalibrierungen sie referenzieren.
+Druckbett-Typen werden in Kalibrierungen verwendet, um Pro-Drucker-Pro-Düse-Pro-Druckbett-Typ-Override-Werte zu speichern. Sie können nicht gelöscht werden, solange eine Filament-Kalibrierung sie referenziert, sie auf einem Drucker installiert sind oder eine Filament-Pro-Druckbett-Typ-Temperaturtabelle sie namentlich nennt — die Fehlermeldung zeigt, was das Löschen blockiert.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -222,7 +222,7 @@ npm run dev                   # development at http://localhost:3456
 npm run build && npm start    # production at http://localhost:3000 (set PORT=3456 to match dev)
 ```
 
-`npm start` runs the standalone server entrypoint (`node .next/standalone/server.js`) — `next start` is not compatible with the `output: "standalone"` build mode the project uses for Docker and Electron packaging.
+`npm start` first runs `start:prep` (copies `.next/static` and `public/` into the standalone output) and then the standalone server entrypoint (`node .next/standalone/server.js`) — `next start` is not compatible with the `output: "standalone"` build mode the project uses for Docker and Electron packaging.
 
 #### Desktop App (from source)
 

--- a/docs/smart-filament-workflow-guide.md
+++ b/docs/smart-filament-workflow-guide.md
@@ -301,8 +301,10 @@ editing, no hunting through notes.
 ![A filament's detail page in Filament DB](images/sfw-filamentdb-filament-detail.png)
 
 **Step 21 — Write an NFC tag for a spool.** To make a physical spool "smart", open that
-filament's detail page in Filament DB, place a blank NFC-V tag on the ACR1552U, and use
-**Export OPT** (OpenPrintTag) to encode the filament's properties to the tag. Peel the tag
+filament's detail page in Filament DB, place a blank NFC-V tag on the ACR1552U (the status
+pill turns green), and click **Write NFC** to encode the filament's properties to the tag.
+(The separate **Export OPT** action instead downloads an OpenPrintTag `.bin` file for use
+with external tag-writing software — it does not write to the reader.) Peel the tag
 and stick it on the spool — from then on any OpenPrintTag-compatible app or printer can
 read it instantly. The Spool Tracker on the same page records weight and remaining
 percentage; re-weigh a spool any time to keep it current.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -346,7 +346,7 @@ Go to **Settings** and click **Bed Types**.
 
 - **Create** -- click + Add Bed Type to define a bed surface (e.g., "Smooth PEI", "Textured PEI", "G10/FR4").
 - **Edit** -- click Edit next to any bed type to change its name, material, or notes.
-- **Delete** -- click Delete to remove a bed type. If any filament calibrations reference it, deletion is blocked.
+- **Delete** -- click Delete to remove a bed type. Deletion is blocked if any filament calibration references it, it's installed on a printer, or a filament's per-bed-type temperature table names it.
 
 Once bed types are defined, the calibration section in the filament form shows a bed type selector so you can store per-bed-type overrides for temperatures, fan settings, and calibration values.
 
@@ -563,9 +563,9 @@ The dashboard's **Needs drying** list surfaces spools whose last cycle is older 
 Want to send a friend your exact PLA + PETG setup?
 
 1. Navigate to **Share** (`/share`)
-2. Click **+ New shared catalog**
-3. Pick filaments (multi-select), set a title, optional description, optional expiry
-4. Click **Publish** — you get back a short URL
+2. Under **Publish a new share**, enter a title (and an optional description)
+3. Pick filaments (multi-select)
+4. Click **Publish** — you get back a short URL (auto-copied to your clipboard), plus an **Open** link on the catalog row
 
 Recipients who open the URL see a read-only list. They can multi-select and click **Import selected** to pull the filaments (plus referenced nozzles/printers/bed-types) into their own instance. Same-named records on the destination are reused, so nothing gets duplicated.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,11 +47,10 @@ Click any filament name in the table to see its full details:
 
 ## Deleting a Filament
 
-Deletion goes through the bulk-actions selection bar:
+There are two ways to delete:
 
-1. Tick the checkbox(es) next to one or more rows in the filament list.
-2. A red selection bar appears above the table with **"Delete {count}"**.
-3. Click it and confirm.
+- **From the filament list** — tick the checkbox(es) next to one or more rows. A red selection bar appears above the table with **"Delete {count}"**; click it and confirm.
+- **From the detail page** — click the red **Delete** button in the top-right action row (added in v1.29). It sends the same soft-delete, and is faster when the filament is already open.
 
 Deletion is **soft** — filaments move to the **trash** rather than disappearing for good. The selection bar includes a small "open trash" link so the destination is visible right when you delete.
 
@@ -212,7 +211,7 @@ Each bed type has:
 - **Material** -- the surface material (PEI, Textured PEI, Spring Steel, Glass, G10/FR4, BuildTak, PEX, Polypropylene, Other)
 - **Notes**
 
-Bed types are used in calibrations to store per-printer per-nozzle per-bed-type override values. They cannot be deleted if they are referenced by any filament calibrations.
+Bed types are used in calibrations to store per-printer per-nozzle per-bed-type override values. They cannot be deleted while they are referenced by any filament calibration, installed on any printer, or named in any filament's per-bed-type temperature table — the error message names what's blocking the delete.
 
 ---
 


### PR DESCRIPTION
## Summary
A full audit of the documentation against the current code (the same kind of sweep as #550/#551) turned up several factual inaccuracies — some pre-existing, some introduced by the bed-type-delete guard in #557. Fixed in the English docs **and** their German mirror.

## Findings fixed
| Sev | File(s) | Fix |
|---|---|---|
| **High** | `smart-filament-workflow-guide.md` (Step 21) | Tag writing uses **Write NFC**, not **Export OPT** (which downloads a `.bin` and never touches the reader). Contradicted `nfc.md` + code. |
| Med | `usage.md`, `tutorial.md`, `api.md` (bed-type delete) | Documented as blocked only by calibration refs → now correctly lists all three guards: calibration, printer `installedBedTypes`, and (#557) `bedTypeTemps[].bedType`. `openapi.json` was already fixed in #565. |
| Med | `usage.md` (Deleting a Filament) | Added the detail-page **Delete** button (v1.29) beside the bulk-bar path. |
| Med | `tutorial.md` (Share a Catalog) | No "+ New shared catalog" button — it's the **Publish a new share** form + **Publish**; dropped the non-existent "optional expiry" UI field; noted the new **Open** link (#555). |
| Low | `api.md` (`GET /api/spools/export-csv`) | Filename is static `spools.csv`, not date-stamped. |
| Low | `setup.md` (npm start) | Noted the `start:prep` static-copy step. |

Each correction was verified against the source (route handlers, page components, i18n labels). Every English change is mirrored in `docs/de/*` using the app's actual German UI labels (`NFC beschreiben`, `OPT exportieren`, `Neuen geteilten Katalog veröffentlichen`, `Öffnen`).

## Audit result
The docs were otherwise **overwhelmingly accurate** — endpoint tables, OpenPrintTag/Bambu tag layouts, CBOR keys, NFC pill labels, SSE scan contract, connection modes, installer filenames, coverage thresholds, and CI matrix all checked out.

## Not done (flagged)
The two guide PDFs (`smart-filament-workflow-guide.pdf`, `de/…pdf`) are produced externally (no generation script in-repo); they lag the `.md` by the Step 21 wording only. Worth a separate regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)