### PR TITLE
feat(mobile): add a spool by default when creating a filament from a scan

### DIFF
--- a/packages/mobile/src/app/create-from-tag.tsx
+++ b/packages/mobile/src/app/create-from-tag.tsx
@@ -71,11 +71,19 @@ export default function CreateFromTagScreen() {
   const [vendor, setVendor] = useState(() => (tag?.brandName ?? '').trim());
   const [type, setType] = useState(() => (tag?.materialType ?? '').trim());
   // Spool-on-create: a scanned roll is one you own, so default to adding a spool
-  // prefilled with the tag's net weight. Clearing the field catalogs the
-  // filament without a spool.
-  const [spoolRemaining, setSpoolRemaining] = useState(() =>
-    tag && typeof tag.weightGrams === 'number' ? String(tag.weightGrams) : '',
-  );
+  // prefilled with the tag's remaining weight. Prefer the ACTUAL remaining
+  // weight (OpenPrintTag key 17) over the nominal full-roll weight so a partial
+  // roll doesn't overstate inventory; clearing the field catalogs the filament
+  // without a spool.
+  const [spoolRemaining, setSpoolRemaining] = useState(() => {
+    const w =
+      typeof tag?.actualWeightGrams === 'number'
+        ? tag.actualWeightGrams
+        : typeof tag?.weightGrams === 'number'
+          ? tag.weightGrams
+          : null;
+    return w != null ? String(w) : '';
+  });
   const [saving, setSaving] = useState(false);
 
   if (!tag) {

--- a/packages/mobile/src/app/create-from-tag.tsx
+++ b/packages/mobile/src/app/create-from-tag.tsx
@@ -70,6 +70,12 @@ export default function CreateFromTagScreen() {
   const [name, setName] = useState(() => deriveName(tag));
   const [vendor, setVendor] = useState(() => (tag?.brandName ?? '').trim());
   const [type, setType] = useState(() => (tag?.materialType ?? '').trim());
+  // Spool-on-create: a scanned roll is one you own, so default to adding a spool
+  // prefilled with the tag's net weight. Clearing the field catalogs the
+  // filament without a spool.
+  const [spoolRemaining, setSpoolRemaining] = useState(() =>
+    tag && typeof tag.weightGrams === 'number' ? String(tag.weightGrams) : '',
+  );
   const [saving, setSaving] = useState(false);
 
   if (!tag) {
@@ -102,10 +108,19 @@ export default function CreateFromTagScreen() {
       Alert.alert('Missing fields', 'Name, vendor, and type are required.');
       return;
     }
+    const remStr = spoolRemaining.trim();
+    let rem: number | null = null;
+    if (remStr !== '') {
+      rem = Number(remStr);
+      if (!Number.isFinite(rem) || rem < 0) {
+        Alert.alert('Invalid weight', 'Enter the grams remaining (0 or more), or clear it to add no spool.');
+        return;
+      }
+    }
     setSaving(true);
     try {
       const api = createApi({ baseUrl, apiKey });
-      const created = await api.createFromTag(tag, { name: n, vendor: v, type: t });
+      const created = await api.createFromTag(tag, { name: n, vendor: v, type: t }, rem);
       // Consume the hand-off now that the filament exists (explicit clear, not
       // during render). Replace so Back doesn't return to this confirm screen.
       clearPendingScan();
@@ -208,13 +223,31 @@ export default function CreateFromTagScreen() {
           autoCapitalize="characters"
         />
 
+        <Text style={[styles.label, styles.spaced, { color: c.text }]}>Remaining filament (g)</Text>
+        <TextInput
+          style={inputStyle}
+          value={spoolRemaining}
+          onChangeText={setSpoolRemaining}
+          placeholder="grams (clear to add no spool)"
+          placeholderTextColor={c.muted}
+          keyboardType="numeric"
+          inputMode="numeric"
+        />
+        <Text style={[styles.hint, { color: c.muted }]}>
+          Adds a spool you own, prefilled from the tag. Clear it to catalog the filament without a spool.
+        </Text>
+
         <Pressable
           style={[styles.button, { backgroundColor: c.tint }, !canCreate && styles.disabled]}
           onPress={create}
           disabled={!canCreate}
         >
           <Text style={[styles.buttonText, { color: c.onTint }]}>
-            {saving ? 'Creating…' : 'Create filament'}
+            {saving
+              ? 'Creating…'
+              : spoolRemaining.trim() !== ''
+                ? 'Create filament + spool'
+                : 'Create filament'}
           </Text>
         </Pressable>
       </ScrollView>

--- a/packages/mobile/src/lib/api.ts
+++ b/packages/mobile/src/lib/api.ts
@@ -97,10 +97,17 @@ export function createApi(cfg: ApiConfig) {
      * `overrides` (the user's confirmed name/vendor/type) win. The phone does
      * no field mapping — design rule #1.
      */
-    createFromTag: (tagData: DecodedOpenPrintTag, overrides: Record<string, unknown>) =>
+    createFromTag: (
+      tagData: DecodedOpenPrintTag,
+      overrides: Record<string, unknown>,
+      // Grams of filament remaining for the spool to create (default = the
+      // tag's net weight). null = don't create a spool (catalog-only). The
+      // server converts this to the spool's gross weight using the tag tare.
+      spoolRemainingGrams: number | null,
+    ) =>
       request<Filament>(cfg, '/api/filaments', {
         method: 'POST',
-        body: JSON.stringify({ tagData, overrides }),
+        body: JSON.stringify({ tagData, overrides, spoolRemainingGrams }),
       }),
     /** Update a spool — location and/or remaining weight (server converts). */
     updateSpool: (filamentId: string, spoolId: string, patch: Record<string, unknown>) =>

--- a/packages/mobile/src/lib/types.ts
+++ b/packages/mobile/src/lib/types.ts
@@ -18,7 +18,11 @@ export interface DecodedOpenPrintTag {
   nozzleTemp?: number;
   nozzleTempMin?: number;
   bedTemp?: number;
+  /** Nominal full-roll net weight (OpenPrintTag key 16), grams. */
   weightGrams?: number;
+  /** ACTUAL remaining filament weight (OpenPrintTag key 17), grams — what's
+   *  really left on a partial roll; defaults to weightGrams on a full roll. */
+  actualWeightGrams?: number;
   spoolUid?: string;
   tagSource?: 'openprinttag' | 'bambu';
   readOnly?: boolean;

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -6418,7 +6418,8 @@
             "description": "Filament fields that override the tag-mapped values — the scanner sends the user-confirmed name/vendor/type (required identity fields). Server-owned fields (instanceId, _purged, …) are stripped."
           },
           "spoolRemainingGrams": {
-            "type": ["number", "null"],
+            "type": "number",
+            "nullable": true,
             "minimum": 0,
             "description": "Grams of filament remaining for the spool to create (the scanner defaults this to the tag's net weight). The server adds the tag tare to derive the spool's gross weight and creates ONE spool. Omit or null to create no spool (catalog-only)."
           }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -6402,7 +6402,7 @@
       },
       "CreateFromTagInput": {
         "type": "object",
-        "description": "Create-from-scan variant of POST /api/filaments (mobile Phase 2, plan §4.4). The server maps the decoded tag to a filament payload, then applies overrides (which win). Same mass-assignment strips as a normal create body; no spool subdocuments are fabricated.",
+        "description": "Create-from-scan variant of POST /api/filaments (mobile Phase 2, plan §4.4). The server maps the decoded tag to a filament payload, then applies overrides (which win). Same mass-assignment strips as a normal create body. When spoolRemainingGrams is sent (the scanner defaults it to the tag's net weight, since you own the roll you scanned), the server also creates ONE spool; usage history is never fabricated.",
         "required": [
           "tagData"
         ],
@@ -6416,6 +6416,11 @@
             "type": "object",
             "additionalProperties": true,
             "description": "Filament fields that override the tag-mapped values — the scanner sends the user-confirmed name/vendor/type (required identity fields). Server-owned fields (instanceId, _purged, …) are stripped."
+          },
+          "spoolRemainingGrams": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "description": "Grams of filament remaining for the spool to create (the scanner defaults this to the tag's net weight). The server adds the tag tare to derive the spool's gross weight and creates ONE spool. Omit or null to create no spool (catalog-only)."
           }
         }
       },

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -354,8 +354,12 @@ export async function POST(request: NextRequest) {
         : null;
     body = { ...mapped, ...overrides };
     if (spoolRemaining != null) {
-      const tare = typeof mapped.spoolWeight === "number" ? mapped.spoolWeight : 0;
-      body.totalWeight = spoolRemaining + tare;
+      // Use the FINAL stored tare (after overrides, which may correct it), and
+      // persist a 0 fallback when the tag carried none (e.g. a Bambu tag) so the
+      // spool's gross weight and the filament's spoolWeight agree — otherwise
+      // `remaining = totalWeight - storedTare` wouldn't equal the entered grams.
+      if (typeof body.spoolWeight !== "number") body.spoolWeight = 0;
+      body.totalWeight = spoolRemaining + body.spoolWeight;
     }
   }
 

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -340,7 +340,23 @@ export async function POST(request: NextRequest) {
       body.overrides && typeof body.overrides === "object" && !Array.isArray(body.overrides)
         ? body.overrides
         : {};
-    body = { ...decodedTagToFilamentPayload(body.tagData), ...overrides };
+    const mapped = decodedTagToFilamentPayload(body.tagData);
+    // Spool-on-create: a scanner owns the roll it just scanned, so it sends the
+    // remaining grams (defaulting to the tag's nominal net weight) and the
+    // server creates ONE spool from it. We convert remaining → the gross
+    // `totalWeight` the auto-spool logic below consumes by adding the tag tare
+    // (the mapped spoolWeight) — the phone never does this math (design rule #1).
+    // Omitting `spoolRemainingGrams` (e.g. a catalog-only or API caller) creates
+    // no spool, so the field is the opt-in the scanner defaults on.
+    const spoolRemaining =
+      typeof body.spoolRemainingGrams === "number" && body.spoolRemainingGrams >= 0
+        ? body.spoolRemainingGrams
+        : null;
+    body = { ...mapped, ...overrides };
+    if (spoolRemaining != null) {
+      const tare = typeof mapped.spoolWeight === "number" ? mapped.spoolWeight : 0;
+      body.totalWeight = spoolRemaining + tare;
+    }
   }
 
   delete body._id;

--- a/tests/create-from-tag-route.test.ts
+++ b/tests/create-from-tag-route.test.ts
@@ -70,10 +70,51 @@ describe("POST /api/filaments — create from decoded tag (#4.4)", () => {
     expect(created.temperatures.nozzle).toBe(250);
     expect(created.temperatures.nozzleRangeMin).toBe(240);
     expect(created.optTags).toEqual([4]);
-    // Tag roll weight + tare land on filament-level fields (no spool subdoc).
+    // Tag roll weight + tare land on filament-level fields.
     expect(created.netFilamentWeight).toBe(1000);
     expect(created.spoolWeight).toBe(215);
-    // No spool fabricated on create (plan §4.4).
+    // No spoolRemainingGrams was sent → no spool (it's opt-in; the scanner
+    // defaults it on, but the catalog/API path stays spool-free).
+    expect(created.spools ?? []).toHaveLength(0);
+  });
+
+  it("creates a spool from spoolRemainingGrams (remaining → gross via the tag tare)", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "Owned Roll", materialType: "PLA", emptySpoolWeight: 200 }),
+        spoolRemainingGrams: 800,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.spools).toHaveLength(1);
+    // gross = remaining (800) + tare (200) = 1000
+    expect(created.spools[0].totalWeight).toBe(1000);
+    expect(created.spoolWeight).toBe(200);
+  });
+
+  it("creates the spool even at 0 g remaining (an empty roll you still own)", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "Empty Roll", materialType: "PLA", emptySpoolWeight: 200 }),
+        spoolRemainingGrams: 0,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.spools).toHaveLength(1);
+    expect(created.spools[0].totalWeight).toBe(200);
+  });
+
+  it("ignores a negative spoolRemainingGrams (no spool rather than a bad one)", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "Neg", materialType: "PLA", emptySpoolWeight: 200 }),
+        spoolRemainingGrams: -5,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
     expect(created.spools ?? []).toHaveLength(0);
   });
 

