### PR TITLE
fix(ui): pair dark-only surfaces with light-mode classes

### DIFF
--- a/src/app/bed-types/page.tsx
+++ b/src/app/bed-types/page.tsx
@@ -173,7 +173,7 @@ export default function BedTypesPage() {
               {bedTypes.map((b) => (
                 <tr
                   key={b._id}
-                  className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(b._id) ? "bg-red-950/20" : ""}`}
+                  className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(b._id) ? "bg-red-50 dark:bg-red-950/20" : ""}`}
                 >
                   <td className="py-2 px-2">
                     <input

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -640,8 +640,8 @@ function NewFilamentContent() {
                 {t("new.prusamentQr")}
               </button>
               {prusamentOpen && (
-                <div className="absolute z-50 mt-1 w-80 bg-gray-800 border border-gray-600 rounded-lg shadow-lg p-3">
-                  <label className="text-xs text-gray-400 block mb-1.5">{t("new.prusament.inputLabel")}</label>
+                <div className="absolute z-50 mt-1 w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg p-3">
+                  <label className="text-xs text-gray-500 dark:text-gray-400 block mb-1.5">{t("new.prusament.inputLabel")}</label>
                   <div className="flex gap-2">
                     <input
                       type="text"
@@ -649,7 +649,7 @@ function NewFilamentContent() {
                       onChange={(e) => setPrusamentInput(e.target.value)}
                       onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handlePrusament(); } }}
                       placeholder="e.g. 4a7b3c... or full URL"
-                      className="flex-1 px-2.5 py-1.5 bg-gray-900 border border-gray-600 rounded text-sm text-gray-100 outline-none placeholder-gray-500"
+                      className="flex-1 px-2.5 py-1.5 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-gray-100 outline-none placeholder-gray-400 dark:placeholder-gray-500"
                       autoFocus
                     />
                     <button
@@ -678,8 +678,8 @@ function NewFilamentContent() {
                 {t("new.importFromTds")}
               </button>
               {tdsOpen && (
-                <div className="absolute z-50 mt-1 w-96 bg-gray-800 border border-gray-600 rounded-lg shadow-lg p-3">
-                  <label className="text-xs text-gray-400 block mb-1.5">{t("new.tds.urlLabel")}</label>
+                <div className="absolute z-50 mt-1 w-96 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg p-3">
+                  <label className="text-xs text-gray-500 dark:text-gray-400 block mb-1.5">{t("new.tds.urlLabel")}</label>
                   <div className="flex gap-2">
                     <input
                       type="text"
@@ -687,7 +687,7 @@ function NewFilamentContent() {
                       onChange={(e) => setTdsUrl(e.target.value)}
                       onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleTds(); } }}
                       placeholder="https://example.com/filament-tds.pdf"
-                      className="flex-1 px-2.5 py-1.5 bg-gray-900 border border-gray-600 rounded text-sm text-gray-100 outline-none placeholder-gray-500"
+                      className="flex-1 px-2.5 py-1.5 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded text-sm text-gray-900 dark:text-gray-100 outline-none placeholder-gray-400 dark:placeholder-gray-500"
                       autoFocus
                     />
                     <button
@@ -700,9 +700,9 @@ function NewFilamentContent() {
                     </button>
                   </div>
                   <div className="flex items-center gap-2 mt-2">
-                    <div className="flex-1 border-t border-gray-700" />
-                    <span className="text-xs text-gray-600">{t("new.tds.or")}</span>
-                    <div className="flex-1 border-t border-gray-700" />
+                    <div className="flex-1 border-t border-gray-200 dark:border-gray-700" />
+                    <span className="text-xs text-gray-400 dark:text-gray-600">{t("new.tds.or")}</span>
+                    <div className="flex-1 border-t border-gray-200 dark:border-gray-700" />
                   </div>
                   <input
                     ref={tdsFileRef}
@@ -715,7 +715,7 @@ function NewFilamentContent() {
                     type="button"
                     onClick={() => tdsFileRef.current?.click()}
                     disabled={tdsLoading}
-                    className="mt-2 w-full px-3 py-1.5 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600 disabled:opacity-50 inline-flex items-center justify-center gap-1.5"
+                    className="mt-2 w-full px-3 py-1.5 text-sm bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 rounded disabled:opacity-50 inline-flex items-center justify-center gap-1.5"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
@@ -725,7 +725,7 @@ function NewFilamentContent() {
                   <p className="text-xs text-gray-500 mt-2">
                     {t("new.tds.aiDescription")}
                     {" "}
-                    <Link href="/settings" className="text-blue-400 hover:text-blue-300 underline" onClick={guardLink("/settings")}>
+                    <Link href="/settings" className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline" onClick={guardLink("/settings")}>
                       {t("new.tds.configureApiKey")}
                     </Link>
                   </p>
@@ -765,9 +765,9 @@ function NewFilamentContent() {
                 {t("new.cloneExisting")}
               </button>
               {cloneOpen && (
-                <div className="absolute z-50 mt-1 w-80 bg-gray-800 border border-gray-600 rounded-lg shadow-lg">
+                <div className="absolute z-50 mt-1 w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg">
                   <input
-                    className="w-full px-3 py-2 bg-transparent border-b border-gray-600 text-sm text-gray-100 outline-none placeholder-gray-500"
+                    className="w-full px-3 py-2 bg-transparent border-b border-gray-200 dark:border-gray-600 text-sm text-gray-900 dark:text-gray-100 outline-none placeholder-gray-400 dark:placeholder-gray-500"
                     placeholder={t("new.clone.searchPlaceholder")}
                     value={cloneSearch}
                     onChange={(e) => { setCloneSearch(e.target.value); setCloneHighlight(-1); }}
@@ -795,7 +795,7 @@ function NewFilamentContent() {
                         id={`clone-opt-${i}`}
                         role="option"
                         aria-selected={i === cloneHighlight}
-                        className={`px-3 py-2 cursor-pointer text-gray-100 hover:bg-gray-700 flex items-center gap-2 text-sm ${i === cloneHighlight ? "bg-gray-600" : ""}`}
+                        className={`px-3 py-2 cursor-pointer text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2 text-sm ${i === cloneHighlight ? "bg-gray-200 dark:bg-gray-600" : ""}`}
                         onMouseDown={(e) => {
                           e.preventDefault();
                           handleClone(f._id);
@@ -806,7 +806,7 @@ function NewFilamentContent() {
                           style={{ backgroundColor: f.color }}
                         />
                         <span className="flex-1 truncate">{f.name}</span>
-                        <span className="text-gray-400 text-xs flex-shrink-0">{f.vendor}</span>
+                        <span className="text-gray-500 dark:text-gray-400 text-xs flex-shrink-0">{f.vendor}</span>
                       </li>
                     ))}
                     {filteredClones.length === 0 && (
@@ -829,24 +829,24 @@ function NewFilamentContent() {
               role="dialog"
               aria-modal="true"
               aria-label={t("new.ini.selectProfile")}
-              className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl max-w-lg w-full mx-4 p-6 pointer-events-auto max-h-[80vh] flex flex-col"
+              className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-2xl max-w-lg w-full mx-4 p-6 pointer-events-auto max-h-[80vh] flex flex-col"
             >
-              <h2 className="text-lg font-bold text-white mb-1">{t("new.ini.selectProfile")}</h2>
-              <p className="text-sm text-gray-400 mb-4">{t("new.ini.profileCount", { count: iniFilaments.length })}</p>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-1">{t("new.ini.selectProfile")}</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{t("new.ini.profileCount", { count: iniFilaments.length })}</p>
               <ul className="overflow-y-auto flex-1 space-y-1">
                 {iniFilaments.map((f, i) => (
                   <li key={i}>
                     <button
                       type="button"
-                      className="w-full text-left px-3 py-2 rounded hover:bg-gray-800 flex items-center gap-2 text-sm"
+                      className="w-full text-left px-3 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center gap-2 text-sm"
                       onClick={() => guardPopulate(() => applyIniFilament(f))}
                     >
                       <div
                         className="w-4 h-4 rounded-full border border-gray-500 flex-shrink-0"
                         style={{ backgroundColor: (f.color as string) || "#808080" }}
                       />
-                      <span className="text-white flex-1 truncate">{f.name as string}</span>
-                      <span className="text-gray-400 text-xs">{f.vendor as string} · {f.type as string}</span>
+                      <span className="text-gray-900 dark:text-white flex-1 truncate">{f.name as string}</span>
+                      <span className="text-gray-500 dark:text-gray-400 text-xs">{f.vendor as string} · {f.type as string}</span>
                     </button>
                   </li>
                 ))}
@@ -855,7 +855,7 @@ function NewFilamentContent() {
                 <button
                   type="button"
                   onClick={() => setIniFilaments(null)}
-                  className="px-4 py-2 text-sm text-gray-300 hover:text-white border border-gray-600 rounded hover:border-gray-500"
+                  className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white border border-gray-300 dark:border-gray-600 rounded hover:border-gray-400 dark:hover:border-gray-500"
                 >
                   {t("common.cancel")}
                 </button>

--- a/src/app/nozzles/page.tsx
+++ b/src/app/nozzles/page.tsx
@@ -178,7 +178,7 @@ export default function NozzlesPage() {
               {nozzles.map((n) => (
                 <tr
                   key={n._id}
-                  className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(n._id) ? "bg-red-950/20" : ""}`}
+                  className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(n._id) ? "bg-red-50 dark:bg-red-950/20" : ""}`}
                 >
                   <td className="py-2 px-2">
                     <input

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -662,7 +662,7 @@ export default function Home() {
   const renderRow = (f: Filament, isVariant = false) => (
     <tr
       key={f._id}
-      className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${isVariant ? "bg-gray-50/50 dark:bg-gray-950/50" : ""} ${selected.has(f._id) ? "bg-red-900/25" : ""}`}
+      className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${isVariant ? "bg-gray-50/50 dark:bg-gray-950/50" : ""} ${selected.has(f._id) ? "bg-red-50 dark:bg-red-900/25" : ""}`}
     >
       <td className="py-2 px-2">
         <input
@@ -765,7 +765,7 @@ export default function Home() {
       <>
         <tr
           key={f._id}
-          className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(f._id) ? "bg-red-900/25" : ""}`}
+          className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(f._id) ? "bg-red-50 dark:bg-red-900/25" : ""}`}
         >
           <td className="py-2 px-2">
             <input
@@ -963,24 +963,24 @@ export default function Home() {
               </svg>
             </button>
             {showImportExport && (
-              <div className="absolute right-0 top-full mt-1 w-52 bg-gray-800 border border-gray-600 rounded-lg shadow-xl z-50 py-1">
+              <div className="absolute right-0 top-full mt-1 w-52 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-xl z-50 py-1">
                 <button
                   onClick={() => { setShowImportExport(false); setShowPrusamentImport(true); }}
-                  className="w-full text-left px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                 >
                   <span className="w-2 h-2 rounded-full bg-orange-500" />
                   {t("filaments.import.prusamentQR")}
                 </button>
                 <button
                   onClick={() => { setShowImportExport(false); setShowAtlasImport(true); }}
-                  className="w-full text-left px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                 >
                   <span className="w-2 h-2 rounded-full bg-purple-500" />
                   {t("filaments.import.fromAtlas")}
                 </button>
                 <a
                   href="/openprinttag"
-                  className="block px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="block px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                   onClick={() => setShowImportExport(false)}
                 >
                   <span className="w-2 h-2 rounded-full bg-teal-500" />
@@ -988,7 +988,7 @@ export default function Home() {
                 </a>
                 <button
                   onClick={() => { setShowImportExport(false); setShowSpoolCsvImport(true); }}
-                  className="w-full text-left px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                 >
                   <span className="w-2 h-2 rounded-full bg-blue-500" />
                   {t("filaments.import.spoolCsv")}
@@ -996,19 +996,19 @@ export default function Home() {
                 <button
                   onClick={() => { setShowImportExport(false); fileInputRef.current?.click(); }}
                   disabled={importing}
-                  className="w-full text-left px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-700 disabled:opacity-50 flex items-center gap-2"
+                  className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 flex items-center gap-2"
                 >
                   <span className="w-2 h-2 rounded-full bg-amber-500" />
                   {importing ? t("filaments.import.importing") : t("filaments.import.file")}
                 </button>
-                <div className="border-t border-gray-600 my-1" />
+                <div className="border-t border-gray-200 dark:border-gray-600 my-1" />
                 <div className="px-4 py-1">
                   <span className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">{t("filaments.export")}</span>
                 </div>
                 {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
                 <a
                   href="/api/filaments/export"
-                  className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                   onClick={() => setShowImportExport(false)}
                 >
                   <span className="w-2 h-2 rounded-full bg-green-500" />
@@ -1017,7 +1017,7 @@ export default function Home() {
                 {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
                 <a
                   href="/api/filaments/export-csv"
-                  className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                   onClick={() => setShowImportExport(false)}
                 >
                   <span className="w-2 h-2 rounded-full bg-green-500" />
@@ -1026,19 +1026,19 @@ export default function Home() {
                 {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
                 <a
                   href="/api/filaments/export-xlsx"
-                  className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                   onClick={() => setShowImportExport(false)}
                 >
                   <span className="w-2 h-2 rounded-full bg-green-500" />
                   {t("filaments.export.xlsx")}
                 </a>
-                <div className="border-t border-gray-600 my-1" />
+                <div className="border-t border-gray-200 dark:border-gray-600 my-1" />
                 <div className="px-4 py-1">
                   <span className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">{t("spools.export")}</span>
                 </div>
                 <a
                   href="/api/spools/export-csv"
-                  className="block px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center gap-2"
+                  className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                   onClick={() => setShowImportExport(false)}
                 >
                   <span className="w-2 h-2 rounded-full bg-green-500" />
@@ -1104,8 +1104,8 @@ export default function Home() {
         // text to red-100 with font-medium, and the Clear button to
         // gray-200 hover-white so all three elements meet WCAG-AA contrast
         // on dark mode.
-        <div className="mb-4 flex items-center gap-3 px-3 py-2.5 bg-red-900/50 border border-red-700 rounded-lg">
-          <span className="text-sm font-medium text-red-100">{t("filaments.bulk.selected", { count: visibleSelectedCount })}</span>
+        <div className="mb-4 flex items-center gap-3 px-3 py-2.5 bg-red-50 dark:bg-red-900/50 border border-red-200 dark:border-red-700 rounded-lg">
+          <span className="text-sm font-medium text-red-700 dark:text-red-100">{t("filaments.bulk.selected", { count: visibleSelectedCount })}</span>
           <button
             onClick={handleBulkDelete}
             disabled={bulkDeleting}
@@ -1121,21 +1121,21 @@ export default function Home() {
             // GH #525.2: let the user stop a long bulk delete partway.
             <button
               onClick={() => { bulkAbortRef.current = true; }}
-              className="text-sm text-gray-200 hover:text-white"
+              className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white"
             >
               {t("filaments.bulk.stop")}
             </button>
           ) : (
             <button
               onClick={() => setSelected(new Set())}
-              className="text-sm text-gray-200 hover:text-white"
+              className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white"
             >
               {t("common.clear")}
             </button>
           )}
-          <span className="ml-auto text-xs text-red-200">
+          <span className="ml-auto text-xs text-red-600 dark:text-red-200">
             {t("filaments.bulk.deleteHint")}{" "}
-            <Link href="/trash" className="underline hover:text-white">
+            <Link href="/trash" className="underline hover:text-red-800 dark:hover:text-white">
               {t("filaments.bulk.openTrash")}
             </Link>
           </span>

--- a/src/app/printers/PrinterForm.tsx
+++ b/src/app/printers/PrinterForm.tsx
@@ -659,7 +659,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
       </fieldset>
 
       {nozzlesFetchError && (
-        <div className="px-3 py-2 bg-yellow-900/30 border border-yellow-800 rounded text-sm text-yellow-300">
+        <div className="px-3 py-2 bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded text-sm text-yellow-700 dark:text-yellow-300">
           {t("printers.form.nozzlesLoadError")}
         </div>
       )}
@@ -710,7 +710,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
       )}
 
       {bedTypesFetchError && (
-        <div className="px-3 py-2 bg-yellow-900/30 border border-yellow-800 rounded text-sm text-yellow-300">
+        <div className="px-3 py-2 bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded text-sm text-yellow-700 dark:text-yellow-300">
           {t("printers.form.bedTypesLoadError")}
         </div>
       )}

--- a/src/app/printers/page.tsx
+++ b/src/app/printers/page.tsx
@@ -135,8 +135,8 @@ export default function PrintersPage() {
       </div>
 
       {selected.size > 0 && (
-        <div className="mb-4 flex items-center gap-3 px-3 py-2 bg-red-950/30 border border-red-800 rounded-lg">
-          <span className="text-sm text-red-300">{t("printers.selected", { count: selected.size })}</span>
+        <div className="mb-4 flex items-center gap-3 px-3 py-2 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg">
+          <span className="text-sm text-red-600 dark:text-red-300">{t("printers.selected", { count: selected.size })}</span>
           <button
             onClick={handleBulkDelete}
             disabled={bulkDeleting}
@@ -146,7 +146,7 @@ export default function PrintersPage() {
           </button>
           <button
             onClick={() => setSelected(new Set())}
-            className="text-sm text-gray-400 hover:text-gray-200"
+            className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
           >
             {t("printers.clear")}
           </button>
@@ -189,7 +189,7 @@ export default function PrintersPage() {
               {printers.map((p) => (
                 <tr
                   key={p._id}
-                  className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(p._id) ? "bg-red-950/20" : ""}`}
+                  className={`border-b border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900 ${selected.has(p._id) ? "bg-red-50 dark:bg-red-950/20" : ""}`}
                 >
                   <td className="py-2 px-2">
                     <input

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -785,7 +785,7 @@ export default function SettingsPage() {
                 onClick={() => { setAiProvider(p.id); setAiResult(null); }}
                 className={`px-3 py-1.5 text-sm rounded border transition-colors ${
                   aiProvider === p.id
-                    ? "border-blue-500 bg-blue-600/20 text-blue-300"
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-600/20 text-blue-600 dark:text-blue-300"
                     : "border-gray-300 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
                 }`}
               >
@@ -928,8 +928,8 @@ export default function SettingsPage() {
               {t("settings.eraseTag")}
             </button>
           ) : (
-            <div className="p-4 border border-yellow-800 rounded-lg bg-yellow-950/30">
-              <p className="text-sm text-yellow-300 mb-3">
+            <div className="p-4 border border-yellow-300 dark:border-yellow-800 rounded-lg bg-yellow-50 dark:bg-yellow-950/30">
+              <p className="text-sm text-yellow-800 dark:text-yellow-300 mb-3">
                 {t("settings.eraseConfirm")}
               </p>
               <div className="flex gap-2 items-center">
@@ -992,8 +992,8 @@ export default function SettingsPage() {
       )}
 
       {/* Danger Zone */}
-      <div className="mt-8 pt-6 border-t border-red-900/50">
-        <h2 className="text-lg font-semibold text-red-400 mb-1">{t("settings.dangerZone")}</h2>
+      <div className="mt-8 pt-6 border-t border-red-200 dark:border-red-900/50">
+        <h2 className="text-lg font-semibold text-red-600 dark:text-red-400 mb-1">{t("settings.dangerZone")}</h2>
         <p className="text-sm text-gray-500 mb-4">
           {t("settings.dangerZoneDesc")}
         </p>
@@ -1001,7 +1001,7 @@ export default function SettingsPage() {
         {!showDeleteConfirm ? (
           <button
             onClick={() => { setShowDeleteConfirm(true); setDeleteResult(null); }}
-            className="px-4 py-2 bg-red-900/50 text-red-400 border border-red-800 rounded text-sm hover:bg-red-900 hover:text-red-300 transition-colors inline-flex items-center gap-2"
+            className="px-4 py-2 bg-red-50 dark:bg-red-900/50 text-red-600 dark:text-red-400 border border-red-300 dark:border-red-800 rounded text-sm hover:bg-red-100 dark:hover:bg-red-900 hover:text-red-700 dark:hover:text-red-300 transition-colors inline-flex items-center gap-2"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
@@ -1009,8 +1009,8 @@ export default function SettingsPage() {
             {t("settings.deleteDatabase")}
           </button>
         ) : (
-          <div className="p-4 border border-red-800 rounded-lg bg-red-950/30">
-            <p className="text-sm text-red-300 mb-3">
+          <div className="p-4 border border-red-300 dark:border-red-800 rounded-lg bg-red-50 dark:bg-red-950/30">
+            <p className="text-sm text-red-700 dark:text-red-300 mb-3">
               {t("settings.deleteTypeConfirm")}
             </p>
             <div className="flex gap-2 items-center">
@@ -1025,7 +1025,7 @@ export default function SettingsPage() {
                   }
                 }}
                 placeholder={t("settings.deleteTypePlaceholder")}
-                className="w-40 px-3 py-1.5 border border-red-800 rounded text-sm bg-transparent text-red-200 placeholder-red-800 focus:outline-none focus:border-red-600"
+                className="w-40 px-3 py-1.5 border border-red-300 dark:border-red-800 rounded text-sm bg-transparent text-red-700 dark:text-red-200 placeholder-red-300 dark:placeholder-red-800 focus:outline-none focus:border-red-600"
                 autoFocus
               />
               <button

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -119,13 +119,13 @@ export default function SetupPage() {
             {/* Atlas (Cloud) */}
             <button
               onClick={() => changeMode("atlas")}
-              className="w-full text-left p-4 border border-gray-600 rounded-lg hover:border-blue-500 hover:bg-blue-500/5 transition-colors"
+              className="w-full text-left p-4 border border-gray-300 dark:border-gray-600 rounded-lg hover:border-blue-500 hover:bg-blue-500/5 transition-colors"
             >
               <div className="flex items-start gap-3">
                 <div className="text-2xl mt-0.5">&#9729;</div>
                 <div>
                   <div className="font-semibold text-gray-900 dark:text-white">{t("setup.atlasTitle")}</div>
-                  <p className="text-sm text-gray-400 mt-1">
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                     {t("setup.atlasDesc")}
                   </p>
                 </div>
@@ -136,13 +136,13 @@ export default function SetupPage() {
             {isElectron && (
               <button
                 onClick={() => changeMode("hybrid")}
-                className="w-full text-left p-4 border border-gray-600 rounded-lg hover:border-purple-500 hover:bg-purple-500/5 transition-colors"
+                className="w-full text-left p-4 border border-gray-300 dark:border-gray-600 rounded-lg hover:border-purple-500 hover:bg-purple-500/5 transition-colors"
               >
                 <div className="flex items-start gap-3">
                   <div className="text-2xl mt-0.5">&#8644;</div>
                   <div>
                     <div className="font-semibold text-gray-900 dark:text-white">{t("setup.hybridTitle")}</div>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                       {t("setup.hybridDesc")} <span className="text-gray-500">{t("setup.recommended")}</span>
                     </p>
                   </div>
@@ -154,13 +154,13 @@ export default function SetupPage() {
             {isElectron && (
               <button
                 onClick={() => changeMode("offline")}
-                className="w-full text-left p-4 border border-gray-600 rounded-lg hover:border-green-500 hover:bg-green-500/5 transition-colors"
+                className="w-full text-left p-4 border border-gray-300 dark:border-gray-600 rounded-lg hover:border-green-500 hover:bg-green-500/5 transition-colors"
               >
                 <div className="flex items-start gap-3">
                   <div className="text-2xl mt-0.5">&#128190;</div>
                   <div>
                     <div className="font-semibold text-gray-900 dark:text-white">{t("setup.offlineTitle")}</div>
-                    <p className="text-sm text-gray-400 mt-1">
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                       {t("setup.offlineDesc")}
                     </p>
                   </div>
@@ -202,7 +202,7 @@ export default function SetupPage() {
           </div>
 
           {error && (
-            <div className="p-3 bg-red-900/30 border border-red-800 rounded text-sm text-red-300 mb-4">
+            <div className="p-3 bg-red-100 dark:bg-red-900/30 border border-red-300 dark:border-red-800 rounded text-sm text-red-700 dark:text-red-300 mb-4">
               {error}
             </div>
           )}
@@ -210,7 +210,7 @@ export default function SetupPage() {
           <div className="flex gap-3">
             <button
               onClick={() => changeMode("")}
-              className="flex-1 px-4 py-2 text-sm text-gray-300 hover:text-white border border-gray-600 rounded hover:border-gray-500"
+              className="flex-1 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white border border-gray-300 dark:border-gray-600 rounded hover:border-gray-400 dark:hover:border-gray-500"
             >
               {t("common.back")}
             </button>
@@ -241,7 +241,7 @@ export default function SetupPage() {
         </div>
 
         {mode === "hybrid" && (
-          <div className="p-3 bg-purple-900/20 border border-purple-800 rounded-lg mb-4 text-xs text-purple-300">
+          <div className="p-3 bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg mb-4 text-xs text-purple-700 dark:text-purple-300">
             <strong>{t("setup.hybridModeLabel")}</strong> {t("setup.hybridModeExplanation")}
           </div>
         )}
@@ -251,7 +251,7 @@ export default function SetupPage() {
           // form (dbConnect reads from process.env at boot). Set the
           // user's expectation up front: this is a connection-test
           // form, not a save-and-configure form.
-          <div className="p-3 bg-amber-900/20 border border-amber-800 rounded-lg mb-4 text-xs text-amber-200">
+          <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg mb-4 text-xs text-amber-700 dark:text-amber-200">
             <strong>{t("setup.webTestOnlyLabel")}</strong> {t("setup.webTestOnlyExplanation")}
           </div>
         )}
@@ -312,7 +312,7 @@ export default function SetupPage() {
             <button
               type="button"
               onClick={() => { changeMode(""); setError(""); setSuccess(""); }}
-              className="px-4 py-2 text-sm text-gray-300 hover:text-white border border-gray-600 rounded hover:border-gray-500"
+              className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white border border-gray-300 dark:border-gray-600 rounded hover:border-gray-400 dark:hover:border-gray-500"
             >
               {t("common.back")}
             </button>


### PR DESCRIPTION
## Summary

GH #624: several surfaces hardcoded dark palettes with no light variant, rendering as dark islands or unreadable controls in light mode. Every instance now carries light-mode classes with the **existing dark appearance preserved** behind `dark:` variants — dark mode is visually unchanged (70 insertions / 70 deletions, pure class-string swaps).

| File | Surface |
|---|---|
| `src/app/page.tsx` | Import/Export dropdown; selected-row tint |
| `src/app/filaments/new/page.tsx` | Prusament / TDS / Clone popovers; INI-profile picker modal |
| `src/app/settings/page.tsx` | AI-provider active chip (copies the currency-button pairing 380 lines up); NFC erase-confirm box; Danger Zone |
| `src/app/setup/page.tsx` | Wizard mode cards; Back buttons; offline error box (copies the correctly-paired Atlas-branch box) |
| `src/app/printers/PrinterForm.tsx` | Fetch-error banners (copies FilamentForm's paired equivalent) |
| `src/app/nozzles/page.tsx`, `src/app/printers/page.tsx`, `src/app/bed-types/page.tsx` | Selected-row tints (`bg-red-50 dark:bg-red-950/20` family, matching the already-paired bulk-action bars) |

Fixes #624

## Test plan
- `npm run lint` → clean
- `npm test` → 111 files / 1879 tests passed
- Diff review: every changed element keeps its original dark classes behind `dark:`; light palettes copied from correctly-paired siblings in the same files

🤖 Generated with [Claude Code](https://claude.com/claude-code)