### PR TITLE
ci(release): sign + notarize macOS builds (opt-in via secrets)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,11 +100,52 @@ jobs:
           npm run electron:fixlinks
           npm run electron:compile
 
+      # macOS code signing + notarization. Exports the signing env (via
+      # $GITHUB_ENV) consumed by the mac packaging steps below. When the secrets
+      # aren't configured, it disables auto-discovery so the build is UNSIGNED —
+      # exactly today's behavior — instead of failing. Notarization is opt-in via
+      # FILAMENTDB_MAC_NOTARIZE, set here only when the Apple key secrets exist.
+      - name: Prepare macOS code signing & notarization
+        if: startsWith(matrix.platform, 'mac')
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          if [ -z "$MAC_CSC_LINK" ] || [ -z "$APPLE_API_KEY_BASE64" ]; then
+            echo "::notice::macOS signing secrets not set — building UNSIGNED (no notarization)."
+            echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+          {
+            echo "CSC_LINK=$MAC_CSC_LINK"
+            echo "CSC_KEY_PASSWORD=$MAC_CSC_KEY_PASSWORD"
+            echo "APPLE_API_KEY=$RUNNER_TEMP/apple_api_key.p8"
+            echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID"
+            echo "APPLE_API_ISSUER=$APPLE_API_ISSUER"
+            echo "FILAMENTDB_MAC_NOTARIZE=true"
+          } >> "$GITHUB_ENV"
+          echo "::notice::macOS signing + notarization enabled."
+
       - name: Rebuild native modules and package (default — host arch matches target)
-        if: matrix.platform != 'linux-arm64' && matrix.platform != 'mac-x64-cross' && matrix.platform != 'win-arm64-cross'
+        if: matrix.platform != 'linux-arm64' && matrix.platform != 'mac-x64-cross' && matrix.platform != 'win-arm64-cross' && matrix.platform != 'mac'
         run: |
           npm run electron:rebuild
           npx electron-builder --config electron-builder.yml ${{ matrix.arch != '' && format('--{0}', matrix.arch) || '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebuild native modules, sign, notarize, and package (macOS arm64)
+        if: matrix.platform == 'mac'
+        run: |
+          npm run electron:rebuild
+          # Notarize only when the Prepare step set the flag (i.e. secrets exist).
+          NOTARIZE_FLAG=""
+          [ "${FILAMENTDB_MAC_NOTARIZE:-}" = "true" ] && NOTARIZE_FLAG="--config.mac.notarize=true"
+          npx electron-builder --config electron-builder.yml --arm64 $NOTARIZE_FLAG
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -146,7 +187,10 @@ jobs:
           # fast rather than shipping an arm64 binary inside an x64 dmg.
           file node_modules/@pokusew/pcsclite/build/Release/pcsclite.node | tee /tmp/arch-check.txt
           grep -q "x86_64" /tmp/arch-check.txt
-          npx electron-builder --config electron-builder.yml --x64
+          # Notarize only when the Prepare step set the flag (i.e. secrets exist).
+          NOTARIZE_FLAG=""
+          [ "${FILAMENTDB_MAC_NOTARIZE:-}" = "true" ] && NOTARIZE_FLAG="--config.mac.notarize=true"
+          npx electron-builder --config electron-builder.yml --x64 $NOTARIZE_FLAG
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Hardened Runtime entitlements for the Electron app. Required because
+    notarization mandates Hardened Runtime (mac.hardenedRuntime: true). Lives in
+    assets/ because that is electron-builder's buildResources directory here
+    (the repo gitignores /build).
+
+    - allow-jit / allow-unsigned-executable-memory: V8 (Electron's JS engine)
+      JITs code and needs writable+executable memory.
+    - disable-library-validation: lets the signed app load the
+      @pokusew/pcsclite native .node, which is signed with a different (or no)
+      Team ID than the app bundle. Without this the app crashes on launch when
+      the NFC module loads.
+    - allow-dyld-environment-variables: Electron/Chromium relies on DYLD env
+      vars in some helper-process launch paths.
+  -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,6 +64,18 @@ files:
 
 mac:
   category: public.app-category.utilities
+  # Code signing + notarization. Signing only happens when the release workflow
+  # provides a Developer ID cert (CSC_LINK); otherwise electron-builder builds
+  # an UNSIGNED dmg as before (the workflow sets CSC_IDENTITY_AUTO_DISCOVERY=
+  # false when the signing secrets are absent). Hardened Runtime is required for
+  # notarization; the entitlements below let V8 JIT and let the signed app load
+  # the @pokusew/pcsclite native module. Notarization itself is enabled per-build
+  # via the CLI flag `--config.mac.notarize=true`, which the workflow appends
+  # ONLY when the Apple notarization secrets are present.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: assets/entitlements.mac.plist
+  entitlementsInherit: assets/entitlements.mac.plist
   # Do NOT hardcode arch here. The release workflow passes --arm64 or --x64
   # per matrix job, and electron-builder treats CLI arch flags as additive
   # when a target has an arch list, so both archs would be built per job.


### PR DESCRIPTION
## Summary

Wires **Developer ID code signing + notarization** into the macOS release builds, so distributed `.dmg`s open without the Gatekeeper "can't be checked for malware" block — and the macOS auto-updater starts working (it can't auto-install unsigned builds today).

**Safe to merge before the secrets exist.** Signing is gated on the secrets: when they're absent the workflow sets `CSC_IDENTITY_AUTO_DISCOVERY=false` and builds an **unsigned** `.dmg` exactly as today. Notarization is opt-in per build via `--config.mac.notarize=true`, which the workflow appends only when the Apple key secrets are present. Windows/Linux jobs are untouched (the mac signing env never reaches them).

## Changes
- `assets/entitlements.mac.plist` — Hardened Runtime entitlements (V8 JIT + `disable-library-validation` so the signed app can load the `@pokusew/pcsclite` native module). In `assets/` because that's electron-builder's `buildResources` dir here (`/build` is gitignored).
- `electron-builder.yml` `mac:` — `hardenedRuntime: true`, `gatekeeperAssess: false`, `entitlements`/`entitlementsInherit`.
- `.github/workflows/release.yml` — a mac-only **Prepare** step exports `CSC_LINK`/`CSC_KEY_PASSWORD` + the App Store Connect API key (`APPLE_API_KEY` path / `_ID` / `_ISSUER`) from secrets; the mac arm64 build is split into its own bash step (the shared step also runs on Windows, where the notarize-flag shell logic wouldn't parse); both mac steps notarize only when enabled.

## To enable (repo secrets — Settings → Secrets and variables → Actions)
| Secret | Value |
|---|---|
| `MAC_CSC_LINK` | base64 of your **Developer ID Application** `.p12` |
| `MAC_CSC_KEY_PASSWORD` | the `.p12` export password |
| `APPLE_API_KEY` | base64 of the App Store Connect **`.p8`** key |
| `APPLE_API_KEY_ID` | the key's **Key ID** |
| `APPLE_API_ISSUER` | the **Issuer ID** |

Once those are set, the next `v*` tag produces signed + notarized macOS installers. Verify a build with `codesign -dvvv` and `spctl -a -vvv` (expect "source=Notarized Developer ID").

> ⚠️ Untestable in CI without the secrets + a tag build — the logic is reviewed and the YAML validated, but the first signed run should be watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
