### PR TITLE
fix(lib): SSRF IPv6 forms, settings round-trip, CSV instanceId, mongo guard doc

### DIFF
--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -368,21 +368,15 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
   for (const [key, value] of Object.entries(json)) {
     if (STRUCTURED_KEYS.has(key)) continue;
     if (CALIBRATION_KEYS.has(key)) continue;
-    // Preserve genuinely multi-valued keys (e.g. compatible_printers) as an
-    // array so every element survives export → re-import; the exporter emits
-    // array-valued settings as multi-element. unwrap() would keep only the
-    // first element (#678). Single/empty values still collapse to a scalar.
+    // Preserve genuinely multi-valued keys (e.g. compatible_printers, or
+    // per-extruder arrays) with their FULL shape — every element, including
+    // empty positional slots — so the next export emits the same multi-element
+    // value and nothing shifts to the wrong slot. unwrap() would keep only the
+    // first element (#678); filtering empties would shift positions (Codex on
+    // #686). Single-element arrays still collapse to a scalar via unwrap below.
     if (Array.isArray(value) && value.length > 1) {
-      const arr = value.map(String).filter((v) => v !== "");
-      if (arr.length > 1) {
-        filament.settings[key] = arr;
-        continue;
-      }
-      if (arr.length === 1) {
-        filament.settings[key] = arr[0];
-        continue;
-      }
-      continue; // all elements empty
+      filament.settings[key] = value.map(String);
+      continue;
     }
     const s = unwrap(value);
     if (s == null) continue;

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -211,8 +211,11 @@ export interface ParsedFilament {
   shrinkageZ?: number;
   temperatures: ParsedTemperatures;
   bedTypeTemps: ParsedBedTypeTemp[];
-  /** Unknown / round-trippable keys. Goes into `settings` on the model. */
-  settings: Record<string, string>;
+  /** Unknown / round-trippable keys. Goes into `settings` on the model.
+   *  Genuinely multi-valued keys (e.g. `compatible_printers`) are kept as
+   *  arrays so they survive the export round-trip (the exporter already emits
+   *  array-valued settings as multi-element). */
+  settings: Record<string, string | string[]>;
 }
 
 export interface CalibrationHints {
@@ -365,6 +368,22 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
   for (const [key, value] of Object.entries(json)) {
     if (STRUCTURED_KEYS.has(key)) continue;
     if (CALIBRATION_KEYS.has(key)) continue;
+    // Preserve genuinely multi-valued keys (e.g. compatible_printers) as an
+    // array so every element survives export → re-import; the exporter emits
+    // array-valued settings as multi-element. unwrap() would keep only the
+    // first element (#678). Single/empty values still collapse to a scalar.
+    if (Array.isArray(value) && value.length > 1) {
+      const arr = value.map(String).filter((v) => v !== "");
+      if (arr.length > 1) {
+        filament.settings[key] = arr;
+        continue;
+      }
+      if (arr.length === 1) {
+        filament.settings[key] = arr[0];
+        continue;
+      }
+      continue; // all elements empty
+    }
     const s = unwrap(value);
     if (s == null) continue;
     filament.settings[key] = s;

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -151,6 +151,18 @@ const CALIBRATION_KEYS = new Set<string>([
 ]);
 
 /**
+ * Passthrough settings keys that are GENUINELY multi-valued in Orca/Bambu
+ * presets AND are not surfaced as scalars by the edit form. Only these keep
+ * their full array shape (every element, including empty positional slots) so
+ * the round-trip preserves them (#678/#686). Every OTHER key unwraps to a
+ * scalar — form-facing keys like `start_filament_gcode` / `end_filament_gcode`
+ * / `filament_notes` are String-cast + `.replace()`d by FilamentForm, so an
+ * array there would throw "replace is not a function" on the edit page
+ * (Codex r2 on #686).
+ */
+const MULTI_VALUED_SETTING_KEYS = new Set<string>(["compatible_printers"]);
+
+/**
  * Resolve a Bambu/Orca JSON value (always a single-element array of
  * stringified values) to a scalar. Returns `undefined` for absent,
  * empty-array, or empty-string values so callers can use `??` chains.
@@ -368,13 +380,14 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
   for (const [key, value] of Object.entries(json)) {
     if (STRUCTURED_KEYS.has(key)) continue;
     if (CALIBRATION_KEYS.has(key)) continue;
-    // Preserve genuinely multi-valued keys (e.g. compatible_printers, or
-    // per-extruder arrays) with their FULL shape — every element, including
-    // empty positional slots — so the next export emits the same multi-element
-    // value and nothing shifts to the wrong slot. unwrap() would keep only the
-    // first element (#678); filtering empties would shift positions (Codex on
-    // #686). Single-element arrays still collapse to a scalar via unwrap below.
-    if (Array.isArray(value) && value.length > 1) {
+    // Only the known multi-valued passthrough keys keep their FULL array shape
+    // (every element, including empty positional slots) so the next export
+    // emits the same multi-element value and nothing shifts slot — unwrap()
+    // would keep only the first element (#678); filtering empties would shift
+    // positions. Every other key (incl. form-facing scalars) unwraps to a
+    // scalar so the edit form's String-cast + `.replace()` can't hit an array
+    // (Codex r2 on #686). Single-element arrays still collapse via unwrap.
+    if (MULTI_VALUED_SETTING_KEYS.has(key) && Array.isArray(value) && value.length > 1) {
       filament.settings[key] = value.map(String);
       continue;
     }

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -151,18 +151,6 @@ const CALIBRATION_KEYS = new Set<string>([
 ]);
 
 /**
- * Passthrough settings keys that are GENUINELY multi-valued in Orca/Bambu
- * presets AND are not surfaced as scalars by the edit form. Only these keep
- * their full array shape (every element, including empty positional slots) so
- * the round-trip preserves them (#678/#686). Every OTHER key unwraps to a
- * scalar — form-facing keys like `start_filament_gcode` / `end_filament_gcode`
- * / `filament_notes` are String-cast + `.replace()`d by FilamentForm, so an
- * array there would throw "replace is not a function" on the edit page
- * (Codex r2 on #686).
- */
-const MULTI_VALUED_SETTING_KEYS = new Set<string>(["compatible_printers"]);
-
-/**
  * Resolve a Bambu/Orca JSON value (always a single-element array of
  * stringified values) to a scalar. Returns `undefined` for absent,
  * empty-array, or empty-string values so callers can use `??` chains.
@@ -223,11 +211,8 @@ export interface ParsedFilament {
   shrinkageZ?: number;
   temperatures: ParsedTemperatures;
   bedTypeTemps: ParsedBedTypeTemp[];
-  /** Unknown / round-trippable keys. Goes into `settings` on the model.
-   *  Genuinely multi-valued keys (e.g. `compatible_printers`) are kept as
-   *  arrays so they survive the export round-trip (the exporter already emits
-   *  array-valued settings as multi-element). */
-  settings: Record<string, string | string[]>;
+  /** Unknown / round-trippable keys. Goes into `settings` on the model. */
+  settings: Record<string, string>;
 }
 
 export interface CalibrationHints {
@@ -380,17 +365,13 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
   for (const [key, value] of Object.entries(json)) {
     if (STRUCTURED_KEYS.has(key)) continue;
     if (CALIBRATION_KEYS.has(key)) continue;
-    // Only the known multi-valued passthrough keys keep their FULL array shape
-    // (every element, including empty positional slots) so the next export
-    // emits the same multi-element value and nothing shifts slot — unwrap()
-    // would keep only the first element (#678); filtering empties would shift
-    // positions. Every other key (incl. form-facing scalars) unwraps to a
-    // scalar so the edit form's String-cast + `.replace()` can't hit an array
-    // (Codex r2 on #686). Single-element arrays still collapse via unwrap.
-    if (MULTI_VALUED_SETTING_KEYS.has(key) && Array.isArray(value) && value.length > 1) {
-      filament.settings[key] = value.map(String);
-      continue;
-    }
+    // NOTE (#678, deferred): unwrap() collapses a multi-element array to its
+    // first element, so a multi-printer `compatible_printers` loses the rest on
+    // a Bambu/Orca round-trip. A faithful fix can't just store the array here —
+    // the `settings` bag is shared by the PrusaSlicer exporter (which would
+    // comma-join an array into one invalid INI line) and the edit form (which
+    // String-casts + `.replace()`s several keys). Round-tripping multi-valued
+    // keys needs arch-aware serialization in each exporter; tracked on #678.
     const s = unwrap(value);
     if (s == null) continue;
     filament.settings[key] = s;

--- a/src/lib/externalUrlGuard.ts
+++ b/src/lib/externalUrlGuard.ts
@@ -110,6 +110,24 @@ export function isPrivateIp(ip: string): boolean {
     return isPrivateIpv4(v4);
   }
 
+  // NAT64 (64:ff9b::/96) carries an embedded IPv4 in the low 32 bits — a
+  // NAT64-wrapped metadata/private address (e.g. 64:ff9b::a9fe:a9fe →
+  // 169.254.169.254) must be range-checked, not treated as a public IPv6 (#673).
+  if (
+    groups[0] === 0x0064 && groups[1] === 0xff9b &&
+    groups[2] === 0 && groups[3] === 0 && groups[4] === 0 && groups[5] === 0
+  ) {
+    const v4 = `${groups[6] >> 8}.${groups[6] & 0xff}.${groups[7] >> 8}.${groups[7] & 0xff}`;
+    return isPrivateIpv4(v4);
+  }
+
+  // 6to4 (2002::/16) embeds the destination IPv4 in groups 1-2; block when that
+  // embedded address is private (e.g. 2002:c0a8:0101:: → 192.168.1.1) (#673).
+  if (groups[0] === 0x2002) {
+    const v4 = `${groups[1] >> 8}.${groups[1] & 0xff}.${groups[2] >> 8}.${groups[2] & 0xff}`;
+    return isPrivateIpv4(v4);
+  }
+
   const first = groups[0];
   if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
   if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -180,10 +180,10 @@ function parseNum(val: unknown): number | null {
  * import created a corrupted duplicate. Mirrors what `/api/spools/import`
  * has done since the Codex P2 follow-up to PR #144.
  *
- * Deliberately NOT applied to `color` / `secondaryColors` / `tdsUrl` /
- * `instanceId` — those are format-validated fields that can never start
- * with a trigger character, so a genuine leading apostrophe (if a user
- * somehow stored one) survives untouched.
+ * Deliberately NOT applied to `color` / `secondaryColors` / `tdsUrl` — those
+ * are format-validated (`#rrggbb`, http(s)://) and can never start with a
+ * trigger character, so a genuine leading apostrophe (if a user somehow stored
+ * one) survives untouched.
  */
 const UNSANITIZE_FIELDS = new Set<keyof ImportRow>([
   "name",
@@ -195,6 +195,11 @@ const UNSANITIZE_FIELDS = new Set<keyof ImportRow>([
   "colorName",
   "spoolType",
   "parentName",
+  // `instanceId` is NOT strictly hex-validated — legacy/custom IDs (e.g.
+  // `custom-id-123`, or one starting with `-`/`+`/`=`/`@`) get formula-prefixed
+  // on export, so it must be unstripped symmetrically or it round-trips
+  // corrupted as `'...` (#679).
+  "instanceId",
 ]);
 
 export function mapHeaders(headers: string[]): (keyof ImportRow | null)[] {

--- a/src/lib/mongoUriGuard.ts
+++ b/src/lib/mongoUriGuard.ts
@@ -59,6 +59,17 @@ async function resolveHostIps(host: string): Promise<string[]> {
 /**
  * Validate a user-supplied MongoDB connection string before it is passed
  * to a `MongoClient`. Throws an `Error` describing the rejection.
+ *
+ * #674 — best-effort by design. This resolves the host (or SRV targets) and
+ * rejects private/metadata IPs at validation time, but `MongoClient.connect()`
+ * performs its OWN independent DNS/SRV resolution at connect time, so a
+ * resolver that returns a public IP here and a private one microseconds later
+ * (DNS rebinding) is a residual TOCTOU. Pinning the validated IP into the URI
+ * isn't viable — it breaks `mongodb+srv` SRV resolution and TLS hostname
+ * verification (the cert is for the name, not the IP). The accepted primary
+ * controls are therefore: this guard as defence-in-depth, the
+ * `assertSameOriginRequest` CSRF guard on every caller (import-atlas / setup),
+ * and the fact that supplying a connection string is an explicit user action.
  */
 export async function assertSafeMongoUri(
   uri: string,

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -111,6 +111,10 @@ describe("parseBambuStudioProfile", () => {
     // A single-element array still collapses to a scalar (the common case).
     const single = parseBambuStudioProfile({ name: ["Y"], compatible_printers: ["Only One 0.4 nozzle"] });
     expect(single.filament.settings.compatible_printers).toBe("Only One 0.4 nozzle");
+    // Empty positional slots are KEPT (not filtered) so per-extruder arrays
+    // don't shift to the wrong slot on re-export (Codex on #686).
+    const sparse = parseBambuStudioProfile({ name: ["Z"], filament_some_array: ["", "right-extruder-value"] });
+    expect(sparse.filament.settings.filament_some_array).toEqual(["", "right-extruder-value"]);
   });
 
   it("passes filament_notes through the settings bag and round-trips it (GH #620)", () => {

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -98,6 +98,21 @@ describe("parseBambuStudioProfile", () => {
     expect(parseBambuStudioProfile({ name: ["X"] }).filament.settings.filament_soluble).toBeUndefined();
   });
 
+  it("preserves a multi-element compatible_printers array in the settings bag (#678)", () => {
+    const printers = [
+      "Bambu Lab X1 Carbon 0.4 nozzle",
+      "Bambu Lab P1S 0.4 nozzle",
+      "Prusa MK4 0.4 nozzle",
+    ];
+    const { filament } = parseBambuStudioProfile({ name: ["X"], compatible_printers: printers });
+    // Pre-fix unwrap() kept only the first element → 2/3 printers lost on
+    // re-export. All three must survive.
+    expect(filament.settings.compatible_printers).toEqual(printers);
+    // A single-element array still collapses to a scalar (the common case).
+    const single = parseBambuStudioProfile({ name: ["Y"], compatible_printers: ["Only One 0.4 nozzle"] });
+    expect(single.filament.settings.compatible_printers).toBe("Only One 0.4 nozzle");
+  });
+
   it("passes filament_notes through the settings bag and round-trips it (GH #620)", () => {
     // The Filament model has no top-level `notes` column (the form stores
     // notes as `settings.filament_notes`), so the key must ride the

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -98,35 +98,18 @@ describe("parseBambuStudioProfile", () => {
     expect(parseBambuStudioProfile({ name: ["X"] }).filament.settings.filament_soluble).toBeUndefined();
   });
 
-  it("preserves a multi-element compatible_printers array in the settings bag (#678)", () => {
-    const printers = [
-      "Bambu Lab X1 Carbon 0.4 nozzle",
-      "Bambu Lab P1S 0.4 nozzle",
-      "Prusa MK4 0.4 nozzle",
-    ];
-    const { filament } = parseBambuStudioProfile({ name: ["X"], compatible_printers: printers });
-    // Pre-fix unwrap() kept only the first element → 2/3 printers lost on
-    // re-export. All three must survive.
-    expect(filament.settings.compatible_printers).toEqual(printers);
-    // A single-element array still collapses to a scalar (the common case).
-    const single = parseBambuStudioProfile({ name: ["Y"], compatible_printers: ["Only One 0.4 nozzle"] });
-    expect(single.filament.settings.compatible_printers).toBe("Only One 0.4 nozzle");
-    // Empty positional slots in an allowlisted multi-valued key are KEPT (not
-    // filtered) so positions don't shift on re-export (Codex on #686).
-    const sparse = parseBambuStudioProfile({ name: ["Z"], compatible_printers: ["", "Printer B 0.4 nozzle"] });
-    expect(sparse.filament.settings.compatible_printers).toEqual(["", "Printer B 0.4 nozzle"]);
-  });
-
-  it("keeps form-facing settings scalar even when they arrive as arrays (Codex r2 #686)", () => {
-    // FilamentForm String-casts + .replace()s these keys, so an array would
-    // throw on the edit page. They must NOT be preserved as arrays.
+  it("collapses a multi-element compatible_printers to its first element (#678 deferred)", () => {
+    // A faithful multi-printer round-trip can't store an array in the shared
+    // settings bag: the PrusaSlicer exporter would comma-join it into one
+    // invalid INI line, and the edit form String-casts + .replace()s several
+    // settings keys. So passthrough values stay scalar (unwrap → first element)
+    // and the multi-value round-trip is tracked on #678 as a larger,
+    // cross-exporter change.
     const { filament } = parseBambuStudioProfile({
       name: ["X"],
-      start_filament_gcode: ["G1 X0", "G1 Y0"],
-      filament_notes: ["line one", "line two"],
+      compatible_printers: ["Bambu X1 0.4 nozzle", "Prusa MK4 0.4 nozzle"],
     });
-    expect(typeof filament.settings.start_filament_gcode).toBe("string");
-    expect(typeof filament.settings.filament_notes).toBe("string");
+    expect(filament.settings.compatible_printers).toBe("Bambu X1 0.4 nozzle");
   });
 
   it("passes filament_notes through the settings bag and round-trips it (GH #620)", () => {

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -111,10 +111,22 @@ describe("parseBambuStudioProfile", () => {
     // A single-element array still collapses to a scalar (the common case).
     const single = parseBambuStudioProfile({ name: ["Y"], compatible_printers: ["Only One 0.4 nozzle"] });
     expect(single.filament.settings.compatible_printers).toBe("Only One 0.4 nozzle");
-    // Empty positional slots are KEPT (not filtered) so per-extruder arrays
-    // don't shift to the wrong slot on re-export (Codex on #686).
-    const sparse = parseBambuStudioProfile({ name: ["Z"], filament_some_array: ["", "right-extruder-value"] });
-    expect(sparse.filament.settings.filament_some_array).toEqual(["", "right-extruder-value"]);
+    // Empty positional slots in an allowlisted multi-valued key are KEPT (not
+    // filtered) so positions don't shift on re-export (Codex on #686).
+    const sparse = parseBambuStudioProfile({ name: ["Z"], compatible_printers: ["", "Printer B 0.4 nozzle"] });
+    expect(sparse.filament.settings.compatible_printers).toEqual(["", "Printer B 0.4 nozzle"]);
+  });
+
+  it("keeps form-facing settings scalar even when they arrive as arrays (Codex r2 #686)", () => {
+    // FilamentForm String-casts + .replace()s these keys, so an array would
+    // throw on the edit page. They must NOT be preserved as arrays.
+    const { filament } = parseBambuStudioProfile({
+      name: ["X"],
+      start_filament_gcode: ["G1 X0", "G1 Y0"],
+      filament_notes: ["line one", "line two"],
+    });
+    expect(typeof filament.settings.start_filament_gcode).toBe("string");
+    expect(typeof filament.settings.filament_notes).toBe("string");
   });
 
   it("passes filament_notes through the settings bag and round-trips it (GH #620)", () => {

--- a/tests/externalUrlGuard.test.ts
+++ b/tests/externalUrlGuard.test.ts
@@ -142,6 +142,20 @@ describe("isPrivateIp — IPv6 block list", () => {
     expect(isPrivateIp("2001:4860:4860::8888")).toBe(false);
     expect(isPrivateIp("2606:4700:4700::1111")).toBe(false);
   });
+
+  it("range-checks NAT64 (64:ff9b::/96) embedded IPv4 (#673)", () => {
+    expect(isPrivateIp("64:ff9b::a9fe:a9fe")).toBe(true); // 169.254.169.254 metadata
+    expect(isPrivateIp("64:ff9b::7f00:1")).toBe(true);    // 127.0.0.1
+    expect(isPrivateIp("64:ff9b::0a00:1")).toBe(true);    // 10.0.0.1
+    expect(isPrivateIp("64:ff9b::808:808")).toBe(false);  // 8.8.8.8 public
+  });
+
+  it("range-checks 6to4 (2002::/16) embedded IPv4 (#673)", () => {
+    expect(isPrivateIp("2002:c0a8:0101::")).toBe(true);   // 192.168.1.1
+    expect(isPrivateIp("2002:a9fe:a9fe::")).toBe(true);   // 169.254.169.254 metadata
+    expect(isPrivateIp("2002:0a00:0001::")).toBe(true);   // 10.0.0.1
+    expect(isPrivateIp("2002:0808:0808::")).toBe(false);  // 8.8.8.8 public
+  });
 });
 
 describe("readBodyCapped — GH #258 response-size guard", () => {

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -778,6 +778,15 @@ describe("rowToImport — formula-prefix strip (GH #627)", () => {
     const row = rowToImport(["'70s Blue PLA", "Vendor", "PLA"], mapping);
     expect(row.name).toBe("'70s Blue PLA");
   });
+
+  it("strips the guard apostrophe from instanceId (not strictly hex) (#679)", () => {
+    // A legacy/custom instanceId starting with a trigger char gets
+    // formula-prefixed on export; without unsanitizing it round-trips
+    // corrupted as `'-custom-id-123`.
+    const mapping = mapHeaders(["Name", "Vendor", "Type", "Instance ID"]);
+    const row = rowToImport(["PLA", "Acme", "PLA", "'-custom-id-123"], mapping);
+    expect(row.instanceId).toBe("-custom-id-123");
+  });
 });
 
 /**


### PR DESCRIPTION
Fixes three lib-level findings from the source audit. (The fourth, #678, is **deferred** — see below.)

| Issue | Sev | Fix |
|---|---|---|
| [#673](https://github.com/hyiger/filament-db/issues/673) | P3 (security) | `isPrivateIp` range-checks the embedded IPv4 inside **NAT64** (`64:ff9b::/96`) and **6to4** (`2002::/16`). |
| [#674](https://github.com/hyiger/filament-db/issues/674) | P3 (security) | Documents the best-effort/TOCTOU nature of `assertSafeMongoUri` (doc-only). |
| [#679](https://github.com/hyiger/filament-db/issues/679) | P3 (data-integrity) | `instanceId` added to `UNSANITIZE_FIELDS` so a formula-prefixed legacy id round-trips. |

## #678 deferred
The original #678 fix (preserve a multi-element `compatible_printers` through Bambu/Orca import) went three Codex rounds because the `settings` bag is **shared**: the edit form String-casts + `.replace()`s several keys, and the PrusaSlicer exporter comma-joins an array into one invalid INI line. A faithful multi-value round-trip needs arch-aware serialization in each exporter — larger than a P3. Reverted to the original behavior; **#678 stays open** to track the proper cross-exporter fix.

## Test plan
- Regression tests for #673 (NAT64/6to4) and #679 (instanceId). Affected suites green; lint + tsc clean.

Closes #673, #674, #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)