### PR TITLE
fix(nfc): detect a tag already resting on the reader at connect time (#572)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1251,53 +1251,87 @@ async function initNfc(): Promise<void> {
     let prevTagPresent = false;
     let lastAutoReadAt = 0;
     const AUTO_READ_COOLDOWN_MS = 4000;
+    // GH #572: small settle before the connect-time verification read so the
+    // reader/native layer is past its initial status burst.
+    const PRESENT_AT_CONNECT_VERIFY_MS = 700;
+
+    // Read the tag and route the result to the renderer. `silentOnError`
+    // suppresses the generic error path (used by the #572 connect-time
+    // verification, which must stay quiet when the reader is empty / holds a
+    // card the user didn't deliberately tap). Cooldown-guarded so a real
+    // placement and the verification can't double-read.
+    const triggerAutoRead = (silentOnError: boolean) => {
+      if (!nfcService) return;
+      const now = Date.now();
+      if (now - lastAutoReadAt < AUTO_READ_COOLDOWN_MS) return;
+      // Stamp BEFORE the async read to prevent concurrent triggers.
+      lastAutoReadAt = now;
+      nfcService.readTag()
+        .then((data) => {
+          mainWindow?.webContents.send("nfc-tag-detected", { data });
+        })
+        .catch((err) => {
+          // Phantom-present recovery: PC/SC said `isPresent=true` but
+          // the connect retries (up to ~6s) all failed — the present
+          // bit was a driver/SCARD_STATE_CHANGED artifact, not a real
+          // tag. Without this corrective clear, the renderer pill is
+          // stuck at "Tag detected" indefinitely (the reason behind
+          // this fix). The service handles the actual state mutation;
+          // we don't emit a separate nfc-tag-detected here because
+          // there is no tag to report on.
+          if (err.message?.includes("Cannot connect to tag")) {
+            nfcService?.clearPhantomPresence();
+            return;
+          }
+          // Blank/erased tags have no NDEF data — tell the renderer so it
+          // can show an "empty tag" indication instead of silently ignoring.
+          // Covers an erased NDEF-formatted tag (No NDEF TLV/record) and a
+          // never-formatted blank tag whose all-zero memory has no CC byte
+          // (#556) — both are the friendly "write me to initialize" case,
+          // not a raw error worth surfacing.
+          if (
+            err.message?.includes("No NDEF TLV") ||
+            err.message?.includes("No NDEF record") ||
+            err.message?.includes("Blank or unformatted")
+          ) {
+            mainWindow?.webContents.send("nfc-tag-detected", { empty: true });
+            return;
+          }
+          // #572: the connect-time verification must not surface an
+          // unexpected error (e.g. a non-OpenPrintTag card already sitting on
+          // the reader); only a deliberate present-edge read does.
+          if (silentOnError) return;
+          mainWindow?.webContents.send("nfc-tag-detected", { error: err.message });
+        });
+    };
+
     nfcService.on("statusChange", (status) => {
       mainWindow?.webContents.send("nfc-status-changed", status);
-
-      if (status.tagPresent && !prevTagPresent && nfcService) {
-        const now = Date.now();
-        if (now - lastAutoReadAt < AUTO_READ_COOLDOWN_MS) {
-          prevTagPresent = status.tagPresent;
-          return;
-        }
-        // Set timestamp BEFORE async read to prevent concurrent triggers
-        lastAutoReadAt = now;
-        nfcService.readTag()
-          .then((data) => {
-            mainWindow?.webContents.send("nfc-tag-detected", { data });
-          })
-          .catch((err) => {
-            // Phantom-present recovery: PC/SC said `isPresent=true` but
-            // the connect retries (up to ~6s) all failed — the present
-            // bit was a driver/SCARD_STATE_CHANGED artifact, not a real
-            // tag. Without this corrective clear, the renderer pill is
-            // stuck at "Tag detected" indefinitely (the reason behind
-            // this fix). The service handles the actual state mutation;
-            // we don't emit a separate nfc-tag-detected here because
-            // there is no tag to report on.
-            if (err.message?.includes("Cannot connect to tag")) {
-              nfcService?.clearPhantomPresence();
-              return;
-            }
-            // Blank/erased tags have no NDEF data — tell the renderer so it
-            // can show an "empty tag" indication instead of silently ignoring.
-            // Covers an erased NDEF-formatted tag (No NDEF TLV/record) and a
-            // never-formatted blank tag whose all-zero memory has no CC byte
-            // (#556) — both are the friendly "write me to initialize" case,
-            // not a raw error worth surfacing.
-            if (
-              err.message?.includes("No NDEF TLV") ||
-              err.message?.includes("No NDEF record") ||
-              err.message?.includes("Blank or unformatted")
-            ) {
-              mainWindow?.webContents.send("nfc-tag-detected", { empty: true });
-              return;
-            }
-            mainWindow?.webContents.send("nfc-tag-detected", { error: err.message });
-          });
+      if (status.tagPresent && !prevTagPresent) {
+        triggerAutoRead(false);
       }
       prevTagPresent = status.tagPresent;
     });
+
+    // GH #572: a tag already resting on the reader at connect time only
+    // produces the first (skipped) status event, so the present-edge path
+    // above never fires. The service emits `presentAtConnect` when that first
+    // event reported present — do a one-shot, silent verification read. A
+    // real tag connects and reads (its connect emits an INUSE status event
+    // that flips tagPresent), and the cooldown stops that from double-reading;
+    // an empty reader / phantom fails the connect and stays quiet. Gated on no
+    // tag already detected (a real placement during the settle wins).
+    nfcService.on("presentAtConnect", () => {
+      setTimeout(() => {
+        if (
+          nfcService?.getStatus().readerConnected &&
+          !nfcService.getStatus().tagPresent
+        ) {
+          triggerAutoRead(true);
+        }
+      }, PRESENT_AT_CONNECT_VERIFY_MS);
+    });
+
     nfcService.on("error", (err) => {
       console.error("NFC error:", err.message);
     });

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -146,6 +146,22 @@ export class NfcService extends EventEmitter {
         // throwing a scary error on every plug-in.
         if (firstStatus) {
           firstStatus = false;
+          // GH #572: PC/SC reports a tag already resting on the reader at
+          // connect time as this very first status event — which we skip to
+          // dodge the documented plug-in phantom (GH #230). For a tag that
+          // never moves there is no further state-change event, so the
+          // present-edge auto-read in main.ts never fires and the pill stays
+          // "Ready — place tag" while a tag is sitting there. We still skip
+          // (not flipping tagPresent here keeps the SAM-slot persistent
+          // phantom from blocking tag-removal detection), but signal that a
+          // card MIGHT be resting so the main process can do a one-shot,
+          // silent verification read: a real tag connects and reads (its
+          // connect emits an INUSE status event that flips tagPresent
+          // organically); a phantom/empty reader fails the connect and stays
+          // quiet.
+          if (isPresent) {
+            this.emit("presentAtConnect");
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary
Fixes the long-standing #572: an NFC tag already resting on the reader isn't detected (you have to lift + re-tap), and it "regresses from time to time."

## Root cause (confirmed live on hardware)
The reader-status handler skips the **first** PC/SC status event per reader to dodge the documented plug-in *phantom* (GH #230). But PC/SC reports a tag that's **already resting** on the reader as exactly that first event — and a tag that never moves produces no further state-change event. So `tagPresent` never flips, the present-edge auto-read never fires, and the pill sits at "Ready — place tag" with a tag on the reader.

Instrumented log on a physical ACR1552U with a tag resting at startup:
```
Reader(1) first event present=true first=true → SKIPPED   ← the resting tag's only event, discarded
```
And because the first-event flag resets on every reader re-discovery (USB churn / sleep-wake / the ACR1552U exposing **two** reader instances), it intermittently regresses — exactly the reported symptom.

## Fix
When that skipped first event reports `present`, the service emits a new **`presentAtConnect`** signal, and the main process does **one** best-effort, **silent** verification read after a short settle:
- A **real tag** connects and reads — and the connect's INUSE status event flips `tagPresent` organically → detected.
- An **empty reader / phantom** fails the connect and stays quiet (and the verification only runs when the first event actually reported a card, so an empty reader does no wasted read and shows no popup).
- The present-edge auto-read is **cooldown-guarded**, so the verification can't double-read.
- We still **skip** (don't flip `tagPresent`) on the first event itself, so the Linux SAM-slot *persistent* phantom can't block tag-removal detection — the existing GH #230 protection is preserved.

`main.ts`: the auto-read body is extracted into a `triggerAutoRead(silentOnError)` helper shared by the present-edge path and the connect-time verification.

## Verification (hardware-in-the-loop, ACR1552U / macOS)
Walked through it live on a physical reader:
- ✅ Tag **resting at startup** → now auto-detected (`presentAtConnect` → verification read → connect → `tagPresent` flips → read dialog)
- ✅ **Empty** reader at startup → first event `present=false` → no verification, no popup
- ✅ Tag **removal** → still clears correctly
- ✅ Normal **fresh placement** → still immediate

The reader-session handler is driven entirely by pcsclite reader/status events and has no unit harness in the repo, so it was validated with the hardware in the loop (logs captured each transition).

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)