### PR TITLE
fix(filaments): readable filter dropdowns in dark mode (#663)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1111,12 +1111,12 @@ export default function Home() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={(e) => { if (e.key === "Escape") setSearch(""); }}
-          className="px-3 py-2 border border-gray-300 rounded text-sm bg-transparent"
+          className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
         />
         <select
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
-          className="px-3 py-2 border border-gray-300 rounded text-sm bg-transparent"
+          className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
         >
           <option value="">{t("filaments.filter.allTypes")}</option>
           {types.map((tp) => (
@@ -1128,7 +1128,7 @@ export default function Home() {
         <select
           value={vendorFilter}
           onChange={(e) => setVendorFilter(e.target.value)}
-          className="px-3 py-2 border border-gray-300 rounded text-sm bg-transparent"
+          className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
         >
           <option value="">{t("filaments.filter.allVendors")}</option>
           {vendors.map((vn) => (


### PR DESCRIPTION
## Summary

Fixes [#663](https://github.com/hyiger/filament-db/issues/663) — reported by @Naugh62: the filter **submenu has no contrast in dark theme**.

The "All Types" / "All Vendors" filter `<select>`s on the home page (and the search input beside them) used `bg-transparent` with **no `dark:` variants**. Giving a `<select>` a transparent background flips Chrome into "author-styled" mode for the option list: it draws the popup on a default **white** background while the option text inherits the dark-theme **light** color — light-on-white, unreadable.

| Before (#663 report) | Fix |
|---|---|
| white popup, near-invisible light-gray options | dark popup, light text (matches the Inventory page selects) |

## Change

Switched the three controls to the same solid-background pattern the **Inventory page** selects already use:
`bg-white dark:bg-gray-900` · `border-gray-300 dark:border-gray-600` · `text-gray-900 dark:text-gray-100`.

With a solid background the option list renders on that background, and `color-scheme: dark` (already on `html.dark` from GH #598) keeps the native popup dark. 3-line change.

## Test plan
- `npm run lint` + `npx tsc --noEmit` clean.
- **Preview-verified** (the native popup is OS-drawn so it can't be screenshotted headlessly, but the controls' computed styles confirm the fix):
  - **dark**: select bg `gray-900`, text `gray-100`, border `gray-600`, `color-scheme: dark`.
  - **light**: select bg `#fff`, near-black text, `color-scheme: light`.
- Closed filter row renders correctly in dark mode (screenshot in the issue thread).

## Scope note
Only the home-page filter **selects** had the popup-contrast bug. Three `bg-transparent` matches on the detail page are `<input>` elements (no option popup) and remain readable in dark mode, so they're left out to keep this scoped to #663.

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)