### PR TITLE
fix(ci): unblock audit gate, harden release-bump input, test hygiene

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,8 +10,36 @@ permissions:
   packages: write
 
 jobs:
+  # GH #641: docker.yml is triggered by the same `v*` tag as release.yml,
+  # but used to go straight checkout → buildx → push with no gate — a tag
+  # cut on a broken commit published a broken `latest` image even while
+  # every release.yml leg failed. Mirror release.yml's lint + test steps
+  # so the image only publishes from a green commit.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install PC/SC development headers (Linux)
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
   docker:
     runs-on: ubuntu-latest
+    needs: test
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -48,11 +48,18 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    env:
+      # GH #636: never interpolate the raw workflow input into shell text —
+      # `${{ }}` substitution happens BEFORE bash parses the script, so
+      # metacharacters in the input would execute (even inside the semver
+      # validation below). Reference "$VERSION" instead; the env assignment
+      # passes the value as data, not script text.
+      VERSION: ${{ github.event.inputs.version }}
     steps:
       - name: Validate version format
         run: |
-          if ! [[ "${{ github.event.inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Version '${{ github.event.inputs.version }}' is not semver (X.Y.Z or X.Y.Z-prerelease). Aborting."
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' is not semver (X.Y.Z or X.Y.Z-prerelease). Aborting."
             exit 1
           fi
 
@@ -95,13 +102,13 @@ jobs:
 
       - name: Check version isn't already used
         run: |
-          if git rev-parse "v${{ github.event.inputs.version }}" >/dev/null 2>&1; then
-            echo "::error::Tag v${{ github.event.inputs.version }} already exists. Pick a higher version."
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists. Pick a higher version."
             exit 1
           fi
           CURRENT=$(node -p "require('./package.json').version")
-          if [ "$CURRENT" = "${{ github.event.inputs.version }}" ]; then
-            echo "::error::package.json is already at ${{ github.event.inputs.version }}. Pick a higher version."
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "::error::package.json is already at $VERSION. Pick a higher version."
             exit 1
           fi
 
@@ -113,7 +120,7 @@ jobs:
       - name: Create bump branch
         id: branch
         run: |
-          BRANCH="bump/v${{ github.event.inputs.version }}"
+          BRANCH="bump/v$VERSION"
           git checkout -b "$BRANCH"
           echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
 
@@ -122,7 +129,7 @@ jobs:
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '${{ github.event.inputs.version }}';
+            pkg.version = process.env.VERSION;
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
@@ -139,14 +146,14 @@ jobs:
           node -e "
             const fs = require('fs');
             const api = JSON.parse(fs.readFileSync('public/openapi.json', 'utf8'));
-            api.info.version = '${{ github.event.inputs.version }}';
+            api.info.version = process.env.VERSION;
             fs.writeFileSync('public/openapi.json', JSON.stringify(api, null, 2) + '\n');
           "
 
       - name: Commit
         run: |
           git add package.json package-lock.json public/openapi.json
-          git commit -m "Bump version to ${{ github.event.inputs.version }}"
+          git commit -m "Bump version to $VERSION"
 
       - name: Push branch
         run: git push -u origin "${{ steps.branch.outputs.name }}"
@@ -159,10 +166,10 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_BUMP_TOKEN }}
         run: |
           PR_URL=$(gh pr create \
-            --title "Bump version to ${{ github.event.inputs.version }}" \
+            --title "Bump version to $VERSION" \
             --body "Automated version bump produced by the Release Bump workflow.
 
-          Updates package.json, package-lock.json, and public/openapi.json to **${{ github.event.inputs.version }}**.
+          Updates package.json, package-lock.json, and public/openapi.json to **$VERSION**.
 
           Auto-merge is enabled — this will land as soon as CI passes.
 
@@ -170,8 +177,8 @@ jobs:
           \`\`\`bash
           git checkout main
           git pull
-          git tag v${{ github.event.inputs.version }}
-          git push origin v${{ github.event.inputs.version }}
+          git tag v$VERSION
+          git push origin v$VERSION
           \`\`\`
           The tag push triggers the existing \`release.yml\` build matrix.")
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
@@ -186,7 +193,7 @@ jobs:
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           ## Bump PR opened
-          - **Version**: \`${{ github.event.inputs.version }}\`
+          - **Version**: \`$VERSION\`
           - **Branch**: \`${{ steps.branch.outputs.name }}\`
           - **PR**: ${{ steps.pr.outputs.url }}
           - **Auto-merge**: enabled (squash) — will land when CI passes
@@ -194,7 +201,7 @@ jobs:
           ## After the PR merges
           \`\`\`bash
           git checkout main && git pull
-          git tag v${{ github.event.inputs.version }}
-          git push origin v${{ github.event.inputs.version }}
+          git tag v$VERSION
+          git push origin v$VERSION
           \`\`\`
           EOF

--- a/package-lock.json
+++ b/package-lock.json
@@ -803,7 +803,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1647,7 +1646,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1670,7 +1668,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1693,7 +1690,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1710,7 +1706,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1727,7 +1722,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1744,7 +1738,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1761,7 +1754,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1778,7 +1770,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1795,7 +1786,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1812,7 +1802,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1829,7 +1818,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1846,7 +1834,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1863,7 +1850,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1886,7 +1872,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1909,7 +1894,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1932,7 +1916,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1955,7 +1938,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1978,7 +1960,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2001,7 +1982,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2024,7 +2004,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2047,7 +2026,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2067,7 +2045,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2087,7 +2064,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2107,7 +2083,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -13279,9 +13254,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "exceljs": {
       "uuid": "^11.1.1"
     },
-    "tmp": "^0.2.6"
+    "tmp": "^0.2.6",
+    "shell-quote": "^1.8.4"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",

--- a/tests/nozzleTypes.test.ts
+++ b/tests/nozzleTypes.test.ts
@@ -1,0 +1,47 @@
+/**
+ * GH #641 — src/lib/nozzleTypes.ts had no direct coverage. Pins the three
+ * `nozzleTypeLabel` branches (empty → "", known value → translated via
+ * i18n key, unknown legacy value → raw passthrough) plus the catalog
+ * invariants the module docblock promises: every `i18nKey` must exist in
+ * BOTH locale files (the i18n-key-coverage test can't see these keys —
+ * they're resolved dynamically, never as a literal `t("…")` call).
+ */
+import { describe, it, expect } from "vitest";
+import { NOZZLE_TYPES, nozzleTypeLabel } from "@/lib/nozzleTypes";
+import en from "@/i18n/locales/en.json";
+import de from "@/i18n/locales/de.json";
+
+const t = (key: string) => `T(${key})`;
+
+describe("nozzleTypeLabel", () => {
+  it("returns empty string for null / undefined / empty value", () => {
+    expect(nozzleTypeLabel(null, t)).toBe("");
+    expect(nozzleTypeLabel(undefined, t)).toBe("");
+    expect(nozzleTypeLabel("", t)).toBe("");
+  });
+
+  it("translates known stored values through their i18n key", () => {
+    expect(nozzleTypeLabel("Brass", t)).toBe("T(nozzleType.Brass)");
+    expect(nozzleTypeLabel("Hardened Steel", t)).toBe(
+      "T(nozzleType.HardenedSteel)",
+    );
+  });
+
+  it("passes unknown legacy values through raw (never an empty cell)", () => {
+    expect(nozzleTypeLabel("Unobtainium", t)).toBe("Unobtainium");
+  });
+});
+
+describe("NOZZLE_TYPES catalog invariants", () => {
+  it("has unique stored values", () => {
+    const values = NOZZLE_TYPES.map((n) => n.value);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("every i18nKey resolves in both en and de locales", () => {
+    for (const { i18nKey } of NOZZLE_TYPES) {
+      expect((en as Record<string, string>)[i18nKey], `${i18nKey} in en`).toBeTruthy();
+      expect((de as Record<string, string>)[i18nKey], `${i18nKey} in de`).toBeTruthy();
+    }
+  });
+});

--- a/tests/opt-resync-route.test.ts
+++ b/tests/opt-resync-route.test.ts
@@ -67,9 +67,17 @@ describe("OpenPrintTag re-sync routes (GH #607)", () => {
     if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
     Filament = mongoose.models.Filament;
     // The detail GET route .populate()s these — register so it doesn't 500.
-    for (const name of ["Nozzle", "Printer", "BedType"]) {
+    // Static imports — `await import(`@/models/${name}`)` triggers a Vite
+    // dynamic-import warning ("file extension must be included in the static
+    // part"); a static lookup table keeps each import string fully literal
+    // (same pattern as tests/compare-route.test.ts).
+    const referenced = [
+      ["Nozzle", await import("@/models/Nozzle")],
+      ["Printer", await import("@/models/Printer")],
+      ["BedType", await import("@/models/BedType")],
+    ] as const;
+    for (const [name, mod] of referenced) {
       if (!mongoose.models[name]) {
-        const mod = await import(`@/models/${name}`);
         mongoose.model(name, mod.default.schema);
       }
     }


### PR DESCRIPTION
## Summary

Merge this one **first** — it unblocks the `npm audit` hard gate that currently fails CI on every push and PR.

### #617 — npm audit gate red
Adds `"shell-quote": "^1.8.4"` to the `overrides` block (same pattern as `postcss`/`tmp`). [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (critical) reached us via `concurrently@9.2.1` (dev-only, `electron:dev`). Verified locally: `npm audit --audit-level=moderate` → `found 0 vulnerabilities`.

### #636 — release-bump.yml shell interpolation
The `workflow_dispatch` version input was interpolated directly into `run:` shell blocks — `${{ }}` substitution happens **before** bash parses the script, so metacharacters in the input would execute (the semver-validation line itself was vulnerable, since substitution precedes evaluation). The input now rides a job-level `VERSION` env var; `node -e` scripts read `process.env.VERSION`. Only the `env:` assignment references the raw expression.

### #641 — test/CI hygiene
- `tests/opt-resync-route.test.ts`: static model imports replace the templated dynamic import, killing the `vite:dynamic-import-vars` warning PR #612 reintroduced (same lookup-table pattern as `tests/compare-route.test.ts`).
- New `tests/nozzleTypes.test.ts`: pins the three `nozzleTypeLabel` branches plus catalog invariants — including that every `nozzleType.*` i18n key exists in **both** locales (these keys are resolved dynamically, so the i18n-key-coverage invariant can't see them).
- `docker.yml`: the GHCR publish job now `needs` a lint+test job, so a `v*` tag cut on a broken commit can no longer publish a broken `latest` image while every release.yml leg fails.

Fixes #617
Fixes #636
Fixes #641

## Test plan
- `npm run lint` → clean
- `npm test` → 112 files / 1884 tests passed (the +5 are the new nozzleTypes tests); no Vite dynamic-import warning in the run output
- `npm audit --audit-level=moderate` → 0 vulnerabilities, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)