### PR TITLE
feat(web): + Add Filament always registers a spool

### DIFF
--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -159,19 +159,28 @@ function NewFilamentContent() {
       }
 
       // Gross: explicit initial weight, else net + tare (0 when no tare), else
-      // unknown. The tare is baked in so remaining resolves back to net.
+      // unknown. When derived from net the tare is baked in so remaining
+      // resolves back to net.
       let gross: number | null;
-      if (total != null) gross = total;
-      else if (effNet != null) gross = effNet + (effTare ?? 0);
-      else gross = null;
+      let derivedFromNet = false;
+      if (total != null) {
+        gross = total;
+      } else if (effNet != null) {
+        gross = effNet + (effTare ?? 0);
+        derivedFromNet = true;
+      } else {
+        gross = null;
+      }
 
-      // A weighted spool whose filament has no effective tare reads as
-      // "untracked" in getRemainingGrams (null spoolWeight → null remaining),
-      // hiding the entered weight. Pin spoolWeight=0 so remaining resolves to
-      // the gross. Skip when there's already a tare: an explicit own value
-      // stays, and a variant's real inherited tare must NOT be clobbered (it
-      // keeps tracking the parent — Codex P2 round 1).
-      if (gross != null && effTare == null && ownTare == null) {
+      // Pin spoolWeight=0 ONLY when the gross was DERIVED FROM NET and there's
+      // no tare: net is filament-only, so net + 0 means remaining = net (and
+      // getRemainingGrams would otherwise read a null-tare spooled filament as
+      // "untracked", hiding the weight). When the user ENTERED the gross
+      // (Initial Weight) with an unknown tare, the gross includes the spool
+      // mass — pinning 0 would overstate remaining by the tare, so leave it
+      // null and let it stay untracked until the tare is known (Codex P2 r6).
+      // effTare == null already implies ownTare == null (effTare ?? own).
+      if (derivedFromNet && effTare == null) {
         data.spoolWeight = 0;
       }
 

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -132,50 +132,42 @@ function NewFilamentContent() {
         typeof v === "number" && Number.isFinite(v) ? v : null;
       const total = num(data.totalWeight);
       const net = num(data.netFilamentWeight);
-      let gross = total;
-      if (gross == null && net != null) {
-        const ownTare = num(data.spoolWeight);
-        const isVariant = typeof data.parentId === "string" && data.parentId !== "";
-        if (ownTare != null) {
-          // Explicit Empty Spool wins for both standalone and variant.
-          gross = net + ownTare;
-        } else if (isVariant) {
-          // No own tare on a variant: try to inherit the parent's so the gross
-          // matches the tare the variant resolves to. initialData._parent is
-          // only populated for ?parentId= creates, so for a form parent-picker
-          // / clone-toolbar variant we fetch the parent to read its tare.
-          const pre = initialData?._parent as { spoolWeight?: number } | undefined;
-          let parentTare = num(pre?.spoolWeight);
-          if (parentTare == null && pre === undefined) {
-            try {
-              const r = await fetch(
-                `/api/filaments/${encodeURIComponent(data.parentId as string)}?raw=true`,
-              );
-              if (r.ok) parentTare = num((await r.json())?.spoolWeight);
-            } catch {
-              /* parentTare stays null → pinned to 0 below */
-            }
-          }
-          if (parentTare != null) {
-            // A real tare to inherit: bake it into the gross and leave
-            // spoolWeight blank so the variant keeps tracking the parent
-            // (Codex P2 round 1 — don't clobber inheritance with a 0).
-            gross = net + parentTare;
-          } else {
-            // No tare to inherit (parent has none, or couldn't be read). Use 0
-            // AND persist it: getRemainingGrams treats a spooled filament whose
-            // spoolWeight is null as untracked, so a blank tare would hide the
-            // entered net as "unknown remaining" (Codex P2 rounds 2-3).
-            gross = net;
-            data.spoolWeight = 0;
-          }
-        } else {
-          // Standalone with no tare: 0 fallback (remaining = net), persisted so
-          // remaining = totalWeight - spoolWeight stays consistent.
-          data.spoolWeight = 0;
-          gross = net;
+      const ownTare = num(data.spoolWeight);
+      const isVariant = typeof data.parentId === "string" && data.parentId !== "";
+
+      // Effective tare = own Empty Spool, else (for a variant) the SELECTED
+      // parent's inherited tare. Always fetch by the current data.parentId —
+      // the form picker can swap the parent after a ?parentId= open, so any
+      // cached parent doc may be stale (Codex P2 rounds 2 + 4).
+      let effTare = ownTare;
+      if (effTare == null && isVariant) {
+        try {
+          const r = await fetch(
+            `/api/filaments/${encodeURIComponent(data.parentId as string)}?raw=true`,
+          );
+          if (r.ok) effTare = num((await r.json())?.spoolWeight);
+        } catch {
+          /* effTare stays null → 0 pinned below */
         }
       }
+
+      // Gross: explicit initial weight, else net + tare (0 when no tare), else
+      // unknown. The tare is baked in so remaining resolves back to net.
+      let gross: number | null;
+      if (total != null) gross = total;
+      else if (net != null) gross = net + (effTare ?? 0);
+      else gross = null;
+
+      // A weighted spool whose filament has no effective tare reads as
+      // "untracked" in getRemainingGrams (null spoolWeight → null remaining),
+      // hiding the entered weight. Pin spoolWeight=0 so remaining resolves to
+      // the gross. Skip when there's already a tare: an explicit own value
+      // stays, and a variant's real inherited tare must NOT be clobbered (it
+      // keeps tracking the parent — Codex P2 round 1).
+      if (gross != null && effTare == null && ownTare == null) {
+        data.spoolWeight = 0;
+      }
+
       data.totalWeight = null;
       data.spools = [{ label: "", totalWeight: gross }];
     }

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -126,9 +126,7 @@ function NewFilamentContent() {
     // "+ Add Filament" registers a spool you own — you only add a filament to
     // the DB because you have it. So always create exactly one spool on create:
     // its gross weight is the entered initial weight, else net + tare, else
-    // unknown. When deriving from net, persist the tare used (0 fallback) so
-    // remaining = totalWeight - spoolWeight stays consistent (mirrors the
-    // create-from-tag route).
+    // unknown.
     if (!Array.isArray(data.spools) || data.spools.length === 0) {
       const num = (v: unknown): number | null =>
         typeof v === "number" && Number.isFinite(v) ? v : null;
@@ -136,9 +134,20 @@ function NewFilamentContent() {
       const net = num(data.netFilamentWeight);
       let gross = total;
       if (gross == null && net != null) {
-        const tare = num(data.spoolWeight) ?? 0;
-        data.spoolWeight = tare;
+        const ownTare = num(data.spoolWeight);
+        const isVariant = typeof data.parentId === "string" && data.parentId !== "";
+        // A variant intentionally leaves the tare blank to inherit the parent's.
+        // Use that inherited tare for the gross and DON'T persist a 0 override —
+        // doing so would stop the variant inheriting and short the spool by the
+        // parent's tare (Codex P2 on #706). A standalone with no tare falls back
+        // to 0 (so remaining = net) and persists it for consistent math.
+        const parent = initialData?._parent as { spoolWeight?: number } | undefined;
+        const inheritedTare = isVariant ? num(parent?.spoolWeight) : null;
+        const tare = ownTare ?? inheritedTare ?? 0;
         gross = net + tare;
+        if (ownTare == null && !isVariant) {
+          data.spoolWeight = 0;
+        }
       }
       data.totalWeight = null;
       data.spools = [{ label: "", totalWeight: gross }];

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -246,7 +246,14 @@ function NewFilamentContent() {
           bedFirstLayer: bedMin ?? bedMax,
         },
         ...(weight != null ? { netFilamentWeight: weight } : {}),
-        ...(emptySpool != null ? { spoolWeight: emptySpool } : {}),
+        // actualWeight is the tag's NET remaining, so pin a 0 tare when the tag
+        // carries no emptySpool — else the derived spool reads as untracked
+        // (null spoolWeight) and hides the entered remaining (Codex P2 r7/r8).
+        ...(emptySpool != null
+          ? { spoolWeight: emptySpool }
+          : actualWeight != null
+            ? { spoolWeight: 0 }
+            : {}),
         ...(actualWeight != null ? { totalWeight: actualWeight + (emptySpool ?? 0) } : {}),
         ...(searchParams.get("shoreA") ? { shoreHardnessA: Number(searchParams.get("shoreA")) } : {}),
         ...(searchParams.get("shoreD") ? { shoreHardnessD: Number(searchParams.get("shoreD")) } : {}),
@@ -419,7 +426,14 @@ function NewFilamentContent() {
       // gross (actual + tare) so the auto-created spool reflects a partially
       // used roll instead of a full one (Codex P2 r7 on #706).
       ...(data.weightGrams != null ? { netFilamentWeight: data.weightGrams } : {}),
-      ...(data.emptySpoolWeight != null ? { spoolWeight: data.emptySpoolWeight } : {}),
+      // actualWeightGrams is NET remaining, so pin a 0 tare when the tag carries
+      // no emptySpoolWeight — else the spool reads as untracked (null
+      // spoolWeight) and hides the remaining (Codex P2 r7/r8).
+      ...(data.emptySpoolWeight != null
+        ? { spoolWeight: data.emptySpoolWeight }
+        : data.actualWeightGrams != null
+          ? { spoolWeight: 0 }
+          : {}),
       ...(data.actualWeightGrams != null
         ? { totalWeight: data.actualWeightGrams + (data.emptySpoolWeight ?? 0) }
         : {}),

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -136,17 +136,40 @@ function NewFilamentContent() {
       if (gross == null && net != null) {
         const ownTare = num(data.spoolWeight);
         const isVariant = typeof data.parentId === "string" && data.parentId !== "";
-        // A variant intentionally leaves the tare blank to inherit the parent's.
-        // Use that inherited tare for the gross and DON'T persist a 0 override —
-        // doing so would stop the variant inheriting and short the spool by the
-        // parent's tare (Codex P2 on #706). A standalone with no tare falls back
-        // to 0 (so remaining = net) and persists it for consistent math.
-        const parent = initialData?._parent as { spoolWeight?: number } | undefined;
-        const inheritedTare = isVariant ? num(parent?.spoolWeight) : null;
-        const tare = ownTare ?? inheritedTare ?? 0;
-        gross = net + tare;
-        if (ownTare == null && !isVariant) {
+        if (ownTare != null) {
+          // Explicit Empty Spool wins for both standalone and variant.
+          gross = net + ownTare;
+        } else if (isVariant) {
+          // A variant leaves the tare blank to inherit the parent's, so the
+          // gross must match that inherited tare (else remaining = net - tare).
+          // initialData._parent is only populated for ?parentId= creates; for a
+          // form parent-picker / clone-toolbar variant we fetch the parent to
+          // read its tare. Leave spoolWeight blank to keep inheriting; only pin
+          // a 0 when the parent can't be read at all (Codex P2 on #706).
+          const pre = initialData?._parent as { spoolWeight?: number } | undefined;
+          let parentTare = num(pre?.spoolWeight);
+          let resolved = pre !== undefined;
+          if (!resolved) {
+            try {
+              const r = await fetch(
+                `/api/filaments/${encodeURIComponent(data.parentId as string)}?raw=true`,
+              );
+              if (r.ok) {
+                const p = await r.json();
+                parentTare = num(p?.spoolWeight);
+                resolved = true;
+              }
+            } catch {
+              /* fall through to the pin-0 fallback below */
+            }
+          }
+          gross = net + (parentTare ?? 0);
+          if (!resolved) data.spoolWeight = 0;
+        } else {
+          // Standalone with no tare: 0 fallback (remaining = net), persisted so
+          // remaining = totalWeight - spoolWeight stays consistent.
           data.spoolWeight = 0;
+          gross = net;
         }
       }
       data.totalWeight = null;

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -123,6 +123,27 @@ function NewFilamentContent() {
   };
 
   const handleSubmit = async (data: Record<string, unknown>) => {
+    // "+ Add Filament" registers a spool you own — you only add a filament to
+    // the DB because you have it. So always create exactly one spool on create:
+    // its gross weight is the entered initial weight, else net + tare, else
+    // unknown. When deriving from net, persist the tare used (0 fallback) so
+    // remaining = totalWeight - spoolWeight stays consistent (mirrors the
+    // create-from-tag route).
+    if (!Array.isArray(data.spools) || data.spools.length === 0) {
+      const num = (v: unknown): number | null =>
+        typeof v === "number" && Number.isFinite(v) ? v : null;
+      const total = num(data.totalWeight);
+      const net = num(data.netFilamentWeight);
+      let gross = total;
+      if (gross == null && net != null) {
+        const tare = num(data.spoolWeight) ?? 0;
+        data.spoolWeight = tare;
+        gross = net + tare;
+      }
+      data.totalWeight = null;
+      data.spools = [{ label: "", totalWeight: gross }];
+    }
+
     const res = await fetch("/api/filaments", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -211,6 +211,9 @@ function NewFilamentContent() {
       const bedMax = searchParams.get("bed") ? Number(searchParams.get("bed")) : null;
       const bedMin = searchParams.get("bedMin") ? Number(searchParams.get("bedMin")) : null;
       const weight = searchParams.get("weight") ? Number(searchParams.get("weight")) : null;
+      // Nominal net (weight) vs actual remaining net + tare (Codex P2 r7 #706).
+      const actualWeight = searchParams.get("actualWeight") ? Number(searchParams.get("actualWeight")) : null;
+      const emptySpool = searchParams.get("emptySpool") ? Number(searchParams.get("emptySpool")) : null;
 
       // Syncing external URL state into form initial data. Can't be derived
       // because the form is controlled elsewhere via formKey remounts.
@@ -243,6 +246,8 @@ function NewFilamentContent() {
           bedFirstLayer: bedMin ?? bedMax,
         },
         ...(weight != null ? { netFilamentWeight: weight } : {}),
+        ...(emptySpool != null ? { spoolWeight: emptySpool } : {}),
+        ...(actualWeight != null ? { totalWeight: actualWeight + (emptySpool ?? 0) } : {}),
         ...(searchParams.get("shoreA") ? { shoreHardnessA: Number(searchParams.get("shoreA")) } : {}),
         ...(searchParams.get("shoreD") ? { shoreHardnessD: Number(searchParams.get("shoreD")) } : {}),
         ...(searchParams.get("optTags") ? { optTags: searchParams.get("optTags")!.split(",").map(Number) } : {}),
@@ -408,7 +413,16 @@ function NewFilamentContent() {
         bed: data.bedTemp ?? null,
         bedFirstLayer: data.bedTempMin ?? data.bedTemp ?? null,
       },
+      // weightGrams is the tag's NOMINAL net capacity; actualWeightGrams is the
+      // current remaining net. Carry the tare (emptySpoolWeight) and, when the
+      // tag reports actual remaining, prefill Initial Weight with the on-scale
+      // gross (actual + tare) so the auto-created spool reflects a partially
+      // used roll instead of a full one (Codex P2 r7 on #706).
       ...(data.weightGrams != null ? { netFilamentWeight: data.weightGrams } : {}),
+      ...(data.emptySpoolWeight != null ? { spoolWeight: data.emptySpoolWeight } : {}),
+      ...(data.actualWeightGrams != null
+        ? { totalWeight: data.actualWeightGrams + (data.emptySpoolWeight ?? 0) }
+        : {}),
       settings: {
         ...(data.chamberTemp != null ? { chamber_temperature: String(data.chamberTemp) } : {}),
         ...(data.countryOfOrigin ? { filament_notes: `"Origin: ${data.countryOfOrigin}"` } : {}),

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -140,31 +140,35 @@ function NewFilamentContent() {
           // Explicit Empty Spool wins for both standalone and variant.
           gross = net + ownTare;
         } else if (isVariant) {
-          // A variant leaves the tare blank to inherit the parent's, so the
-          // gross must match that inherited tare (else remaining = net - tare).
-          // initialData._parent is only populated for ?parentId= creates; for a
-          // form parent-picker / clone-toolbar variant we fetch the parent to
-          // read its tare. Leave spoolWeight blank to keep inheriting; only pin
-          // a 0 when the parent can't be read at all (Codex P2 on #706).
+          // No own tare on a variant: try to inherit the parent's so the gross
+          // matches the tare the variant resolves to. initialData._parent is
+          // only populated for ?parentId= creates, so for a form parent-picker
+          // / clone-toolbar variant we fetch the parent to read its tare.
           const pre = initialData?._parent as { spoolWeight?: number } | undefined;
           let parentTare = num(pre?.spoolWeight);
-          let resolved = pre !== undefined;
-          if (!resolved) {
+          if (parentTare == null && pre === undefined) {
             try {
               const r = await fetch(
                 `/api/filaments/${encodeURIComponent(data.parentId as string)}?raw=true`,
               );
-              if (r.ok) {
-                const p = await r.json();
-                parentTare = num(p?.spoolWeight);
-                resolved = true;
-              }
+              if (r.ok) parentTare = num((await r.json())?.spoolWeight);
             } catch {
-              /* fall through to the pin-0 fallback below */
+              /* parentTare stays null → pinned to 0 below */
             }
           }
-          gross = net + (parentTare ?? 0);
-          if (!resolved) data.spoolWeight = 0;
+          if (parentTare != null) {
+            // A real tare to inherit: bake it into the gross and leave
+            // spoolWeight blank so the variant keeps tracking the parent
+            // (Codex P2 round 1 — don't clobber inheritance with a 0).
+            gross = net + parentTare;
+          } else {
+            // No tare to inherit (parent has none, or couldn't be read). Use 0
+            // AND persist it: getRemainingGrams treats a spooled filament whose
+            // spoolWeight is null as untracked, so a blank tare would hide the
+            // entered net as "unknown remaining" (Codex P2 rounds 2-3).
+            gross = net;
+            data.spoolWeight = 0;
+          }
         } else {
           // Standalone with no tare: 0 fallback (remaining = net), persisted so
           // remaining = totalWeight - spoolWeight stays consistent.

--- a/src/app/filaments/new/page.tsx
+++ b/src/app/filaments/new/page.tsx
@@ -131,23 +131,30 @@ function NewFilamentContent() {
       const num = (v: unknown): number | null =>
         typeof v === "number" && Number.isFinite(v) ? v : null;
       const total = num(data.totalWeight);
-      const net = num(data.netFilamentWeight);
+      const ownNet = num(data.netFilamentWeight);
       const ownTare = num(data.spoolWeight);
       const isVariant = typeof data.parentId === "string" && data.parentId !== "";
 
-      // Effective tare = own Empty Spool, else (for a variant) the SELECTED
-      // parent's inherited tare. Always fetch by the current data.parentId —
-      // the form picker can swap the parent after a ?parentId= open, so any
-      // cached parent doc may be stale (Codex P2 rounds 2 + 4).
+      // A variant leaves Net / Empty Spool blank to inherit them — FilamentForm
+      // keeps parent placeholders out of submitted state, so data.netFilament-
+      // Weight / spoolWeight are null even when the parent has values. Fetch the
+      // SELECTED parent (by current data.parentId — the picker can swap it after
+      // a ?parentId= open, so a cached doc may be stale; Codex P2 rounds 2/4/5)
+      // and fill in whichever of net/tare the variant left blank.
+      let effNet = ownNet;
       let effTare = ownTare;
-      if (effTare == null && isVariant) {
+      if (isVariant && (effNet == null || effTare == null)) {
         try {
           const r = await fetch(
             `/api/filaments/${encodeURIComponent(data.parentId as string)}?raw=true`,
           );
-          if (r.ok) effTare = num((await r.json())?.spoolWeight);
+          if (r.ok) {
+            const parent = await r.json();
+            if (effNet == null) effNet = num(parent?.netFilamentWeight);
+            if (effTare == null) effTare = num(parent?.spoolWeight);
+          }
         } catch {
-          /* effTare stays null → 0 pinned below */
+          /* leave effNet/effTare as-is — falls through to unknown / 0-pin */
         }
       }
 
@@ -155,7 +162,7 @@ function NewFilamentContent() {
       // unknown. The tare is baked in so remaining resolves back to net.
       let gross: number | null;
       if (total != null) gross = total;
-      else if (net != null) gross = net + (effTare ?? 0);
+      else if (effNet != null) gross = effNet + (effTare ?? 0);
       else gross = null;
 
       // A weighted spool whose filament has no effective tare reads as

--- a/src/components/NfcReadDialog.tsx
+++ b/src/components/NfcReadDialog.tsx
@@ -118,6 +118,10 @@ export default function NfcReadDialog() {
     if (data.bedTempMin != null) params.set("bedMin", String(data.bedTempMin));
     if (data.chamberTemp != null) params.set("chamber", String(data.chamberTemp));
     if (data.weightGrams != null) params.set("weight", String(data.weightGrams));
+    // Actual remaining net + tare so the new-filament form can seed a spool
+    // that reflects a partially used roll, not a full one (Codex P2 r7 #706).
+    if (data.actualWeightGrams != null) params.set("actualWeight", String(data.actualWeightGrams));
+    if (data.emptySpoolWeight != null) params.set("emptySpool", String(data.emptySpoolWeight));
     if (data.countryOfOrigin) params.set("country", data.countryOfOrigin);
     if (data.shoreHardnessA != null) params.set("shoreA", String(data.shoreHardnessA));
     if (data.shoreHardnessD != null) params.set("shoreD", String(data.shoreHardnessD));

--- a/src/components/NfcReadDialog.tsx
+++ b/src/components/NfcReadDialog.tsx
@@ -143,12 +143,14 @@ export default function NfcReadDialog() {
     if (data.secondaryColors && data.secondaryColors.length > 0) {
       params.set("secondaryColors", data.secondaryColors.join(","));
     }
-    // Carry the spool-specific weights (actual remaining + tare) so a variant
-    // created from a partially used tag records the real roll, not a full
-    // inherited one. Nominal net is intentionally NOT passed — the variant
-    // inherits it from the parent (Codex P2 r8 on #706).
-    if (data.actualWeightGrams != null) params.set("actualWeight", String(data.actualWeightGrams));
-    if (data.emptySpoolWeight != null) params.set("emptySpool", String(data.emptySpoolWeight));
+    // NOTE: the tag's actual remaining weight + tare are deliberately NOT
+    // carried here. A variant-from-tag goes through both the from_nfc effect
+    // AND the ?parentId= parent-loader on /filaments/new, and the latter
+    // currently replaces initialData wholesale — so any weights set here are
+    // discarded before the form renders (the same pre-existing race already
+    // drops the name/color above). Wiring spool weights through that path
+    // correctly is tracked as a separate follow-up; until then we don't pass
+    // values that would be silently lost (Codex #706 r9).
     dismissTagRead();
     router.push(`/filaments/new?${params}`);
   };

--- a/src/components/NfcReadDialog.tsx
+++ b/src/components/NfcReadDialog.tsx
@@ -143,6 +143,12 @@ export default function NfcReadDialog() {
     if (data.secondaryColors && data.secondaryColors.length > 0) {
       params.set("secondaryColors", data.secondaryColors.join(","));
     }
+    // Carry the spool-specific weights (actual remaining + tare) so a variant
+    // created from a partially used tag records the real roll, not a full
+    // inherited one. Nominal net is intentionally NOT passed — the variant
+    // inherits it from the parent (Codex P2 r8 on #706).
+    if (data.actualWeightGrams != null) params.set("actualWeight", String(data.actualWeightGrams));
+    if (data.emptySpoolWeight != null) params.set("emptySpool", String(data.emptySpoolWeight));
     dismissTagRead();
     router.push(`/filaments/new?${params}`);
   };

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1160,7 +1160,7 @@
   "form.placeholder.initialWeight": "Spule auf Waage wiegen",
   "form.netFilamentHint": "Filamentgewicht ohne Spule (aus TDS oder Verpackung).",
   "form.emptySpoolHint": "Gewicht der leeren Spulenrolle (ohne Filament).",
-  "form.initialWeightHint": "Erstellt Ihre erste Spule. Weitere können auf der Detailseite hinzugefügt werden.",
+  "form.initialWeightHint": "Legt das aktuelle Gewicht der neuen Spule fest. Für ein neues Filament wird immer eine Spule erstellt — bei leerem Feld aus Netto + Leergewicht abgeleitet. Weitere können auf der Detailseite hinzugefügt werden.",
   "form.initialWeightHintEdit": "Spulen werden auf der Detailseite hinzugefügt oder entfernt; dieses Feld zeigt die Summe.",
   "form.minPrintSpeed": "Min. Druckgeschw. (mm/s)",
   "form.maxPrintSpeed": "Max. Druckgeschw. (mm/s)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1160,7 +1160,7 @@
   "form.placeholder.initialWeight": "Weigh spool on scale",
   "form.netFilamentHint": "Filament weight without the spool (from TDS or packaging).",
   "form.emptySpoolHint": "Weight of the empty spool reel (without filament).",
-  "form.initialWeightHint": "Creates your first spool. Add more from the detail page.",
+  "form.initialWeightHint": "Sets the new spool's current weight. A spool is always created for a new filament — if blank, it's derived from Net + Empty Spool. Add more from the detail page.",
   "form.initialWeightHintEdit": "Add or remove spools from the detail page; this field shows the aggregate.",
   "form.minPrintSpeed": "Min Print Speed (mm/s)",
   "form.maxPrintSpeed": "Max Print Speed (mm/s)",


### PR DESCRIPTION
You only add a filament to the DB because you own it — so **creating one via "+ Add Filament" now always creates exactly one spool** (no opt-out, per the chosen behavior).

## Behavior
- On create, the new-filament page always attaches one spool. Its **gross weight** = the entered **Initial Weight**, else **Net + Empty Spool tare**, else unknown (a weight-TBD spool).
- When the gross is derived from Net, the **tare used is persisted** (0 fallback) so `remaining = totalWeight − spoolWeight` equals the net — mirrors the create-from-tag route fix.
- **Scoped to create** (the new page): edit, mobile create-from-tag, and bulk import are untouched. Guarded so it won't clobber a spool a prefill path already set.
- Updated the "Initial Weight" hint (en + de): a spool is always created; the field sets its weight (or it's derived from Net + Empty Spool).

## Notes
Client-side glue on top of the existing embedded-spool create path (allowlist + photo validation), which is covered by `embedded-spool-photo-validation.test.ts`. `tsc` + `eslint` + i18n key-parity all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)