### PR TITLE
fix(nfc): clarify the ready-state badge's behavior in its tooltip (#575 item 7)

### DIFF
--- a/src/components/NfcStatus.tsx
+++ b/src/components/NfcStatus.tsx
@@ -41,6 +41,13 @@ export default function NfcStatus() {
 
   let dotColor: string;
   let label: string;
+  // Optional plain-language hint appended to the tooltip for states whose
+  // short pill label can read as over-promising. GH #575 item 7: "Ready —
+  // place tag" implies a tag resting on the reader will be picked up, but a
+  // read only fires on a fresh placement (the arrival edge) — detection of an
+  // already-resting tag is tracked separately in #572. The hint sets accurate
+  // expectations without bloating the space-constrained pill.
+  let hint: string | null = null;
 
   if (errorHint) {
     // Error takes precedence over reader/tag state — the user needs to
@@ -53,6 +60,7 @@ export default function NfcStatus() {
   } else if (!status.tagPresent) {
     dotColor = "bg-yellow-400";
     label = t("nfc.status.readyPlaceTag");
+    hint = t("nfc.status.readyPlaceTagHint");
   } else {
     dotColor = "bg-green-400";
     // `loadedTagName` is gated on the reader's tagPresent state in the
@@ -72,7 +80,9 @@ export default function NfcStatus() {
   // explains what to do.
   const tooltip = status.lastError
     ? `${label}\n\n${status.lastError.message}`
-    : label;
+    : hint
+      ? `${label}\n\n${hint}`
+      : label;
 
   // GH #451 follow-up (Codex P2 on PR #475): when an NFC scan has
   // landed but the dialog is currently dismissed (either auto-suppressed

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -582,6 +582,7 @@
   "nfc.readDialog.bambuReadOnly": "Bambu Lab Spule (schreibgeschützt)",
   "nfc.status.noReader": "Kein NFC-Leser",
   "nfc.status.readyPlaceTag": "Bereit — Tag auflegen",
+  "nfc.status.readyPlaceTagHint": "Lege einen Tag auf den Reader, um ihn zu lesen — das Ergebnis erscheint überall in der App. Liegt bereits ein Tag auf dem Reader, hebe ihn an und lege ihn erneut auf.",
   "nfc.status.tagDetected": "Tag erkannt",
   "nfc.status.tagDetectedWithUid": "Tag erkannt ({uid})",
   "nfc.status.tagLoaded": "Geladen: {name}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -582,6 +582,7 @@
   "nfc.readDialog.bambuReadOnly": "Bambu Lab spool (read-only)",
   "nfc.status.noReader": "No NFC reader",
   "nfc.status.readyPlaceTag": "Ready — place tag",
+  "nfc.status.readyPlaceTagHint": "Place a tag on the reader to read it — the result opens anywhere in the app. A tag already resting on the reader may need to be lifted and placed again.",
   "nfc.status.tagDetected": "Tag detected",
   "nfc.status.tagDetectedWithUid": "Tag detected ({uid})",
   "nfc.status.tagLoaded": "Loaded: {name}",


### PR DESCRIPTION
## Summary
Completes **#575**. Items 1–6 shipped in v1.34.6 (#578/#579); this addresses the last item.

### #575.7 — "Ready — place tag" badge over-promises
The pill reads as a promise that any tag near the reader gets picked up, but a read only fires on a **fresh placement** (the arrival edge), and the scan result opens **app-wide**, not only inside the Add form. Added a tooltip hint to the ready state:

> *"Place a tag on the reader to read it — the result opens anywhere in the app. A tag already resting on the reader may need to be lifted and placed again."*

"place" is kept (not "tap") because this is a hold-on-reader desktop device (ACR1552U), where you rest the tag on the reader.

This is the **wording** half of item 7. Actually *detecting* an already-resting tag (and recovering a stuck reader session) is the deeper reader-session behavior tracked in **#572** (deferred to a hardware-in-the-loop session).

## Changes
- `src/components/NfcStatus.tsx` — per-state `hint` appended to the pill's tooltip for the ready state.
- `src/i18n/locales/{en,de}.json` — new `nfc.status.readyPlaceTagHint`.

## Notes
- Renderer-only; no change to NFC read/write mechanics. `NfcStatus` renders only in Electron, so this can't be exercised in the web preview — verified by inspection + the i18n key-coverage parity test. ESLint + `tsc` clean.

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)