### PR TITLE
fix(form): snap NFC-decoded density/diameter to the input step (#570, P1)

### DIFF
--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import CollapsibleSection, { expandAndScrollToSection } from "@/components/CollapsibleSection";
 import FormToc, { FormTocMobileButton, type TocEntry } from "@/components/FormToc";
 import FilamentSwatch from "@/components/FilamentSwatch";
+import { snapToStep } from "@/lib/snapToStep";
 import {
   filterColorSuggestions,
   lookupCssNamedColor,
@@ -247,14 +248,27 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
     secondaryColors: initialData?.secondaryColors ?? [],
     colorName: initialData?.colorName || "",
     cost: initialData?.cost?.toString() || "",
-    density: initialData?.density?.toString() || "",
+    // density + diameter are CBOR half-floats on an OpenPrintTag, so an
+    // NFC/TDS prefill can hand us e.g. 1.2392578125 / 2.849609375. Snap to
+    // the inputs' step="0.01" grid so the value the user sees is one the
+    // field can actually hold — otherwise native step validation blocks
+    // save on every NFC-read filament (#570). Snapping an already-clean
+    // stored value (1.24, 2.85, 1.75) is a no-op.
+    density:
+      initialData?.density != null
+        ? snapToStep(initialData.density, 0.01).toString()
+        : "",
     // Variants leave diameter blank when inheriting from the parent — falling
     // back to "1.75" here would paint a value into the input that the user
     // never typed, and saving would persist 1.75 as an explicit override
     // (even if the parent's diameter is e.g. 2.85). The submit-side fallback
     // in handleSubmit keeps 1.75 as the default for standalone filaments.
     diameter:
-      initialData?.diameter?.toString() || (initialData?.parentId ? "" : "1.75"),
+      initialData?.diameter != null
+        ? snapToStep(initialData.diameter, 0.01).toString()
+        : initialData?.parentId
+          ? ""
+          : "1.75",
     temperatures: {
       nozzle: initialData?.temperatures?.nozzle?.toString() || "",
       nozzleFirstLayer: initialData?.temperatures?.nozzleFirstLayer?.toString() || "",

--- a/src/lib/snapToStep.ts
+++ b/src/lib/snapToStep.ts
@@ -1,0 +1,37 @@
+/**
+ * Snap a number to a numeric `<input step="…">` grid.
+ *
+ * OpenPrintTag stores `density` and `filament_diameter` as CBOR half-floats
+ * (10-bit mantissa → 1/1024 resolution), so a tag programmed with density
+ * 1.24 decodes to 1.2392578125 and a 2.85 mm diameter decodes to
+ * 2.849609375. Threading those raw values straight into the Add-Filament
+ * form's `step="0.01"` inputs trips the browser's native step validation
+ * ("the two nearest valid values are 1.23 and 1.24") and blocks save (#570).
+ *
+ * Rounding the inbound value to the field's own step is the form's job —
+ * decode stays lossless (the round-trip/precision decode tests rely on it),
+ * the form just snaps the value it shows the user to a value the field can
+ * actually hold.
+ *
+ * Rounds to the nearest multiple of `step`, then trims binary floating-point
+ * dust by fixing to the step's own decimal precision (so 285 * 0.01 surfaces
+ * as 2.85, not 2.8500000000000005).
+ *
+ * Non-finite inputs and a non-positive `step` are returned unchanged.
+ */
+export function snapToStep(value: number, step: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(step) || step <= 0) {
+    return value;
+  }
+  const decimals = decimalPlaces(step);
+  const snapped = Math.round(value / step) * step;
+  return Number(snapped.toFixed(decimals));
+}
+
+/** Number of decimal places in a step value (0.01 → 2, 1 → 0, 1e-3 → 3). */
+function decimalPlaces(step: number): number {
+  if (Number.isInteger(step)) return 0;
+  const s = step.toString();
+  if (s.includes("e-")) return parseInt(s.split("e-")[1], 10);
+  return s.split(".")[1]?.length ?? 0;
+}

--- a/tests/snapToStep.test.ts
+++ b/tests/snapToStep.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { snapToStep } from "@/lib/snapToStep";
+
+describe("snapToStep", () => {
+  it("snaps a CBOR half-float density to the 0.01 step (#570)", () => {
+    // 1.24 programmed on a tag decodes to this half-float artifact.
+    expect(snapToStep(1.2392578125, 0.01)).toBe(1.24);
+  });
+
+  it("snaps a 2.85 mm diameter half-float artifact to the 0.01 step", () => {
+    expect(snapToStep(2.849609375, 0.01)).toBe(2.85);
+  });
+
+  it("leaves an already on-step value unchanged", () => {
+    expect(snapToStep(1.75, 0.01)).toBe(1.75);
+    expect(snapToStep(1.24, 0.01)).toBe(1.24);
+    expect(snapToStep(0, 0.01)).toBe(0);
+  });
+
+  it("rounds to the nearest step", () => {
+    expect(snapToStep(1.236, 0.01)).toBe(1.24);
+    expect(snapToStep(1.232, 0.01)).toBe(1.23);
+  });
+
+  it("trims binary floating-point dust", () => {
+    // 285 * 0.01 === 2.8500000000000005 before the toFixed pass.
+    expect(snapToStep(2.849609375, 0.01)).toBe(2.85);
+    expect(Number.isInteger(snapToStep(2.85, 0.01) * 100)).toBe(true);
+  });
+
+  it("supports integer steps", () => {
+    expect(snapToStep(214.7, 1)).toBe(215);
+    expect(snapToStep(215, 1)).toBe(215);
+  });
+
+  it("supports finer steps", () => {
+    expect(snapToStep(1.23456, 0.001)).toBe(1.235);
+  });
+
+  it("returns the value unchanged for a non-positive or non-finite step", () => {
+    expect(snapToStep(1.5, 0)).toBe(1.5);
+    expect(snapToStep(1.5, -0.01)).toBe(1.5);
+    expect(snapToStep(1.5, NaN)).toBe(1.5);
+  });
+
+  it("returns non-finite values unchanged", () => {
+    expect(snapToStep(NaN, 0.01)).toBeNaN();
+    expect(snapToStep(Infinity, 0.01)).toBe(Infinity);
+  });
+});


### PR DESCRIPTION
## Summary
Reading a programmed tag via **Add Filament → New Filament from NFC Tag** filled **Density = `1.2392578125`**, and the density input's `step="0.01"` then rejected it ("the two nearest valid values are 1.23 and 1.24") — so an NFC-read filament **could not be saved** without hand-editing the field (#570, P1).

## Root cause
OpenPrintTag stores `density` and `filament_diameter` as **CBOR half-floats** (10-bit mantissa → 1/1024 resolution). A tag programmed with density `1.24` decodes to `1.2392578125`; a `2.85` mm diameter decodes to `2.849609375`. The form threaded those raw values straight into its `step="0.01"` density/diameter inputs. (The scan modal only *looked* correct because it displays `toFixed(2)`.)

## Fix
Decode must stay lossless — the precision/round-trip decode tests assert the exact float (e.g. `toBeCloseTo(1.2345678, 4)`), so rounding at decode is out. The fix lives at the **form's inbound conversion**: snap `density` and `diameter` to the field's `0.01` step via a new pure helper `snapToStep(value, step)`. Snapping an already-clean stored value (`1.24`, `2.85`, `1.75`) is a no-op, so edit / clone / TDS paths are unaffected.

## Verification (`next dev`)
`/filaments/new?from_nfc=1&name=Test&vendor=Acme&density=1.2392578125&diameter=2.849609375`:
- density input → `1.24`, diameter input → `2.85`, both `checkValidity() === true`
- whole form `checkValidity() === true` → submits

## Tests
`tests/snapToStep.test.ts` (9 cases): half-float density/diameter artifacts, floating-point dust trimming, integer + finer steps, and the non-finite/non-positive-step guards. ESLint + `tsc` clean.

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)