### PR TITLE
Bump version to 1.38.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.38.2",
+      "version": "1.38.3",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
         "electron-store": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.38.2",
+    "version": "1.38.3",
     "license": {
       "name": "MIT"
     }


### PR DESCRIPTION
Patch release **1.38.3** — a source-audit bug-fix sweep.

Updates the version in `package.json`, `package-lock.json` (both occurrences), and `public/openapi.json`.

## What's in 1.38.3
A full source audit (#671–#684); 13 findings fixed across 4 PRs:
- **API robustness ([#685](https://github.com/hyiger/filament-db/pull/685))** — slicer/calibration/spool-check routes no longer 500 on a filament name with a literal `%`; usage date → clean 400; PrusaSlicer import body size cap; bulk export `?ids=` validation → 400.
- **Lib security + round-trip ([#686](https://github.com/hyiger/filament-db/pull/686))** — SSRF guard blocks NAT64/6to4-wrapped private IPv4; `instanceId` CSV formula-escape round-trip; mongo-guard TOCTOU documented.
- **Electron services ([#687](https://github.com/hyiger/filament-db/pull/687))** — sync engine torn down on hybrid→atlas switch; MIFARE per-sector auth guard; embedded-mongo start race.
- **Frontend ([#688](https://github.com/hyiger/filament-db/pull/688))** — INI picker focus trap; AI-provider selector sync on key remove; dead ref removed.

No P0/P1 findings. After this merges, tag `v1.38.3` to trigger the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)