### PR TITLE
Bump version to 1.36.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.36.0",
+      "version": "1.36.1",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
         "electron-store": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.36.0",
+    "version": "1.36.1",
     "license": {
       "name": "MIT"
     }


### PR DESCRIPTION
Patch release **1.36.1** — bundles the codebase-review fix batch merged since v1.36.0 (12 PRs, all bug fixes / hardening, no features).

Updates the version in `package.json`, `package-lock.json` (both occurrences), and `public/openapi.json`.

## What's in 1.36.1
- **API hardening**: slicer-sync validators + atomic calibration writes (#645), `openprinttagSnapshot` mass-assignment strip + embedded-spool photo validation + AMS-slot validation (#646), soft-delete consistency in aggregations/delete-guards/resolveFilament (#648), idempotent print-history refund (#644)
- **Import/export**: Prusament error handling + row caps + CSV/XLSX round-trip fidelity (#649), Bambu/Orca `filament_notes` round-trip (#643)
- **OpenPrintTag**: encoder + import-path hex/integer validation (#650)
- **Electron**: absolute `powershell` path, device-path allowlist, gated status getters, value-level CSP parity test (#651)
- **UI**: SSR-safe locale/currency init + fetch error handling (#647), light-mode pairing (#652), dialog a11y + translated labels (#653)
- **CI/tooling**: unblocked `npm audit` gate, hardened release-bump input, test hygiene (#642)

After this merges, tag `v1.36.1` to trigger the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)