### PR TITLE
fix(electron): NFC init hangs the main process on Linux when pcscd isn't running (#609)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1238,6 +1238,26 @@ function isSmartCardServiceRunning(timeoutMs = 5000): Promise<boolean> {
 }
 
 /**
+ * GH #609: on Linux, @pokusew/pcsclite's synchronous `pcsclite()` call
+ * establishes a PC/SC context that blocks/spins the main thread when the
+ * pcscd daemon isn't running — the same event-loop wedge as the Windows
+ * SCardSvr case (GH #176). With the event loop stuck right after the window
+ * is shown, the renderer never presents: on Wayland no window appears at all,
+ * on X11 the WM maps a blank "Not Responding" frame. pcscd exposes a Unix
+ * socket while running, so its absence is a fast, non-blocking signal that NFC
+ * init would hang — skip it in that case. Honours PCSCLITE_CSOCK_NAME for
+ * non-default socket locations.
+ */
+function isPcscdRunning(): boolean {
+  const custom = process.env.PCSCLITE_CSOCK_NAME;
+  if (custom) return fs.existsSync(custom);
+  return (
+    fs.existsSync("/run/pcscd/pcscd.comm") ||
+    fs.existsSync("/var/run/pcscd/pcscd.comm")
+  );
+}
+
+/**
  * Initialize the NFC service. Deferred until the main window is visible
  * (wired to the window's "show" event) — `new NfcService()` calls
  * `pcsclite()`, whose native constructor runs a synchronous
@@ -1254,13 +1274,17 @@ async function initNfc(): Promise<void> {
   if (nfcInitStarted) return;
   nfcInitStarted = true;
 
-  // Skipped on Windows when SCardSvr is stopped — pcsclite()'s sync
-  // SCardEstablishContext blocks the main thread there (GH #176). On
-  // Linux/Mac the probe is a no-op and the service is attempted as before.
+  // Skipped when the platform's smart-card service isn't available, because
+  // pcsclite()'s synchronous SCardEstablishContext blocks/spins the main
+  // thread there: Windows when SCardSvr is stopped (GH #176), and Linux when
+  // pcscd isn't running (GH #609 — the blank / "Not Responding" window). macOS
+  // uses CryptoTokenKit and has no equivalent wedge, so it's attempted as before.
   const skipNfcReason =
     process.platform === "win32" && !(await isSmartCardServiceRunning())
       ? "Smart Card service (SCardSvr) is not running on this Windows host"
-      : null;
+      : process.platform === "linux" && !isPcscdRunning()
+        ? "pcscd (PC/SC smart-card daemon) is not running on this Linux host"
+        : null;
   if (skipNfcReason) {
     diag(`skipping NFC init: ${skipNfcReason}`);
     return;


### PR DESCRIPTION
## Summary
Fixes #609 — on Linux the app starts but hangs on a blank / "uninitialized" window.

**Root cause:** `initNfc()` (fired on window-show) calls `new NfcService()` → `pcsclite()`, whose native constructor runs a **synchronous `SCardEstablishContext`**. When the **pcscd** daemon isn't running, that call **blocks/spins the main thread**. With the event loop wedged right after the window is shown, the renderer never presents:
- **Wayland:** the surface never commits a buffer → **no window appears at all**
- **X11/XWayland:** the WM maps the frame anyway → **blank "Not Responding" window**

The existing guard for this exact failure mode (the synchronous pcsclite wedge) only covered **Windows** (`SCardSvr`). Linux had none, even though the code comments already flagged it as a known risk (GH #238, Raspberry Pi OS).

## Fix
Extend the skip-NFC guard to Linux: when pcscd's Unix socket is absent, skip NFC init entirely instead of constructing `NfcService`. The check is a fast, non-blocking `fs.existsSync` on the pcscd socket (`/run/pcscd/pcscd.comm`, with `/var/run` fallback and `PCSCLITE_CSOCK_NAME` honoured). On hosts without a running PC/SC daemon, NFC simply stays disabled and the app loads normally; where pcscd is running, behaviour is unchanged.

## Testing
Reproduced on **arm64 Ubuntu / GNOME-Wayland** with pcscd not installed/running:
- **Before:** native Wayland → no window; forced X11 → blank "Not Responding" frame (clicking *Wait* doesn't recover — the loop is spinning).
- **After:** `[diag] skipping NFC init: pcscd ... is not running`, `ready-to-show` fires, main process idle (`Sl`, not `Rl`), and the **full UI renders** under native Wayland (no GPU flags, no X11 forcing needed).

## Note
Earlier revisions of this branch chased a GPU/Ozone angle (hence the branch name) — those were treating symptoms. The NFC main-thread wedge is the actual root cause; this PR is scoped to that one fix.

For the reporter: confirm whether `systemctl status pcscd` shows it stopped/not-installed — that's the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
