### PR TITLE
Bump version to 1.36.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.36.1",
+      "version": "1.36.2",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
         "electron-store": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.36.1",
+    "version": "1.36.2",
     "license": {
       "name": "MIT"
     }


### PR DESCRIPTION
Patch release **1.36.2** — ships the OpenPrintTag re-sync inheritance fix merged since v1.36.1.

Updates the version in `package.json`, `package-lock.json` (both occurrences), and `public/openapi.json`.

## What's in 1.36.2
- **OpenPrintTag "Check for updates" respects variant inheritance (#607 / #655)** — checking a variant filament no longer offers fields it inherits from its parent as spurious updates, and the check/sync routes agree on what's applyable (including correctly handling inherited vs variant-owned array clears).

After this merges, tag `v1.36.2` to trigger the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)