--- a/tests/create-from-tag-route.test.ts
+++ b/tests/create-from-tag-route.test.ts
@@ -118,6 +118,34 @@ describe("POST /api/filaments — create from decoded tag (#4.4)", () => {
     expect(created.spools ?? []).toHaveLength(0);
   });
 
+  it("uses the override-corrected tare for the spool's gross weight", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "OverrideTare", materialType: "PLA", emptySpoolWeight: 200 }),
+        overrides: { spoolWeight: 250 },
+        spoolRemainingGrams: 800,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.spoolWeight).toBe(250);
+    // gross = remaining (800) + FINAL tare (250) = 1050; remaining still 800.
+    expect(created.spools[0].totalWeight).toBe(1050);
+  });
+
+  it("persists a 0 tare when the tag carries none, keeping remaining math consistent", async () => {
+    const res = await createFilament(
+      postReq({
+        tagData: tag({ brandName: "B", materialName: "NoTare", materialType: "PLA" }),
+        spoolRemainingGrams: 800,
+      }),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.spoolWeight).toBe(0);
+    expect(created.spools[0].totalWeight).toBe(800);
+  });
+
   it("lets user overrides win over the tag (the confirm-screen edits)", async () => {
     const res = await createFilament(
       postReq({


### PR DESCRIPTION
**You don't catalog a filament you don't own** — for a scanner, creating from a scanned roll should default to giving you a spool of it. Phase 2 deliberately created the filament *only* ("never fabricate a spool on create"); this reverses that for the scanner case.

## Behavior
- The create-from-tag screen gains a **"Remaining filament (g)"** field, **prefilled with the tag's net weight**. Default = add a spool of the roll you scanned. Edit it for a partial roll, or **clear it to catalog the filament without a spool**.
- The button reads "Create filament + spool" when a weight is set.

## How (design rule #1 — no weight math on the phone)
- The phone sends `spoolRemainingGrams` (what the user sees). The server's create-from-tag branch converts it to the spool's **gross** weight by adding the tag tare (the mapped `spoolWeight`) and lets the existing auto-spool logic create **one** spool.
- It's **opt-in**: omitting `spoolRemainingGrams` (catalog-only / API callers) creates no spool — so the prior "no spool on create" path is preserved for non-scanner use. Usage history is still never fabricated.

## Tests / docs
Route tests: spool created (remaining→gross via tare), `0 g` still creates a spool (an empty roll you own), negative ignored, omitted → no spool. `CreateFromTagInput` gains `spoolRemainingGrams` in OpenAPI. `tsc` + `eslint` + `expo lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)