### PR TITLE
fix(mobile): minimal nav back button (silence iOS auto-layout warning)

### DIFF
--- a/packages/mobile/src/app/_layout.tsx
+++ b/packages/mobile/src/app/_layout.tsx
@@ -8,7 +8,10 @@ export default function RootLayout() {
   return (
     <ServerConfigProvider>
       <ThemeProvider value={scheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
+        {/* Minimal back button (chevron only, no previous-title label): a long
+            title like "Filament DB Scanner" overflowed the nav bar's back-button
+            slot and tripped a UIKit auto-layout constraint warning on iOS. */}
+        <Stack screenOptions={{ headerBackButtonDisplayMode: 'minimal' }}>
           <Stack.Screen name="index" options={{ title: 'Filament DB Scanner' }} />
           <Stack.Screen name="settings" options={{ title: 'Server connection' }} />
           <Stack.Screen


### PR DESCRIPTION
The iOS console logged a recurring Auto Layout constraint conflict on every navigation push:

```
ButtonBarButtonVisualProvider…Button.width <= 163  vs  'fittingSizeHTarget' …width == 214.333
Will attempt to recover by breaking constraint …width <= 163
```

That's the native-stack **back button** rendering the previous screen's title as its label (e.g. "Filament DB Scanner" when you're on "New filament"), which is wider than the slot UIKit gives it. UIKit recovers by truncating, so it's **benign** — the app works — but it's noisy.

Setting `headerBackButtonDisplayMode: 'minimal'` on the Stack shows just the chevron (no title label), which removes the over-wide constraint and tidies the header. (The `RCTScrollViewComponentView … focusItemsInRect:` line in the same log is an informational Fabric note, not an error — nothing to change.)

`tsc` ✓ + `expo lint` ✓. Cosmetic / nav-only; can't be device-verified from CI, but the option is the documented fix for this exact warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)