### PR TITLE
fix(ui): INI picker focus trap, AI-provider sync on key remove, dead ref

### DIFF
--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -140,7 +140,6 @@ function FilamentDetail() {
   // Legacy single-spool inline weight update
   const [weightInput, setWeightInput] = useState("");
   const [weightSaving, setWeightSaving] = useState(false);
-  const weightRef = useRef<HTMLInputElement>(null);
 
   // GH #405 follow-up (Codex on PR #460): store the error TYPE rather
   // than the translated string. With `t` removed from the fetch
@@ -1372,7 +1371,6 @@ function FilamentDetail() {
                 <label htmlFor="filament-scale-weight" className="text-sm text-gray-500 flex-shrink-0">{t("detail.weight.updateScaleWeight")}:</label>
                 <input
                   id="filament-scale-weight"
-                  ref={weightRef}
                   type="number"
                   step="1"
                   min="0"

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -39,6 +39,48 @@ function NewFilamentContent() {
   // INI picker state
   const [iniFilaments, setIniFilaments] = useState<Record<string, unknown>[] | null>(null);
   const iniFileRef = useRef<HTMLInputElement>(null);
+  const iniDialogRef = useRef<HTMLDivElement>(null);
+
+  // #682: focus-trap the INI profile picker like the app's other dialogs —
+  // move focus in on open, cycle Tab/Shift+Tab within it, Escape to close, and
+  // restore focus to the trigger on close.
+  useEffect(() => {
+    if (!iniFilaments) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const focusables = () =>
+      Array.from(
+        iniDialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      ).filter((el) => !el.hasAttribute("disabled"));
+    focusables()[0]?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setIniFilaments(null);
+        return;
+      }
+      if (e.key === "Tab") {
+        const f = focusables();
+        if (f.length === 0) return;
+        e.preventDefault();
+        const idx = f.indexOf(document.activeElement as HTMLElement);
+        const next = e.shiftKey
+          ? idx <= 0
+            ? f.length - 1
+            : idx - 1
+          : idx === f.length - 1
+            ? 0
+            : idx + 1;
+        f[next].focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [iniFilaments]);
 
   // Prusament QR state
   const [prusamentInput, setPrusamentInput] = useState("");
@@ -839,6 +881,7 @@ function NewFilamentContent() {
           <div className="fixed inset-0 z-50 bg-black/60" onClick={() => setIniFilaments(null)} />
           <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
             <div
+              ref={iniDialogRef}
               role="dialog"
               aria-modal="true"
               aria-label={t("new.ini.selectProfile")}

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -41,11 +41,16 @@ function NewFilamentContent() {
   const iniFileRef = useRef<HTMLInputElement>(null);
   const iniDialogRef = useRef<HTMLDivElement>(null);
 
+  // Declared up here (used by the focus-trap effect below + guardPopulate).
+  const [showPopulateDialog, setShowPopulateDialog] = useState(false);
+
   // #682: focus-trap the INI profile picker like the app's other dialogs —
   // move focus in on open, cycle Tab/Shift+Tab within it, Escape to close, and
-  // restore focus to the trigger on close.
+  // restore focus to the trigger on close. Suspended while the unsaved-changes
+  // confirmation is open (guardPopulate keeps the picker mounted underneath it)
+  // so the trap doesn't steal Tab back from that nested dialog (Codex on #688).
   useEffect(() => {
-    if (!iniFilaments) return;
+    if (!iniFilaments || showPopulateDialog) return;
     const previouslyFocused = document.activeElement as HTMLElement | null;
     const focusables = () =>
       Array.from(
@@ -80,7 +85,7 @@ function NewFilamentContent() {
       document.removeEventListener("keydown", onKey);
       previouslyFocused?.focus?.();
     };
-  }, [iniFilaments]);
+  }, [iniFilaments, showPopulateDialog]);
 
   // Prusament QR state
   const [prusamentInput, setPrusamentInput] = useState("");
@@ -116,7 +121,6 @@ function NewFilamentContent() {
       action();
     }
   };
-  const [showPopulateDialog, setShowPopulateDialog] = useState(false);
 
   const handleSubmit = async (data: Record<string, unknown>) => {
     const res = await fetch("/api/filaments", {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -884,6 +884,10 @@ export default function SettingsPage() {
                   await fetch("/api/tds", { method: "DELETE" });
                 }
                 setAiConfigured(false);
+                // Keep the visible provider selector in sync with what we just
+                // persisted (aiProvider: "gemini"); otherwise it keeps showing
+                // the old provider after the key is removed (#683).
+                setAiProvider("gemini");
                 setAiResult({ ok: true, message: t("settings.aiKeyRemoved") });
               }}
               className="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white rounded text-sm hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"


### PR DESCRIPTION
Fixes three frontend findings from the source audit.

| Issue | Sev | Fix |
|---|---|---|
| [#682](https://github.com/hyiger/filament-db/issues/682) | P3 (a11y) | The INI profile picker modal (`filaments/new`) declared `role="dialog" aria-modal` but had no keyboard semantics. Added a focus trap matching the app's other dialogs: focus in on open, Tab/Shift+Tab cycle within it, **Escape** closes, focus restores to the trigger on close. |
| [#683](https://github.com/hyiger/filament-db/issues/683) | P3 (ux) | Removing the AI key persisted `aiProvider: "gemini"` but never updated the on-screen provider selector. Sync it with `setAiProvider("gemini")`. |
| [#684](https://github.com/hyiger/filament-db/issues/684) | P3 | Removed the dead `weightRef` on the filament detail page (declared + attached but never read). |

## Test plan
- `npm run lint` (incl. `react-hooks/set-state-in-effect`) + `npx tsc --noEmit` clean; full suite green (2025).
- Preview-verified `/filaments/new` and `/settings` render with no console errors after the changes. The deep interactions (picker focus trap needs a multi-profile INI upload; AI-remove needs a configured key) weren't scripted, but the focus-trap mirrors the existing `ConfirmDialog` implementation verbatim.

Closes #682, #683, #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)