### PR TITLE
Bump version to 1.37.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.36.2",
+  "version": "1.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.36.2",
+      "version": "1.37.0",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
         "electron-store": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.36.2",
+  "version": "1.37.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.36.2",
+    "version": "1.37.0",
     "license": {
       "name": "MIT"
     }


### PR DESCRIPTION
Minor release **1.37.0** — two small user-facing features merged since v1.36.2.

Updates the version in `package.json`, `package-lock.json` (both occurrences), and `public/openapi.json`.

## What's in 1.37.0
- **Spool + location totals on the Filaments home stat line (#616)** — the header now shows "N spool(s) in M location(s)" alongside the type/vendor counts, consistent with the Inventory page (counts the unassigned bucket; includes legacy single-spool rows).
- **View a spool's logged usage history (#608)** — the spool card's usage line is now an expandable disclosure listing each entry (date · grams · job label · source), newest first.

After this merges, tag `v1.37.0` to trigger the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)