### PR TITLE
Bump version to 1.38.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.38.0",
+      "version": "1.38.1",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
         "electron-store": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.38.0",
+    "version": "1.38.1",
     "license": {
       "name": "MIT"
     }


### PR DESCRIPTION
Patch release **1.38.1**.

Updates the version in `package.json`, `package-lock.json` (both occurrences), and `public/openapi.json`.

## What's in 1.38.1
- **Readable filter dropdowns in dark mode ([#663](https://github.com/hyiger/filament-db/issues/663))** — the "All Types" / "All Vendors" filter selects on the Filaments page no longer render their option popup as light-on-white in dark theme.
- **CI dependency hygiene ([#665](https://github.com/hyiger/filament-db/pull/665))** — `joi` pinned to `^18.2.1` via `overrides` to clear [GHSA-q7cg-457f-vx79](https://github.com/advisories/GHSA-q7cg-457f-vx79).
- **Docs accuracy ([#664](https://github.com/hyiger/filament-db/pull/664))** — drift fixed across the guides (EN + DE) and screenshots refreshed to the v1.38.0 UI.

After this merges, tag `v1.38.1` to trigger the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)