### PR TITLE
Bump version to 1.38.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
         "electron-store": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.37.0",
+    "version": "1.38.0",
     "license": {
       "name": "MIT"
     }


### PR DESCRIPTION
Minor release **1.38.0** — adds the Technical Reference panel feature.

Updates the version in `package.json`, `package-lock.json` (both occurrences), and `public/openapi.json`.

## What's in 1.38.0
- **Technical Reference panel on the filament detail page ([#614](https://github.com/hyiger/filament-db/issues/614))** — renders the chapter of the *FDM Polymers Technical Reference* matching the filament's type (PLA → PLA family, PETG → copolyesters, PA → nylons, …), bundled offline from the project wiki. Replaces the old "Show all PrusaSlicer settings" dump. Lazy-loaded, dark-mode aware, sanitized markdown; resolver covers compound/recycled/Shore-suffixed type names.

After this merges, tag `v1.38.0` to trigger the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)