### PR TITLE
fix(updater): enable correct-arch macOS auto-update (zip + multi-arch latest-mac.yml)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,28 @@ jobs:
         shell: bash
         run: rm -f dist-electron/*.blockmap
 
+      # macOS auto-update needs ONE multi-arch latest-mac.yml so electron-updater
+      # serves the native arch. Each mac job emits its own single-arch
+      # latest-mac.yml; uploading both would let the later one win and serve one
+      # arch to every Mac (the macOS analogue of the Windows #586 collision
+      # below). Stash each arch's yml as an artifact and drop it from the upload
+      # set; the `merge-mac-metadata` job combines them into the multi-arch file.
+      - name: Stash mac update metadata for the multi-arch merge
+        if: startsWith(matrix.platform, 'mac')
+        shell: bash
+        run: |
+          mkdir -p mac-update-yml
+          cp dist-electron/latest-mac.yml "mac-update-yml/latest-mac-${{ matrix.arch }}.yml"
+          rm -f dist-electron/latest-mac.yml
+
+      - name: Upload mac update metadata artifact
+        if: startsWith(matrix.platform, 'mac')
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-update-yml-${{ matrix.arch }}
+          path: mac-update-yml/latest-mac-${{ matrix.arch }}.yml
+          retention-days: 1
+
       # GH #586: Windows update metadata is named `latest.yml` with NO arch
       # suffix (unlike latest-mac.yml / latest-linux-arm64.yml), so the x64 and
       # the arm64 Windows jobs each emit one and the later softprops upload
@@ -228,11 +250,13 @@ jobs:
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
         with:
-          # Installers (FilamentDB-*) AND the electron-updater metadata files
-          # (latest-mac.yml, latest-mac-x64.yml, latest-linux.yml,
+          # Installers (FilamentDB-* — dmg, zip, AppImage, deb, exe) AND the
+          # electron-updater metadata files (latest-linux.yml,
           # latest-linux-arm64.yml, latest.yml). Without the yml files the
           # auto-updater cannot resolve the newest release and every update
-          # check fails with a 404.
+          # check fails with a 404. NOTE: the mac jobs deleted their
+          # latest-mac.yml above (stashed for the merge); the multi-arch
+          # latest-mac.yml is uploaded by the merge-mac-metadata job instead.
           files: |
             dist-electron/FilamentDB-*
             dist-electron/latest*.yml
@@ -240,6 +264,48 @@ jobs:
           # build steps re-run softprops/action-gh-release. Without
           # append_body, an empty `body` input replaces whatever notes were
           # set via `gh release create` minutes earlier.
+          append_body: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Combine the two macOS jobs' single-arch latest-mac.yml into ONE multi-arch
+  # file and upload it. electron-updater filters the yml's `files` by the
+  # running arch and downloads the matching .zip, so this is what makes an Apple
+  # Silicon Mac auto-update to the arm64 build and an Intel Mac to the x64 build.
+  # Runs after the whole build matrix so both arch artifacts exist.
+  merge-mac-metadata:
+    name: Merge multi-arch latest-mac.yml
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      # --ignore-scripts: only js-yaml (pure JS) is needed for the merge; skip
+      # the native-module postinstall (pcsclite) that needs PC/SC headers.
+      - run: npm ci --ignore-scripts
+      - name: Download both arches' latest-mac.yml
+        uses: actions/download-artifact@v4
+        with:
+          pattern: mac-update-yml-*
+          path: mac-yml
+          merge-multiple: true
+      - name: Merge into a multi-arch latest-mac.yml
+        run: |
+          ls -la mac-yml
+          node scripts/merge-mac-latest-yml.mjs \
+            mac-yml/latest-mac-arm64.yml \
+            mac-yml/latest-mac-x64.yml \
+            > latest-mac.yml
+          echo "=== merged latest-mac.yml ==="
+          cat latest-mac.yml
+      - name: Upload merged latest-mac.yml to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: latest-mac.yml
           append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,12 @@ jobs:
           # Notarize only when the Prepare step set the flag (i.e. secrets exist).
           NOTARIZE_FLAG=""
           [ "${FILAMENTDB_MAC_NOTARIZE:-}" = "true" ] && NOTARIZE_FLAG="--config.mac.notarize=true"
-          npx electron-builder --config electron-builder.yml --arm64 $NOTARIZE_FLAG
+          # --publish never: electron-builder's `publish: github` config would
+          # otherwise upload this job's SINGLE-arch latest-mac.yml on the tag
+          # build (GH_TOKEN is set), racing the multi-arch merge job and serving
+          # one arch to every Mac if that merge is ever skipped. Installers go up
+          # via softprops; the yml is owned by merge-mac-metadata. (Mirrors #586.)
+          npx electron-builder --config electron-builder.yml --arm64 $NOTARIZE_FLAG --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -190,7 +195,10 @@ jobs:
           # Notarize only when the Prepare step set the flag (i.e. secrets exist).
           NOTARIZE_FLAG=""
           [ "${FILAMENTDB_MAC_NOTARIZE:-}" = "true" ] && NOTARIZE_FLAG="--config.mac.notarize=true"
-          npx electron-builder --config electron-builder.yml --x64 $NOTARIZE_FLAG
+          # --publish never — see the macOS arm64 step: stop electron-builder
+          # publishing this job's single-arch latest-mac.yml; merge-mac-metadata
+          # owns the mac update channel.
+          npx electron-builder --config electron-builder.yml --x64 $NOTARIZE_FLAG --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -86,8 +86,16 @@ mac:
   # per matrix job, and electron-builder treats CLI arch flags as additive
   # when a target has an arch list, so both archs would be built per job.
   # Leaving arch unset means the CLI flag alone determines what gets built.
+  #
+  # `zip` is REQUIRED for auto-update: electron-updater's macOS updater
+  # (Squirrel.Mac) downloads a .zip of the app and throws "ZIP file not
+  # provided" when the release ships only a .dmg. The .dmg stays for manual
+  # download. The global artifactName embeds ${arch}, so the zips land as
+  # FilamentDB-<version>-mac-arm64.zip / -mac-x64.zip — the "arm64" in the name
+  # is what electron-updater's MacUpdater filters on to install the native arch.
   target:
     - dmg
+    - zip
 
 win:
   # Do NOT hardcode arch here (mirrors the mac config above). Each CI matrix

--- a/electron/auto-updater.ts
+++ b/electron/auto-updater.ts
@@ -7,18 +7,22 @@ import { assertTrustedSender } from "./ipc-security";
  * running and surfaces a download-and-restart prompt when an update is ready.
  *
  * Notes on signing:
- * - On macOS, unsigned apps cannot auto-install. We still detect that an
- *   update exists and prompt the user to download the new DMG manually via
- *   the GitHub release page.
+ * - On macOS, auto-update works now that builds are Developer ID-signed +
+ *   notarized (v1.39.1+) AND the release ships per-arch `.zip` artifacts with a
+ *   merged multi-arch `latest-mac.yml`: electron-updater requires a `.zip`
+ *   (throws "ZIP file not provided" for a dmg-only release) and filters the
+ *   yml's `files` by the running arch, so it downloads the NATIVE build. The
+ *   "View release" link stays as a manual fallback (e.g. if a download fails).
  * - On Windows, unsigned NSIS installers work fine with auto-update (the
  *   user just sees an SmartScreen warning on launch).
  * - On Linux, AppImage updates work when the app was launched via
  *   AppImageLauncher or a similar integration. deb updates are NOT handled
  *   here — package managers should be used.
  *
- * The release workflow already produces `latest-mac.yml`, `latest-linux.yml`,
- * `latest-linux-arm64.yml` for each v* tag, which is what electron-updater
- * reads from the GitHub release.
+ * The release workflow produces `latest-mac.yml` (multi-arch, merged from the
+ * arm64 + x64 jobs), `latest-linux.yml`, `latest-linux-arm64.yml`, and
+ * `latest.yml` (Windows x64) for each v* tag — what electron-updater reads from
+ * the GitHub release.
  */
 
 interface UpdateInfo {

--- a/scripts/merge-mac-latest-yml.mjs
+++ b/scripts/merge-mac-latest-yml.mjs
@@ -1,0 +1,86 @@
+// Merge two single-arch electron-updater `latest-mac.yml` files (arm64 + x64)
+// into ONE multi-arch `latest-mac.yml`.
+//
+// Why: electron-updater's MacUpdater filters the `files` array by the running
+// arch — it keeps entries whose URL contains "arm64" on Apple Silicon (or under
+// Rosetta) and the non-arm64 entries on Intel, then downloads the matching
+// `.zip`. So a single yml that lists BOTH arches' zips makes the updater install
+// the NATIVE build. Without this merge the two macOS release jobs each emit a
+// `latest-mac.yml` and the later upload wins, serving one arch to every Mac —
+// the macOS analogue of the Windows `latest.yml` collision fixed in GH #586.
+//
+// electron-updater also REQUIRES a `.zip` (it throws "ZIP file not provided"
+// when only a `.dmg` is present), which is why the mac build target now emits
+// both `dmg` + `zip`.
+//
+// Usage:
+//   node scripts/merge-mac-latest-yml.mjs <arm64.yml> <x64.yml> > latest-mac.yml
+
+import { readFileSync } from "node:fs";
+// Use the `yaml` package — the same direct dependency the app already parses
+// OpenPrintTag YAML with (src/lib/openprinttagBrowser.ts). electron-updater
+// reads the file with its own parser, so any standards-compliant YAML is fine.
+import { parse, stringify } from "yaml";
+
+/**
+ * Merge arm64 + x64 `latest-mac.yml` documents into one multi-arch document.
+ *
+ * - Combines the `files` arrays (x64 first, then arm64), deduped by `url`.
+ * - Keeps `version` / `releaseDate` and bases the legacy top-level
+ *   `path` / `sha512` / `size` on the x64 doc. electron-updater prefers the
+ *   arch-filtered `files` array (getFileList returns it whenever it's
+ *   non-empty), so the top-level fields are only a fallback for very old
+ *   clients; x64 is the broadest-compatible default (runs on arm64 via Rosetta).
+ *
+ * @param {string} arm64Yml raw contents of the arm64 latest-mac.yml
+ * @param {string} x64Yml   raw contents of the x64 latest-mac.yml
+ * @returns {string} the merged multi-arch latest-mac.yml
+ */
+export function mergeMacLatestYml(arm64Yml, x64Yml) {
+  const arm = parse(arm64Yml);
+  const x64 = parse(x64Yml);
+  if (arm == null || typeof arm !== "object") {
+    throw new Error("arm64 latest-mac.yml is empty or not a mapping");
+  }
+  if (x64 == null || typeof x64 !== "object") {
+    throw new Error("x64 latest-mac.yml is empty or not a mapping");
+  }
+
+  const seen = new Set();
+  const files = [];
+  for (const f of [...(x64.files ?? []), ...(arm.files ?? [])]) {
+    if (f == null || typeof f.url !== "string") continue;
+    if (seen.has(f.url)) continue;
+    seen.add(f.url);
+    files.push(f);
+  }
+  if (files.length === 0) {
+    throw new Error("no `files` entries found in either latest-mac.yml");
+  }
+  if (!files.some((f) => f.url.includes("arm64"))) {
+    throw new Error("merged latest-mac.yml has no arm64 entry — arm64 Macs would get no native build");
+  }
+  if (!files.some((f) => !f.url.includes("arm64"))) {
+    throw new Error("merged latest-mac.yml has no x64 entry — Intel Macs would get no native build");
+  }
+
+  // Base on the x64 document (its top-level path points at the x64 zip), then
+  // replace `files` with the combined multi-arch list. lineWidth: 0 disables
+  // line folding so base64 sha512 values are never wrapped.
+  const merged = { ...x64, files };
+  return stringify(merged, { lineWidth: 0 });
+}
+
+// CLI entry — guarded so importing this module (e.g. from tests) doesn't run it.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [armPath, x64Path] = process.argv.slice(2);
+  if (!armPath || !x64Path) {
+    console.error(
+      "Usage: node scripts/merge-mac-latest-yml.mjs <arm64.yml> <x64.yml> > latest-mac.yml",
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    mergeMacLatestYml(readFileSync(armPath, "utf8"), readFileSync(x64Path, "utf8")),
+  );
+}

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -25,13 +25,6 @@ export default function UpdateBanner() {
   // error still surfaces instead of staying hidden behind a stale dismiss.
   const [dismissedError, setDismissedError] = useState<string | null>(null);
   const isElectron = typeof window !== "undefined" && !!window.electronAPI;
-  // macOS Gatekeeper blocks unsigned auto-installs. Even the download path
-  // currently fails ("ZIP file not provided") because we don't ship mac
-  // .zip artifacts and the per-arch yml lookup picks the wrong installer
-  // on Apple Silicon (GH #154). Until those ship, route mac users straight
-  // to the GitHub release page where they can grab the right .dmg manually.
-  const isMac =
-    typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   useEffect(() => {
     if (!isElectron) return;
@@ -79,21 +72,15 @@ export default function UpdateBanner() {
     body = (
       <>
         <span>{t("update.available", { version: status.version ?? "" })}</span>
-        {!isMac && (
-          <button
-            onClick={handleDownload}
-            className="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-xs"
-          >
-            {t("update.download")}
-          </button>
-        )}
+        <button
+          onClick={handleDownload}
+          className="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-xs"
+        >
+          {t("update.download")}
+        </button>
         <button
           onClick={handleOpenPage}
-          className={
-            isMac
-              ? "px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-xs"
-              : "text-xs underline opacity-80 hover:opacity-100"
-          }
+          className="text-xs underline opacity-80 hover:opacity-100"
         >
           {t("update.viewRelease")}
         </button>

--- a/tests/mergeMacLatestYml.test.ts
+++ b/tests/mergeMacLatestYml.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+// The merge logic ships as a CLI helper used by release.yml; import the pure
+// function directly (the .mjs guards its CLI entry behind import.meta check).
+import { mergeMacLatestYml } from "../scripts/merge-mac-latest-yml.mjs";
+
+const ARM64_YML = `version: 1.41.0
+files:
+  - url: FilamentDB-1.41.0-mac-arm64.zip
+    sha512: ARM64ZIPSHA512==
+    size: 111
+  - url: FilamentDB-1.41.0-mac-arm64.dmg
+    sha512: ARM64DMGSHA512==
+    size: 222
+path: FilamentDB-1.41.0-mac-arm64.zip
+sha512: ARM64ZIPSHA512==
+releaseDate: '2026-06-13T00:00:00.000Z'
+`;
+
+const X64_YML = `version: 1.41.0
+files:
+  - url: FilamentDB-1.41.0-mac-x64.zip
+    sha512: X64ZIPSHA512==
+    size: 333
+  - url: FilamentDB-1.41.0-mac-x64.dmg
+    sha512: X64DMGSHA512==
+    size: 444
+path: FilamentDB-1.41.0-mac-x64.zip
+sha512: X64ZIPSHA512==
+releaseDate: '2026-06-13T00:00:00.000Z'
+`;
+
+interface MacYml {
+  version: string;
+  path: string;
+  sha512: string;
+  releaseDate: string;
+  files: { url: string; sha512: string; size: number }[];
+}
+
+function parseYml(s: string): MacYml {
+  return parse(s) as MacYml;
+}
+
+describe("mergeMacLatestYml", () => {
+  it("combines both arches' files into one document", () => {
+    const merged = parseYml(mergeMacLatestYml(ARM64_YML, X64_YML));
+    const urls = merged.files.map((f) => f.url);
+    expect(urls).toContain("FilamentDB-1.41.0-mac-arm64.zip");
+    expect(urls).toContain("FilamentDB-1.41.0-mac-x64.zip");
+    expect(urls).toContain("FilamentDB-1.41.0-mac-arm64.dmg");
+    expect(urls).toContain("FilamentDB-1.41.0-mac-x64.dmg");
+    expect(merged.files).toHaveLength(4);
+    expect(merged.version).toBe("1.41.0");
+  });
+
+  it("preserves the arm64 substring electron-updater filters on", () => {
+    const merged = parseYml(mergeMacLatestYml(ARM64_YML, X64_YML));
+    // MacUpdater keeps files whose url contains "arm64" on Apple Silicon and the
+    // rest on Intel. Both groups must be non-empty for native installs to work.
+    expect(merged.files.some((f) => f.url.includes("arm64"))).toBe(true);
+    expect(merged.files.some((f) => !f.url.includes("arm64"))).toBe(true);
+  });
+
+  it("preserves per-file checksums (no cross-arch corruption)", () => {
+    const merged = parseYml(mergeMacLatestYml(ARM64_YML, X64_YML));
+    const arm64Zip = merged.files.find((f) => f.url === "FilamentDB-1.41.0-mac-arm64.zip");
+    const x64Zip = merged.files.find((f) => f.url === "FilamentDB-1.41.0-mac-x64.zip");
+    expect(arm64Zip?.sha512).toBe("ARM64ZIPSHA512==");
+    expect(x64Zip?.sha512).toBe("X64ZIPSHA512==");
+  });
+
+  it("bases the legacy top-level path on x64 (broadest compatibility)", () => {
+    const merged = parseYml(mergeMacLatestYml(ARM64_YML, X64_YML));
+    expect(merged.path).toBe("FilamentDB-1.41.0-mac-x64.zip");
+    expect(merged.sha512).toBe("X64ZIPSHA512==");
+  });
+
+  it("dedupes by url if an entry appears in both inputs", () => {
+    // Simulate an overlap (e.g. a universal artifact listed in both docs).
+    const shared = `version: 1.41.0
+files:
+  - url: FilamentDB-1.41.0-mac-arm64.zip
+    sha512: SHARED==
+    size: 111
+  - url: FilamentDB-1.41.0-mac-x64.zip
+    sha512: X64==
+    size: 333
+path: FilamentDB-1.41.0-mac-x64.zip
+sha512: X64==
+releaseDate: '2026-06-13T00:00:00.000Z'
+`;
+    const merged = parseYml(mergeMacLatestYml(ARM64_YML, shared));
+    const arm64ZipCount = merged.files.filter(
+      (f) => f.url === "FilamentDB-1.41.0-mac-arm64.zip",
+    ).length;
+    expect(arm64ZipCount).toBe(1);
+  });
+
+  it("throws when an input is empty or not a mapping", () => {
+    expect(() => mergeMacLatestYml("", X64_YML)).toThrow();
+    expect(() => mergeMacLatestYml(ARM64_YML, "")).toThrow();
+  });
+
+  it("throws when one arch is missing entirely (would strand those Macs)", () => {
+    const x64Only = `version: 1.41.0
+files:
+  - url: FilamentDB-1.41.0-mac-x64.zip
+    sha512: X64==
+    size: 333
+path: FilamentDB-1.41.0-mac-x64.zip
+sha512: X64==
+releaseDate: '2026-06-13T00:00:00.000Z'
+`;
+    // Both inputs x64-only → no arm64 entry → throws rather than ship a yml
+    // that strands Apple Silicon users.
+    expect(() => mergeMacLatestYml(x64Only, x64Only)).toThrow(/arm64/);
+  });
+});


### PR DESCRIPTION
## Why

After signing/notarization landed (v1.39.1), the macOS update banner still only offered **View release** — no in-app Download/Install. Signing was necessary but not sufficient. Two gaps remained, both confirmed against the installed `electron-updater@6.8.3` source:

1. **No `.zip` artifact.** `MacUpdater` calls `findFile(files, "zip", ...)` and throws **`ZIP file not provided`** for a dmg-only release — it can't auto-update from a `.dmg`.
2. **`latest-mac.yml` arch collision.** Both macOS jobs emit `latest-mac.yml`; the later softprops upload wins, so every Mac was served one arch (the macOS analogue of the Windows `latest.yml` collision fixed in #586). `MacUpdater` *filters the yml's `files` by the running arch* (keeps `arm64`-in-URL files on Apple Silicon / Rosetta, the rest on Intel), so a single yml listing **both** arches lets it pick the native build.

The `UpdateBanner` `isMac` gate existed precisely because of #1/#2 and routed Mac users to the release page.

## Changes

- **`electron-builder.yml`** — `mac.target: [dmg, zip]`. The global `artifactName` embeds `${arch}`, so zips land as `…-mac-arm64.zip` / `…-mac-x64.zip` (the `arm64` substring is what the updater filters on).
- **`release.yml`** — each mac job stashes its single-arch `latest-mac.yml` as an artifact and removes it from the upload set; a new **`merge-mac-metadata`** job merges them into one multi-arch `latest-mac.yml` and uploads it.
- **`scripts/merge-mac-latest-yml.mjs`** — pure merge helper (uses the `yaml` dep the app already parses OpenPrintTag YAML with; throws if either arch is missing so we never ship a yml that strands one platform). Unit-tested in **`tests/mergeMacLatestYml.test.ts`** (7 cases).
- **`UpdateBanner.tsx`** — drop the `isMac` gate; Mac gets the Download button like every platform. **View release** stays as a manual fallback.
- **`auto-updater.ts`** — refresh the stale "macOS can't auto-install" docblock.

## Verified locally

`tsc` ✓ · `eslint` ✓ · `mergeMacLatestYml` (7) + `auto-updater` (3) tests ✓ · both YAML files parse · `mac.target=[dmg,zip]` · `merge-mac-metadata` job present.

## ⚠️ Validation caveat (CI-only path)

The merge job + zip target can't be exercised without cutting a release. **It takes effect on the NEXT release**: that build ships the zip + multi-arch `latest-mac.yml`. Recommended check after the next tag: download `latest-mac.yml` from the release and confirm its `files` array lists both `-mac-arm64.zip` and `-mac-x64.zip`. The v1.40.0 → next transition still needs **one manual install** (the running app predates this change); auto-update is native-arch thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)