### PR TITLE
fix(api): enforce validators and atomic calibration writes on slicer per-id sync

### DIFF
--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -9,6 +9,11 @@ import {
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
+import {
+  isInvertedNozzleRange,
+  effectiveNozzleRangeForUpdate,
+  inheritNozzleRangeFromParent,
+} from "@/lib/temperatureRange";
 
 /**
  * Top-level body keys that map to structured Filament DB fields.
@@ -25,6 +30,36 @@ const STRUCTURED_KEYS = new Set([
   "maxVolumetricSpeed",
   "temperatures",
 ]);
+
+/** Top-level numeric structured fields — must arrive as finite numbers. */
+const NUMERIC_FIELDS = ["density", "cost", "diameter", "maxVolumetricSpeed"] as const;
+
+/** Numeric temperature sub-fields accepted from the sync body. */
+const TEMP_FIELDS = [
+  "nozzle",
+  "nozzleFirstLayer",
+  "bed",
+  "bedFirstLayer",
+  "nozzleRangeMin",
+  "nozzleRangeMax",
+] as const;
+
+/**
+ * GH #618: coerce a numeric body value the way Mongoose casts Number
+ * schema paths — accept finite numbers and finite numeric strings,
+ * reject everything else. Returns the coerced number, or undefined when
+ * the value isn't usable (the caller 400s naming the field). Pre-fix, a
+ * body like `cost: "abc"` rode into `$set` verbatim and surfaced as a
+ * CastError-500, and objects/Infinity slipped through the same way.
+ */
+function coerceFiniteNumber(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim() !== "") {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
 
 /**
  * GET /api/filaments/{id}/orcaslicer
@@ -119,23 +154,63 @@ export async function POST(
     if (body.type != null) update.type = body.type;
     if (body.vendor != null) update.vendor = body.vendor;
     if (body.color != null) update.color = body.color;
-    if (body.density != null) update.density = body.density;
-    if (body.cost != null) update.cost = body.cost;
-    if (body.diameter != null) update.diameter = body.diameter;
-    if (body.maxVolumetricSpeed != null) update.maxVolumetricSpeed = body.maxVolumetricSpeed;
 
-    // Temperatures
+    // GH #618: numeric fields must coerce to finite numbers (numeric
+    // strings are accepted, matching the cast Mongoose applies on save).
+    // Anything else is a client error — pre-fix `cost: "abc"` threw a
+    // CastError that surfaced as a generic 500.
+    for (const field of NUMERIC_FIELDS) {
+      const v = body[field];
+      if (v == null) continue;
+      const n = coerceFiniteNumber(v);
+      if (n === undefined) {
+        return errorResponse(`${field} must be a finite number`, 400);
+      }
+      update[field] = n;
+    }
+
+    // Temperatures — same finite-number coercion per sub-field (GH #618).
+    let touchesNozzleRange = false;
     if (body.temperatures && typeof body.temperatures === "object") {
       const src = body.temperatures as Record<string, unknown>;
       const temps: Record<string, unknown> = {};
-      if (src.nozzle != null) temps.nozzle = src.nozzle;
-      if (src.nozzleFirstLayer != null) temps.nozzleFirstLayer = src.nozzleFirstLayer;
-      if (src.bed != null) temps.bed = src.bed;
-      if (src.bedFirstLayer != null) temps.bedFirstLayer = src.bedFirstLayer;
-      if (src.nozzleRangeMin != null) temps.nozzleRangeMin = src.nozzleRangeMin;
-      if (src.nozzleRangeMax != null) temps.nozzleRangeMax = src.nozzleRangeMax;
+      for (const field of TEMP_FIELDS) {
+        const v = src[field];
+        if (v == null) continue;
+        const n = coerceFiniteNumber(v);
+        if (n === undefined) {
+          return errorResponse(`temperatures.${field} must be a finite number`, 400);
+        }
+        temps[field] = n;
+      }
+      touchesNozzleRange = "nozzleRangeMin" in temps || "nozzleRangeMax" in temps;
       if (Object.keys(temps).length > 0) {
         update.temperatures = { ...filament.temperatures, ...temps };
+      }
+    }
+
+    // #574 / GH #618: reject an inverted nozzle range (min > max) the same
+    // way the regular PUT does — the per-field 0–600 validators can't catch
+    // the cross-field relationship. `update.temperatures` is a full replace
+    // built from stored + incoming, so it IS the effective own range; only
+    // validate when the sync actually touches an endpoint, so pre-existing
+    // bad data can't 400 an unrelated sync. A variant inherits any endpoint
+    // it leaves null from its parent (resolveFilament: own ?? parent), so
+    // resolve the parent's endpoints in before checking (#577).
+    if (touchesNozzleRange) {
+      const own = effectiveNozzleRangeForUpdate(update, filament.temperatures);
+      let effRange = own;
+      if (filament.parentId) {
+        const parent = await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
+          .select("temperatures.nozzleRangeMin temperatures.nozzleRangeMax")
+          .lean();
+        effRange = inheritNozzleRangeFromParent(own, parent?.temperatures);
+      }
+      if (isInvertedNozzleRange(effRange)) {
+        return errorResponse(
+          "Nozzle range minimum temperature must be less than or equal to the maximum",
+          400,
+        );
       }
     }
 
@@ -155,7 +230,22 @@ export async function POST(
       update.settings = merge.settings;
     }
 
-    await Filament.updateOne({ _id: filament._id }, { $set: update });
+    // GH #618: `runValidators` so the #337 numeric range validators fire
+    // on an OrcaSlicer sync (negative cost/density, out-of-range temps) —
+    // `context: "query"` matches the Bambu sync route (Codex P2 on #387).
+    // The shared helper maps a ValidationError to a JSON 400.
+    try {
+      await Filament.updateOne(
+        { _id: filament._id },
+        { $set: update },
+        { runValidators: true, context: "query" },
+      );
+    } catch (validationErr) {
+      return errorResponseFromCaught(
+        validationErr,
+        "OrcaSlicer profile contained invalid values",
+      );
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -484,13 +484,15 @@ export async function POST(
       ownCalibrations.length > 0 || !calParent ? filament : calParent;
     const compatTarget =
       ownCompatNozzles.length > 0 || !calParent ? filament : calParent;
-    // GH #265 (Codex P1): when the calibration belongs on the PARENT
-    // (an inheriting variant), we record just the nozzle + fields here
-    // and apply them with an atomic per-entry write after the main
-    // update — never a read-modify-write of the parent's whole
-    // `calibrations` array, which would lose a concurrent sibling's
-    // write.
-    let parentCalibrationWrite:
+    // GH #265 (Codex P1) / GH #618: the matched calibration entry is
+    // recorded here and applied with an atomic per-entry write after the
+    // main update — never a read-modify-write of the whole `calibrations`
+    // array, which would lose a concurrent sync's entry for a different
+    // nozzle. #265 fixed the parent-targeted case (an inheriting variant
+    // syncing its parent); #618 extends the same construction to the
+    // own-calibrations case, which used to fold a whole-array $set into
+    // the main update.
+    let calibrationWrite:
       | { nozzleId: string; fields: Record<string, number | null> }
       | null = null;
 
@@ -546,31 +548,18 @@ export async function POST(
           const matchingNozzle = await Nozzle.findOne(nozzleQuery).lean();
 
           if (matchingNozzle) {
-            const nozzleId = String(matchingNozzle._id);
-            // GH #265: write to whichever document owns this filament's
-            // effective calibrations.
-            if (String(calTarget._id) === String(filament._id)) {
-              // The filament itself owns calibrations (standalone, or a
-              // variant that overrides them) — fold the change into this
-              // request's own single $set on this document.
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const calibrations = [...((calTarget.calibrations as any[]) || [])];
-              const idx = calibrations.findIndex(
-                (cal) => String(cal.nozzle) === nozzleId && !cal.printer,
-              );
-              if (idx >= 0) {
-                Object.assign(calibrations[idx], calFields);
-              } else {
-                calibrations.push({ nozzle: nozzleId, printer: null, ...calFields });
-              }
-              update.calibrations = calibrations;
-            } else {
-              // An inheriting variant — the calibration belongs on the
-              // parent. Defer to an atomic per-entry write (below) so a
-              // concurrent sibling sync of the same parent can't be
-              // clobbered by a whole-array overwrite.
-              parentCalibrationWrite = { nozzleId, fields: calFields };
-            }
+            // GH #265: the entry lands on whichever document owns this
+            // filament's effective calibrations (`calTarget` — the
+            // filament itself for a standalone or an overriding variant,
+            // the parent for an inheriting variant). GH #618: BOTH cases
+            // defer to the atomic per-entry write below — the own-document
+            // case used to spread `[...calTarget.calibrations]` into the
+            // main $set, a read-modify-write that dropped a concurrent
+            // sync's entry for a different nozzle.
+            calibrationWrite = {
+              nozzleId: String(matchingNozzle._id),
+              fields: calFields,
+            };
           }
         }
       }
@@ -597,15 +586,34 @@ export async function POST(
     }
     update.settings = merge.settings;
 
-    await Filament.findByIdAndUpdate(filament._id, { $set: update });
+    // GH #618: `runValidators` so the numeric range validators (#337)
+    // actually fire on a PrusaSlicer sync — without it a config like
+    // `filament_cost = -3` parses clean and persists a negative cost the
+    // regular PUT would have rejected. `context: "query"` matches the
+    // Bambu sync route (Codex P2 on #387); the shared helper maps a
+    // ValidationError to a JSON 400 rather than a generic 500.
+    try {
+      await Filament.findByIdAndUpdate(
+        filament._id,
+        { $set: update },
+        { runValidators: true, context: "query" },
+      );
+    } catch (validationErr) {
+      return errorResponseFromCaught(
+        validationErr,
+        "PrusaSlicer config contained invalid values",
+      );
+    }
 
-    // GH #265 (Codex P1): persist an inheriting variant's calibration
-    // change on its parent with an ATOMIC per-entry write — never a
-    // read-modify-write of the parent's whole `calibrations` array, so
-    // two variants syncing the same parent concurrently can't drop each
-    // other's entries.
-    if (parentCalibrationWrite) {
-      const { nozzleId, fields } = parentCalibrationWrite;
+    // GH #265 (Codex P1) / GH #618: persist the calibration change on its
+    // owning document (`calTarget` — the filament itself or, for an
+    // inheriting variant, its parent) with an ATOMIC per-entry write —
+    // never a read-modify-write of the whole `calibrations` array, so two
+    // syncs hitting the same document concurrently (two variants syncing
+    // one parent, or two nozzle contexts syncing one filament) can't drop
+    // each other's entries.
+    if (calibrationWrite) {
+      const { nozzleId, fields } = calibrationWrite;
       const setEntry: Record<string, number | null> = {};
       for (const [k, v] of Object.entries(fields)) {
         setEntry[`calibrations.$.${k}`] = v;

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -411,4 +411,215 @@ describe("API route correctness", () => {
     expect(res.status).toBe(400);
     expect((await res.json()).error).toMatch(/settings/i);
   });
+
+  // ── #618: slicer sync writes run validators + atomic calibration ────
+
+  describe("#618 — slicer per-id sync validation and atomic calibration writes", () => {
+    it("prusaslicer sync rejects a negative filament_cost with 400 and persists nothing", async () => {
+      const f = await Filament.create({
+        name: "Cost Host",
+        vendor: "T",
+        type: "PLA",
+        cost: 25,
+      });
+
+      const res = await slicerSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}`, {
+          config: { filament_cost: "-3" },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      // Pre-fix: the write skipped the #337 validators, returned 200, and
+      // cost: -3 persisted. The schema's min:0 must reject it as a 400.
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/cost/i);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.cost).toBe(25);
+    });
+
+    it("orcaslicer sync rejects a non-numeric cost with 400, not 500", async () => {
+      const f = await Filament.create({
+        name: "Orca Type Host",
+        vendor: "T",
+        type: "PLA",
+        cost: 10,
+      });
+
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, { cost: "abc" }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      // Pre-fix: "abc" rode into $set verbatim → CastError → generic 500.
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/cost/i);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.cost).toBe(10);
+    });
+
+    it("orcaslicer sync rejects a negative cost via the schema validators", async () => {
+      const f = await Filament.create({
+        name: "Orca Negative Host",
+        vendor: "T",
+        type: "PLA",
+        cost: 10,
+      });
+
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, { cost: -3 }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      // Pre-fix: the write skipped runValidators and -3 persisted silently.
+      expect(res.status).toBe(400);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.cost).toBe(10);
+    });
+
+    it("orcaslicer sync rejects an inverted nozzle range with 400", async () => {
+      const f = await Filament.create({
+        name: "Orca Range Host",
+        vendor: "T",
+        type: "PLA",
+      });
+
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, {
+          temperatures: { nozzleRangeMin: 300, nozzleRangeMax: 200 },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/minimum.*maximum/i);
+    });
+
+    it("orcaslicer sync rejects a lone min that inverts against the STORED max", async () => {
+      // The sync merges incoming temps into the stored subdoc, so a body
+      // carrying only nozzleRangeMin must be checked against the stored max.
+      const f = await Filament.create({
+        name: "Orca Stored-Max Host",
+        vendor: "T",
+        type: "PLA",
+        temperatures: { nozzleRangeMax: 200 },
+      });
+
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, {
+          temperatures: { nozzleRangeMin: 300 },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("orcaslicer sync rejects a lone min that inverts against an INHERITED parent max", async () => {
+      // A variant inherits any endpoint it leaves null from its parent
+      // (resolveFilament: own ?? parent), so own min 300 + parent max 200
+      // is an inverted effective range even though the body looks partial.
+      const parent = await Filament.create({
+        name: "Orca Range Parent",
+        vendor: "T",
+        type: "PLA",
+        temperatures: { nozzleRangeMax: 200 },
+      });
+      const variant = await Filament.create({
+        name: "Orca Range Variant",
+        vendor: "T",
+        type: "PLA",
+        color: "#111111",
+        parentId: parent._id,
+      });
+
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${variant._id}/orcaslicer`, {
+          temperatures: { nozzleRangeMin: 300 },
+        }),
+        { params: Promise.resolve({ id: String(variant._id) }) },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("orcaslicer sync still applies valid values (numeric-string coercion included)", async () => {
+      const f = await Filament.create({
+        name: "Orca Happy Host",
+        vendor: "T",
+        type: "PLA",
+        temperatures: { bed: 60 },
+      });
+
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, {
+          cost: "12.5",
+          temperatures: { nozzle: 215 },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.cost).toBe(12.5);
+      expect(fresh.temperatures.nozzle).toBe(215);
+      // The merge preserves stored temps the sync didn't touch.
+      expect(fresh.temperatures.bed).toBe(60);
+    });
+
+    it("sequential calibration syncs for different nozzles both persist (atomic per-entry writes)", async () => {
+      const n04 = await Nozzle.create({
+        name: "0.4 Brass",
+        diameter: 0.4,
+        type: "brass",
+      });
+      const n06 = await Nozzle.create({
+        name: "0.6 Brass",
+        diameter: 0.6,
+        type: "brass",
+      });
+      const f = await Filament.create({
+        name: "Cal Host",
+        vendor: "T",
+        type: "PLA",
+        compatibleNozzles: [n04._id, n06._id],
+      });
+
+      // First sync calibrates the 0.4 nozzle...
+      let res = await slicerSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}?nozzle_diameter=0.4`, {
+          config: { extrusion_multiplier: "1.05" },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+
+      // ...the second calibrates the 0.6 — it must APPEND ($push), not
+      // replace the array.
+      res = await slicerSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}?nozzle_diameter=0.6`, {
+          config: { extrusion_multiplier: "0.95" },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+
+      // A re-sync of the 0.4 nozzle updates its entry IN PLACE via the
+      // $elemMatch-filtered positional $set — no duplicate entry.
+      res = await slicerSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}?nozzle_diameter=0.4`, {
+          config: { extrusion_multiplier: "1.1", pressure_advance: "0.045" },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.calibrations).toHaveLength(2);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cal04 = fresh.calibrations.find((c: any) => String(c.nozzle) === String(n04._id));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cal06 = fresh.calibrations.find((c: any) => String(c.nozzle) === String(n06._id));
+      expect(cal04.extrusionMultiplier).toBe(1.1);
+      expect(cal04.pressureAdvance).toBe(0.045);
+      expect(cal06.extrusionMultiplier).toBe(0.95);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Three related fixes in the slicer per-id sync paths.

### 1. PrusaSlicer sync write skips validators
`POST /api/filaments/{id}` wrote `{ $set: update }` with no `runValidators`, so the GH #337 numeric validators never fired — `filament_cost = "-3"` parseFloat'd clean and persisted a negative cost the regular PUT would have rejected. The write now passes `{ runValidators: true, context: "query" }` (the same options the Bambu sync route adopted via Codex P2 on #387), and a `ValidationError` surfaces as a JSON 400 via `errorResponseFromCaught` instead of a raw 500.

### 2. OrcaSlicer sync had no type checks either
`POST /api/filaments/{id}/orcaslicer` accepted `cost: "abc"` (CastError → generic 500) and persisted negative numbers silently. Now:
- Numeric body fields (`density`, `cost`, `diameter`, `maxVolumetricSpeed`, and each `temperatures.*` sub-field) are coerced through a finite-number check — numeric strings are accepted (matching the cast Mongoose applies on save), anything else 400s naming the field.
- The write runs with `{ runValidators: true, context: "query" }` so the #337 `min`/`max` validators fire.
- The inverted-nozzle-range guard the regular PUT enforces (#574/#577) now runs here too, reusing `effectiveNozzleRangeForUpdate` / `inheritNozzleRangeFromParent` / `isInvertedNozzleRange` — covering the merge-with-stored-endpoint case and a variant inheriting an endpoint from its parent. Gated on the sync actually touching a range endpoint so pre-existing bad data can't 400 an unrelated sync.

### 3. Own-calibrations whole-array read-modify-write race
The own-calibrations branch of the PrusaSlicer sync spread `[...calTarget.calibrations]`, mutated, and `$set` the whole array — two concurrent syncs for different nozzles could drop each other's entries. GH #265 already made the *parent*-targeted branch atomic per-entry; this PR unifies both branches onto that construction: an `$elemMatch`-filtered positional `$set` for the existing-entry case, a conditional `$push` for the new-entry case, and the step-3 fallback `$set` for the lost-insert race. Per-nozzle calibration context and `high_flow` disambiguation are unchanged.

Fixes #618

## Test plan
- [x] New regression tests in `tests/api-route-correctness.test.ts` (#618 describe block):
  - PrusaSlicer sync with negative `filament_cost` → 400, nothing persisted
  - OrcaSlicer sync with `cost: "abc"` → 400 (was 500), `cost: -3` → 400 via schema validators
  - OrcaSlicer inverted nozzle range → 400 (direct, lone-min vs stored max, lone-min vs inherited parent max)
  - OrcaSlicer happy path still applies valid values incl. numeric-string coercion and stored-temp merge
  - Sequential per-nozzle calibration syncs: append for a new nozzle, in-place update on re-sync, both entries present (pins the `$elemMatch`/`$push` shape)
- [x] `npm run lint` clean
- [x] `npm test` — 111 files, 1887 tests, all passing

Note: the failing "Security audit" CI step is pre-existing (#617, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)