### PR TITLE
fix(import): preserve filament_notes through the Bambu/Orca settings bag

### DIFF
--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -226,7 +226,6 @@ export function buildStructuredUpdate(
   setIfNotInherited("density", parsed.density);
   setIfNotInherited("cost", parsed.cost);
   setIfNotInherited("maxVolumetricSpeed", parsed.maxVolumetricSpeed);
-  if (parsed.notes != null) u.notes = parsed.notes; // not inheritable
   setIfNotInherited("shrinkageXY", parsed.shrinkageXY);
   setIfNotInherited("shrinkageZ", parsed.shrinkageZ);
 

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -71,12 +71,17 @@ const STRUCTURED_KEYS = new Set<string>([
   "filament_density",
   "filament_cost",
   "filament_max_volumetric_speed",
-  "filament_notes",
   // `filament_soluble` deliberately NOT here — the Filament model has no
   // `soluble` column, so even if the parser extracted it Mongoose strict
   // mode would silently drop the value on the update. Letting it fall
   // through to the settings bag preserves the round-trip exactly the way
   // we handle other model-less Bambu keys (Codex P1 on PR #387 round 2).
+  // `filament_notes` is NOT here either, for the same reason (GH #620):
+  // the model has no top-level `notes` column (the form stores notes in
+  // the settings bag as `filament_notes`), so listing it as structured
+  // destroyed the value — strict mode stripped the write AND the key was
+  // excluded from the settings bag. Riding the bag keeps it lossless and
+  // makes imported notes show up in the form's Notes field.
   "filament_shrink",
   "filament_shrinkage_compensation_z",
   // temperatures
@@ -202,7 +207,6 @@ export interface ParsedFilament {
   density?: number;
   cost?: number;
   maxVolumetricSpeed?: number;
-  notes?: string;
   shrinkageXY?: number;
   shrinkageZ?: number;
   temperatures: ParsedTemperatures;
@@ -268,7 +272,6 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
     density: num(json.filament_density),
     cost: num(json.filament_cost),
     maxVolumetricSpeed: num(json.filament_max_volumetric_speed),
-    notes: unwrap(json.filament_notes),
     temperatures: {
       nozzle: num(json.nozzle_temperature),
       nozzleFirstLayer: num(json.nozzle_temperature_initial_layer),

--- a/tests/bambuStudioApply.test.ts
+++ b/tests/bambuStudioApply.test.ts
@@ -40,7 +40,6 @@ describe("buildStructuredUpdate", () => {
           density: 1.24,
           cost: 24.99,
           maxVolumetricSpeed: 12,
-          notes: "test",
           shrinkageXY: 1.5,
           shrinkageZ: 1.0,
         }),
@@ -53,7 +52,6 @@ describe("buildStructuredUpdate", () => {
       expect(update.density).toBe(1.24);
       expect(update.cost).toBe(24.99);
       expect(update.maxVolumetricSpeed).toBe(12);
-      expect(update.notes).toBe("test");
       expect(update.shrinkageXY).toBe(1.5);
       expect(update.shrinkageZ).toBe(1.0);
       expect(unset).toEqual([]);

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -98,6 +98,40 @@ describe("parseBambuStudioProfile", () => {
     expect(parseBambuStudioProfile({ name: ["X"] }).filament.settings.filament_soluble).toBeUndefined();
   });
 
+  it("passes filament_notes through the settings bag and round-trips it (GH #620)", () => {
+    // The Filament model has no top-level `notes` column (the form stores
+    // notes as `settings.filament_notes`), so the key must ride the
+    // settings passthrough bag like `filament_soluble`. Pre-fix it was
+    // listed in STRUCTURED_KEYS — excluded from the bag AND silently
+    // stripped by Mongoose strict mode on the applier's `u.notes` write,
+    // destroying the value entirely.
+    const { filament } = parseBambuStudioProfile({
+      name: ["Noted PLA"],
+      filament_notes: ["Dried 6h @ 55C. Prints best with 0.2mm layers."],
+    });
+    expect(filament.settings.filament_notes).toBe(
+      "Dried 6h @ 55C. Prints best with 0.2mm layers.",
+    );
+
+    // Round-trip: a doc carrying the settings-bag key re-exports the key
+    // verbatim, and a second parse lands it back in the settings bag.
+    const [exported] = generateOrcaSlicerProfiles([
+      {
+        name: "Noted PLA",
+        type: "PLA",
+        vendor: "QA Labs",
+        settings: filament.settings,
+      },
+    ]);
+    expect(exported.filament_notes).toEqual([
+      "Dried 6h @ 55C. Prints best with 0.2mm layers.",
+    ]);
+    const reparsed = parseBambuStudioProfile(exported);
+    expect(reparsed.filament.settings.filament_notes).toBe(
+      "Dried 6h @ 55C. Prints best with 0.2mm layers.",
+    );
+  });
+
   it("extracts calibration hints when present and flags hasAnyHint", () => {
     const { calibrationHints } = parseBambuStudioProfile({
       name: ["X"],

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -110,6 +110,27 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.temperatures.bed).toBe(65);
     });
 
+    it("preserves filament_notes in the settings bag through import (GH #620)", async () => {
+      // The Filament model has no top-level `notes` field — pre-fix the
+      // importer extracted filament_notes as a structured field, Mongoose
+      // strict mode silently stripped it, and the key was also excluded
+      // from the settings bag: the value was destroyed. It must land in
+      // `settings.filament_notes` so re-export emits it verbatim.
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        multipartReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({ filament_notes: ["Dried 6h @ 55C before printing"] }),
+        ),
+      );
+      expect(res.status).toBe(200);
+
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      expect(stored.settings.filament_notes).toBe("Dried 6h @ 55C before printing");
+      // No phantom top-level field should appear either.
+      expect(stored.notes).toBeUndefined();
+    });
+
     it("requires filament_type AND filament_vendor on create", async () => {
       const { POST } = await import("@/app/api/filaments/bambustudio/route");
       const noType = await POST(


### PR DESCRIPTION
## Summary

The Bambu Studio / OrcaSlicer preset importer silently destroyed `filament_notes`: the key was listed in `STRUCTURED_KEYS` (so it was excluded from the settings passthrough bag), the parser extracted it into `ParsedFilament.notes`, and the applier wrote `u.notes` — but the Filament schema has no top-level `notes` field (the only `notes` fields are nested in `spools[].dryCycles[]`), so Mongoose strict mode stripped the write. Import a preset with notes → notes gone; re-export emits no `filament_notes` — violating the module's own round-trip guarantee.

This routes `filament_notes` through the `settings` passthrough bag instead — the exact treatment the file already documents (and chose deliberately) for `filament_soluble`. It's also how the rest of the app models notes: `FilamentForm` reads/writes notes as `settings.filament_notes`, and both `filamentToOrcaSlicerKeys` / the PrusaSlicer bundle emit the settings bag verbatim on export. So imported notes now surface in the form's Notes field and survive export → import → export unchanged.

Fixes #620

## Changes

- `src/lib/bambuStudioImport.ts` — drop `"filament_notes"` from `STRUCTURED_KEYS` (with a comment mirroring the `filament_soluble` rationale); remove the dead `notes` field from `ParsedFilament` and the `notes: unwrap(json.filament_notes)` parse.
- `src/lib/bambuStudioApply.ts` — remove the strict-mode-stripped `u.notes` write in `buildStructuredUpdate`.
- `tests/bambuStudioImport.test.ts` — new case: `filament_notes` lands in the settings bag, re-exports verbatim via `generateOrcaSlicerProfiles`, and re-parses back into the bag.
- `tests/bambustudio-route.test.ts` — new case: an imported preset's notes are retrievable at `settings.filament_notes` on the stored doc (and no phantom top-level `notes` appears).
- `tests/bambuStudioApply.test.ts` — drop the `notes` assertions that pinned the dead write.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 111 files / 1881 tests passed
- [x] Targeted: `tests/bambuStudioImport.test.ts`, `tests/bambustudio-route.test.ts`, `tests/bambuStudioApply.test.ts` (62 tests)

Note: the CI "Security audit" step is failing on main pre-existing (#617) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)