### PR TITLE
Bump version to 1.38.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.38.1",
+      "version": "1.38.2",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
         "electron-store": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.38.1",
+    "version": "1.38.2",
     "license": {
       "name": "MIT"
     }


### PR DESCRIPTION
Patch release **1.38.2**.

Updates the version in `package.json`, `package-lock.json` (both occurrences), and `public/openapi.json`.

## What's in 1.38.2
- **Windows auto-update fix ([#586](https://github.com/hyiger/filament-db/issues/586))** — keep x64 as the single Windows update channel so an x64 install no longer intermittently auto-installs the arm64 build (which produced Windows' "Problem with Shortcut — 'Filament DB.exe' has been changed or moved" error). The fix takes effect for updates **to** this release onward.

After this merges, tag `v1.38.2` to trigger the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)