### PR TITLE
Fix dark-mode native controls (dropdowns/scrollbars) via color-scheme (#598)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,13 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
+  /* Tell the browser to render native UI (the `<select>` option popup,
+   * scrollbars, date/color pickers, form-control text) in light mode by
+   * default; `html.dark` flips it to dark. Without this, class-based dark
+   * mode leaves the OS-drawn `<option>` list white with light text —
+   * unreadable (GH #598). The `.dark` rule below is more specific, so it
+   * wins when the dark class is present. */
+  color-scheme: light;
   --background: #ffffff;
   --foreground: #171717;
   /* Height of the persistent global AppHeader (rendered by app/layout.tsx).
@@ -27,6 +34,9 @@
 }
 
 html.dark {
+  /* Native controls (select option lists, scrollbars, pickers) follow the
+   * dark theme — fixes the white-popup-with-light-text dropdown (GH #598). */
+  color-scheme: dark;
   --background: #0a0a0a;
   --foreground: #ededed;
 }


### PR DESCRIPTION
Closes #598.

## Problem
In dark mode, opening a `<select>` (e.g. the spool **Location** picker) shows the option popup with a **white background and light-gray text** — nearly unreadable (see reporter's screenshot). Same root issue affects scrollbars and date/color pickers.

## Root cause
The app does class-based dark mode (`html.dark`) but **never sets the `color-scheme` CSS property** (verified: the codebase only uses `prefers-color-scheme` *media queries*, never the property). Browsers render OS-drawn native UI — the `<option>` list, scrollbars, pickers — according to `color-scheme`, which defaulted to light. The *closed* control looks fine because it's Tailwind-styled; the OS-drawn popup isn't.

## Fix
`src/app/globals.css`:
- `:root { color-scheme: light; }`
- `html.dark { color-scheme: dark; }` (more specific, wins under the dark class)

One CSS declaration per theme — every native control now follows the active theme. No JS, no per-component changes.

## Verification
- CSS-only; build + existing suite unaffected.
- The `<option>` popup is OS-drawn (not in the DOM), so this is the canonical fix; the closed-control Tailwind styling is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)