### PR TITLE
fix(electron): pin powershell path, device-path allowlist, gate status getters, isolate sync closes; value-level CSP parity test

### DIFF
--- a/electron/auto-updater.ts
+++ b/electron/auto-updater.ts
@@ -75,7 +75,13 @@ export function initAutoUpdater(win: BrowserWindow) {
   // "No handler registered". In dev, the mutating handlers short-circuit
   // with a "dev-mode" error instead of touching the real updater, which
   // electron-updater refuses to run when app.isPackaged is false.
-  ipcMain.handle("update-get-status", () => currentState);
+  // GH #623: read-only, but gated like its siblings (#434) — the state
+  // carries version/release-notes/error text, and an open getter was an
+  // undocumented asymmetry vs. the trusted-sender posture everywhere else.
+  ipcMain.handle("update-get-status", (event) => {
+    assertTrustedSender(event, "update-get-status");
+    return currentState;
+  });
 
   // GH #434: update-check and update-download were gated only on
   // `app.isPackaged`. In a release build a sub-frame could drive

--- a/electron/label-printer.ts
+++ b/electron/label-printer.ts
@@ -26,7 +26,7 @@ import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { writeFile, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 
 const execFileP = promisify(execFile);
 
@@ -44,8 +44,31 @@ const MANAGED_QUEUE = "FilamentDB_Label";
 const EXEC_TIMEOUT_MS = 15_000;
 
 /** On Linux a GUI app's PATH often omits /usr/sbin where lpadmin/lpinfo
- *  live, so we try the bare name first then the sbin path. */
+ *  live, so we try the bare name first then the sbin path. (The CUPS tools
+ *  stay bare names on purpose: Unix execvp never searches the cwd, and
+ *  their install paths vary across distros — see windowsPowershellPath()
+ *  for why Windows gets the opposite treatment.) */
 const SBIN = "/usr/sbin";
+
+/**
+ * Absolute path to powershell.exe (GH #623). Windows' CreateProcess
+ * resolves a bare executable name from the application's own directory
+ * and the current directory BEFORE System32, so a `powershell.exe`
+ * planted next to a portable/unpacked run would be picked up first and
+ * turn these calls into an arbitrary-code-execution sink. Anchor to an
+ * absolute path — the exact pattern the sc.exe probe in electron/main.ts
+ * uses. Exported for the unit test; built with win32.join so the path is
+ * identical regardless of the host the test runs on.
+ */
+export function windowsPowershellPath(): string {
+  return win32.join(
+    process.env.SystemRoot || "C:\\Windows",
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
 
 export interface LabelPrinterDevice {
   /** Opaque print target: a CUPS queue name, a `usb://…` device URI, or a
@@ -175,7 +198,7 @@ async function listWindowsPrinters(): Promise<LabelPrinterDevice[]> {
   const script =
     "@(Get-Printer | Select-Object Name) | ConvertTo-Json -Compress";
   const { stdout } = await execFileP(
-    "powershell",
+    windowsPowershellPath(),
     ["-NoProfile", "-NonInteractive", "-Command", script],
     { timeout: EXEC_TIMEOUT_MS },
   );
@@ -226,12 +249,20 @@ export async function printLabel(target: string, bytes: Uint8Array): Promise<voi
 }
 
 async function printCups(target: string, bytes: Uint8Array): Promise<void> {
-  // A target containing a scheme ("usb://…") is a raw device → route it
-  // through our managed raw queue. Otherwise it's an installed queue name.
+  // A `usb://…` target is a raw device → route it through our managed raw
+  // queue. Otherwise it's an installed queue name. Only the usb scheme is
+  // accepted — it's the only scheme listLabelPrinters ever surfaces — so a
+  // stored target with any other scheme (ipp://, file://, …) is refused
+  // instead of being forwarded verbatim to `lpadmin -v` (GH #623).
   let queue = target;
-  if (/^[a-z]+:\/\//i.test(target)) {
+  if (/^usb:\/\//i.test(target)) {
     await ensureManagedQueue(target);
     queue = MANAGED_QUEUE;
+  } else if (/^[a-z][a-z0-9+.-]*:\/\//i.test(target)) {
+    throw new Error(
+      `Unsupported print target "${target}" — only usb:// devices and installed ` +
+        `print queues are supported. Open Settings → Label Printer and select your printer again.`,
+    );
   }
 
   await new Promise<void>((resolve, reject) => {
@@ -317,7 +348,7 @@ async function printWindows(printerName: string, bytes: Uint8Array): Promise<voi
   await writeFile(scriptPath, WINDOWS_RAW_PRINT_PS1, "utf8");
   try {
     await execFileP(
-      "powershell",
+      windowsPowershellPath(),
       [
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", scriptPath,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -906,7 +906,12 @@ ipcMain.handle("test-connection", async (event, uri: string) => {
 // assertTrustedSender and a constrained payload allowlist.
 
 // Sync
-ipcMain.handle("get-sync-status", () => {
+// GH #623: read-only, but gate on the trusted sender anyway — the sync
+// status carries the last error text (which can name the Atlas DB), and
+// leaving the getter open was an undocumented asymmetry vs. every other
+// handler's "contain XSS to the renderer" posture.
+ipcMain.handle("get-sync-status", (event) => {
+  assertTrustedSender(event, "get-sync-status");
   return syncService?.getStatus() ?? {
     state: "idle",
     lastSyncAt: null,
@@ -959,7 +964,10 @@ ipcMain.handle("check-atlas-connectivity", async (event) => {
 });
 
 // NFC IPC handlers
-ipcMain.handle("nfc-get-status", () => {
+// GH #623: read-only, but the status discloses the reader name + tagUid —
+// same trusted-sender gate as the read/write/format handlers.
+ipcMain.handle("nfc-get-status", (event) => {
+  assertTrustedSender(event, "nfc-get-status");
   return nfcService?.getStatus() ?? {
     readerConnected: false,
     readerName: null,
@@ -1070,6 +1078,20 @@ ipcMain.handle("label-printer-set-device-path", (event, devicePath: string | nul
   if (devicePath == null) {
     (store as Store<Record<string, unknown>>).delete("labelPrinterDevicePath");
   } else {
+    // GH #623: only accept the shapes listLabelPrinters ever surfaces —
+    // a `usb://…` device URI (the one scheme the CUPS lister emits) or an
+    // installed queue / Windows printer name. Anything else (ipp://,
+    // file://, a path with slashes) could otherwise be persisted by a
+    // compromised renderer and later handed to `lpadmin -v` by printCups,
+    // binding the managed queue to an attacker-chosen device URI.
+    const isUsbUri = /^usb:\/\//i.test(devicePath);
+    const isQueueName =
+      !devicePath.includes("/") && !/^[a-z][a-z0-9+.-]*:\/\//i.test(devicePath);
+    if (!isUsbUri && !isQueueName) {
+      throw new Error(
+        "devicePath must be a usb:// device URI or an installed printer/queue name",
+      );
+    }
     (store as Store<Record<string, unknown>>).set("labelPrinterDevicePath", devicePath);
   }
   return { ok: true };

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -600,8 +600,12 @@ export class SyncService extends EventEmitter {
       return [];
     } finally {
       this.syncing = false;
-      await local.close();
-      await remote.close();
+      // GH #623: close the two clients independently. The earlier
+      // sequential `await local.close(); await remote.close();` meant a
+      // rejected local close skipped the remote close entirely, leaking
+      // the Atlas client/pool once per failed cycle — unbounded over a
+      // long session on the 5-minute sync interval.
+      await Promise.allSettled([local.close(), remote.close()]);
     }
   }
 

--- a/tests/csp-parity.test.ts
+++ b/tests/csp-parity.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 /**
- * GH #408 — Electron CSP parity guard.
+ * GH #408 / #635 — Electron CSP parity guard.
  *
  * The Electron renderer's `onHeadersReceived` overrides whatever CSP
  * the embedded Next.js server sends, so any directive present in the
@@ -12,11 +12,18 @@ import { resolve } from "node:path";
  * v1.30.3 both shipped with that exact drift; this test fails fast
  * when a future change touches one side and forgets the other.
  *
- * The ONE intentional asymmetry is `connect-src` — Electron adds
- * `ws://localhost:* http://localhost:*` for the embedded server.
- * `script-src` ALSO carries a dev-vs-packaged variance (Turbopack
- * needs `unsafe-eval` in dev), so we just verify both files declare
- * the directive and don't compare its tokens.
+ * GH #635: the original test compared directive NAME sets only, so a
+ * token added to one side (the exact v1.30.3 `img-src https:` drift,
+ * #371) slipped through. It now parses each CSP into directive →
+ * value-token sets and diffs the tokens per directive, with explicit
+ * carve-outs for the two documented variances:
+ *   - `connect-src` — Electron adds `ws://localhost:* http://localhost:*`
+ *     for the embedded server. Web's tokens must be a SUBSET of
+ *     Electron's, and the extras must be EXACTLY that localhost pair.
+ *   - `script-src` — both files declare a dev and a prod variant
+ *     (Turbopack/RSC need `'unsafe-eval'` in dev only; web gates on
+ *     NODE_ENV, Electron on app.isPackaged). The two variant sets must
+ *     pair up exactly across the files.
  */
 const REPO_ROOT = resolve(__dirname, "..");
 
@@ -27,15 +34,14 @@ const REPO_ROOT = resolve(__dirname, "..");
  * `"default-src 'self'"`. The directive name there is right after a
  * `"` — not after a `;`.
  *
- * Replace the position-anchored regex with one that finds each known
- * CSP directive name preceded by ANY non-word boundary (`;`, `"`, `'`,
- * `\``, whitespace, BOL) and followed by whitespace + a value. This
- * matches both:
+ * So each known directive name is matched preceded by ANY non-word
+ * boundary (`;`, `"`, `'`, `\``, whitespace, BOL) and followed by
+ * whitespace + a value. This matches both:
  *   - one big template literal: `"… ;${scriptSrc}; style-src 'self'…"`
  *   - per-line quoted strings: `"default-src 'self'"`, `"style-src…"`
  * Comments in the file (the prose mentioning a directive name) won't
- * match because they're not followed by whitespace + a CSP value
- * unless the test ALSO accepts a comma / period, which we don't.
+ * match because they're stripped first, and a survivor would still
+ * need its value to start with a CSP value token.
  */
 const KNOWN_DIRECTIVES = [
   "default-src",
@@ -54,6 +60,11 @@ const KNOWN_DIRECTIVES = [
   "manifest-src",
   "child-src",
 ] as const;
+
+/** The ONE intentional `connect-src` asymmetry: Electron's allowance for
+ *  the embedded Next server. Anything else appearing on only one side is
+ *  drift and must fail the parity check. */
+const CONNECT_SRC_ELECTRON_EXTRAS = ["http://localhost:*", "ws://localhost:*"];
 
 /**
  * Strip JS / TS comments before scanning for directives. Codex
@@ -75,42 +86,221 @@ function stripComments(text: string): string {
     .replace(/(^|[^:])\/\/.*$/gm, "$1");
 }
 
-function readDirectives(filePath: string): Set<string> {
+/** A plausible first token of a CSP directive value — filters out any
+ *  stray prose match that survived comment stripping. */
+const VALUE_START =
+  /^(?:'(?:self|none|unsafe-(?:inline|eval))'|https?:|wss?:|data:|blob:|\*|[a-z0-9.\-]+)/i;
+
+/**
+ * Parse a source file into directive → list of value-token arrays.
+ * A directive can occur more than once (the dev/prod `script-src`
+ * variants); each occurrence keeps its own token array. The value run
+ * ends at a `;`, a string-literal boundary (`"` / backtick), a template
+ * placeholder (`$`), or end-of-line — single quotes stay IN the run
+ * because CSP keyword tokens are single-quoted.
+ */
+function readDirectiveTokens(filePath: string): Map<string, string[][]> {
   const raw = readFileSync(resolve(REPO_ROOT, filePath), "utf8");
   const text = stripComments(raw);
-  const seen = new Set<string>();
+  const found = new Map<string, string[][]>();
   for (const name of KNOWN_DIRECTIVES) {
     // Match the directive name preceded by a non-word-char boundary
     // (so `style-src` doesn't accidentally match inside `frame-style-src`)
-    // and followed by whitespace + a value that starts with a CSP value
-    // token (`'self'`, `'none'`, `https:`, `data:`, `blob:`, `*`, `ws:`,
-    // or a hostname-like character).
+    // and capture the value run that follows.
     const pattern = new RegExp(
-      String.raw`(?:^|[^a-z\-])` +
+      String.raw`(?:^|[^a-zA-Z\-])` +
         name.replace(/-/g, "\\-") +
-        String.raw`\s+(?:'(?:self|none|unsafe-(?:inline|eval))'|https?:|wss?:|data:|blob:|\*|[a-z0-9.\-]+)`,
-      "i",
+        String.raw`[ \t]+([^;"\`$\n]+)`,
+      "g",
     );
-    if (pattern.test(text)) {
-      seen.add(name);
+    for (const match of text.matchAll(pattern)) {
+      const value = match[1].trim();
+      if (!value || !VALUE_START.test(value)) continue;
+      const tokens = value.split(/\s+/);
+      const list = found.get(name) ?? [];
+      list.push(tokens);
+      found.set(name, list);
     }
   }
-  return seen;
+  return found;
+}
+
+/** Sorted union of every occurrence's tokens. */
+function unionTokens(occurrences: string[][]): string[] {
+  return [...new Set(occurrences.flat())].sort();
+}
+
+/** Canonical, order-independent key per variant — used to pair the
+ *  dev/prod `script-src` declarations across the two files. */
+function variantKeys(occurrences: string[][]): string[] {
+  return occurrences.map((tokens) => [...new Set(tokens)].sort().join(" ")).sort();
+}
+
+/**
+ * Value-level diff of the two CSPs. Returns one human-readable problem
+ * string per mismatch — empty means parity (modulo the documented
+ * carve-outs). Kept as a pure function so the guard itself can be
+ * exercised against synthetic drift below (GH #635: the test must fail
+ * when e.g. `https://cdn.example` lands in one side's `img-src` only).
+ */
+function diffCspTokens(
+  web: Map<string, string[][]>,
+  electron: Map<string, string[][]>,
+): string[] {
+  const problems: string[] = [];
+  const names = [...new Set([...web.keys(), ...electron.keys()])].sort();
+  for (const name of names) {
+    const w = web.get(name) ?? [];
+    const e = electron.get(name) ?? [];
+    if (w.length === 0) {
+      problems.push(`${name}: declared in the Electron CSP but missing from the web CSP`);
+      continue;
+    }
+    if (e.length === 0) {
+      problems.push(`${name}: declared in the web CSP but missing from the Electron CSP`);
+      continue;
+    }
+    if (name === "connect-src") {
+      // Carve-out: Electron adds the embedded-server localhost pair on
+      // top of the web tokens — nothing more, nothing less.
+      const webSet = new Set(w.flat());
+      const electronSet = new Set(e.flat());
+      const missing = [...webSet].filter((t) => !electronSet.has(t)).sort();
+      if (missing.length > 0) {
+        problems.push(`connect-src: Electron is missing web tokens [${missing.join(" ")}]`);
+      }
+      const extras = [...electronSet].filter((t) => !webSet.has(t)).sort();
+      if (extras.join(" ") !== CONNECT_SRC_ELECTRON_EXTRAS.join(" ")) {
+        problems.push(
+          `connect-src: Electron extras must be exactly [${CONNECT_SRC_ELECTRON_EXTRAS.join(" ")}] ` +
+            `(the embedded-server allowance), got [${extras.join(" ") || "none"}]`,
+        );
+      }
+      continue;
+    }
+    if (name === "script-src") {
+      // Carve-out: both sides declare a dev and a prod variant (the
+      // dev-only 'unsafe-eval' gating). Compare the variant SETS so a
+      // token added to one side's dev OR prod variant still trips.
+      const webVariants = variantKeys(w);
+      const electronVariants = variantKeys(e);
+      if (webVariants.join(" | ") !== electronVariants.join(" | ")) {
+        problems.push(
+          `script-src: variants differ — web [${webVariants.join(" | ")}] ` +
+            `vs electron [${electronVariants.join(" | ")}]`,
+        );
+      }
+      continue;
+    }
+    const webUnion = unionTokens(w);
+    const electronUnion = unionTokens(e);
+    if (webUnion.join(" ") !== electronUnion.join(" ")) {
+      problems.push(
+        `${name}: tokens differ — web [${webUnion.join(" ")}] vs electron [${electronUnion.join(" ")}]`,
+      );
+    }
+  }
+  return problems;
 }
 
 describe("CSP parity — web (next.config.ts) vs Electron (electron/main.ts)", () => {
-  it("every directive on the web side is also present on the Electron side", () => {
-    const web = readDirectives("next.config.ts");
-    const electron = readDirectives("electron/main.ts");
-    const missing = [...web].filter((d) => !electron.has(d));
-    expect(missing).toEqual([]);
+  const web = readDirectiveTokens("next.config.ts");
+  const electron = readDirectiveTokens("electron/main.ts");
+
+  it("the parser actually finds both CSPs (guards against a refactor blinding this test)", () => {
+    // If either file moves its CSP somewhere the regex can't see, both
+    // maps go empty and a naive diff would vacuously pass — pin the
+    // core directives so that failure mode is loud instead.
+    for (const name of ["default-src", "script-src", "img-src", "connect-src", "object-src"]) {
+      expect(web.has(name), `web CSP should declare ${name}`).toBe(true);
+      expect(electron.has(name), `Electron CSP should declare ${name}`).toBe(true);
+    }
+  });
+
+  it("every directive carries the same value tokens on both sides (GH #635)", () => {
+    expect(diffCspTokens(web, electron)).toEqual([]);
+  });
+
+  it("connect-src: Electron's only extras are the embedded-server localhost pair", () => {
+    const webSet = new Set((web.get("connect-src") ?? []).flat());
+    const electronSet = new Set((electron.get("connect-src") ?? []).flat());
+    for (const token of webSet) {
+      expect(electronSet.has(token), `Electron connect-src should carry web's "${token}"`).toBe(true);
+    }
+    const extras = [...electronSet].filter((t) => !webSet.has(t)).sort();
+    expect(extras).toEqual(CONNECT_SRC_ELECTRON_EXTRAS);
+  });
+
+  it("script-src: the dev and prod variants pair up exactly across both files", () => {
+    const webVariants = variantKeys(web.get("script-src") ?? []);
+    const electronVariants = variantKeys(electron.get("script-src") ?? []);
+    // Two declarations per file: prod (no eval) + dev ('unsafe-eval').
+    expect(webVariants).toHaveLength(2);
+    expect(electronVariants).toEqual(webVariants);
   });
 
   it("Electron CSP carries the four hardening directives added in #408", () => {
-    const electron = readDirectives("electron/main.ts");
     expect(electron.has("frame-ancestors")).toBe(true);
     expect(electron.has("base-uri")).toBe(true);
     expect(electron.has("form-action")).toBe(true);
     expect(electron.has("object-src")).toBe(true);
+  });
+});
+
+describe("CSP parity guard self-test (GH #635)", () => {
+  // The #371 regression shape: a source token added to ONE side's
+  // img-src. The original name-set comparison passed on this; the
+  // value-level diff must flag it.
+  it("flags a token added to only one side's img-src", () => {
+    const web = new Map([["img-src", [["'self'", "data:"]]]]);
+    const electron = new Map([["img-src", [["'self'", "data:", "https://cdn.example"]]]]);
+    expect(diffCspTokens(web, electron)).toEqual([
+      expect.stringContaining("img-src: tokens differ"),
+    ]);
+  });
+
+  it("flags a directive present on only one side", () => {
+    const web = new Map([["media-src", [["'self'"]]]]);
+    const electron = new Map<string, string[][]>();
+    expect(diffCspTokens(web, electron)).toEqual([
+      expect.stringContaining("missing from the Electron CSP"),
+    ]);
+  });
+
+  it("flags a connect-src extra beyond the documented localhost pair", () => {
+    const web = new Map([["connect-src", [["'self'"]]]]);
+    const electron = new Map([
+      ["connect-src", [["'self'", "ws://localhost:*", "http://localhost:*", "https://evil.example"]]],
+    ]);
+    expect(diffCspTokens(web, electron)).toEqual([
+      expect.stringContaining("connect-src: Electron extras must be exactly"),
+    ]);
+  });
+
+  it("accepts the documented carve-outs (localhost pair + dev-only unsafe-eval)", () => {
+    const web = new Map([
+      ["connect-src", [["'self'"]]],
+      ["script-src", [["'self'", "'unsafe-inline'", "'unsafe-eval'"], ["'self'", "'unsafe-inline'"]]],
+    ]);
+    const electron = new Map([
+      ["connect-src", [["'self'", "ws://localhost:*", "http://localhost:*"]]],
+      ["script-src", [["'self'", "'unsafe-inline'"], ["'self'", "'unsafe-inline'", "'unsafe-eval'"]]],
+    ]);
+    expect(diffCspTokens(web, electron)).toEqual([]);
+  });
+
+  it("flags a token added to only one side's script-src dev variant", () => {
+    const web = new Map([
+      ["script-src", [["'self'", "'unsafe-inline'", "'unsafe-eval'"], ["'self'", "'unsafe-inline'"]]],
+    ]);
+    const electron = new Map([
+      ["script-src", [
+        ["'self'", "'unsafe-inline'"],
+        ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://cdn.example"],
+      ]],
+    ]);
+    expect(diffCspTokens(web, electron)).toEqual([
+      expect.stringContaining("script-src: variants differ"),
+    ]);
   });
 });

--- a/tests/label-printer.test.ts
+++ b/tests/label-printer.test.ts
@@ -67,7 +67,7 @@ vi.mock("node:child_process", () => {
   return { execFile, spawn };
 });
 
-import { listLabelPrinters, printLabel } from "../electron/label-printer";
+import { listLabelPrinters, printLabel, windowsPowershellPath } from "../electron/label-printer";
 
 const BYTES = new Uint8Array([0x1b, 0x40, 0x41, 0x42]);
 const BROTHER_URI = "usb://Brother/PT-P710BT?serial=000M5G671606";
@@ -185,6 +185,70 @@ d("printLabel (CUPS)", () => {
   it("rejects when lp can't be spawned", async () => {
     h.state.spawn.errorOnSpawn = new Error("spawn lp ENOENT");
     await expect(printLabel("HP_DeskJet", BYTES)).rejects.toThrow(/ENOENT/);
+  });
+});
+
+d("printLabel — non-usb scheme targets (GH #623)", () => {
+  // Only `usb://` device URIs are valid raw-device targets — it's the one
+  // scheme listLabelPrinters surfaces. Any other scheme must be refused
+  // instead of being forwarded to `lpadmin -v` (which would bind the
+  // managed queue to an attacker-chosen device URI).
+  it.each([
+    "ipp://attacker.example/printers/q",
+    "file:///etc/passwd",
+    "socket://10.0.0.5",
+  ])("rejects %s and never reaches lpadmin or lp", async (target) => {
+    await expect(printLabel(target, BYTES)).rejects.toThrow(/only usb:\/\/ devices/i);
+    expect(h.state.spawnCalls.some((c) => c.cmd === "lp")).toBe(false);
+    expect(h.state.execCalls.some((c) => c.cmd === "lpadmin")).toBe(false);
+  });
+});
+
+describe("windowsPowershellPath (GH #623)", () => {
+  // Windows' CreateProcess resolves a bare executable name from the app /
+  // current directory BEFORE System32, so the transport must invoke
+  // powershell.exe by absolute path (same hardening as the sc.exe probe in
+  // electron/main.ts). Built with win32.join, so the expected string is
+  // identical on any test host.
+  it("anchors to %SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", () => {
+    vi.stubEnv("SystemRoot", "D:\\WinNT");
+    try {
+      expect(windowsPowershellPath()).toBe(
+        "D:\\WinNT\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("defaults to C:\\Windows when SystemRoot is unset", () => {
+    const prev = process.env.SystemRoot;
+    delete process.env.SystemRoot;
+    try {
+      expect(windowsPowershellPath()).toBe(
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      );
+    } finally {
+      if (prev !== undefined) process.env.SystemRoot = prev;
+    }
+  });
+
+  it("listLabelPrinters invokes powershell by absolute path, not bare name", async () => {
+    // Force the Windows branch — execFile is mocked, so nothing is spawned.
+    const desc = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { ...desc, value: "win32" });
+    try {
+      h.state.execImpl = () => ({ stdout: '[{"Name":"Brother PT-P710BT"}]' });
+      const devices = await listLabelPrinters();
+      expect(devices).toEqual([
+        { path: "Brother PT-P710BT", friendlyName: "Brother PT-P710BT", looksLikePrinter: true },
+      ]);
+      expect(h.state.execCalls).toHaveLength(1);
+      expect(h.state.execCalls[0].cmd).toBe(windowsPowershellPath());
+      expect(h.state.execCalls[0].cmd).toMatch(/powershell\.exe$/);
+    } finally {
+      Object.defineProperty(process, "platform", desc);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

### #623 — four Electron hardening items
- **PATH-resolved `powershell` (Windows binary planting)**: both label-printer call sites now resolve `powershell.exe` via `%SystemRoot%\System32\WindowsPowerShell\v1.0\` through a shared helper — `CreateProcess` searches the application directory and cwd *before* System32, the exact threat `electron/main.ts` already closed for `sc.exe`. Unix CUPS tools stay bare-name (execvp doesn't search cwd; install paths vary across distros) with a comment saying so.
- **Device-path allowlist**: `label-printer-set-device-path` accepts only `usb://` URIs (the one scheme the CUPS lister emits) or installed-queue names without `/` or a scheme; `printCups` refuses to forward non-usb schemes to `lpadmin`, closing the `file://`/`ipp://` queue-binding gadget. Legacy serial-path rejection unchanged.
- **Status getters gated**: `get-sync-status`, `nfc-get-status`, and `update-get-status` now carry `assertTrustedSender` like every sibling handler — closes the undocumented asymmetry (and the `tagUid` read from sub-frames).
- **Sync close isolation**: `sync()`'s `finally` uses `Promise.allSettled([local.close(), remote.close()])` so a local close failure can no longer skip the remote close and leak the Atlas client pool every 5-minute cycle.

### #635 — CSP parity test now diffs values, not names
`tests/csp-parity.test.ts` parsed each CSP into directive **name** sets only — adding `https://cdn.example` to one side's `img-src` would have passed (the very #371 asymmetry the test was built against). It now parses directive → token sets and diffs tokens per directive, with carve-outs limited to the two documented variances: `connect-src` (web tokens must be a subset of Electron's; the extras must be exactly the localhost pair) and the dev-gated `script-src 'unsafe-eval'`.

Fixes #623
Fixes #635

## Test plan
- `npm run lint` → clean
- `npm run electron:compile` → bundles cleanly (electron/ is outside tsconfig)
- `npm test` → 111 files / 1893 tests passed (+14, incl. new label-printer transport cases for the allowlist and absolute-path expectations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)