### PR TITLE
fix(openprinttag): import multicolor materials with correct colors + arrangement (#604)

### DIFF
--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -130,8 +130,22 @@ const TAG_STRING_TO_OPT: Record<string, string> = {
   color_changing: "COLOR_CHANGING",
   fuzzy: "FUZZY",
   gradient: "GRADIENT",
+  // GH #604: real-world OPT YAMLs use `gradual_color_change` for the
+  // gradient arrangement. Without this alias the parser drops the tag,
+  // optTags doesn't get OPT_TAG.GRADIENT (27), and `deriveArrangement`
+  // returns "solid" — so the imported filament renders as a flat
+  // single-color swatch instead of a gradient even when its
+  // secondary_colors list is fully populated.
+  gradual_color_change: "GRADIENT",
   dual_color: "DUAL_COLOR",
   triple_color: "TRIPLE_COLOR",
+  // GH #604: the same canonical-vs-real-world divergence as gradient
+  // applies to the coextruded arrangement — the spec docs use
+  // `dual_color`/`triple_color` but real OPT YAMLs use the more
+  // descriptive `coextruded` tag. Map it to DUAL_COLOR by default;
+  // `deriveArrangement` collapses both DUAL/TRIPLE into "coextruded"
+  // anyway, so the slot count is already implicit in secondaryColors.
+  coextruded: "DUAL_COLOR",
   hygroscopic: "HYGROSCOPIC",
   anti_static: "ANTI_STATIC",
   esd_safe: "ESD_SAFE",
@@ -243,21 +257,50 @@ export function parseMaterialYaml(
     const brand = brandMap.get(brandSlug);
     const props = (raw.properties || {}) as Record<string, unknown>;
     const primaryColor = raw.primary_color as Record<string, unknown> | undefined;
-    // GH #477: parse secondary_color_0..4 in slot order (spec keys 20–24).
-    // Each is a `{ color_rgba: "AABBCCDD" }` object on the raw material;
-    // rgbaToHex drops the alpha to match our `#RRGGBB`-only model.
-    const SECONDARY_KEYS = [
-      "secondary_color_0",
-      "secondary_color_1",
-      "secondary_color_2",
-      "secondary_color_3",
-      "secondary_color_4",
-    ];
+    // GH #477 / GH #604: secondary colors can arrive in two shapes.
+    //
+    //   1. Modern OPT db (real-world data, e.g. amolen-*-multicolor-* YAMLs):
+    //      a flat list under `secondary_colors:` (plural), each entry
+    //      `{ color_rgba: "RRGGBBAA" }`.
+    //   2. Spec-aligned keyed slots `secondary_color_0..4:` (singular),
+    //      each entry `{ color_rgba: "RRGGBBAA" }`. Spec keys 20–24.
+    //
+    // The pre-#604 parser only read shape (2), so every multi-color
+    // OPT-imported filament came in with secondaryColors = [], the
+    // primary fell back to "#808080", and the filament rendered as a
+    // single grey swatch with no arrangement.
+    //
+    // Read shape (1) first because that's what the actual OPT database
+    // emits; fall through to (2) so we stay forward-compatible if a
+    // future schema cleanup keys the slots individually. In either case
+    // rgbaToHex drops the alpha byte (we model RGB only) and we cap at
+    // 5 entries to match the spec.
     const secondaryColors: string[] = [];
-    for (const key of SECONDARY_KEYS) {
-      const slot = raw[key] as Record<string, unknown> | undefined;
-      const hex = rgbaToHex(slot?.color_rgba as string | undefined);
-      if (hex) secondaryColors.push(hex);
+    const SECONDARY_CAP = 5;
+    const secondaryList = raw.secondary_colors;
+    if (Array.isArray(secondaryList)) {
+      for (const entry of secondaryList.slice(0, SECONDARY_CAP)) {
+        const hex = rgbaToHex(
+          (entry as Record<string, unknown> | null | undefined)?.color_rgba as
+            | string
+            | undefined,
+        );
+        if (hex) secondaryColors.push(hex);
+      }
+    }
+    if (secondaryColors.length === 0) {
+      const SECONDARY_KEYS = [
+        "secondary_color_0",
+        "secondary_color_1",
+        "secondary_color_2",
+        "secondary_color_3",
+        "secondary_color_4",
+      ];
+      for (const key of SECONDARY_KEYS) {
+        const slot = raw[key] as Record<string, unknown> | undefined;
+        const hex = rgbaToHex(slot?.color_rgba as string | undefined);
+        if (hex) secondaryColors.push(hex);
+      }
     }
     const photos = raw.photos as Array<Record<string, unknown>> | undefined;
 

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -361,6 +361,94 @@ type: PLA`;
     expect(m).not.toBeNull();
     expect(m!.brandName).toBe("unknown-brand");
   });
+
+  // GH #604: real OPT YAMLs put secondary colors in a list under the
+  // `secondary_colors:` (plural) key and tag the gradient arrangement
+  // as `gradual_color_change`, not the spec-doc `gradient`. Pre-fix the
+  // parser only read the keyed `secondary_color_0..4` slots and only
+  // knew about the `gradient` tag string, so every multicolor OPT
+  // import landed as a single grey filament with no arrangement.
+  it("parses the secondary_colors list shape and gradual_color_change tag (GH #604)", () => {
+    // Verbatim shape from
+    // openprinttag-database/main-pr/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-gold.yaml
+    // — primary_color absent, three secondaries under a YAML list, gradient
+    // declared via `gradual_color_change`.
+    const yaml = `uuid: ccf32809-fbef-527a-8487-ccb75ceafab6
+slug: amolen-pla-silk-shiny-gradient-black-shiny-red-gold
+brand:
+  slug: amolen
+name: PLA Silk Shiny Gradient Black & Shiny Red Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#000000ff'
+- color_rgba: '#98282fff'
+- color_rgba: '#ddb95dff'
+tags:
+- silk
+- gradual_color_change
+- industrially_compostable
+properties:
+  density: 1.28`;
+
+    const m = parseMaterialYaml(yaml, new Map([["amolen", { name: "Amolen" }]]));
+    expect(m).not.toBeNull();
+    // No primary color → null. allColors() will fall through to secondaries.
+    expect(m!.color).toBeNull();
+    // Three secondaries in the right order, alpha byte stripped.
+    expect(m!.secondaryColors).toEqual(["#000000", "#98282f", "#ddb95d"]);
+    // Raw tags pass through unchanged; mapToFilamentPayload does the
+    // alias resolution to optTag numbers.
+    expect(m!.tags).toEqual(["silk", "gradual_color_change", "industrially_compostable"]);
+  });
+
+  it("caps secondary_colors at 5 entries (spec keys 20-24)", () => {
+    const yaml = `uuid: abc
+slug: too-many-colors
+brand:
+  slug: amolen
+name: Rainbow Plus
+class: FFF
+type: PLA
+secondary_colors:
+- color_rgba: '#ff0000ff'
+- color_rgba: '#00ff00ff'
+- color_rgba: '#0000ffff'
+- color_rgba: '#ffff00ff'
+- color_rgba: '#ff00ffff'
+- color_rgba: '#00ffffff'
+- color_rgba: '#ffffffff'`;
+    const m = parseMaterialYaml(yaml, new Map([["amolen", { name: "Amolen" }]]));
+    expect(m).not.toBeNull();
+    expect(m!.secondaryColors).toHaveLength(5);
+    expect(m!.secondaryColors).toEqual([
+      "#ff0000",
+      "#00ff00",
+      "#0000ff",
+      "#ffff00",
+      "#ff00ff",
+    ]);
+  });
+
+  it("still parses the legacy keyed secondary_color_0..4 shape", () => {
+    // Belt-and-braces — if an older spec snapshot or a future schema
+    // tidy-up keys the slots individually, we still get the colors.
+    const yaml = `uuid: def
+slug: legacy-keyed
+brand:
+  slug: amolen
+name: Legacy Keyed
+class: FFF
+type: PLA
+secondary_color_0:
+  color_rgba: '#aa0000ff'
+secondary_color_1:
+  color_rgba: '#00aa00ff'`;
+    const m = parseMaterialYaml(yaml, new Map([["amolen", { name: "Amolen" }]]));
+    expect(m).not.toBeNull();
+    expect(m!.secondaryColors).toEqual(["#aa0000", "#00aa00"]);
+  });
 });
 
 describe("mapToFilamentPayload", () => {
@@ -449,6 +537,92 @@ describe("mapToFilamentPayload", () => {
 
     const payload = mapToFilamentPayload(material);
     expect(payload.color).toBe("#808080");
+  });
+
+  // GH #604: the OPT YAML uses `gradual_color_change` for the gradient
+  // arrangement. The pre-fix TAG_STRING_TO_OPT only knew `gradient`,
+  // so the resolved optTags array didn't include 27 (GRADIENT) and the
+  // imported filament rendered as a solid swatch even when secondary
+  // colors were populated.
+  it("aliases gradual_color_change to OPT_TAG.GRADIENT (#604)", () => {
+    const material = {
+      slug: "test-gradient",
+      uuid: "test-uuid",
+      brandSlug: "amolen",
+      brandName: "Amolen",
+      name: "Gradient",
+      type: "PLA",
+      abbreviation: "PLA",
+      color: null,
+      secondaryColors: ["#000000", "#98282f", "#ddb95d"],
+      density: 1.28,
+      nozzleTempMin: null,
+      nozzleTempMax: null,
+      bedTempMin: null,
+      bedTempMax: null,
+      chamberTemp: null,
+      preheatTemp: null,
+      dryingTemp: null,
+      dryingTime: null,
+      hardnessShoreD: null,
+      transmissionDistance: null,
+      tags: ["silk", "gradual_color_change", "industrially_compostable"],
+      photoUrl: null,
+      productUrl: null,
+      completenessScore: 4,
+      completenessTier: "partial" as const,
+    };
+
+    const payload = mapToFilamentPayload(material);
+    const optTags = payload.optTags as number[];
+    // SILK = 17, GRADIENT = 27, BIODEGRADABLE = 12 (industrially_compostable
+    // alias). The order in the array isn't asserted — `deriveArrangement`
+    // looks them up by `includes`.
+    expect(optTags).toContain(17);
+    expect(optTags).toContain(27);
+    expect(optTags).toContain(12);
+    // And the multi-color slots survive into the payload — null primary
+    // (no `#808080` phantom) so allColors() falls through to the
+    // secondary list at render time.
+    expect(payload.color).toBeNull();
+    expect(payload.secondaryColors).toEqual(["#000000", "#98282f", "#ddb95d"]);
+  });
+
+  it("aliases coextruded to OPT_TAG.DUAL_COLOR so the arrangement renders (#604)", () => {
+    const material = {
+      slug: "test-coextruded",
+      uuid: "test-uuid",
+      brandSlug: "amolen",
+      brandName: "Amolen",
+      name: "Dual",
+      type: "PLA",
+      abbreviation: "PLA",
+      color: null,
+      secondaryColors: ["#000000", "#ffffff"],
+      density: null,
+      nozzleTempMin: null,
+      nozzleTempMax: null,
+      bedTempMin: null,
+      bedTempMax: null,
+      chamberTemp: null,
+      preheatTemp: null,
+      dryingTemp: null,
+      dryingTime: null,
+      hardnessShoreD: null,
+      transmissionDistance: null,
+      tags: ["coextruded"],
+      photoUrl: null,
+      productUrl: null,
+      completenessScore: 1,
+      completenessTier: "stub" as const,
+    };
+
+    const payload = mapToFilamentPayload(material);
+    const optTags = payload.optTags as number[];
+    // DUAL_COLOR = 28 — deriveArrangement collapses DUAL/TRIPLE into
+    // "coextruded", so the slot count being 2 vs 3 doesn't change the
+    // rendered arrangement.
+    expect(optTags).toContain(28);
   });
 
   it("maps abrasive tag to optTags", () => {


### PR DESCRIPTION
## Summary

Closes [#604](https://github.com/hyiger/filament-db/issues/604). The reported material:

> https://github.com/OpenPrintTag/openprinttag-database/blob/main-pr/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-gold.yaml

imports as a single \`#808080\` (the gray default), no color name, no arrangement — instead of a gradient with three colors. Two adjacent bugs in \`src/lib/openprinttagBrowser.ts\`:

1. The parser looked for keyed slots \`secondary_color_0..4:\`, but every multicolor YAML in the upstream OPT database uses a **list under \`secondary_colors:\` (plural)**. The slot loop returned an empty array, so \`mapToFilamentPayload\`'s \`color: m.color || (secondaryColors.length > 0 ? null : \"#808080\")\` fall-through hit the gray default — exactly the symptom on the issue.

2. \`TAG_STRING_TO_OPT\` mapped \`gradient\` but not \`gradual_color_change\` (real YAMLs use the latter). Without the alias the GRADIENT (27) tag was never added, and \`deriveArrangement\` returned \"solid\". Same gap for \`coextruded\` → \`DUAL_COLOR\` (28).

## Fix

- Parse \`secondary_colors:\` list first (real-world shape); fall through to the keyed loop as belt-and-braces.
- Cap at 5 entries to match the spec keys 20–24.
- Add \`gradual_color_change\` → GRADIENT and \`coextruded\` → DUAL_COLOR to \`TAG_STRING_TO_OPT\`.

## Tests

5 new in \`tests/openprinttagBrowser.test.ts\`:

- The exact reported YAML round-trips with null primary + three secondaries + raw \`gradual_color_change\` tag pass-through
- 5-entry cap (drops items 6+)
- Legacy keyed-slot path still works (forward compat)
- \`mapToFilamentPayload\` aliases \`gradual_color_change\` → optTag 27 (GRADIENT) and preserves null primary + secondaries
- \`mapToFilamentPayload\` aliases \`coextruded\` → optTag 28 (DUAL_COLOR)

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean (one pre-existing \`qrcode\` types warning, unrelated)
- [x] \`npm test\` — 1845/1845 passing (5 new)
- [ ] Manual: open OpenPrintTag browser → search 'amolen-pla-silk' → import the reported material → confirm it lands with null primary + three secondaries + gradient arrangement (swatch reads as a smooth left→right gradient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)