### PR TITLE
fix(swatch): preserve color through translucent/transparent finish

### DIFF
--- a/src/components/FilamentSwatch.tsx
+++ b/src/components/FilamentSwatch.tsx
@@ -190,45 +190,61 @@ export default function FilamentSwatch({
       ? `${title ?? baseColor} · ${finish}`
       : title;
 
-  // Transparent / translucent: real alpha over a checkered backdrop.
-  // Falls back to a neutral light grey if we couldn't parse the hex
-  // (callers do their own sanity checks; this is belt-and-braces).
+  // Transparent / translucent: actual color as the base + a diagonal
+  // cross-hatch overlay as the "see-through" cue. The earlier treatment
+  // (real alpha over a light-grey checker) washed dark colors into
+  // mid-grey — a translucent smoky-black PVB rendered as the same
+  // neutral gray as the parent "color group" swatch (user feedback,
+  // 2026-06). The hatch overlay keeps the see-through reading while
+  // letting the underlying color stay recognisable.
+  //
+  // Hatch line color is picked from the base color's luminance so the
+  // pattern reads on both dark (white-ish hatch) and light (dark-grey
+  // hatch) fills. Translucent uses a denser/heavier hatch; transparent
+  // uses a sparser/lighter one so the two finishes stay visually
+  // distinct (translucent reads more "milky", transparent more "airy").
+  //
+  // Falls back to the prior checker treatment if we couldn't parse the
+  // hex — that path is unreachable in practice (every caller validates)
+  // but keeps belt-and-braces behaviour on bad input.
   if ((finish === "transparent" || finish === "translucent") && rgb) {
-    const alpha = finish === "transparent" ? 0.25 : 0.55;
-    const fillRgba = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+    const isDark = relativeLuminance(rgb) < 0.5;
+    // Line colors:
+    //   dark fill → light hatch (whiteish)
+    //   light fill → dark hatch (slate-grey)
+    // Translucent has higher opacity → reads as a denser milky texture.
+    // Transparent is half that opacity + slightly thinner repeat →
+    // reads as a lighter, more see-through texture.
+    const hatchOpacity = finish === "translucent" ? 0.55 : 0.3;
+    const lineRgba = isDark
+      ? `rgba(255, 255, 255, ${hatchOpacity})`
+      : `rgba(31, 41, 55, ${hatchOpacity})`;
+    // Translucent: 2px line every 6px, both diagonals (denser cross-hatch).
+    // Transparent: 1px line every 7px, both diagonals (sparser).
+    const lineWidth = finish === "translucent" ? 2 : 1;
+    const gap = finish === "translucent" ? 6 : 7;
     return (
       <div
         className={`rounded-full border border-gray-400 dark:border-gray-500 flex-shrink-0 relative overflow-hidden ${className}`}
-        style={dimensionStyle}
+        style={{ ...dimensionStyle, backgroundColor: baseColor }}
         title={finalTitle}
         aria-label={finalLabel}
         role="img"
         data-finish={finish}
       >
-        {/* Checker backdrop — the universal "this is see-through" signal. */}
+        {/* Diagonal cross-hatch overlay — the see-through cue, riding
+            on top of the filament's actual color rather than replacing
+            it with a wash. Mirrors the parent "color group" hatch
+            geometry so the visual vocabulary is consistent. */}
         <div
           aria-hidden="true"
           style={{
             position: "absolute",
             inset: 0,
-            backgroundColor: "#f3f4f6",
             backgroundImage: [
-              "linear-gradient(45deg, #cbd5e1 25%, transparent 25%)",
-              "linear-gradient(-45deg, #cbd5e1 25%, transparent 25%)",
-              "linear-gradient(45deg, transparent 75%, #cbd5e1 75%)",
-              "linear-gradient(-45deg, transparent 75%, #cbd5e1 75%)",
+              `repeating-linear-gradient(45deg, ${lineRgba} 0 ${lineWidth}px, transparent ${lineWidth}px ${gap}px)`,
+              `repeating-linear-gradient(-45deg, ${lineRgba} 0 ${lineWidth}px, transparent ${lineWidth}px ${gap}px)`,
             ].join(", "),
-            backgroundSize: "6px 6px",
-            backgroundPosition: "0 0, 0 3px, 3px -3px, -3px 0",
-          }}
-        />
-        {/* Tinted alpha overlay — the filament's actual color, washed. */}
-        <div
-          aria-hidden="true"
-          style={{
-            position: "absolute",
-            inset: 0,
-            backgroundColor: fillRgba,
           }}
         />
       </div>


### PR DESCRIPTION
## Problem

Translucent and transparent swatches were rendering as a flat mid-grey checker — the actual filament color got washed out so badly it was indistinguishable from the neutral 'color group' (parent) swatch.

You reported it on a real \`PVB Smoky Black\` row in the inventory list — even though that filament is stored as a mid-grey hex, the rendered swatch lost the color entirely. With a true dark hex (e.g. #202020) the math is even worse:

> smoky-black #202020 at 55% alpha over light checker (#f3f4f6) → rgb(127) — pure mid-grey

Root cause: the previous treatment was \`color at alpha\` over a \`light-grey checker\` backdrop. That layering deletes any base color whose luminance is far from the checker's.

## Fix

Invert the layering:

- **Base** = the actual filament color at full opacity
- **Overlay** = a diagonal cross-hatch (luminance-aware line color) that conveys "see-through" without nuking the color

Translucent gets a dense hatch (2px / 6px gap, line opacity 0.55) so it reads as a milky/frosted texture. Transparent gets a sparser hatch (1px / 7px gap, line opacity 0.3) so it reads as a more open / airier texture — visually distinct so the two finishes don't collapse.

Same hatch geometry as the parent 'color group' swatch, so the visual vocabulary stays consistent.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean (one pre-existing \`qrcode\` types warning, unrelated)
- [x] \`tests/filamentFinish.test.ts\` (finish derivation) passes 10/10
- [ ] Manual — pull the branch, open the filament list, confirm the PVB Smoky Black swatch now shows mid-grey with a dark hatch overlay (and that a translucent dark-color filament shows the dark color with a light hatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)