### PR TITLE
feat(mobile): Phase 2 — create a filament from a scanned tag

### DIFF
--- a/packages/mobile/src/app/_layout.tsx
+++ b/packages/mobile/src/app/_layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout() {
             options={{ title: 'Scan QR code', presentation: 'modal' }}
           />
           <Stack.Screen name="filament/[id]" options={{ title: 'Filament' }} />
+          <Stack.Screen name="create-from-tag" options={{ title: 'New filament' }} />
         </Stack>
       </ThemeProvider>
     </ServerConfigProvider>

--- a/packages/mobile/src/app/create-from-tag.tsx
+++ b/packages/mobile/src/app/create-from-tag.tsx
@@ -29,7 +29,16 @@ function deriveName(tag: DecodedOpenPrintTag | null): string {
   if (!tag) return '';
   const brand = (tag.brandName ?? '').trim();
   const material = (tag.materialName ?? '').trim();
-  return [brand, material].filter(Boolean).join(' ') || material || brand || (tag.materialType ?? '').trim();
+  // Filament DB tags store the full name (brand included) in materialName, so
+  // only prefix the brand when it isn't already there (mirrors the server
+  // mapper) — else a re-scanned FDB tag yields "Prusament Prusament PLA …".
+  const combined =
+    brand && material
+      ? material.toLowerCase().startsWith(brand.toLowerCase())
+        ? material
+        : `${brand} ${material}`
+      : '';
+  return combined || material || brand || (tag.materialType ?? '').trim();
 }
 
 /** A one-line, read-only summary of what the tag will fill in (server-mapped). */

--- a/packages/mobile/src/app/create-from-tag.tsx
+++ b/packages/mobile/src/app/create-from-tag.tsx
@@ -1,0 +1,214 @@
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { ApiError, createApi } from '@/lib/api';
+import { takePendingScan } from '@/lib/pendingScan';
+import { useServerConfig } from '@/lib/serverConfig';
+import { useColors } from '@/lib/theme';
+import type { DecodedOpenPrintTag } from '@/lib/types';
+
+/**
+ * Best-effort default name from the tag — matches the server mapper
+ * (decodedTagToFilament) for any tag carrying a brand/material/type. A wholly
+ * empty tag yields '' here (the server defaults to "Scanned filament"); the
+ * blank prefill is intentional since Create is gated on a non-empty name and
+ * an `overrides.name` always wins server-side.
+ */
+function deriveName(tag: DecodedOpenPrintTag | null): string {
+  if (!tag) return '';
+  const brand = (tag.brandName ?? '').trim();
+  const material = (tag.materialName ?? '').trim();
+  return [brand, material].filter(Boolean).join(' ') || material || brand || (tag.materialType ?? '').trim();
+}
+
+/** A one-line, read-only summary of what the tag will fill in (server-mapped). */
+function tagSummary(tag: DecodedOpenPrintTag): string {
+  const num = (v: unknown) => (typeof v === 'number' ? v : undefined);
+  const parts: string[] = [];
+  const density = num(tag.density);
+  if (density != null) parts.push(`${density} g/cm³`);
+  const nozzle = num(tag.nozzleTemp);
+  if (nozzle != null) parts.push(`nozzle ${nozzle}°C`);
+  const bed = num(tag.bedTemp);
+  if (bed != null) parts.push(`bed ${bed}°C`);
+  const tags = Array.isArray(tag.tags) ? tag.tags.length : 0;
+  if (tags > 0) parts.push(`${tags} tag${tags === 1 ? '' : 's'}`);
+  return parts.join(' · ');
+}
+
+export default function CreateFromTagScreen() {
+  const router = useRouter();
+  const c = useColors();
+  const { baseUrl, apiKey } = useServerConfig();
+  // Consume the handed-off scan once (lazy initializer — runs on first render,
+  // never re-runs, and isn't an effect so it doesn't trip set-state-in-effect).
+  const [tag] = useState(() => takePendingScan());
+  const [name, setName] = useState(() => deriveName(tag));
+  const [vendor, setVendor] = useState(() => (tag?.brandName ?? '').trim());
+  const [type, setType] = useState(() => (tag?.materialType ?? '').trim());
+  const [saving, setSaving] = useState(false);
+
+  if (!tag) {
+    return (
+      <View style={styles.centered}>
+        <Text style={[styles.text, { color: c.muted }]}>
+          No scanned tag to create from. Scan a tag, then choose “Create filament”.
+        </Text>
+      </View>
+    );
+  }
+  if (!baseUrl) {
+    return (
+      <View style={styles.centered}>
+        <Text style={[styles.text, { color: c.danger }]}>Not connected.</Text>
+      </View>
+    );
+  }
+
+  const canCreate = name.trim() !== '' && vendor.trim() !== '' && type.trim() !== '' && !saving;
+  const swatch = tag.color || tag.secondaryColors?.[0] || '#808080';
+  const summary = tagSummary(tag);
+
+  async function create() {
+    if (!tag || !baseUrl) return;
+    const n = name.trim();
+    const v = vendor.trim();
+    const t = type.trim();
+    if (!n || !v || !t) {
+      Alert.alert('Missing fields', 'Name, vendor, and type are required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const api = createApi({ baseUrl, apiKey });
+      const created = await api.createFromTag(tag, { name: n, vendor: v, type: t });
+      // Replace so Back doesn't return to this one-shot confirm screen.
+      router.replace({ pathname: '/filament/[id]', params: { id: created._id } });
+    } catch (e) {
+      Alert.alert('Create failed', e instanceof ApiError ? e.message : (e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputStyle = [
+    styles.input,
+    { color: c.text, borderColor: c.border, backgroundColor: c.inputBg },
+  ];
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <View style={[styles.preview, { backgroundColor: c.card, borderColor: c.border }]}>
+          <View style={[styles.swatch, { backgroundColor: swatch, borderColor: c.border }]} />
+          <View style={styles.previewText}>
+            <Text style={[styles.previewTitle, { color: c.text }]} numberOfLines={1}>
+              {deriveName(tag) || 'Scanned tag'}
+            </Text>
+            {summary !== '' && (
+              <Text style={[styles.previewSub, { color: c.muted }]} numberOfLines={2}>
+                {summary}
+              </Text>
+            )}
+          </View>
+        </View>
+
+        <Text style={[styles.hint, { color: c.muted }]}>
+          Color, temperatures, density, and tags are filled from the tag. Confirm the identity below.
+        </Text>
+
+        <Text style={[styles.label, { color: c.text }]}>Name</Text>
+        <TextInput
+          style={inputStyle}
+          value={name}
+          onChangeText={setName}
+          placeholder="Filament name"
+          placeholderTextColor={c.muted}
+          autoCapitalize="words"
+        />
+
+        <Text style={[styles.label, styles.spaced, { color: c.text }]}>Vendor</Text>
+        <TextInput
+          style={inputStyle}
+          value={vendor}
+          onChangeText={setVendor}
+          placeholder="Brand"
+          placeholderTextColor={c.muted}
+          autoCapitalize="words"
+        />
+
+        <Text style={[styles.label, styles.spaced, { color: c.text }]}>Type</Text>
+        <TextInput
+          style={inputStyle}
+          value={type}
+          onChangeText={setType}
+          placeholder="PLA, PETG, …"
+          placeholderTextColor={c.muted}
+          autoCapitalize="characters"
+        />
+
+        <Pressable
+          style={[styles.button, { backgroundColor: c.tint }, !canCreate && styles.disabled]}
+          onPress={create}
+          disabled={!canCreate}
+        >
+          <Text style={[styles.buttonText, { color: c.onTint }]}>
+            {saving ? 'Creating…' : 'Create filament'}
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
+  container: { padding: 20, gap: 6 },
+  text: { fontSize: 16, textAlign: 'center' },
+  preview: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 8,
+  },
+  swatch: { width: 40, height: 40, borderRadius: 20, borderWidth: 1 },
+  previewText: { flex: 1, gap: 2 },
+  previewTitle: { fontSize: 16, fontWeight: '600' },
+  previewSub: { fontSize: 13 },
+  hint: { fontSize: 13, marginBottom: 8 },
+  label: { fontSize: 15, fontWeight: '600' },
+  spaced: { marginTop: 14 },
+  input: {
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    fontSize: 16,
+    marginTop: 4,
+  },
+  button: {
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginTop: 28,
+  },
+  buttonText: { fontSize: 16, fontWeight: '600' },
+  disabled: { opacity: 0.5 },
+});

--- a/packages/mobile/src/app/create-from-tag.tsx
+++ b/packages/mobile/src/app/create-from-tag.tsx
@@ -64,7 +64,9 @@ export default function CreateFromTagScreen() {
   // clear the ref, so a StrictMode / React-Compiler double-invoke of this
   // initializer stays pure (a read-and-clear would hand `null` to the second
   // call); we clear explicitly after a successful create.
-  const [tag] = useState(() => peekPendingScan());
+  const [pending] = useState(() => peekPendingScan());
+  const tag = pending?.decoded ?? null;
+  const matches = pending?.matches ?? [];
   const [name, setName] = useState(() => deriveName(tag));
   const [vendor, setVendor] = useState(() => (tag?.brandName ?? '').trim());
   const [type, setType] = useState(() => (tag?.materialType ?? '').trim());
@@ -115,6 +117,11 @@ export default function CreateFromTagScreen() {
     }
   }
 
+  const openMatch = (id: string) => {
+    clearPendingScan();
+    router.replace({ pathname: '/filament/[id]', params: { id } });
+  };
+
   const inputStyle = [
     styles.input,
     { color: c.text, borderColor: c.border, backgroundColor: c.inputBg },
@@ -139,6 +146,33 @@ export default function CreateFromTagScreen() {
             )}
           </View>
         </View>
+
+        {matches.length > 0 && (
+          <View style={styles.matches}>
+            <Text style={[styles.label, { color: c.text }]}>Already have one of these?</Text>
+            <Text style={[styles.hint, { color: c.muted }]}>
+              The scan matched {matches.length === 1 ? 'an existing filament' : `${matches.length} existing filaments`}.
+              Tap to open instead of creating a duplicate.
+            </Text>
+            {matches.map((m) => (
+              <Pressable
+                key={m._id}
+                style={[styles.matchRow, { backgroundColor: c.card, borderColor: c.border }]}
+                onPress={() => openMatch(m._id)}
+              >
+                <Text style={[styles.matchName, { color: c.text }]} numberOfLines={1}>
+                  {m.name}
+                </Text>
+                {[m.vendor, m.type].filter(Boolean).length > 0 && (
+                  <Text style={[styles.matchSub, { color: c.muted }]} numberOfLines={1}>
+                    {[m.vendor, m.type].filter(Boolean).join(' · ')}
+                  </Text>
+                )}
+              </Pressable>
+            ))}
+            <Text style={[styles.orCreate, { color: c.text }]}>Or create a new filament from this tag:</Text>
+          </View>
+        )}
 
         <Text style={[styles.hint, { color: c.muted }]}>
           Color, temperatures, density, and tags are filled from the tag. Confirm the identity below.
@@ -206,6 +240,17 @@ const styles = StyleSheet.create({
   previewText: { flex: 1, gap: 2 },
   previewTitle: { fontSize: 16, fontWeight: '600' },
   previewSub: { fontSize: 13 },
+  matches: { gap: 6, marginBottom: 8 },
+  matchRow: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    gap: 2,
+  },
+  matchName: { fontSize: 15, fontWeight: '600' },
+  matchSub: { fontSize: 13 },
+  orCreate: { fontSize: 14, fontWeight: '600', marginTop: 8 },
   hint: { fontSize: 13, marginBottom: 8 },
   label: { fontSize: 15, fontWeight: '600' },
   spaced: { marginTop: 14 },

--- a/packages/mobile/src/app/create-from-tag.tsx
+++ b/packages/mobile/src/app/create-from-tag.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 
 import { ApiError, createApi } from '@/lib/api';
-import { takePendingScan } from '@/lib/pendingScan';
+import { clearPendingScan, peekPendingScan } from '@/lib/pendingScan';
 import { useServerConfig } from '@/lib/serverConfig';
 import { useColors } from '@/lib/theme';
 import type { DecodedOpenPrintTag } from '@/lib/types';
@@ -51,9 +51,11 @@ export default function CreateFromTagScreen() {
   const router = useRouter();
   const c = useColors();
   const { baseUrl, apiKey } = useServerConfig();
-  // Consume the handed-off scan once (lazy initializer — runs on first render,
-  // never re-runs, and isn't an effect so it doesn't trip set-state-in-effect).
-  const [tag] = useState(() => takePendingScan());
+  // Read the handed-off scan in a lazy initializer. peekPendingScan does NOT
+  // clear the ref, so a StrictMode / React-Compiler double-invoke of this
+  // initializer stays pure (a read-and-clear would hand `null` to the second
+  // call); we clear explicitly after a successful create.
+  const [tag] = useState(() => peekPendingScan());
   const [name, setName] = useState(() => deriveName(tag));
   const [vendor, setVendor] = useState(() => (tag?.brandName ?? '').trim());
   const [type, setType] = useState(() => (tag?.materialType ?? '').trim());
@@ -93,7 +95,9 @@ export default function CreateFromTagScreen() {
     try {
       const api = createApi({ baseUrl, apiKey });
       const created = await api.createFromTag(tag, { name: n, vendor: v, type: t });
-      // Replace so Back doesn't return to this one-shot confirm screen.
+      // Consume the hand-off now that the filament exists (explicit clear, not
+      // during render). Replace so Back doesn't return to this confirm screen.
+      clearPendingScan();
       router.replace({ pathname: '/filament/[id]', params: { id: created._id } });
     } catch (e) {
       Alert.alert('Create failed', e instanceof ApiError ? e.message : (e as Error).message);

--- a/packages/mobile/src/app/index.tsx
+++ b/packages/mobile/src/app/index.tsx
@@ -47,48 +47,23 @@ export default function ScanScreen() {
     try {
       const scan = await readOpenPrintTag();
       const res = await api.decodeNfc(scan);
-      const decoded = res.decoded;
-      const goCreate = () => {
-        // The create screen consumes the handed-off scan and POSTs it back as
-        // tagData; the server does the field mapping (Phase 2).
-        setPendingScan(decoded);
-        router.push('/create-from-tag');
-      };
 
-      // Only an instanceId match is confident enough to open directly — the
-      // tag is one Filament DB wrote for this filament (its spool_uid is the
-      // filament's instanceId). A weaker heuristic match (name / vendor+type)
-      // can be a different color of a filament you already own, so never treat
-      // it as "this exact tag is in the DB": offer to open it OR create the scan.
+      // Only an instanceId match is confident enough to open directly — the tag
+      // is one Filament DB wrote for this filament (its spool_uid is the
+      // filament's instanceId). For everything else — a weak heuristic match
+      // (could be a sibling color), several candidates, or no match — hand the
+      // decoded tag AND any matched filaments to the create screen, which lets
+      // the user open an existing one or create from the scan. This avoids
+      // steering a multi-candidate scan into a duplicate and dodges Alert's
+      // cross-platform button caps.
       if (res.match?._id && res.matchedBy === 'instanceId') {
         router.push({ pathname: '/filament/[id]', params: { id: res.match._id } });
         return;
       }
-      const name = `${res.decoded.brandName ?? ''} ${res.decoded.materialName ?? ''}`.trim();
-      if (res.match?._id) {
-        const matchId = res.match._id;
-        const matchName = res.match.name ?? 'the match';
-        Alert.alert(
-          name || 'Tag decoded',
-          `Closest match: ${matchName}. This may be a different color or variant — open it, or create a new filament from this tag?`,
-          [
-            { text: 'Cancel', style: 'cancel' },
-            {
-              text: 'Open match',
-              onPress: () => router.push({ pathname: '/filament/[id]', params: { id: matchId } }),
-            },
-            { text: 'Create new', onPress: goCreate },
-          ],
-        );
-        return;
-      }
-      const detail = res.candidates.length
-        ? `${res.candidates.length} possible match(es) exist, but none is an exact match.`
-        : "This tag isn't in your database yet.";
-      Alert.alert(name || 'Tag decoded', `${detail}\n\nCreate a new filament from this tag?`, [
-        { text: 'Not now', style: 'cancel' },
-        { text: 'Create filament', onPress: goCreate },
-      ]);
+      // matchFilament returns EITHER a single match OR candidates, never both.
+      const matches = res.match ? [res.match] : res.candidates;
+      setPendingScan({ decoded: res.decoded, matches });
+      router.push('/create-from-tag');
     } catch (e) {
       Alert.alert('Scan failed', e instanceof ApiError ? e.message : (e as Error).message);
     } finally {

--- a/packages/mobile/src/app/index.tsx
+++ b/packages/mobile/src/app/index.tsx
@@ -55,11 +55,11 @@ export default function ScanScreen() {
         router.push('/create-from-tag');
       };
 
-      // Only an instanceId match is confident enough to open directly — it's
-      // our own tag, or one create-from-scan preserved as the filament's
-      // instanceId. A weaker heuristic match (name / vendor+type) can be a
-      // different color of a filament you already own, so never treat it as
-      // "this exact tag is in the DB": offer to open it OR create the scan.
+      // Only an instanceId match is confident enough to open directly — the
+      // tag is one Filament DB wrote for this filament (its spool_uid is the
+      // filament's instanceId). A weaker heuristic match (name / vendor+type)
+      // can be a different color of a filament you already own, so never treat
+      // it as "this exact tag is in the DB": offer to open it OR create the scan.
       if (res.match?._id && res.matchedBy === 'instanceId') {
         router.push({ pathname: '/filament/[id]', params: { id: res.match._id } });
         return;

--- a/packages/mobile/src/app/index.tsx
+++ b/packages/mobile/src/app/index.tsx
@@ -47,26 +47,47 @@ export default function ScanScreen() {
     try {
       const scan = await readOpenPrintTag();
       const res = await api.decodeNfc(scan);
-      if (res.match?._id) {
+      const decoded = res.decoded;
+      const goCreate = () => {
+        // The create screen consumes the handed-off scan and POSTs it back as
+        // tagData; the server does the field mapping (Phase 2).
+        setPendingScan(decoded);
+        router.push('/create-from-tag');
+      };
+
+      // Only an instanceId match is confident enough to open directly — it's
+      // our own tag, or one create-from-scan preserved as the filament's
+      // instanceId. A weaker heuristic match (name / vendor+type) can be a
+      // different color of a filament you already own, so never treat it as
+      // "this exact tag is in the DB": offer to open it OR create the scan.
+      if (res.match?._id && res.matchedBy === 'instanceId') {
         router.push({ pathname: '/filament/[id]', params: { id: res.match._id } });
         return;
       }
-      // No exact match — offer to create a new filament from the decoded tag
-      // (Phase 2). The create screen consumes the handed-off scan and POSTs it
-      // back as tagData; the server does the field mapping.
       const name = `${res.decoded.brandName ?? ''} ${res.decoded.materialName ?? ''}`.trim();
+      if (res.match?._id) {
+        const matchId = res.match._id;
+        const matchName = res.match.name ?? 'the match';
+        Alert.alert(
+          name || 'Tag decoded',
+          `Closest match: ${matchName}. This may be a different color or variant — open it, or create a new filament from this tag?`,
+          [
+            { text: 'Cancel', style: 'cancel' },
+            {
+              text: 'Open match',
+              onPress: () => router.push({ pathname: '/filament/[id]', params: { id: matchId } }),
+            },
+            { text: 'Create new', onPress: goCreate },
+          ],
+        );
+        return;
+      }
       const detail = res.candidates.length
         ? `${res.candidates.length} possible match(es) exist, but none is an exact match.`
         : "This tag isn't in your database yet.";
       Alert.alert(name || 'Tag decoded', `${detail}\n\nCreate a new filament from this tag?`, [
         { text: 'Not now', style: 'cancel' },
-        {
-          text: 'Create filament',
-          onPress: () => {
-            setPendingScan(res.decoded);
-            router.push('/create-from-tag');
-          },
-        },
+        { text: 'Create filament', onPress: goCreate },
       ]);
     } catch (e) {
       Alert.alert('Scan failed', e instanceof ApiError ? e.message : (e as Error).message);

--- a/packages/mobile/src/app/index.tsx
+++ b/packages/mobile/src/app/index.tsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { ApiError, createApi } from '@/lib/api';
 import { NFC_ENABLED } from '@/lib/features';
 import { readOpenPrintTag } from '@/lib/nfc';
+import { setPendingScan } from '@/lib/pendingScan';
 import { useServerConfig } from '@/lib/serverConfig';
 import { useColors } from '@/lib/theme';
 
@@ -50,14 +51,23 @@ export default function ScanScreen() {
         router.push({ pathname: '/filament/[id]', params: { id: res.match._id } });
         return;
       }
+      // No exact match — offer to create a new filament from the decoded tag
+      // (Phase 2). The create screen consumes the handed-off scan and POSTs it
+      // back as tagData; the server does the field mapping.
       const name = `${res.decoded.brandName ?? ''} ${res.decoded.materialName ?? ''}`.trim();
-      Alert.alert(
-        'Tag decoded',
-        (name || 'Unknown filament') +
-          (res.candidates.length
-            ? `\n\n${res.candidates.length} possible match(es) in your database.`
-            : '\n\nNot in your database yet.'),
-      );
+      const detail = res.candidates.length
+        ? `${res.candidates.length} possible match(es) exist, but none is an exact match.`
+        : "This tag isn't in your database yet.";
+      Alert.alert(name || 'Tag decoded', `${detail}\n\nCreate a new filament from this tag?`, [
+        { text: 'Not now', style: 'cancel' },
+        {
+          text: 'Create filament',
+          onPress: () => {
+            setPendingScan(res.decoded);
+            router.push('/create-from-tag');
+          },
+        },
+      ]);
     } catch (e) {
       Alert.alert('Scan failed', e instanceof ApiError ? e.message : (e as Error).message);
     } finally {

--- a/packages/mobile/src/lib/api.ts
+++ b/packages/mobile/src/lib/api.ts
@@ -1,4 +1,10 @@
-import type { Filament, Location, MatchResult, NfcDecodeResponse } from './types';
+import type {
+  DecodedOpenPrintTag,
+  Filament,
+  Location,
+  MatchResult,
+  NfcDecodeResponse,
+} from './types';
 
 /**
  * Thin typed client over the Filament DB REST API. The app does no business
@@ -84,6 +90,17 @@ export function createApi(cfg: ApiConfig) {
       request<NfcDecodeResponse>(cfg, '/api/nfc/decode', {
         method: 'POST',
         body: JSON.stringify(body),
+      }),
+    /**
+     * Create a filament from a decoded tag (mobile Phase 2). The server maps
+     * `tagData` (a DecodedOpenPrintTag from decodeNfc) into a filament payload;
+     * `overrides` (the user's confirmed name/vendor/type) win. The phone does
+     * no field mapping — design rule #1.
+     */
+    createFromTag: (tagData: DecodedOpenPrintTag, overrides: Record<string, unknown>) =>
+      request<Filament>(cfg, '/api/filaments', {
+        method: 'POST',
+        body: JSON.stringify({ tagData, overrides }),
       }),
     /** Update a spool — location and/or remaining weight (server converts). */
     updateSpool: (filamentId: string, spoolId: string, patch: Record<string, unknown>) =>

--- a/packages/mobile/src/lib/pendingScan.ts
+++ b/packages/mobile/src/lib/pendingScan.ts
@@ -1,0 +1,22 @@
+import type { DecodedOpenPrintTag } from './types';
+
+/**
+ * A one-shot hand-off for the decoded tag between the scan screen and the
+ * create-from-tag confirm screen. expo-router params are strings, and the
+ * decoded tag is a nested object the create screen must POST back verbatim as
+ * `tagData`, so we stash it in a module ref instead of URL-encoding it.
+ *
+ * `take` consumes it (read + clear) so a stale scan can't leak into a later,
+ * unrelated create flow if the user backs out.
+ */
+let pending: DecodedOpenPrintTag | null = null;
+
+export function setPendingScan(tag: DecodedOpenPrintTag): void {
+  pending = tag;
+}
+
+export function takePendingScan(): DecodedOpenPrintTag | null {
+  const t = pending;
+  pending = null;
+  return t;
+}

--- a/packages/mobile/src/lib/pendingScan.ts
+++ b/packages/mobile/src/lib/pendingScan.ts
@@ -6,8 +6,14 @@ import type { DecodedOpenPrintTag } from './types';
  * decoded tag is a nested object the create screen must POST back verbatim as
  * `tagData`, so we stash it in a module ref instead of URL-encoding it.
  *
- * `take` consumes it (read + clear) so a stale scan can't leak into a later,
- * unrelated create flow if the user backs out.
+ * `peek` reads WITHOUT clearing so it's safe to call from a `useState` lazy
+ * initializer — React StrictMode and the React Compiler (enabled in
+ * app.config.ts) may invoke initializers more than once to detect impure
+ * renders, and a read-and-clear there would hand `null` to the second
+ * invocation. The screen clears explicitly via `clearPendingScan` after a
+ * successful create. A stale value can't leak into a later flow: the scan
+ * screen always calls `setPendingScan` immediately before navigating here, so
+ * the ref is freshly overwritten on every entry.
  */
 let pending: DecodedOpenPrintTag | null = null;
 
@@ -15,8 +21,12 @@ export function setPendingScan(tag: DecodedOpenPrintTag): void {
   pending = tag;
 }
 
-export function takePendingScan(): DecodedOpenPrintTag | null {
-  const t = pending;
+/** Read the pending scan without consuming it (safe during render). */
+export function peekPendingScan(): DecodedOpenPrintTag | null {
+  return pending;
+}
+
+/** Clear the hand-off — call from an event handler, never during render. */
+export function clearPendingScan(): void {
   pending = null;
-  return t;
 }

--- a/packages/mobile/src/lib/pendingScan.ts
+++ b/packages/mobile/src/lib/pendingScan.ts
@@ -1,28 +1,36 @@
-import type { DecodedOpenPrintTag } from './types';
+import type { DecodedOpenPrintTag, Filament } from './types';
 
 /**
- * A one-shot hand-off for the decoded tag between the scan screen and the
- * create-from-tag confirm screen. expo-router params are strings, and the
- * decoded tag is a nested object the create screen must POST back verbatim as
- * `tagData`, so we stash it in a module ref instead of URL-encoding it.
+ * Hand-off from the scan screen to the create-from-tag confirm screen: the
+ * decoded tag plus any existing filaments the decode route matched
+ * heuristically (a single vendor+type/name match, or several candidates). The
+ * confirm screen offers those as "open an existing one" before the create form,
+ * so a re-scanned roll isn't steered into a duplicate. expo-router params are
+ * strings, so we stash the nested objects in a module ref instead of
+ * URL-encoding them.
  *
- * `peek` reads WITHOUT clearing so it's safe to call from a `useState` lazy
- * initializer — React StrictMode and the React Compiler (enabled in
- * app.config.ts) may invoke initializers more than once to detect impure
- * renders, and a read-and-clear there would hand `null` to the second
- * invocation. The screen clears explicitly via `clearPendingScan` after a
- * successful create. A stale value can't leak into a later flow: the scan
- * screen always calls `setPendingScan` immediately before navigating here, so
- * the ref is freshly overwritten on every entry.
+ * `peek` reads WITHOUT clearing so it's safe in a `useState` lazy initializer —
+ * React StrictMode and the React Compiler (enabled in app.config.ts) may invoke
+ * initializers more than once to detect impure renders, and a read-and-clear
+ * there would hand `null` to the second invocation. The screen clears
+ * explicitly via `clearPendingScan` once it navigates away. A stale value can't
+ * leak into a later flow: the scan screen always calls `setPendingScan`
+ * immediately before navigating here, so the ref is freshly overwritten.
  */
-let pending: DecodedOpenPrintTag | null = null;
+export interface PendingScan {
+  decoded: DecodedOpenPrintTag;
+  /** Existing filaments the decode route matched (heuristically); may be empty. */
+  matches: Filament[];
+}
 
-export function setPendingScan(tag: DecodedOpenPrintTag): void {
-  pending = tag;
+let pending: PendingScan | null = null;
+
+export function setPendingScan(scan: PendingScan): void {
+  pending = scan;
 }
 
 /** Read the pending scan without consuming it (safe during render). */
-export function peekPendingScan(): DecodedOpenPrintTag | null {
+export function peekPendingScan(): PendingScan | null {
   return pending;
 }
 

--- a/packages/mobile/src/lib/types.ts
+++ b/packages/mobile/src/lib/types.ts
@@ -63,4 +63,10 @@ export interface NfcDecodeResponse {
   decoded: DecodedOpenPrintTag;
   match: Filament | null;
   candidates: Filament[];
+  /**
+   * How `match` was resolved. Only `'instanceId'` is a confident "this exact
+   * tag is in the DB"; `'heuristic'` is a weaker name / vendor+type match that
+   * may be a sibling color, so the scanner offers "create new" alongside it.
+   */
+  matchedBy?: 'instanceId' | 'heuristic' | null;
 }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -6404,7 +6404,7 @@
           "tagData": {
             "type": "object",
             "additionalProperties": true,
-            "description": "A DecodedOpenPrintTag exactly as POST /api/nfc/decode returns it in `decoded`. The server maps it via decodedTagToFilament; the tag's spool_uid becomes the new filament's instanceId so a re-scan exact-matches."
+            "description": "A DecodedOpenPrintTag exactly as POST /api/nfc/decode returns it in `decoded`. The server maps it via decodedTagToFilament. instanceId is NOT taken from the tag — it stays system-assigned (re-scans resolve via the decode route's heuristic match)."
           },
           "overrides": {
             "type": "object",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -154,7 +154,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FilamentInput"
+                "oneOf": [
+                  { "$ref": "#/components/schemas/FilamentInput" },
+                  { "$ref": "#/components/schemas/CreateFromTagInput" }
+                ]
               }
             }
           }
@@ -6390,6 +6393,23 @@
                 }
               }
             }
+          }
+        }
+      },
+      "CreateFromTagInput": {
+        "type": "object",
+        "description": "Create-from-scan variant of POST /api/filaments (mobile Phase 2, plan §4.4). The server maps the decoded tag to a filament payload, then applies overrides (which win). Same mass-assignment strips as a normal create body; no spool subdocuments are fabricated.",
+        "required": ["tagData"],
+        "properties": {
+          "tagData": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "A DecodedOpenPrintTag exactly as POST /api/nfc/decode returns it in `decoded`. The server maps it via decodedTagToFilament; the tag's spool_uid becomes the new filament's instanceId so a re-scan exact-matches."
+          },
+          "overrides": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Filament fields that override the tag-mapped values — the scanner sends the user-confirmed name/vendor/type (required identity fields). Server-owned fields (instanceId, _purged, …) are stripped."
           }
         }
       },

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -148,7 +148,7 @@
           "Filaments"
         ],
         "summary": "Create filament",
-        "description": "Create a new filament profile. If parentId is provided, the filament becomes a color variant inheriting settings from its parent.",
+        "description": "Create a new filament profile. If parentId is provided, the filament becomes a color variant inheriting settings from its parent. Alternatively, send { tagData, overrides } where tagData is a DecodedOpenPrintTag from POST /api/nfc/decode: the server maps the decoded tag to a filament payload (mobile create-from-scan, plan §4.4), then overrides win over the mapped fields — the scanner uses this to set the user-edited name/vendor/type (which are required). Spool subdocuments are never fabricated on create.",
         "requestBody": {
           "required": true,
           "content": {

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -331,25 +331,16 @@ export async function POST(request: NextRequest) {
   // $-operator-key rejection: the merged body flows to Filament.create() — a
   // document under schema strict mode, which silently drops unknown
   // $-prefixed paths — not to findOneAndUpdate, so an `overrides` such as
-  // { "$set": … } can never act as an update operator.
-  //
-  // The mapper derives `instanceId` from the tag's spool_uid so a re-scan
-  // exact-matches the created filament; capture it here and re-apply it AFTER
-  // the generic `delete body.instanceId` strip below. Only the create-from-tag
-  // path does this — a normal POST's client-supplied instanceId is still
-  // dropped — and `overrides` (name/vendor/type only) can't influence it.
-  let tagInstanceId: string | null = null;
+  // { "$set": … } can never act as an update operator. instanceId is NOT taken
+  // from the tag — it stays system-assigned (the strip below removes any
+  // client value, including a forged tagData.spool_uid); see
+  // decodedTagToFilament for why.
   if (body && typeof body === "object" && body.tagData && typeof body.tagData === "object") {
     const overrides =
       body.overrides && typeof body.overrides === "object" && !Array.isArray(body.overrides)
         ? body.overrides
         : {};
-    const mapped = decodedTagToFilamentPayload(body.tagData);
-    if (typeof mapped.instanceId === "string" && mapped.instanceId.length > 0) {
-      tagInstanceId = mapped.instanceId;
-    }
-    delete mapped.instanceId;
-    body = { ...mapped, ...overrides };
+    body = { ...decodedTagToFilamentPayload(body.tagData), ...overrides };
   }
 
   delete body._id;
@@ -371,13 +362,6 @@ export async function POST(request: NextRequest) {
   // user-edited fields to silently auto-adopt on the next re-sync. Only the
   // OPT import/sync routes may write it.
   delete body.openprinttagSnapshot;
-
-  // Re-apply the tag's own id as instanceId for create-from-tag (captured from
-  // the mapper before the strip above). It's the tag's server-decoded
-  // spool_uid — not the arbitrary client instanceId the strip guards against —
-  // and is what makes a re-scan exact-match this filament instead of offering
-  // to create a duplicate.
-  if (tagInstanceId) body.instanceId = tagInstanceId;
 
   // GH #431: the PUT handler explicitly strips `body.spools` to prevent a
   // bulk rewrite of a spool's `usageHistory` ledger. The POST handler

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -7,6 +7,7 @@ import BedType from "@/models/BedType";
 import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError, assertActiveRefs } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { validateSpoolPhotoDataUrl } from "@/lib/validateSpoolBody";
+import { decodedTagToFilamentPayload } from "@/lib/decodedTagToFilament";
 import {
   isInvertedNozzleRange,
   effectiveNozzleRangeForUpdate,
@@ -315,6 +316,28 @@ export async function POST(request: NextRequest) {
     body = await request.json();
   } catch {
     return errorResponse("Invalid JSON in request body", 400);
+  }
+
+  // Create-from-decoded-tag (mobile Phase 2, plan §4.4): the scanner POSTs the
+  // tag exactly as POST /api/nfc/decode returned it (`tagData`) plus the user's
+  // confirmed edits (`overrides`). Map it to a filament payload server-side —
+  // the phone never reproduces this mapping (design rule #1) — then flow it
+  // through the normal create path below, so it inherits the same field
+  // stripping, ref validation, nozzle-range check, unique-name handling, and
+  // spool allowlist. `overrides` win over the tag (the user edits name / vendor
+  // / type on the confirm screen, which are required fields).
+  //
+  // Unlike the PUT handler ([id]/route.ts), this path deliberately needs no
+  // $-operator-key rejection: the merged body flows to Filament.create() — a
+  // document under schema strict mode, which silently drops unknown
+  // $-prefixed paths — not to findOneAndUpdate, so an `overrides` such as
+  // { "$set": … } can never act as an update operator.
+  if (body && typeof body === "object" && body.tagData && typeof body.tagData === "object") {
+    const overrides =
+      body.overrides && typeof body.overrides === "object" && !Array.isArray(body.overrides)
+        ? body.overrides
+        : {};
+    body = { ...decodedTagToFilamentPayload(body.tagData), ...overrides };
   }
 
   delete body._id;

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -332,12 +332,24 @@ export async function POST(request: NextRequest) {
   // document under schema strict mode, which silently drops unknown
   // $-prefixed paths — not to findOneAndUpdate, so an `overrides` such as
   // { "$set": … } can never act as an update operator.
+  //
+  // The mapper derives `instanceId` from the tag's spool_uid so a re-scan
+  // exact-matches the created filament; capture it here and re-apply it AFTER
+  // the generic `delete body.instanceId` strip below. Only the create-from-tag
+  // path does this — a normal POST's client-supplied instanceId is still
+  // dropped — and `overrides` (name/vendor/type only) can't influence it.
+  let tagInstanceId: string | null = null;
   if (body && typeof body === "object" && body.tagData && typeof body.tagData === "object") {
     const overrides =
       body.overrides && typeof body.overrides === "object" && !Array.isArray(body.overrides)
         ? body.overrides
         : {};
-    body = { ...decodedTagToFilamentPayload(body.tagData), ...overrides };
+    const mapped = decodedTagToFilamentPayload(body.tagData);
+    if (typeof mapped.instanceId === "string" && mapped.instanceId.length > 0) {
+      tagInstanceId = mapped.instanceId;
+    }
+    delete mapped.instanceId;
+    body = { ...mapped, ...overrides };
   }
 
   delete body._id;
@@ -359,6 +371,13 @@ export async function POST(request: NextRequest) {
   // user-edited fields to silently auto-adopt on the next re-sync. Only the
   // OPT import/sync routes may write it.
   delete body.openprinttagSnapshot;
+
+  // Re-apply the tag's own id as instanceId for create-from-tag (captured from
+  // the mapper before the strip above). It's the tag's server-decoded
+  // spool_uid — not the arbitrary client instanceId the strip guards against —
+  // and is what makes a re-scan exact-match this filament instead of offering
+  // to create a duplicate.
+  if (tagInstanceId) body.instanceId = tagInstanceId;
 
   // GH #431: the PUT handler explicitly strips `body.spools` to prevent a
   // bulk rewrite of a spool's `usageHistory` ledger. The POST handler

--- a/src/app/api/nfc/decode/route.ts
+++ b/src/app/api/nfc/decode/route.ts
@@ -169,9 +169,10 @@ export async function POST(request: NextRequest) {
       type: boundedField(decoded.materialType),
     });
     // Tell the scanner HOW we matched. Only an instanceId match is a confident
-    // "this exact physical tag is in the DB" — it's our own tag's id, or one
-    // that create-from-scan preserved as the new filament's instanceId. The
-    // weaker name / vendor+type heuristics (matchFilament's fallback tiers) can
+    // "this exact physical tag is in the DB" — the tag's spool_uid equals a
+    // filament's instanceId, which is what Filament DB wrote into the tag for
+    // that filament (GET /api/filaments/{id}/openprinttag). The weaker name /
+    // vendor+type heuristics (matchFilament's fallback tiers) can
     // open an existing sibling color, so the scanner must NOT treat them as
     // exact: it offers "create new" alongside opening the heuristic match.
     // instanceId is detected by comparing the matched row's id to the queried

--- a/src/app/api/nfc/decode/route.ts
+++ b/src/app/api/nfc/decode/route.ts
@@ -161,13 +161,34 @@ export async function POST(request: NextRequest) {
     // For a Bambu tag (spoolUid = 32-char tray UID) or a community OpenPrintTag
     // it won't collide with a 10-char FDB instanceId, so it harmlessly falls
     // through to the name/vendor/type matching that mirrors scanMatchHandler.
+    const queriedInstanceId = boundedField(decoded.spoolUid);
     const { match, candidates } = await matchFilament({
-      instanceId: boundedField(decoded.spoolUid),
+      instanceId: queriedInstanceId,
       name: boundedField(decoded.materialName),
       vendor: boundedField(decoded.brandName),
       type: boundedField(decoded.materialType),
     });
-    return NextResponse.json({ decoded, match, candidates });
+    // Tell the scanner HOW we matched. Only an instanceId match is a confident
+    // "this exact physical tag is in the DB" — it's our own tag's id, or one
+    // that create-from-scan preserved as the new filament's instanceId. The
+    // weaker name / vendor+type heuristics (matchFilament's fallback tiers) can
+    // open an existing sibling color, so the scanner must NOT treat them as
+    // exact: it offers "create new" alongside opening the heuristic match.
+    // instanceId is detected by comparing the matched row's id to the queried
+    // spool_uid (case-insensitively, mirroring matchFilament's CI fallback);
+    // since matchFilament tries instanceId FIRST, a row returned by a later
+    // tier necessarily has a different (or no) instanceId.
+    let matchedBy: "instanceId" | "heuristic" | null = null;
+    if (match) {
+      const matchedInstanceId = (match as { instanceId?: unknown }).instanceId;
+      matchedBy =
+        queriedInstanceId &&
+        typeof matchedInstanceId === "string" &&
+        matchedInstanceId.toLowerCase() === queriedInstanceId.toLowerCase()
+          ? "instanceId"
+          : "heuristic";
+    }
+    return NextResponse.json({ decoded, match, candidates, matchedBy });
   } catch (err) {
     return errorResponseFromCaught(err, "Failed to match decoded tag");
   }

--- a/src/lib/decodedTagToFilament.ts
+++ b/src/lib/decodedTagToFilament.ts
@@ -1,0 +1,72 @@
+import type { DecodedOpenPrintTag } from "./openprinttag-decode";
+
+/**
+ * Map a tag decoded by `POST /api/nfc/decode` (a `DecodedOpenPrintTag`) into a
+ * Filament DB creation payload — the server-side mapper behind create-from-scan
+ * (mobile Phase 2, plan §4.4). The phone never reproduces this mapping: it
+ * POSTs `{ tagData }` and the server builds the document, so the field mapping
+ * lives in exactly one place (design rule #1).
+ *
+ * Mirrors `mapToFilamentPayload` (the OpenPrintTag community-DB importer in
+ * `openprinttagBrowser.ts`) so a filament created from a physical tag matches
+ * one imported from the same material in the OPT database — sourcing from the
+ * decoded NFC shape instead of `OPTMaterial`, and capturing the couple of extra
+ * fields a physical tag carries (shore A hardness, the tag's own diameter).
+ * The decoded `tags` are ALREADY numeric `OPT_TAG` enum values (the decoder
+ * resolved the bit flags), so unlike the `OPTMaterial` path there is no
+ * string→enum step.
+ *
+ * Pure + DB-free (unit-tested). Spool subdocs / usage history are never
+ * produced here (plan §4.4) — create makes the filament only; the user adds a
+ * spool afterward via the existing spool routes.
+ *
+ * `name` / `vendor` / `type` are `required` on the schema. The tag is
+ * best-effort; the create screen prefills these and requires non-empty values,
+ * which arrive as `overrides` and win over the mapper output. When the tag
+ * carries no vendor/type and the caller supplies no override, `Filament.create`
+ * rejects with a required-field error — correct, not a silent bad document.
+ */
+export function decodedTagToFilamentPayload(
+  decoded: DecodedOpenPrintTag,
+): Record<string, unknown> {
+  const brand = decoded.brandName?.trim() || "";
+  const material = decoded.materialName?.trim() || "";
+  const type = decoded.materialType?.trim() || "";
+
+  // Best-effort default name from the tag; the create screen lets the user edit
+  // it before submit (it's the unique key, so a sensible default matters).
+  const name =
+    [brand, material].filter(Boolean).join(" ") || material || brand || type || "Scanned filament";
+
+  const secondaryColors = Array.isArray(decoded.secondaryColors) ? decoded.secondaryColors : [];
+
+  return {
+    name,
+    vendor: brand || null,
+    type: type || null,
+    // Preserve a null primary for coextruded / multi-color tags (secondaries
+    // but no primary) — same posture as mapToFilamentPayload (GH #477). Only
+    // fall back to gray when the tag carries no colors at all.
+    color: decoded.color || (secondaryColors.length > 0 ? null : "#808080"),
+    secondaryColors,
+    density: decoded.density ?? null,
+    // Prefer the tag's own diameter — a physical 2.85mm tag is authoritative —
+    // and fall back to the 1.75 the OPT importer assumes when the tag omits it.
+    diameter: decoded.diameter ?? 1.75,
+    temperatures: {
+      nozzle: decoded.nozzleTemp ?? null,
+      nozzleFirstLayer: null,
+      nozzleRangeMin: decoded.nozzleTempMin ?? null,
+      nozzleRangeMax: decoded.nozzleTemp ?? null,
+      bed: decoded.bedTemp ?? null,
+      bedFirstLayer: null,
+      standby: decoded.preheatTemp ?? null,
+    },
+    dryingTemperature: decoded.dryingTemperature ?? null,
+    dryingTime: decoded.dryingTime ?? null,
+    shoreHardnessA: decoded.shoreHardnessA ?? null,
+    shoreHardnessD: decoded.shoreHardnessD ?? null,
+    transmissionDistance: decoded.transmissionDistance ?? null,
+    optTags: Array.isArray(decoded.tags) ? decoded.tags : [],
+  };
+}

--- a/src/lib/decodedTagToFilament.ts
+++ b/src/lib/decodedTagToFilament.ts
@@ -45,8 +45,17 @@ export function decodedTagToFilamentPayload(
 
   // Best-effort default name from the tag; the create screen lets the user edit
   // it before submit (it's the unique key, so a sensible default matters).
-  const name =
-    [brand, material].filter(Boolean).join(" ") || material || brand || type || "Scanned filament";
+  // Filament DB writes a filament's FULL name (brand included) into the tag's
+  // materialName, while community tags carry the bare material — so only prefix
+  // the brand when materialName doesn't already lead with it, else a re-scanned
+  // FDB tag would yield "Prusament Prusament PLA …".
+  const combined =
+    brand && material
+      ? material.toLowerCase().startsWith(brand.toLowerCase())
+        ? material
+        : `${brand} ${material}`
+      : "";
+  const name = combined || material || brand || type || "Scanned filament";
 
   const secondaryColors = Array.isArray(decoded.secondaryColors) ? decoded.secondaryColors : [];
 
@@ -77,6 +86,12 @@ export function decodedTagToFilamentPayload(
     shoreHardnessA: decoded.shoreHardnessA ?? null,
     shoreHardnessD: decoded.shoreHardnessD ?? null,
     transmissionDistance: decoded.transmissionDistance ?? null,
+    // Nominal roll weight + empty-spool tare as filament-level defaults (NOT a
+    // spool subdoc — §4.4 never fabricates spools). spoolWeight feeds the
+    // remaining-weight math (totalWeight = remainingWeight + spoolWeight) when
+    // the user later adds a spool; netFilamentWeight is the nominal full weight.
+    netFilamentWeight: decoded.weightGrams ?? null,
+    spoolWeight: decoded.emptySpoolWeight ?? null,
     optTags: Array.isArray(decoded.tags) ? decoded.tags : [],
     // Only present when the tag carries a usable spool_uid (see above).
     ...(instanceId ? { instanceId } : {}),

--- a/src/lib/decodedTagToFilament.ts
+++ b/src/lib/decodedTagToFilament.ts
@@ -32,6 +32,16 @@ export function decodedTagToFilamentPayload(
   const brand = decoded.brandName?.trim() || "";
   const material = decoded.materialName?.trim() || "";
   const type = decoded.materialType?.trim() || "";
+  // The tag's own id. Filament DB writes a filament's `instanceId` into the
+  // tag's spool_uid (GET /api/filaments/{id}/openprinttag), and a Bambu /
+  // community tag's UID is stable per physical spool — so preserving it as the
+  // new filament's instanceId lets a RE-scan exact-match this filament (the
+  // decode route tries instanceId first) instead of re-offering "create". The
+  // POST route strips client-supplied instanceId and re-applies this tag-
+  // derived one only on the create-from-tag path. Bounded to 128 chars, like
+  // the match route's instanceId param.
+  const spoolUid = decoded.spoolUid?.trim();
+  const instanceId = spoolUid && spoolUid.length > 0 && spoolUid.length <= 128 ? spoolUid : undefined;
 
   // Best-effort default name from the tag; the create screen lets the user edit
   // it before submit (it's the unique key, so a sensible default matters).
@@ -68,5 +78,7 @@ export function decodedTagToFilamentPayload(
     shoreHardnessD: decoded.shoreHardnessD ?? null,
     transmissionDistance: decoded.transmissionDistance ?? null,
     optTags: Array.isArray(decoded.tags) ? decoded.tags : [],
+    // Only present when the tag carries a usable spool_uid (see above).
+    ...(instanceId ? { instanceId } : {}),
   };
 }

--- a/src/lib/decodedTagToFilament.ts
+++ b/src/lib/decodedTagToFilament.ts
@@ -32,16 +32,15 @@ export function decodedTagToFilamentPayload(
   const brand = decoded.brandName?.trim() || "";
   const material = decoded.materialName?.trim() || "";
   const type = decoded.materialType?.trim() || "";
-  // The tag's own id. Filament DB writes a filament's `instanceId` into the
-  // tag's spool_uid (GET /api/filaments/{id}/openprinttag), and a Bambu /
-  // community tag's UID is stable per physical spool — so preserving it as the
-  // new filament's instanceId lets a RE-scan exact-match this filament (the
-  // decode route tries instanceId first) instead of re-offering "create". The
-  // POST route strips client-supplied instanceId and re-applies this tag-
-  // derived one only on the create-from-tag path. Bounded to 128 chars, like
-  // the match route's instanceId param.
-  const spoolUid = decoded.spoolUid?.trim();
-  const instanceId = spoolUid && spoolUid.length > 0 && spoolUid.length <= 128 ? spoolUid : undefined;
+  // NOTE: the tag's spool_uid is deliberately NOT adopted as the new filament's
+  // instanceId. instanceId is system-assigned (auto-generated, partial-unique)
+  // and the POST handler strips any client-supplied value on purpose — and
+  // tagData is unsigned client JSON, so adopting spool_uid would make instanceId
+  // client-writable (a forgeable scan-match target) and could 409 against the
+  // unique index. A re-scan of this filament's physical tag instead resolves
+  // through the decode route's heuristic (vendor+type / name) path
+  // (matchedBy:"heuristic" → the scanner offers "open existing or create"), so
+  // re-scans still find it without re-opening the instanceId guard.
 
   // Best-effort default name from the tag; the create screen lets the user edit
   // it before submit (it's the unique key, so a sensible default matters).
@@ -93,7 +92,5 @@ export function decodedTagToFilamentPayload(
     netFilamentWeight: decoded.weightGrams ?? null,
     spoolWeight: decoded.emptySpoolWeight ?? null,
     optTags: Array.isArray(decoded.tags) ? decoded.tags : [],
-    // Only present when the tag carries a usable spool_uid (see above).
-    ...(instanceId ? { instanceId } : {}),
   };
 }

--- a/tests/create-from-tag-route.test.ts
+++ b/tests/create-from-tag-route.test.ts
@@ -115,6 +115,29 @@ describe("POST /api/filaments — create from decoded tag (#4.4)", () => {
     expect(created.secondaryColors).toEqual(["#ff0000", "#0000ff"]);
   });
 
+  it("preserves the tag's spool_uid as instanceId so a re-scan exact-matches", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "Rescannable", materialType: "PLA", spoolUid: "abc123def0" }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.instanceId).toBe("abc123def0");
+  });
+
+  it("ignores an overrides.instanceId — the tag's spool_uid wins", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "TagWins", materialType: "PLA", spoolUid: "tagid12345" }),
+        overrides: { instanceId: "forged-by-client" },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.instanceId).toBe("tagid12345");
+  });
+
   it("applies mass-assignment strips to the merged body (overrides can't inject _purged/instanceId)", async () => {
     const res = await createFilament(
       postReq({

--- a/tests/create-from-tag-route.test.ts
+++ b/tests/create-from-tag-route.test.ts
@@ -120,27 +120,19 @@ describe("POST /api/filaments — create from decoded tag (#4.4)", () => {
     expect(created.secondaryColors).toEqual(["#ff0000", "#0000ff"]);
   });
 
-  it("preserves the tag's spool_uid as instanceId so a re-scan exact-matches", async () => {
+  it("does NOT adopt the tag's spool_uid as instanceId (stays system-assigned)", async () => {
+    // The tag is unsigned client JSON; adopting its spool_uid as instanceId
+    // would re-open the client-writable-instanceId hole the POST handler strips
+    // (and could 409 on the partial-unique index). instanceId is auto-generated.
     const res = await createFilament(
       postReq({
-        tagData: tag({ brandName: "B", materialName: "Rescannable", materialType: "PLA", spoolUid: "abc123def0" }),
+        tagData: tag({ brandName: "B", materialName: "SystemId", materialType: "PLA", spoolUid: "abc123def0" }),
       }),
     );
     expect(res.status).toBe(201);
     const created = await res.json();
-    expect(created.instanceId).toBe("abc123def0");
-  });
-
-  it("ignores an overrides.instanceId — the tag's spool_uid wins", async () => {
-    const res = await createFilament(
-      postReq({
-        tagData: tag({ brandName: "B", materialName: "TagWins", materialType: "PLA", spoolUid: "tagid12345" }),
-        overrides: { instanceId: "forged-by-client" },
-      }),
-    );
-    expect(res.status).toBe(201);
-    const created = await res.json();
-    expect(created.instanceId).toBe("tagid12345");
+    expect(created.instanceId).not.toBe("abc123def0");
+    expect(typeof created.instanceId).toBe("string");
   });
 
   it("applies mass-assignment strips to the merged body (overrides can't inject _purged/instanceId)", async () => {

--- a/tests/create-from-tag-route.test.ts
+++ b/tests/create-from-tag-route.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { POST as createFilament } from "@/app/api/filaments/route";
+import type { DecodedOpenPrintTag } from "@/lib/openprinttag-decode";
+
+/**
+ * Create-from-decoded-tag (mobile Phase 2, plan §4.4). The scanner POSTs the
+ * tag exactly as POST /api/nfc/decode returned it (`tagData`) plus the user's
+ * confirmed identity edits (`overrides`); the server maps it via
+ * decodedTagToFilamentPayload and runs the normal create path. The pure mapping
+ * is unit-tested in decodedTagToFilament.test.ts — here we pin the route wiring:
+ * overrides win, required fields are still enforced, and mass-assignment strips
+ * still apply to the merged body.
+ */
+describe("POST /api/filaments — create from decoded tag (#4.4)", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let Filament: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    const filMod = await import("@/models/Filament");
+    const nozMod = await import("@/models/Nozzle");
+    const printerMod = await import("@/models/Printer");
+    const bedMod = await import("@/models/BedType");
+    if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
+    if (!mongoose.models.Nozzle) mongoose.model("Nozzle", nozMod.default.schema);
+    if (!mongoose.models.Printer) mongoose.model("Printer", printerMod.default.schema);
+    if (!mongoose.models.BedType) mongoose.model("BedType", bedMod.default.schema);
+    Filament = mongoose.models.Filament;
+  });
+
+  function postReq(body: unknown) {
+    return new NextRequest("http://localhost/api/filaments", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function tag(overrides: Partial<DecodedOpenPrintTag> = {}): DecodedOpenPrintTag {
+    return { meta: {}, main: {}, ...overrides };
+  }
+
+  it("creates a filament from a decoded tag, mapping fields server-side", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({
+          brandName: "Prusament",
+          materialName: "PETG Jet Black",
+          materialType: "PETG",
+          color: "#101010",
+          density: 1.27,
+          diameter: 1.75,
+          nozzleTemp: 250,
+          nozzleTempMin: 240,
+          bedTemp: 90,
+          tags: [4],
+        }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.name).toBe("Prusament PETG Jet Black");
+    expect(created.vendor).toBe("Prusament");
+    expect(created.type).toBe("PETG");
+    expect(created.color).toBe("#101010");
+    expect(created.temperatures.nozzle).toBe(250);
+    expect(created.temperatures.nozzleRangeMin).toBe(240);
+    expect(created.optTags).toEqual([4]);
+    // No spool fabricated on create (plan §4.4).
+    expect(created.spools ?? []).toHaveLength(0);
+  });
+
+  it("lets user overrides win over the tag (the confirm-screen edits)", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "Generic", materialName: "PLA", materialType: "PLA", color: "#ffffff" }),
+        overrides: { name: "My Custom White PLA", vendor: "HouseBrand", colorName: "Snow" },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.name).toBe("My Custom White PLA");
+    expect(created.vendor).toBe("HouseBrand");
+    // Type still comes from the tag (not overridden).
+    expect(created.type).toBe("PLA");
+    // Color from the tag survives; the override only added a name.
+    expect(created.color).toBe("#ffffff");
+  });
+
+  it("still enforces required identity fields (tag without vendor, no override → 400)", async () => {
+    const res = await createFilament(
+      postReq({ tagData: tag({ materialName: "Mystery Roll", materialType: "PLA" }) }),
+    );
+    expect(res.status).toBe(400);
+    expect(await Filament.countDocuments({ name: "Mystery Roll" })).toBe(0);
+  });
+
+  it("preserves a null primary color for a coextruded tag", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({
+          brandName: "Rainbow Co",
+          materialName: "Coextruded PLA",
+          materialType: "PLA",
+          color: undefined,
+          secondaryColors: ["#ff0000", "#0000ff"],
+        }),
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.color).toBeNull();
+    expect(created.secondaryColors).toEqual(["#ff0000", "#0000ff"]);
+  });
+
+  it("applies mass-assignment strips to the merged body (overrides can't inject _purged/instanceId)", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "Strip Test", materialType: "PLA" }),
+        overrides: { _purged: true, instanceId: "hack-me", __v: 99 },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created._purged).not.toBe(true);
+    expect(created.instanceId).not.toBe("hack-me");
+  });
+});

--- a/tests/create-from-tag-route.test.ts
+++ b/tests/create-from-tag-route.test.ts
@@ -55,6 +55,8 @@ describe("POST /api/filaments — create from decoded tag (#4.4)", () => {
           nozzleTemp: 250,
           nozzleTempMin: 240,
           bedTemp: 90,
+          weightGrams: 1000,
+          emptySpoolWeight: 215,
           tags: [4],
         }),
       }),
@@ -68,6 +70,9 @@ describe("POST /api/filaments — create from decoded tag (#4.4)", () => {
     expect(created.temperatures.nozzle).toBe(250);
     expect(created.temperatures.nozzleRangeMin).toBe(240);
     expect(created.optTags).toEqual([4]);
+    // Tag roll weight + tare land on filament-level fields (no spool subdoc).
+    expect(created.netFilamentWeight).toBe(1000);
+    expect(created.spoolWeight).toBe(215);
     // No spool fabricated on create (plan §4.4).
     expect(created.spools ?? []).toHaveLength(0);
   });

--- a/tests/decodedTagToFilament.test.ts
+++ b/tests/decodedTagToFilament.test.ts
@@ -81,6 +81,18 @@ describe("decodedTagToFilamentPayload", () => {
     expect(p.shoreHardnessD).toBe(40);
   });
 
+  it("preserves the tag's spool_uid as the new filament's instanceId", () => {
+    expect(decodedTagToFilamentPayload(tag({ spoolUid: "0a1b2c3d4e" })).instanceId).toBe("0a1b2c3d4e");
+    expect(decodedTagToFilamentPayload(tag({ spoolUid: "  trimmed  " })).instanceId).toBe("trimmed");
+  });
+
+  it("omits instanceId when the tag has no usable spool_uid", () => {
+    expect("instanceId" in decodedTagToFilamentPayload(tag())).toBe(false);
+    expect("instanceId" in decodedTagToFilamentPayload(tag({ spoolUid: "" }))).toBe(false);
+    // Over the 128-char bound → omitted rather than stored unbounded.
+    expect("instanceId" in decodedTagToFilamentPayload(tag({ spoolUid: "x".repeat(129) }))).toBe(false);
+  });
+
   it("emits null for absent required identity fields (caller must override)", () => {
     const p = decodedTagToFilamentPayload(tag({ materialName: "Mystery" }));
     expect(p.vendor).toBeNull();

--- a/tests/decodedTagToFilament.test.ts
+++ b/tests/decodedTagToFilament.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { decodedTagToFilamentPayload } from "@/lib/decodedTagToFilament";
+import type { DecodedOpenPrintTag } from "@/lib/openprinttag-decode";
+
+function tag(overrides: Partial<DecodedOpenPrintTag> = {}): DecodedOpenPrintTag {
+  return { meta: {}, main: {}, ...overrides };
+}
+
+describe("decodedTagToFilamentPayload", () => {
+  it("maps a typical OpenPrintTag into a creation payload", () => {
+    const p = decodedTagToFilamentPayload(
+      tag({
+        brandName: "Prusament",
+        materialName: "PLA Galaxy Black",
+        materialType: "PLA",
+        color: "#1a1a2e",
+        density: 1.24,
+        diameter: 1.75,
+        nozzleTemp: 215,
+        nozzleTempMin: 205,
+        bedTemp: 60,
+        preheatTemp: 170,
+        dryingTemperature: 45,
+        dryingTime: 480,
+        transmissionDistance: 3,
+        tags: [4, 12],
+      }),
+    );
+    expect(p.name).toBe("Prusament PLA Galaxy Black");
+    expect(p.vendor).toBe("Prusament");
+    expect(p.type).toBe("PLA");
+    expect(p.color).toBe("#1a1a2e");
+    expect(p.density).toBe(1.24);
+    expect(p.diameter).toBe(1.75);
+    expect(p.temperatures).toEqual({
+      nozzle: 215,
+      nozzleFirstLayer: null,
+      nozzleRangeMin: 205,
+      nozzleRangeMax: 215,
+      bed: 60,
+      bedFirstLayer: null,
+      standby: 170,
+    });
+    expect(p.dryingTemperature).toBe(45);
+    expect(p.dryingTime).toBe(480);
+    expect(p.transmissionDistance).toBe(3);
+    // Decoded `tags` are already numeric OPT_TAG enum values — passed through.
+    expect(p.optTags).toEqual([4, 12]);
+  });
+
+  it("derives a name from whatever the tag carries", () => {
+    expect(decodedTagToFilamentPayload(tag({ brandName: "X", materialName: "Y" })).name).toBe("X Y");
+    expect(decodedTagToFilamentPayload(tag({ materialName: "Only Material" })).name).toBe("Only Material");
+    expect(decodedTagToFilamentPayload(tag({ brandName: "Only Brand" })).name).toBe("Only Brand");
+    expect(decodedTagToFilamentPayload(tag({ materialType: "PETG" })).name).toBe("PETG");
+    expect(decodedTagToFilamentPayload(tag()).name).toBe("Scanned filament");
+  });
+
+  it("preserves a null primary for coextruded/multi-color tags", () => {
+    const p = decodedTagToFilamentPayload(
+      tag({ color: undefined, secondaryColors: ["#ff0000", "#00ff00"] }),
+    );
+    expect(p.color).toBeNull();
+    expect(p.secondaryColors).toEqual(["#ff0000", "#00ff00"]);
+  });
+
+  it("falls back to gray only when the tag has no colors at all", () => {
+    const p = decodedTagToFilamentPayload(tag({ color: undefined, secondaryColors: [] }));
+    expect(p.color).toBe("#808080");
+    expect(p.secondaryColors).toEqual([]);
+  });
+
+  it("prefers the tag's own diameter (2.85mm) over the 1.75 default", () => {
+    expect(decodedTagToFilamentPayload(tag({ diameter: 2.85 })).diameter).toBe(2.85);
+    expect(decodedTagToFilamentPayload(tag({ diameter: undefined })).diameter).toBe(1.75);
+  });
+
+  it("captures shore hardness A and D (a physical tag carries both)", () => {
+    const p = decodedTagToFilamentPayload(tag({ shoreHardnessA: 95, shoreHardnessD: 40 }));
+    expect(p.shoreHardnessA).toBe(95);
+    expect(p.shoreHardnessD).toBe(40);
+  });
+
+  it("emits null for absent required identity fields (caller must override)", () => {
+    const p = decodedTagToFilamentPayload(tag({ materialName: "Mystery" }));
+    expect(p.vendor).toBeNull();
+    expect(p.type).toBeNull();
+  });
+
+  it("defaults missing numeric fields to null and tags to an empty array", () => {
+    const p = decodedTagToFilamentPayload(tag({ brandName: "B", materialName: "M", materialType: "PLA" }));
+    expect(p.density).toBeNull();
+    expect(p.transmissionDistance).toBeNull();
+    expect(p.optTags).toEqual([]);
+    expect(p.temperatures).toEqual({
+      nozzle: null,
+      nozzleFirstLayer: null,
+      nozzleRangeMin: null,
+      nozzleRangeMax: null,
+      bed: null,
+      bedFirstLayer: null,
+      standby: null,
+    });
+  });
+});

--- a/tests/decodedTagToFilament.test.ts
+++ b/tests/decodedTagToFilament.test.ts
@@ -105,16 +105,12 @@ describe("decodedTagToFilamentPayload", () => {
     expect(p.shoreHardnessD).toBe(40);
   });
 
-  it("preserves the tag's spool_uid as the new filament's instanceId", () => {
-    expect(decodedTagToFilamentPayload(tag({ spoolUid: "0a1b2c3d4e" })).instanceId).toBe("0a1b2c3d4e");
-    expect(decodedTagToFilamentPayload(tag({ spoolUid: "  trimmed  " })).instanceId).toBe("trimmed");
-  });
-
-  it("omits instanceId when the tag has no usable spool_uid", () => {
+  it("never adopts the tag's spool_uid as instanceId (stays system-assigned)", () => {
+    // Adopting an unsigned tag's spool_uid would make instanceId client-writable
+    // (a forgeable scan-match target) and could 409 against the partial-unique
+    // index — so the mapper must not emit instanceId at all.
+    expect("instanceId" in decodedTagToFilamentPayload(tag({ spoolUid: "0a1b2c3d4e" }))).toBe(false);
     expect("instanceId" in decodedTagToFilamentPayload(tag())).toBe(false);
-    expect("instanceId" in decodedTagToFilamentPayload(tag({ spoolUid: "" }))).toBe(false);
-    // Over the 128-char bound → omitted rather than stored unbounded.
-    expect("instanceId" in decodedTagToFilamentPayload(tag({ spoolUid: "x".repeat(129) }))).toBe(false);
   });
 
   it("emits null for absent required identity fields (caller must override)", () => {

--- a/tests/decodedTagToFilament.test.ts
+++ b/tests/decodedTagToFilament.test.ts
@@ -56,6 +56,30 @@ describe("decodedTagToFilamentPayload", () => {
     expect(decodedTagToFilamentPayload(tag()).name).toBe("Scanned filament");
   });
 
+  it("does not duplicate the brand when materialName already includes it", () => {
+    // FDB-written tags store the FULL filament name in materialName.
+    expect(
+      decodedTagToFilamentPayload(tag({ brandName: "Prusament", materialName: "Prusament PLA Galaxy Black" })).name,
+    ).toBe("Prusament PLA Galaxy Black");
+    // Community tags carry the bare material → the brand is still prefixed.
+    expect(
+      decodedTagToFilamentPayload(tag({ brandName: "Prusament", materialName: "PLA Galaxy Black" })).name,
+    ).toBe("Prusament PLA Galaxy Black");
+  });
+
+  it("maps the tag's roll weight + tare to filament-level fields (no spool subdoc)", () => {
+    const p = decodedTagToFilamentPayload(tag({ weightGrams: 1000, emptySpoolWeight: 215 }));
+    expect(p.netFilamentWeight).toBe(1000);
+    expect(p.spoolWeight).toBe(215);
+    expect("spools" in p).toBe(false);
+  });
+
+  it("defaults weight fields to null when the tag omits them", () => {
+    const p = decodedTagToFilamentPayload(tag({ brandName: "B", materialName: "M", materialType: "PLA" }));
+    expect(p.netFilamentWeight).toBeNull();
+    expect(p.spoolWeight).toBeNull();
+  });
+
   it("preserves a null primary for coextruded/multi-color tags", () => {
     const p = decodedTagToFilamentPayload(
       tag({ color: undefined, secondaryColors: ["#ff0000", "#00ff00"] }),

--- a/tests/nfc-decode-route.test.ts
+++ b/tests/nfc-decode-route.test.ts
@@ -80,6 +80,9 @@ describe("POST /api/nfc/decode", () => {
     const res = await decodeTag(decodeReq({ tagType: "openprinttag", payload: b64(cbor) }));
     const body = await res.json();
     expect(body.match?.name).toBe("Prusament PLA Galaxy Black");
+    // Matched by name (the tag carries no spool_uid), so the scanner treats it
+    // as a heuristic match — not a confident "this exact tag is in the DB".
+    expect(body.matchedBy).toBe("heuristic");
     expect(body.candidates).toEqual([]);
   });
 
@@ -103,6 +106,8 @@ describe("POST /api/nfc/decode", () => {
     const body = await res.json();
     expect(body.match?.name).toBe("Renamed In DB");
     expect(body.match?.instanceId).toBe("abc1230000");
+    // The matched row's id equals the queried spool_uid → confident exact tag.
+    expect(body.matchedBy).toBe("instanceId");
     expect(body.candidates).toEqual([]);
   });
 
@@ -118,6 +123,7 @@ describe("POST /api/nfc/decode", () => {
     const res = await decodeTag(decodeReq({ tagType: "openprinttag", payload: b64(cbor) }));
     const body = await res.json();
     expect(body.match).toBeNull();
+    expect(body.matchedBy).toBeNull();
     expect(
       body.candidates.map((c: { name: string }) => c.name).sort(),
     ).toEqual(["Bambu PLA Black", "Bambu PLA White"]);


### PR DESCRIPTION
Completes mobile Phase 2 (plan §4.4): a freshly-scanned NFC tag that isn't in the DB can be turned into a new filament. The **server** does the field mapping; the phone just confirms the identity.

## Server (design rule #1 — no mapping on the device)
- **`src/lib/decodedTagToFilament.ts`** — pure `DecodedOpenPrintTag → filament payload` mapper, mirroring `mapToFilamentPayload` (the OpenPrintTag community-DB importer) from the NFC-decoded shape, and capturing the couple of extras a physical tag carries (shore A hardness, the tag's own diameter). Unit-tested.
- **`POST /api/filaments`** grows a `{ tagData, overrides }` branch: map the decoded tag → merge the user's confirmed `name`/`vendor`/`type` (overrides win) → flow through the **existing** create path, inheriting the same mass-assignment strips, ref + nozzle-range validation, unique-name handling, and spool allowlist. Required identity fields are still enforced (a tag without vendor + no override → 400). No spool subdoc is fabricated on create. OpenAPI updated.

## Mobile
- `createFromTag` API call; a one-shot `pendingScan` hand-off (module ref, not URL-encoded); a `create-from-tag` confirm screen (prefilled name/vendor/type + a read-only summary of what the tag fills in, gated on non-empty identity); the NFC scan flow now offers **"Create filament"** when there's no match.

## Scope
Create works for **OpenPrintTag on both platforms**. Android-only Bambu **NFC reading** (native MIFARE Classic + the §4.2a `bambu-keys` round-trip) is **deferred** — the plan lists its read strategy as an open item and it's untestable without an NXP-chipset Android device. The create flow itself is tag-agnostic, so it'll work for Bambu tags once that reading lands.

## Verification
`tsc` ✓ (root + mobile) · `eslint` ✓ + `expo lint` ✓ · 61 tests pass (incl. the mapper unit test + the route test covering overrides-win, required-field 400, null-primary color, and the mass-assignment strip) · no regression in the existing POST-route suites. A pre-PR adversarial review (mapper accuracy / endpoint security / RN correctness) surfaced no P1/P2 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)