### PR TITLE
fix(api): route robustness — double-decode, date guard, size cap, ids validation

### DIFF
--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -39,8 +39,9 @@ export async function GET(
       );
     }
 
-    // Find filament by name or ObjectId
-    const decodedName = decodeURIComponent(id);
+    // Find filament by name or ObjectId. `params.id` is ALREADY URL-decoded —
+    // re-decoding throws URIError on a name with a literal `%` (#671).
+    const decodedName = id;
     let filament = await Filament.findOne({ name: decodedName, _deletedAt: null })
       .populate("calibrations.nozzle")
       .populate("calibrations.printer")

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -134,8 +134,10 @@ export async function POST(
     await dbConnect();
     const { id } = await params;
 
-    // Find filament by name or ObjectId
-    const decodedName = decodeURIComponent(id);
+    // Find filament by name or ObjectId. The App Router `params.id` is ALREADY
+    // URL-decoded — re-decoding throws URIError on a name with a literal `%`
+    // ("ABS 100%") and 500s the sync-back (#671; cf. resolveFilamentForExport).
+    const decodedName = id;
     let filament = await Filament.findOne({ name: decodedName, _deletedAt: null });
     if (!filament && /^[a-f0-9]{24}$/i.test(id)) {
       filament = await Filament.findOne({ _id: id, _deletedAt: null });

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -419,9 +419,10 @@ export async function POST(
       return errorResponse("No config provided", 400);
     }
 
-    // Try to find by name first (PrusaSlicer sends URL-encoded name),
-    // then fall back to ObjectId
-    const decodedName = decodeURIComponent(id);
+    // Find by name first (slicers address filaments by name), then ObjectId.
+    // `params.id` is ALREADY URL-decoded — re-decoding throws URIError on a
+    // name with a literal `%` ("ABS 100%") and 500s the sync (#671).
+    const decodedName = id;
     let filament = await Filament.findOne({ name: decodedName, _deletedAt: null });
     if (!filament && /^[a-f0-9]{24}$/i.test(id)) {
       filament = await Filament.findOne({ _id: id, _deletedAt: null });

--- a/src/app/api/filaments/[id]/spool-check/route.ts
+++ b/src/app/api/filaments/[id]/spool-check/route.ts
@@ -42,8 +42,9 @@ export async function GET(
       return errorResponse("weight must be a non-negative number", 400);
     }
 
-    // Find filament by name or ObjectId
-    const decodedName = decodeURIComponent(id);
+    // Find filament by name or ObjectId. `params.id` is ALREADY URL-decoded —
+    // re-decoding throws URIError on a name with a literal `%` (#671).
+    const decodedName = id;
     let filament = await Filament.findOne({ name: decodedName, _deletedAt: null }).lean();
     if (!filament && /^[a-f0-9]{24}$/i.test(id)) {
       filament = await Filament.findOne({ _id: id, _deletedAt: null }).lean();

--- a/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
@@ -46,6 +46,12 @@ export async function POST(
   }
   const jobLabel = typeof body.jobLabel === "string" ? body.jobLabel : "";
   const date = body.date ? new Date(body.date) : new Date();
+  // Reject an unparseable date with a clean 400 rather than letting the
+  // Invalid Date reach the subdocument and surface as a raw Mongoose cast
+  // error (#675; matches the print-history POST date guard).
+  if (Number.isNaN(date.getTime())) {
+    return errorResponse("date is not a valid date", 400);
+  }
 
   try {
     await dbConnect();

--- a/src/app/api/filaments/orcaslicer/route.ts
+++ b/src/app/api/filaments/orcaslicer/route.ts
@@ -6,6 +6,10 @@ import "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
 import { generateOrcaSlicerProfiles } from "@/lib/orcaSlicerBundle";
+import { errorResponse } from "@/lib/apiErrorHandler";
+
+/** 24-hex ObjectId, for validating user-supplied `?ids=` before a `$in`. */
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
 
 /**
  * GET /api/filaments/orcaslicer
@@ -35,7 +39,14 @@ export async function GET(request: NextRequest) {
     if (typeFilter) query.type = typeFilter;
     if (vendorFilter) query.vendor = vendorFilter;
     if (idsFilter) {
-      query._id = { $in: idsFilter.split(",").map((id) => id.trim()) };
+      // Validate each id is a real ObjectId before the $in — an invalid value
+      // would otherwise throw a Mongoose CastError and 500 (#677).
+      const ids = idsFilter.split(",").map((id) => id.trim()).filter(Boolean);
+      const bad = ids.filter((id) => !OBJECT_ID_RE.test(id));
+      if (bad.length > 0) {
+        return errorResponse(`Invalid filament ID(s): ${bad.join(", ")}`, 400);
+      }
+      query._id = { $in: ids };
     }
 
     const filaments = await Filament.find(query)

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -133,7 +133,10 @@ export async function POST(request: NextRequest) {
     await dbConnect();
 
     const body = await request.text();
-    if (body.length > MAX_UPLOAD_SIZE) {
+    // Byte length, not String.length (UTF-16 code units) — a non-ASCII UTF-8
+    // body can exceed 10 MB of bytes while staying under the char count when
+    // Content-Length was missing/wrong (Codex P2 on PR #685).
+    if (Buffer.byteLength(body, "utf8") > MAX_UPLOAD_SIZE) {
       return errorResponse("Request body too large. Maximum is 10 MB.", 413);
     }
     if (!body.trim()) {

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -7,8 +7,11 @@ import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
 import { generatePrusaSlicerBundle } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
-import { isDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { isDuplicateKeyError, checkContentLength, errorResponse, MAX_UPLOAD_SIZE } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
+
+/** 24-hex ObjectId, for validating user-supplied `?ids=` before a `$in`. */
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
 
 /**
  * GET /api/filaments/prusaslicer
@@ -38,7 +41,14 @@ export async function GET(request: NextRequest) {
     if (typeFilter) query.type = typeFilter;
     if (vendorFilter) query.vendor = vendorFilter;
     if (idsFilter) {
-      query._id = { $in: idsFilter.split(",").map((id) => id.trim()) };
+      // Validate each id is a real ObjectId before the $in — an invalid value
+      // would otherwise throw a Mongoose CastError and 500 (#677).
+      const ids = idsFilter.split(",").map((id) => id.trim()).filter(Boolean);
+      const bad = ids.filter((id) => !OBJECT_ID_RE.test(id));
+      if (bad.length > 0) {
+        return errorResponse(`Invalid filament ID(s): ${bad.join(", ")}`, 400);
+      }
+      query._id = { $in: ids };
     }
 
     const filaments = await Filament.find(query)
@@ -116,10 +126,16 @@ export async function POST(request: NextRequest) {
   const guard = assertSameOriginRequest(request);
   if (guard) return guard;
 
+  const sizeError = checkContentLength(request);
+  if (sizeError) return sizeError;
+
   try {
     await dbConnect();
 
     const body = await request.text();
+    if (body.length > MAX_UPLOAD_SIZE) {
+      return errorResponse("Request body too large. Maximum is 10 MB.", 413);
+    }
     if (!body.trim()) {
       return NextResponse.json({ error: "Empty request body" }, { status: 400 });
     }

--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -202,6 +202,29 @@ export function checkFileSize(file: File): NextResponse | null {
 }
 
 /**
+ * GH #676: cap a raw (non-multipart) request body via its Content-Length
+ * header BEFORE buffering it with `request.text()`/`.json()`, so a huge body
+ * can't drive unbounded memory use. Returns a 413 when the declared length
+ * exceeds the limit (default `MAX_UPLOAD_SIZE`), else null. A missing/lying
+ * Content-Length isn't caught here — callers that need a hard guarantee
+ * should additionally check the buffered length.
+ */
+export function checkContentLength(
+  request: Request,
+  max: number = MAX_UPLOAD_SIZE,
+): NextResponse | null {
+  const declared = Number(request.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > max) {
+    const sizeMB = (declared / (1024 * 1024)).toFixed(1);
+    return errorResponse(
+      `Request body too large (${sizeMB} MB). Maximum is ${(max / (1024 * 1024)).toFixed(0)} MB.`,
+      413,
+    );
+  }
+  return null;
+}
+
+/**
  * GH #338: short-circuit a route when the body isn't `multipart/form-data`,
  * before the downstream `await request.formData()` throws the runtime's
  * "Content-Type was not one of …" error — which the catch-all error

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -639,10 +639,13 @@ describe("API route correctness", () => {
         getReq("http://localhost/api/filaments/ABS%20100%25/spool-check?weight=10"),
         { params: Promise.resolve({ id: "ABS 100%" }) },
       );
-      // Pre-fix: decodeURIComponent("ABS 100%") throws → caught → 500.
-      expect(res.status).not.toBe(500);
+      // Pre-fix: decodeURIComponent("ABS 100%") threw → caught → 500. The
+      // route must actually RESOLVE the filament (200 + its name echoed back),
+      // not merely avoid a 500 — so a regression to 404/400 also fails (Codex
+      // P3 on PR #685).
+      expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.filamentName ?? body.name ?? "ABS 100%").toBeDefined();
+      expect(body.filament).toBe("ABS 100%");
       expect(String(f._id)).toBeTruthy();
     });
 

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -11,6 +11,8 @@ import { POST as postPrintHistory } from "@/app/api/print-history/route";
 import { POST as scanPublish } from "@/app/api/scan/publish/route";
 import { POST as slicerSync } from "@/app/api/filaments/[id]/route";
 import { POST as orcaSync } from "@/app/api/filaments/[id]/orcaslicer/route";
+import { GET as orcaBulkExport } from "@/app/api/filaments/orcaslicer/route";
+import { GET as prusaBulkExport } from "@/app/api/filaments/prusaslicer/route";
 
 /**
  * Code-review issues #265, #266, #267, #268, #269, #271, #272, #273,
@@ -620,6 +622,57 @@ describe("API route correctness", () => {
       expect(cal04.extrusionMultiplier).toBe(1.1);
       expect(cal04.pressureAdvance).toBe(0.045);
       expect(cal06.extrusionMultiplier).toBe(0.95);
+    });
+  });
+
+  // ── #671: route params are already URL-decoded — don't re-decode ──────
+
+  describe("#671 — a filament name with a literal '%' resolves (no double-decode)", () => {
+    it("spool-check GET resolves an 'ABS 100%' filament instead of 500ing", async () => {
+      const f = await Filament.create({
+        name: "ABS 100%",
+        vendor: "Acme",
+        type: "ABS",
+        totalWeight: 1000,
+      });
+      const res = await spoolCheck(
+        getReq("http://localhost/api/filaments/ABS%20100%25/spool-check?weight=10"),
+        { params: Promise.resolve({ id: "ABS 100%" }) },
+      );
+      // Pre-fix: decodeURIComponent("ABS 100%") throws → caught → 500.
+      expect(res.status).not.toBe(500);
+      const body = await res.json();
+      expect(body.filamentName ?? body.name ?? "ABS 100%").toBeDefined();
+      expect(String(f._id)).toBeTruthy();
+    });
+
+    it("orcaslicer POST sync-back does not 500 on a '%' name from the decode", async () => {
+      await Filament.create({ name: "PLA 50%off", vendor: "Acme", type: "PLA" });
+      const res = await orcaSync(
+        jsonReq("http://localhost/api/filaments/PLA%2050%25off/orcaslicer", {
+          filament_settings_id: "PLA 50%off",
+          name: "PLA 50%off",
+        }),
+        { params: Promise.resolve({ id: "PLA 50%off" }) },
+      );
+      expect(res.status).not.toBe(500);
+    });
+  });
+
+  // ── #677: bulk slicer export ?ids= with a non-ObjectId → 400 not 500 ──
+
+  describe("#677 — bulk slicer export rejects a non-ObjectId in ?ids= with 400", () => {
+    it("orcaslicer GET", async () => {
+      const res = await orcaBulkExport(
+        getReq("http://localhost/api/filaments/orcaslicer?ids=not-an-id"),
+      );
+      expect(res.status).toBe(400);
+    });
+    it("prusaslicer GET", async () => {
+      const res = await prusaBulkExport(
+        getReq("http://localhost/api/filaments/prusaslicer?ids=not-an-id"),
+      );
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/tests/spool-subroute.test.ts
+++ b/tests/spool-subroute.test.ts
@@ -120,6 +120,19 @@ describe("spool sub-routes", () => {
       );
       expect(res.status).toBe(404);
     });
+
+    it("rejects an unparseable date with a clean 400 (#675)", async () => {
+      const f = await seedFilament();
+      const sid = String(f.spools[0]._id);
+      const res = await postUsage(
+        postReq(
+          `http://localhost/api/filaments/${f._id}/spools/${sid}/usage`,
+          { grams: 10, date: "not-a-date" },
+        ),
+        { params: Promise.resolve({ id: String(f._id), spoolId: sid }) },
+      );
+      expect(res.status).toBe(400);
+    });
   });
 
   describe("POST .../spools/{spoolId}/dry-cycles", () => {


### PR DESCRIPTION
Fixes four API-route findings from the source audit.

| Issue | Sev | Fix |
|---|---|---|
| [#671](https://github.com/hyiger/filament-db/issues/671) | **P2** | The slicer sync-back / calibration / spool-check handlers ran `decodeURIComponent()` on the App Router `params.id`, which is **already decoded** — a name with a literal `%` ("ABS 100%") threw `URIError` → 500. Dropped the redundant decode in all 4 spots (orcaslicer POST, `filaments/[id]` POST, calibration GET, spool-check GET), matching `resolveFilamentForExport`. |
| [#675](https://github.com/hyiger/filament-db/issues/675) | P3 | Spool usage POST now rejects an unparseable `date` with a clean **400** instead of a raw Mongoose cast error. |
| [#676](https://github.com/hyiger/filament-db/issues/676) | P3 | PrusaSlicer INI import caps the body — new `checkContentLength()` helper rejects an oversized `Content-Length` (**413**) before buffering, plus a post-read length backstop. |
| [#677](https://github.com/hyiger/filament-db/issues/677) | P3 | Bulk PrusaSlicer/OrcaSlicer exports validate each `?ids=` entry is a 24-hex ObjectId → **400** instead of 500ing on a CastError. |

## Test plan
- Regression tests added: `%`-name resolves (spool-check + orcaslicer sync-back), bad date → 400, bad `?ids=` → 400 (both bulk exports).
- Full suite green; `npm run lint` + `npx tsc --noEmit` clean.

Closes #671, #675, #676, #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)