### PR TITLE
fix(electron): sync teardown on atlas switch, MIFARE auth guard, mongo start race

### DIFF
--- a/electron/local-mongo.ts
+++ b/electron/local-mongo.ts
@@ -5,6 +5,8 @@ import fs from "fs";
 
 let mongod: MongoMemoryServer | null = null;
 let uri: string | null = null;
+/** In-flight start, so concurrent callers share one create() (#681). */
+let starting: Promise<string> | null = null;
 
 /**
  * Start an embedded local MongoDB instance.
@@ -12,7 +14,20 @@ let uri: string | null = null;
  */
 export async function startLocalMongo(): Promise<string> {
   if (mongod && uri) return uri;
+  // #681: `mongod` is only assigned AFTER MongoMemoryServer.create() resolves,
+  // so two overlapping callers (e.g. a hybrid resolveMongoUri racing the
+  // atlas-fallback path) would both pass the guard above and each spawn a
+  // mongod → port conflict + orphaned server. Share one in-flight start.
+  if (starting) return starting;
+  starting = doStartLocalMongo();
+  try {
+    return await starting;
+  } finally {
+    starting = null;
+  }
+}
 
+async function doStartLocalMongo(): Promise<string> {
   const dbPath = path.join(app.getPath("userData"), "mongodb-data");
   if (!fs.existsSync(dbPath)) {
     fs.mkdirSync(dbPath, { recursive: true });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -634,6 +634,18 @@ async function resolveMongoUri(): Promise<string | null> {
   if (mode === "atlas") {
     if (!atlasUri) return null;
 
+    // Switching to pure Atlas — stop any sync engine left over from a prior
+    // hybrid (or atlas-fallback) session. Without this the atlas-success path
+    // below returns without ever tearing down the old SyncService, so it keeps
+    // its 5-minute interval last-write-wins syncing a now-abandoned local
+    // mongod against Atlas — a timer leak and a data-integrity hazard (#672).
+    // The fallback path re-creates sync via initSyncService when Atlas is
+    // unreachable.
+    if (syncService) {
+      syncService.destroy();
+      syncService = null;
+    }
+
     // Test Atlas connectivity — fall back to local if unreachable
     try {
       const { MongoClient } = await import("mongodb");

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -530,15 +530,20 @@ export class NfcService extends EventEmitter {
       const firstBlock = sector * 4;
       const key = keys[sector];
 
+      // loadMifareKey loads a key into a reader slot — it's reader-level, not
+      // sector-specific, so a failure here is a real PCSC/hardware error that
+      // MUST surface, not be masked as a "damaged sector" (Codex on #687).
+      await this.loadMifareKey(protocol, 0, key);
+
       try {
-        await this.loadMifareKey(protocol, 0, key);
         await this.authenticateMifareBlock(protocol, firstBlock, 0x60, 0); // Key A
       } catch (err) {
         // Sector-0 auth failing means this isn't a (readable) Bambu tag, so
-        // surface that. But a LATER sector failing (damaged / partially-read
-        // tag) must not abort the whole read with a misleading OpenPrintTag
-        // error — zero-fill its blocks and keep going so parseBambuBlocks
-        // gets what it can (#680; mirrors the per-block read guard below).
+        // surface that. But a LATER sector's auth failing (damaged /
+        // partially-read tag) must not abort the whole read with a misleading
+        // OpenPrintTag error — zero-fill its blocks and keep going so
+        // parseBambuBlocks gets what it can (#680; mirrors the per-block read
+        // guard below).
         if (sector === 0) throw err;
         for (let i = 0; i < 3; i++) blocks[firstBlock + i] = Buffer.alloc(16);
         continue;

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -530,8 +530,19 @@ export class NfcService extends EventEmitter {
       const firstBlock = sector * 4;
       const key = keys[sector];
 
-      await this.loadMifareKey(protocol, 0, key);
-      await this.authenticateMifareBlock(protocol, firstBlock, 0x60, 0); // Key A
+      try {
+        await this.loadMifareKey(protocol, 0, key);
+        await this.authenticateMifareBlock(protocol, firstBlock, 0x60, 0); // Key A
+      } catch (err) {
+        // Sector-0 auth failing means this isn't a (readable) Bambu tag, so
+        // surface that. But a LATER sector failing (damaged / partially-read
+        // tag) must not abort the whole read with a misleading OpenPrintTag
+        // error — zero-fill its blocks and keep going so parseBambuBlocks
+        // gets what it can (#680; mirrors the per-block read guard below).
+        if (sector === 0) throw err;
+        for (let i = 0; i < 3; i++) blocks[firstBlock + i] = Buffer.alloc(16);
+        continue;
+      }
 
       // Read 3 data blocks per sector (block 3 of each sector is the trailer)
       for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
Fixes three Electron-services findings from the source audit.

| Issue | Sev | Fix |
|---|---|---|
| [#672](https://github.com/hyiger/filament-db/issues/672) | **P2** (data-integrity) | `resolveMongoUri()`'s atlas-success branch never tore down a `SyncService` left over from a prior hybrid session — so a hybrid→atlas switch (Atlas reachable) left an orphaned engine last-write-wins syncing the **abandoned local mongod** against Atlas every 5 min (timer leak + corruption hazard). Now tears sync down at the top of the atlas block (the fallback path re-creates it). |
| [#680](https://github.com/hyiger/filament-db/issues/680) | P3 | `readBambuTag` guarded the per-block reads but not the per-sector `loadMifareKey`/`authenticateMifareBlock`. A damaged later sector aborted the whole read with a misleading OpenPrintTag error. Now sector-0 auth failure still propagates (not a Bambu tag); a later sector zero-fills + continues. |
| [#681](https://github.com/hyiger/filament-db/issues/681) | P3 | `startLocalMongo` guarded only on the resolved `mongod && uri` (set **after** `create()`), so two overlapping callers could each spawn a mongod (port conflict + orphan). Memoized the in-flight start. |

## Test plan
- `electron/` is outside the vitest/tsc suite, so no unit tests — verified via `npm run electron:compile` (esbuild bundles `main.js` + `preload.js`, no errors) and `npm run lint` clean. All three are small, logic-only changes (the #672 teardown mirrors the existing offline-branch teardown verbatim).

Closes #672, #680, #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)