### PR TITLE
chore(deps): override joi to ^18.2.1 (clear GHSA-q7cg-457f-vx79 audit failure)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10227,9 +10227,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
       "uuid": "^11.1.1"
     },
     "tmp": "^0.2.6",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "joi": "^18.2.1"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",


### PR DESCRIPTION
## Summary

A newly-published moderate advisory — **[GHSA-q7cg-457f-vx79](https://github.com/advisories/GHSA-q7cg-457f-vx79)** (`joi <18.2.1`, uncaught `RangeError` on deeply nested input through recursive `link()` schemas) — started failing the **`npm audit` "Security audit" step** on every PR's CI (including unrelated docs PRs).

`joi` is only a **transitive devDependency** via `wait-on@9.0.5 → joi@18.1.2`. This pins it to the patched **18.2.1** through the existing `overrides` block — the same hygiene pattern already used for `tmp` ([#392](https://github.com/hyiger/filament-db/pull/392)), `postcss`, and `shell-quote`.

## Verification
- `npm audit` → **found 0 vulnerabilities**
- `npm ls joi` → `wait-on@9.0.5 → joi@18.2.1`
- Diff is minimal: the `overrides` entry + joi's `version`/`resolved`/`integrity` in the lockfile. No runtime deps touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)