### PR TITLE
fix(api): make print-history delete refund idempotent across retries

### DIFF
--- a/src/app/api/print-history/[id]/route.ts
+++ b/src/app/api/print-history/[id]/route.ts
@@ -159,6 +159,11 @@ export async function PUT(
  * This handles the "print failed, undo this entry" case from issue #92. The
  * refund is best-effort: if a spool has since been deleted we log the refund
  * loss but still remove the history entry.
+ *
+ * GH #621: each usage row's refund is conditioned on its matching
+ * usageHistory entry actually being removed in this pass, so a retry after a
+ * mid-loop failure (the 409 path) can't refund an already-refunded spool a
+ * second time. See the comment block inside the refund loop.
  */
 export async function DELETE(
   request: NextRequest,
@@ -211,6 +216,58 @@ export async function DELETE(
         ? filament.spools.find((s) => String(s._id) === String(u.spoolId))
         : null;
       if (!spool) continue;
+
+      // GH #621: locate the usageHistory entry this usage row pays back
+      // BEFORE touching any weight, and refund only when an entry is
+      // actually removed. The refund used to be unconditional and the
+      // tombstone only lands after the loop — so a mid-loop failure (e.g.
+      // a VersionError mapped to the 409 "Please retry" below) left
+      // earlier filaments refunded with their entries removed while the
+      // job stayed `_deletedAt: null`, and the advertised retry refunded
+      // them AGAIN (unbounded when netFilamentWeight is null, since the
+      // gross clamp only applies when capacity is known). Keying the
+      // refund to entry removal makes each iteration idempotent: on
+      // retry the entry is already gone → nothing removed → no second
+      // refund.
+      //
+      // Match preference, exactly ONE entry consumed per usage row:
+      //   1. jobId + grams. A job can carry multiple usage rows against
+      //      the same spool (POST pushes one usageHistory entry per row,
+      //      all sharing this jobId), so each row must consume its own
+      //      entry — sweeping every jobId match at once would leave the
+      //      later rows with nothing to remove and skip their refunds.
+      //   2. jobId alone (grams drifted; jobId is still unambiguous).
+      //   3. Legacy (grams, startedAt) for entries written before the
+      //      v1.12.x audit that don't carry a jobId — but only when the
+      //      entry has source "job" or "slicer", which restricts the
+      //      candidate set to print-history-driven rows and avoids
+      //      accidentally clobbering a manual usage log that happens to
+      //      share both fields. First match only, as before.
+      const history = spool.usageHistory || [];
+      const matchesJob = (h: (typeof history)[number]) =>
+        Boolean(h.jobId) && String(h.jobId) === String(entry._id);
+      let removeIdx = history.findIndex((h) => matchesJob(h) && h.grams === u.grams);
+      if (removeIdx === -1) {
+        removeIdx = history.findIndex((h) => matchesJob(h));
+      }
+      if (removeIdx === -1) {
+        removeIdx = history.findIndex(
+          (h) =>
+            !h.jobId &&
+            (h.source === "job" || h.source === "slicer") &&
+            h.grams === u.grams &&
+            h.date.getTime() === entry.startedAt.getTime(),
+        );
+      }
+      // No matching entry → this row's debit is no longer (or was never)
+      // represented on the spool: either a prior partial pass already
+      // removed it and refunded the weight, or the spool never carried
+      // it. Either way there is nothing to undo — refunding here is
+      // exactly the double-refund #621 describes.
+      if (removeIdx === -1) continue;
+
+      spool.usageHistory = history.filter((_, idx) => idx !== removeIdx);
+
       // Refund weight. GH #228 + Codex P1 review on PR #229: clamp at
       // the spool's **gross** full-weight ceiling. `spool.totalWeight`
       // is what the user reads off the scale — filament + empty spool —
@@ -254,34 +311,6 @@ export async function DELETE(
           spool.totalWeight = refunded;
         }
       }
-      // Remove the matching usageHistory entry by jobId. Older entries
-      // written before the v1.12.x audit don't carry a jobId; for those
-      // we fall back to the legacy (grams, startedAt) match — but only
-      // when the entry has source "job" or "slicer", which restricts
-      // the candidate set to print-history-driven rows and avoids
-      // accidentally clobbering a manual usage log that happens to
-      // share both fields.
-      spool.usageHistory = (spool.usageHistory || []).filter(
-        (h, idx, arr) => {
-          // New world: jobId match is unambiguous.
-          if (h.jobId && String(h.jobId) === String(entry._id)) return false;
-
-          // Legacy fallback (entries created before jobId existed).
-          if (h.jobId) return true;
-          if (h.source !== "job" && h.source !== "slicer") return true;
-          if (h.grams !== u.grams) return true;
-          if (h.date.getTime() !== entry.startedAt.getTime()) return true;
-          // Remove only the first matching legacy entry per usage row.
-          const firstMatch = arr.findIndex(
-            (x) =>
-              !x.jobId &&
-              (x.source === "job" || x.source === "slicer") &&
-              x.grams === u.grams &&
-              x.date.getTime() === entry.startedAt.getTime(),
-          );
-          return idx !== firstMatch;
-        },
-      );
       await filament.save();
     }
 

--- a/tests/print-history.test.ts
+++ b/tests/print-history.test.ts
@@ -636,6 +636,203 @@ describe("print-history DELETE (undo)", () => {
     // No clamp: refund 50 onto 0 → 50.
     expect(after.spools[0].totalWeight).toBe(50);
   });
+
+  // ─── GH #621: retry after a partial failure must not double-refund ───
+
+  it("retry after a mid-loop save failure refunds each filament exactly once (GH #621)", async () => {
+    // The bug: the refund loop saves per filament and the _deletedAt
+    // tombstone only lands after the loop. If filament B's save throws
+    // (VersionError → the route's 409 "Please retry"), filament A is
+    // already refunded with its usageHistory entry removed while the job
+    // is still active — and the advertised retry used to refund A AGAIN.
+    // netFilamentWeight is deliberately unset on A so the gross-capacity
+    // clamp can't mask the double-refund.
+    const a = await Filament.create({
+      name: "Partial Fail A",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      // netFilamentWeight intentionally unset → no clamp ceiling
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    const b = await Filament.create({
+      name: "Partial Fail B",
+      vendor: "Test",
+      type: "PETG",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [{ label: "", totalWeight: 800 }],
+    });
+
+    const postRes = await postPrintHistory(
+      new NextRequest("http://localhost/api/print-history", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jobLabel: "two-filament job",
+          source: "manual",
+          usage: [
+            { filamentId: String(a._id), grams: 50 },
+            { filamentId: String(b._id), grams: 25 },
+          ],
+        }),
+      }),
+    );
+    expect(postRes.status).toBe(201);
+    const job = await postRes.json();
+    expect((await Filament.findById(a._id)).spools[0].totalWeight).toBe(950);
+    expect((await Filament.findById(b._id)).spools[0].totalWeight).toBe(775);
+
+    // Make the SECOND filament.save() inside the DELETE loop throw a
+    // VersionError (a concurrent edit landing mid-loop — exactly what
+    // OCC raises in production). Same prototype-patch technique as
+    // tests/print-history-concurrency.test.ts: the route holds its own
+    // static model reference, so a spy on the test-side class wouldn't
+    // see the route's calls.
+    const proto = mongoose.Model.prototype as unknown as {
+      save: () => Promise<unknown>;
+    };
+    const originalSave = proto.save;
+    let saveCalls = 0;
+    proto.save = async function () {
+      saveCalls++;
+      if (saveCalls === 2) {
+        throw new mongoose.Error.VersionError(
+          this as unknown as mongoose.Document,
+          0,
+          ["spools"],
+        );
+      }
+      return originalSave.apply(this);
+    };
+
+    let firstDel;
+    try {
+      firstDel = await deletePrintHistory(delReq(job._id), {
+        params: Promise.resolve({ id: job._id }),
+      });
+    } finally {
+      proto.save = originalSave;
+    }
+    expect(firstDel.status).toBe(409);
+
+    // Partial state after the failure: A refunded + entry removed, B
+    // untouched, job still active (no tombstone).
+    const aMid = await Filament.findById(a._id);
+    expect(aMid.spools[0].totalWeight).toBe(1000);
+    expect(aMid.spools[0].usageHistory).toHaveLength(0);
+    const bMid = await Filament.findById(b._id);
+    expect(bMid.spools[0].totalWeight).toBe(775);
+    expect(bMid.spools[0].usageHistory).toHaveLength(1);
+    expect((await PrintHistory.findById(job._id))._deletedAt).toBeNull();
+
+    // The advertised retry. Must finish the job: refund B, tombstone the
+    // entry — and NOT refund A a second time.
+    const retry = await deletePrintHistory(delReq(job._id), {
+      params: Promise.resolve({ id: job._id }),
+    });
+    expect(retry.status).toBe(200);
+
+    const aAfter = await Filament.findById(a._id);
+    // Pre-#621 this was 1050 (refund applied twice, unbounded — no clamp).
+    expect(aAfter.spools[0].totalWeight).toBe(1000);
+    const bAfter = await Filament.findById(b._id);
+    expect(bAfter.spools[0].totalWeight).toBe(800);
+    expect(bAfter.spools[0].usageHistory).toHaveLength(0);
+
+    const tombstone = await PrintHistory.findById(job._id);
+    expect(tombstone._deletedAt).toBeInstanceOf(Date);
+  });
+
+  it("refunds every usage row when a job carries multiple rows against the same spool", async () => {
+    // POST allows several usage rows for the same filament; without an
+    // explicit spoolId they all resolve to the same spool, each pushing
+    // its own usageHistory entry under the shared jobId. The #621 fix
+    // consumes exactly ONE entry per usage row (preferring the
+    // jobId+grams match) — a remove-all-jobId-matches sweep would leave
+    // the second row with nothing to remove and skip its refund.
+    const f = await Filament.create({
+      name: "Two Rows One Spool",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    const postRes = await postPrintHistory(
+      new NextRequest("http://localhost/api/print-history", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jobLabel: "two-part job",
+          source: "manual",
+          usage: [
+            { filamentId: String(f._id), grams: 50 },
+            { filamentId: String(f._id), grams: 30 },
+          ],
+        }),
+      }),
+    );
+    expect(postRes.status).toBe(201);
+    const job = await postRes.json();
+    const afterPost = await Filament.findById(f._id);
+    expect(afterPost.spools[0].totalWeight).toBe(920);
+    expect(afterPost.spools[0].usageHistory).toHaveLength(2);
+
+    const delRes = await deletePrintHistory(delReq(job._id), {
+      params: Promise.resolve({ id: job._id }),
+    });
+    expect(delRes.status).toBe(200);
+
+    const refunded = await Filament.findById(f._id);
+    // Both rows refunded: 920 + 50 + 30 = 1000.
+    expect(refunded.spools[0].totalWeight).toBe(1000);
+    expect(refunded.spools[0].usageHistory).toHaveLength(0);
+  });
+
+  it("does not refund a usage row whose spool has no matching usageHistory entry (GH #621)", async () => {
+    // Same fixture as "does not remove a manual entry even when fallback
+    // runs", now pinning the WEIGHT: the only entry on the spool is a
+    // manual log the source-restricted fallback refuses to touch, so
+    // nothing is removed — and, new in #621, nothing is refunded either.
+    // Pre-#621 the route refunded the 150g anyway, drifting the spool
+    // weight out of sync with the surviving manual ledger entry (and
+    // doing so again on every repeat of the same delete-shaped call).
+    const startedAt = new Date("2026-04-30T12:00:00Z");
+    const f = await Filament.create({
+      name: "No Entry No Refund",
+      vendor: "Test",
+      type: "PLA",
+      spoolWeight: 200,
+      netFilamentWeight: 1000,
+      spools: [
+        {
+          label: "",
+          totalWeight: 850,
+          usageHistory: [
+            { grams: 150, jobLabel: "manual-only", date: startedAt, source: "manual", jobId: null },
+          ],
+        },
+      ],
+    });
+    const orphan = await PrintHistory.create({
+      jobLabel: "ghost",
+      usage: [{ filamentId: f._id, spoolId: f.spools[0]._id, grams: 150 }],
+      startedAt,
+      source: "manual",
+    });
+
+    const delRes = await deletePrintHistory(delReq(String(orphan._id)), {
+      params: Promise.resolve({ id: String(orphan._id) }),
+    });
+    expect(delRes.status).toBe(200);
+
+    const fresh = await Filament.findById(f._id);
+    // Weight unchanged — no entry was removed, so no refund applies.
+    expect(fresh.spools[0].totalWeight).toBe(850);
+    expect(fresh.spools[0].usageHistory).toHaveLength(1);
+    expect(fresh.spools[0].usageHistory[0].source).toBe("manual");
+  });
 });
 
 describe("analytics GET — double-counting regression", () => {


### PR DESCRIPTION
## Summary

`DELETE /api/print-history/{id}` refunds spool weight per filament (`await filament.save()` inside the loop) and only writes the `_deletedAt` tombstone after the loop. The refund was unconditional — not keyed to the matching `jobId` usageHistory entry still being present. If filament #2's save threw mid-loop (VersionError → the route's documented 409 "Please retry"), filament #1 was already refunded with its usageHistory entry removed while the job stayed active, so the advertised retry refunded filament #1 **again** — unbounded when `netFilamentWeight` is null, since the gross-capacity clamp only applies when capacity is known.

Fixes #621

## Fix

Each loop iteration now locates the usageHistory entry the usage row pays back **before** touching any weight, and applies the refund only when an entry is actually removed in this pass. Match preference (exactly one entry consumed per usage row):

1. **jobId + grams** — a job can carry multiple usage rows against the same spool (POST pushes one entry per row, all sharing the jobId), so each row must consume its own entry. The old code swept *every* jobId match at once; under refund-only-if-removed conditioning that sweep would have left later rows with nothing to remove and skipped their refunds, so the sweep became a one-entry-per-row match. End state for data POST creates is identical (N rows ↔ N entries).
2. **jobId alone** — grams drifted; jobId is still unambiguous.
3. **Legacy `(grams, startedAt)`** — pre-v1.12.x entries without a jobId, still restricted to `source: "job" | "slicer"` (manual logs sharing both fields stay protected) and still first-match-only.

No match → `continue` (no refund, no save). On retry, filament #1's entry is already gone → nothing removed → no second refund; the retry finishes filament #2 and lands the tombstone. The GH #228/#229 gross-capacity clamp logic and the parent-inheritance lookup are unchanged — only the ordering/conditioning moved.

## Judgment call: refund-without-entry removed

A usage row whose spool has **no** matching usageHistory entry at all used to get a refund anyway. This change removes that refund — deliberately:

- Refunding without removing a ledger entry is precisely the unbounded double-refund shape from #621 (every repeat of the same delete-shaped call inflated the weight again).
- In the orphan-PrintHistory-vs-manual-entry case (the existing "does not remove a manual entry even when fallback runs" fixture), the old refund drifted the spool weight out of sync with the surviving manual entry that analytics still counts.
- I checked `tests/print-history*` and `tests/api-validation-and-semantics.test.ts`: no existing test pinned the spool **weight** in that scenario (the manual-entry test asserts only the surviving entry). A new test now pins the corrected behavior (weight unchanged when nothing is removed).

## Test plan

- New: `retry after a mid-loop save failure refunds each filament exactly once (GH #621)` — two filaments in one job, second `save()` throws VersionError via the same prototype-patch technique as `tests/print-history-concurrency.test.ts`, first DELETE returns 409, retry returns 200; filament A ends at exactly its pre-job weight (pre-fix: +50g extra), filament B is refunded, tombstone lands.
- New: `refunds every usage row when a job carries multiple rows against the same spool` — pins the one-entry-per-usage-row semantics (a remove-all sweep would under-refund the second row).
- New: `does not refund a usage row whose spool has no matching usageHistory entry (GH #621)` — pins the judgment call above.
- Existing happy-path, legacy-fallback, manual-protection, gross-clamp, variant-inheritance, and tombstone-idempotency (repeat DELETE → 404) tests all pass unchanged.
- `npm run lint` clean; full suite: **111 test files / 1882 tests passed**.

Note: CI's "Security audit" step fails pre-existing (#617, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)