### PR TITLE
feat(mobile): Phase 3 — spool deep links, inventory actions, offline write queue

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/ui": "~56.0.17",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "eslint-config-expo": "~56.0.4",
         "expo": "~56.0.11",
         "expo-build-properties": "~56.0.18",
@@ -2522,6 +2523,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {
@@ -7343,6 +7356,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8228,6 +8250,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@expo/ui": "~56.0.17",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "eslint-config-expo": "~56.0.4",
     "expo": "~56.0.11",
     "expo-build-properties": "~56.0.18",

--- a/packages/mobile/src/app/_layout.tsx
+++ b/packages/mobile/src/app/_layout.tsx
@@ -1,12 +1,38 @@
 import { DarkTheme, DefaultTheme, Stack, ThemeProvider } from 'expo-router';
-import { useColorScheme } from 'react-native';
+import { useEffect } from 'react';
+import { AppState, useColorScheme } from 'react-native';
 
-import { ServerConfigProvider } from '@/lib/serverConfig';
+import { createApi } from '@/lib/api';
+import { ServerConfigProvider, useServerConfig } from '@/lib/serverConfig';
+import { flushQueue } from '@/lib/writeQueue';
+
+/**
+ * Drains the offline write queue when the app is foregrounded (and on mount /
+ * server-config change), so spool edits made offline sync app-wide — not only
+ * when a filament detail screen happens to be focused. Fire-and-forget:
+ * flushQueue is idempotent and guards against concurrent runs.
+ */
+function QueueFlusher() {
+  const { baseUrl, apiKey } = useServerConfig();
+  useEffect(() => {
+    if (!baseUrl) return;
+    const flush = () => {
+      flushQueue(createApi({ baseUrl, apiKey })).catch(() => {});
+    };
+    flush();
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') flush();
+    });
+    return () => sub.remove();
+  }, [baseUrl, apiKey]);
+  return null;
+}
 
 export default function RootLayout() {
   const scheme = useColorScheme();
   return (
     <ServerConfigProvider>
+      <QueueFlusher />
       <ThemeProvider value={scheme === 'dark' ? DarkTheme : DefaultTheme}>
         {/* Minimal back button (chevron only, no previous-title label): a long
             title like "Filament DB Scanner" overflowed the nav bar's back-button

--- a/packages/mobile/src/app/filament/[id].tsx
+++ b/packages/mobile/src/app/filament/[id].tsx
@@ -393,6 +393,10 @@ function SpoolRow({
   const [saving, setSaving] = useState<string | null>(null);
   // Feature B: log usage input state.
   const [usageGrams, setUsageGrams] = useState('');
+  // Feature B: dry-cycle inputs (at least one required so an accidental tap
+  // can't log a blank cycle and reset dry-due tracking — Codex P2).
+  const [dryTemp, setDryTemp] = useState('');
+  const [dryDuration, setDryDuration] = useState('');
 
   /** Feature C: route every spool mutation through the offline write queue.
    * Returns `{ ok }` — false on a real server error so callers can keep the
@@ -490,12 +494,30 @@ function SpoolRow({
 
   // Feature B: log dry cycle.
   async function logDryCycle() {
-    await runWrite(
-      'dry',
-      'Log dry cycle',
-      { kind: 'logDryCycle', cycle: {} },
-      {},
-    );
+    const t = dryTemp.trim() ? Number(dryTemp) : null;
+    const d = dryDuration.trim() ? Number(dryDuration) : null;
+    // Require at least one detail — a blank cycle would still stamp a date and
+    // mark the spool freshly dried on the dashboard (Codex P2).
+    if (t == null && d == null) {
+      Alert.alert('Add a detail', 'Enter a temperature (°C) or duration (min) for the dry cycle.');
+      return;
+    }
+    if (t != null && (!Number.isFinite(t) || t < 0 || t > 300)) {
+      Alert.alert('Invalid temperature', 'Temperature must be between 0 and 300 °C.');
+      return;
+    }
+    if (d != null && (!Number.isFinite(d) || d < 0)) {
+      Alert.alert('Invalid duration', 'Duration must be 0 minutes or more.');
+      return;
+    }
+    const cycle: { tempC?: number; durationMin?: number } = {};
+    if (t != null) cycle.tempC = t;
+    if (d != null) cycle.durationMin = d;
+    const res = await runWrite('dry', 'Log dry cycle', { kind: 'logDryCycle', cycle }, {});
+    if (res.ok) {
+      setDryTemp('');
+      setDryDuration('');
+    }
   }
 
   return (
@@ -609,21 +631,37 @@ function SpoolRow({
         </Pressable>
       </View>
 
-      {/* Log dry cycle */}
-      <Pressable
-        style={[
-          styles.smallButton,
-          styles.actionButton,
-          { backgroundColor: c.card, borderColor: c.border },
-          saving === 'dry' && styles.disabled,
-        ]}
-        onPress={logDryCycle}
-        disabled={saving !== null}
-      >
-        <Text style={[styles.smallButtonText, { color: c.text }]}>
-          {saving === 'dry' ? '…' : 'Log dry cycle'}
-        </Text>
-      </Pressable>
+      {/* Log dry cycle — temp and/or duration (at least one required) */}
+      <Text style={[styles.fieldLabel, { color: c.muted }]}>Log dry cycle</Text>
+      <View style={styles.row}>
+        <TextInput
+          style={[styles.dryInput, { color: c.text, borderColor: c.border, backgroundColor: c.inputBg }]}
+          value={dryTemp}
+          onChangeText={setDryTemp}
+          keyboardType="numeric"
+          inputMode="numeric"
+          placeholder="°C"
+          placeholderTextColor={c.muted}
+        />
+        <TextInput
+          style={[styles.dryInput, { color: c.text, borderColor: c.border, backgroundColor: c.inputBg }]}
+          value={dryDuration}
+          onChangeText={setDryDuration}
+          keyboardType="numeric"
+          inputMode="numeric"
+          placeholder="min"
+          placeholderTextColor={c.muted}
+        />
+        <Pressable
+          style={[styles.smallButton, { backgroundColor: c.tint }, saving === 'dry' && styles.disabled]}
+          onPress={logDryCycle}
+          disabled={saving !== null}
+        >
+          <Text style={[styles.smallButtonText, { color: c.onTint }]}>
+            {saving === 'dry' ? '…' : 'Log'}
+          </Text>
+        </Pressable>
+      </View>
     </View>
   );
 }
@@ -655,6 +693,14 @@ const styles = StyleSheet.create({
   fieldLabel: { fontSize: 13, marginTop: 4 },
   row: { flexDirection: 'row', gap: 8, alignItems: 'center' },
   weightInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 16,
+  },
+  dryInput: {
     flex: 1,
     borderWidth: 1,
     borderRadius: 8,

--- a/packages/mobile/src/app/filament/[id].tsx
+++ b/packages/mobile/src/app/filament/[id].tsx
@@ -434,8 +434,14 @@ function SpoolRow({
       { kind: 'logUsage', grams: g },
       optimisticPatch,
     );
-    // Clear the input only on success/queued — keep it on a server error to retry.
-    if (ok) setUsageGrams('');
+    if (ok) {
+      setUsageGrams('');
+      // Reflect the decrement in the remaining-weight field too — otherwise it
+      // keeps the pre-usage value and a later Save writes it back, undoing the
+      // usage (Codex P2). Usage is online-only (not queued), so `remaining`
+      // here minus g equals the server's new remaining.
+      if (remaining != null) setGrams(String(Math.max(0, remaining - g)));
+    }
   }
 
   // Feature B: log dry cycle.

--- a/packages/mobile/src/app/filament/[id].tsx
+++ b/packages/mobile/src/app/filament/[id].tsx
@@ -1,5 +1,5 @@
-import { useLocalSearchParams } from 'expo-router';
-import { useEffect, useRef, useState } from 'react';
+import { useFocusEffect, useLocalSearchParams } from 'expo-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -15,6 +15,13 @@ import { ApiError, createApi, type Api } from '@/lib/api';
 import { useServerConfig } from '@/lib/serverConfig';
 import { useColors, type ThemeColors } from '@/lib/theme';
 import type { Filament, Location, Spool } from '@/lib/types';
+import {
+  flushQueue,
+  pendingCount,
+  submitWrite,
+  subscribePending,
+  type WriteOp,
+} from '@/lib/writeQueue';
 
 /** Human-readable rows of the filament's present properties for the detail card. */
 function buildDetailRows(f: Filament): { label: string; value: string }[] {
@@ -59,6 +66,42 @@ function buildDetailRows(f: Filament): { label: string; value: string }[] {
   return rows;
 }
 
+/** Track the live offline-queue pending count and flush on screen focus. */
+function usePendingSync(api: Api | null, setReloadKey: React.Dispatch<React.SetStateAction<number>>): number {
+  const [pending, setPending] = useState(0);
+
+  // Read initial count after mount (async IIFE — state set after await, not synchronously).
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const count = await pendingCount();
+      if (active) setPending(count);
+    })();
+    const unsub = subscribePending((count) => {
+      setPending(count);
+    });
+    return () => {
+      active = false;
+      unsub();
+    };
+  }, []);
+
+  // Flush on focus, and bump reloadKey if anything was flushed.
+  useFocusEffect(
+    useCallback(() => {
+      if (!api) return;
+      (async () => {
+        const result = await flushQueue(api);
+        if (result.flushed > 0) {
+          setReloadKey((k) => k + 1);
+        }
+      })();
+    }, [api, setReloadKey]),
+  );
+
+  return pending;
+}
+
 export default function FilamentDetailScreen() {
   const { id, spool: spoolParam } = useLocalSearchParams<{ id: string; spool?: string }>();
   const { baseUrl, apiKey } = useServerConfig();
@@ -72,6 +115,21 @@ export default function FilamentDetailScreen() {
   // highlight that spool's card once the filament (with its spools) loads.
   const [highlightSpoolId, setHighlightSpoolId] = useState<string | null>(null);
   const deepLinkHandled = useRef(false);
+  // Feature A: scroll-to-spool support.
+  const scrollRef = useRef<ScrollView>(null);
+  const scrolledToSpool = useRef(false);
+
+  // Build the api instance once baseUrl is known (used by usePendingSync too).
+  // Memoized so its identity is stable across renders — the focus-effect and
+  // the SpoolRow `api` prop depend on it, and a fresh object each render would
+  // re-subscribe / re-render needlessly.
+  const api = useMemo(
+    () => (baseUrl ? createApi({ baseUrl, apiKey }) : null),
+    [baseUrl, apiKey],
+  );
+
+  // Feature C: pending-sync count + flush-on-focus.
+  const pending = usePendingSync(api, setReloadKey);
 
   // Fetch on mount (and on Retry, which bumps reloadKey). All setState runs
   // inside the async IIFE *after* an await — never synchronously in the effect
@@ -80,12 +138,12 @@ export default function FilamentDetailScreen() {
   useEffect(() => {
     if (!baseUrl || !id) return;
     let active = true;
-    const api = createApi({ baseUrl, apiKey });
+    const fetchApi = createApi({ baseUrl, apiKey });
     (async () => {
       try {
         const [f, locs] = await Promise.all([
-          api.getFilament(id),
-          api.getLocations().catch(() => [] as Location[]),
+          fetchApi.getFilament(id),
+          fetchApi.getLocations().catch(() => [] as Location[]),
         ]);
         if (!active) return;
         setFilament(f);
@@ -116,6 +174,7 @@ export default function FilamentDetailScreen() {
   useEffect(() => {
     if (deepLinkHandled.current || !filament || !spoolParam) return;
     deepLinkHandled.current = true;
+    // Feature A: include retired spools in the check too.
     if (!filament.spools?.some((s) => s._id === spoolParam)) return;
     const set = setTimeout(() => setHighlightSpoolId(spoolParam), 0);
     const clear = setTimeout(() => setHighlightSpoolId(null), 2600);
@@ -155,7 +214,6 @@ export default function FilamentDetailScreen() {
     );
   }
 
-  const api = createApi({ baseUrl, apiKey });
   const tare = filament.spoolWeight ?? 0;
   const allSpools = filament.spools ?? [];
   const activeSpools = allSpools.filter((s) => !s.retired);
@@ -163,6 +221,14 @@ export default function FilamentDetailScreen() {
   const detailRows = buildDetailRows(filament);
   const hasColor = !!filament.color || (filament.secondaryColors?.length ?? 0) > 0;
   const swatchColor = filament.color || filament.secondaryColors?.[0] || '#808080';
+
+  // Feature A: if the deep-linked spool is retired and not in activeSpools, include it.
+  const deepLinkedSpool = spoolParam ? allSpools.find((s) => s._id === spoolParam) : undefined;
+  const deepLinkedIsRetiredExtra =
+    deepLinkedSpool?.retired && !activeSpools.some((s) => s._id === spoolParam);
+  const spoolsToRender: Spool[] = deepLinkedIsRetiredExtra
+    ? [...activeSpools, deepLinkedSpool as Spool]
+    : activeSpools;
 
   // The spool PUT returns the RAW (unresolved) filament — for a variant that
   // inherits density / temps / weights from its parent, those come back null.
@@ -172,12 +238,30 @@ export default function FilamentDetailScreen() {
   const handleSpoolUpdated = (updated: Filament) =>
     setFilament((prev) => (prev ? { ...prev, spools: updated.spools } : updated));
 
+  // Feature C: optimistic local patch (no server round-trip needed for the UI).
+  const handleLocalPatch = (spoolId: string, patch: Partial<Spool>) => {
+    setFilament((prev) =>
+      prev
+        ? { ...prev, spools: prev.spools?.map((s) => (s._id === spoolId ? { ...s, ...patch } : s)) }
+        : prev,
+    );
+  };
+
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScrollView ref={scrollRef} contentContainerStyle={styles.container}>
       <Text style={[styles.name, { color: c.text }]}>{filament.name}</Text>
       <Text style={[styles.sub, { color: c.muted }]}>
         {[filament.vendor, filament.type].filter(Boolean).join(' · ')}
       </Text>
+
+      {/* Feature C: pending-sync pill */}
+      {pending > 0 && (
+        <View style={[styles.pendingPill, { borderColor: c.border }]}>
+          <Text style={[styles.pendingPillText, { color: c.muted }]}>
+            {pending} change{pending === 1 ? '' : 's'} pending sync
+          </Text>
+        </View>
+      )}
 
       {(hasColor || detailRows.length > 0) && (
         <View style={[styles.detailCard, { backgroundColor: c.card, borderColor: c.border }]}>
@@ -204,26 +288,40 @@ export default function FilamentDetailScreen() {
       )}
 
       <Text style={[styles.sectionHeading, { color: c.text }]}>Spools</Text>
-      {activeSpools.length === 0 ? (
+      {spoolsToRender.length === 0 ? (
         <Text style={[styles.muted, { color: c.muted }]}>
           {retiredCount > 0
             ? `No active spools (${retiredCount} retired).`
             : 'No spools tracked yet on this filament.'}
         </Text>
       ) : (
-        activeSpools.map((s) => (
-          <SpoolRow
-            key={s._id}
-            api={api}
-            filamentId={filament._id}
-            spool={s}
-            tare={tare}
-            locations={locations}
-            colors={c}
-            highlighted={s._id === highlightSpoolId}
-            onUpdated={handleSpoolUpdated}
-          />
-        ))
+        spoolsToRender.map((s) => {
+          const isHighlighted = s._id === highlightSpoolId;
+          return (
+            <SpoolRow
+              key={s._id}
+              api={api as Api}
+              filamentId={filament._id}
+              spool={s}
+              tare={tare}
+              locations={locations}
+              colors={c}
+              highlighted={isHighlighted}
+              onUpdated={handleSpoolUpdated}
+              onLocalPatch={handleLocalPatch}
+              onLayoutY={
+                isHighlighted
+                  ? (y) => {
+                      if (!scrolledToSpool.current) {
+                        scrolledToSpool.current = true;
+                        scrollRef.current?.scrollTo({ y, animated: true });
+                      }
+                    }
+                  : undefined
+              }
+            />
+          );
+        })
       )}
     </ScrollView>
   );
@@ -238,6 +336,8 @@ function SpoolRow({
   colors: c,
   highlighted = false,
   onUpdated,
+  onLocalPatch,
+  onLayoutY,
 }: {
   api: Api;
   filamentId: string;
@@ -247,10 +347,41 @@ function SpoolRow({
   colors: ThemeColors;
   highlighted?: boolean;
   onUpdated: (f: Filament) => void;
+  onLocalPatch: (spoolId: string, patch: Partial<Spool>) => void;
+  onLayoutY?: (y: number) => void;
 }) {
   const remaining = spool.totalWeight == null ? null : Math.max(0, Math.round(spool.totalWeight - tare));
   const [grams, setGrams] = useState(remaining == null ? '' : String(remaining));
   const [saving, setSaving] = useState<string | null>(null);
+  // Feature B: log usage input state.
+  const [usageGrams, setUsageGrams] = useState('');
+
+  /** Feature C: route every spool mutation through the offline write queue. */
+  /** Returns true when the write went through or was queued; false on a real
+   * server error (so callers can keep the user's input to retry). */
+  async function runWrite(
+    saveKey: string,
+    label: string,
+    write: WriteOp,
+    optimisticPatch: Partial<Spool>,
+  ): Promise<boolean> {
+    setSaving(saveKey);
+    try {
+      const result = await submitWrite(api, { filamentId, spoolId: spool._id, label, write });
+      if (result.queued) {
+        onLocalPatch(spool._id, optimisticPatch);
+        Alert.alert('Saved offline', 'This change will sync when the server is reachable.');
+      } else {
+        onUpdated(result.result as Filament);
+      }
+      return true;
+    } catch (e) {
+      Alert.alert('Update failed', (e as Error).message);
+      return false;
+    } finally {
+      setSaving(null);
+    }
+  }
 
   async function saveWeight() {
     const n = Number(grams);
@@ -258,25 +389,63 @@ function SpoolRow({
       Alert.alert('Invalid weight', 'Enter the grams of filament remaining (0 or more).');
       return;
     }
-    setSaving('weight');
-    try {
-      onUpdated(await api.updateSpool(filamentId, spool._id, { remainingWeight: n }));
-    } catch (e) {
-      Alert.alert('Update failed', (e as Error).message);
-    } finally {
-      setSaving(null);
-    }
+    await runWrite(
+      'weight',
+      `Set remaining to ${n} g`,
+      { kind: 'updateSpool', patch: { remainingWeight: n } },
+      { totalWeight: n + tare },
+    );
   }
 
-  async function move(locationId: string | null) {
-    setSaving(locationId ?? 'none');
-    try {
-      onUpdated(await api.updateSpool(filamentId, spool._id, { locationId }));
-    } catch (e) {
-      Alert.alert('Move failed', (e as Error).message);
-    } finally {
-      setSaving(null);
+  async function move(locationId: string | null, locationName?: string) {
+    await runWrite(
+      locationId ?? 'none',
+      locationId ? `Move to ${locationName ?? 'location'}` : 'Clear location',
+      { kind: 'updateSpool', patch: { locationId } },
+      { locationId },
+    );
+  }
+
+  // Feature B: retire / un-retire toggle.
+  async function toggleRetire() {
+    const newRetired = !spool.retired;
+    await runWrite(
+      'retire',
+      newRetired ? 'Retire spool' : 'Un-retire spool',
+      { kind: 'updateSpool', patch: { retired: newRetired } },
+      { retired: newRetired },
+    );
+  }
+
+  // Feature B: log usage.
+  async function logUsage() {
+    const g = Number(usageGrams);
+    if (!usageGrams.trim() || !Number.isFinite(g) || g <= 0) {
+      Alert.alert('Invalid amount', 'Enter a positive number of grams used.');
+      return;
     }
+    const optimisticTotalWeight =
+      spool.totalWeight == null ? undefined : Math.max(0, spool.totalWeight - g);
+    const optimisticPatch: Partial<Spool> =
+      optimisticTotalWeight !== undefined ? { totalWeight: optimisticTotalWeight } : {};
+    const ok = await runWrite(
+      'usage',
+      `Use ${g} g`,
+      { kind: 'logUsage', grams: g },
+      optimisticPatch,
+    );
+    // Clear the input only on success/queued — keep it on a server error to retry.
+    if (ok) setUsageGrams('');
+  }
+
+  // Feature B: log dry cycle.
+  async function logDryCycle() {
+    await runWrite(
+      'dry',
+      'Log dry cycle',
+      { kind: 'logDryCycle', cycle: {} },
+      {},
+    );
   }
 
   return (
@@ -286,6 +455,7 @@ function SpoolRow({
         { backgroundColor: c.card, borderColor: c.border },
         highlighted && { borderColor: c.tint, backgroundColor: c.inputBg },
       ]}
+      onLayout={onLayoutY ? (e) => onLayoutY(e.nativeEvent.layout.y) : undefined}
     >
       <Text style={[styles.cardTitle, { color: c.text }]}>{spool.label || 'Spool'}</Text>
 
@@ -322,7 +492,7 @@ function SpoolRow({
                 styles.chip,
                 { borderColor: active ? c.tint : c.border, backgroundColor: active ? c.tint : 'transparent' },
               ]}
-              onPress={() => move(loc._id)}
+              onPress={() => move(loc._id, loc.name)}
               disabled={saving === loc._id}
             >
               <Text style={[styles.chipText, { color: active ? c.onTint : c.text }]}>{loc.name}</Text>
@@ -343,6 +513,64 @@ function SpoolRow({
           <Text style={[styles.chipText, { color: !spool.locationId ? c.onTint : c.text }]}>None</Text>
         </Pressable>
       </View>
+
+      {/* Feature B: inventory actions */}
+      <View style={[styles.divider, { borderColor: c.border }]} />
+
+      {/* Retire / Un-retire */}
+      <Pressable
+        style={[
+          styles.smallButton,
+          styles.actionButton,
+          { backgroundColor: spool.retired ? c.tint : c.card, borderColor: c.border },
+          saving === 'retire' && styles.disabled,
+        ]}
+        onPress={toggleRetire}
+        disabled={saving === 'retire'}
+      >
+        <Text style={[styles.smallButtonText, { color: spool.retired ? c.onTint : c.text }]}>
+          {saving === 'retire' ? '…' : spool.retired ? 'Un-retire' : 'Retire'}
+        </Text>
+      </Pressable>
+
+      {/* Log usage */}
+      <Text style={[styles.fieldLabel, { color: c.muted }]}>Log usage (g)</Text>
+      <View style={styles.row}>
+        <TextInput
+          style={[styles.weightInput, { color: c.text, borderColor: c.border, backgroundColor: c.inputBg }]}
+          value={usageGrams}
+          onChangeText={setUsageGrams}
+          keyboardType="numeric"
+          inputMode="numeric"
+          placeholder="grams used"
+          placeholderTextColor={c.muted}
+        />
+        <Pressable
+          style={[styles.smallButton, { backgroundColor: c.tint }, saving === 'usage' && styles.disabled]}
+          onPress={logUsage}
+          disabled={saving === 'usage'}
+        >
+          <Text style={[styles.smallButtonText, { color: c.onTint }]}>
+            {saving === 'usage' ? '…' : 'Log'}
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* Log dry cycle */}
+      <Pressable
+        style={[
+          styles.smallButton,
+          styles.actionButton,
+          { backgroundColor: c.card, borderColor: c.border },
+          saving === 'dry' && styles.disabled,
+        ]}
+        onPress={logDryCycle}
+        disabled={saving === 'dry'}
+      >
+        <Text style={[styles.smallButtonText, { color: c.text }]}>
+          {saving === 'dry' ? '…' : 'Log dry cycle'}
+        </Text>
+      </Pressable>
     </View>
   );
 }
@@ -396,4 +624,21 @@ const styles = StyleSheet.create({
   },
   chipText: { fontSize: 14 },
   disabled: { opacity: 0.5 },
+  pendingPill: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    alignSelf: 'flex-start',
+    marginBottom: 4,
+  },
+  pendingPillText: { fontSize: 13 },
+  divider: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    marginVertical: 4,
+  },
+  actionButton: {
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+  },
 });

--- a/packages/mobile/src/app/filament/[id].tsx
+++ b/packages/mobile/src/app/filament/[id].tsx
@@ -69,34 +69,39 @@ function buildDetailRows(f: Filament): { label: string; value: string }[] {
 /** Track the live offline-queue pending count and flush on screen focus. */
 function usePendingSync(api: Api | null, setReloadKey: React.Dispatch<React.SetStateAction<number>>): number {
   const [pending, setPending] = useState(0);
+  const prevPending = useRef(0);
 
-  // Read initial count after mount (async IIFE — state set after await, not synchronously).
+  // Read initial count after mount (async IIFE — state set after await, not
+  // synchronously). Then track changes: a DROP means a flush applied writes —
+  // including the app-wide foreground flusher in _layout, which doesn't itself
+  // tell this screen to reload (Codex P2) — so re-fetch to show the synced
+  // server state rather than just clearing the pill. An increase is an enqueue,
+  // already reflected locally by the optimistic patch, so no re-fetch.
   useEffect(() => {
     let active = true;
     (async () => {
       const count = await pendingCount();
-      if (active) setPending(count);
+      if (active) {
+        prevPending.current = count;
+        setPending(count);
+      }
     })();
     const unsub = subscribePending((count) => {
+      if (count < prevPending.current) setReloadKey((k) => k + 1);
+      prevPending.current = count;
       setPending(count);
     });
     return () => {
       active = false;
       unsub();
     };
-  }, []);
+  }, [setReloadKey]);
 
-  // Flush on focus, and bump reloadKey if anything was flushed.
+  // Drain on focus; the subscriber above re-fetches on the resulting count drop.
   useFocusEffect(
     useCallback(() => {
-      if (!api) return;
-      (async () => {
-        const result = await flushQueue(api);
-        if (result.flushed > 0) {
-          setReloadKey((k) => k + 1);
-        }
-      })();
-    }, [api, setReloadKey]),
+      if (api) flushQueue(api).catch(() => {});
+    }, [api]),
   );
 
   return pending;
@@ -297,6 +302,12 @@ export default function FilamentDetailScreen() {
       ) : (
         spoolsToRender.map((s) => {
           const isHighlighted = s._id === highlightSpoolId;
+          // Scroll to the DEEP-LINK TARGET row, not the highlighted one: the
+          // highlight is set after first render and only changes colors, so RN
+          // wouldn't re-fire layout — the scroll would never run for a spool
+          // below the fold. Keying on spoolParam attaches onLayout from the
+          // first render, so it fires on mount (Codex P2).
+          const isDeepLinkTarget = !!spoolParam && s._id === spoolParam;
           return (
             <SpoolRow
               key={s._id}
@@ -310,7 +321,7 @@ export default function FilamentDetailScreen() {
               onUpdated={handleSpoolUpdated}
               onLocalPatch={handleLocalPatch}
               onLayoutY={
-                isHighlighted
+                isDeepLinkTarget
                   ? (y) => {
                       if (!scrolledToSpool.current) {
                         scrolledToSpool.current = true;

--- a/packages/mobile/src/app/filament/[id].tsx
+++ b/packages/mobile/src/app/filament/[id].tsx
@@ -518,7 +518,7 @@ function SpoolRow({
         <Pressable
           style={[styles.smallButton, { backgroundColor: c.tint }, saving === 'weight' && styles.disabled]}
           onPress={saveWeight}
-          disabled={saving === 'weight'}
+          disabled={saving !== null}
         >
           <Text style={[styles.smallButtonText, { color: c.onTint }]}>
             {saving === 'weight' ? '…' : 'Save'}
@@ -538,7 +538,7 @@ function SpoolRow({
                 { borderColor: active ? c.tint : c.border, backgroundColor: active ? c.tint : 'transparent' },
               ]}
               onPress={() => move(loc._id, loc.name)}
-              disabled={saving === loc._id}
+              disabled={saving !== null}
             >
               <Text style={[styles.chipText, { color: active ? c.onTint : c.text }]}>{loc.name}</Text>
             </Pressable>
@@ -553,7 +553,7 @@ function SpoolRow({
             },
           ]}
           onPress={() => move(null)}
-          disabled={saving === 'none'}
+          disabled={saving !== null}
         >
           <Text style={[styles.chipText, { color: !spool.locationId ? c.onTint : c.text }]}>None</Text>
         </Pressable>
@@ -571,7 +571,7 @@ function SpoolRow({
           saving === 'retire' && styles.disabled,
         ]}
         onPress={toggleRetire}
-        disabled={saving === 'retire'}
+        disabled={saving !== null}
       >
         <Text style={[styles.smallButtonText, { color: spool.retired ? c.onTint : c.text }]}>
           {saving === 'retire' ? '…' : spool.retired ? 'Un-retire' : 'Retire'}
@@ -593,7 +593,7 @@ function SpoolRow({
         <Pressable
           style={[styles.smallButton, { backgroundColor: c.tint }, saving === 'usage' && styles.disabled]}
           onPress={logUsage}
-          disabled={saving === 'usage'}
+          disabled={saving !== null}
         >
           <Text style={[styles.smallButtonText, { color: c.onTint }]}>
             {saving === 'usage' ? '…' : 'Log'}
@@ -610,7 +610,7 @@ function SpoolRow({
           saving === 'dry' && styles.disabled,
         ]}
         onPress={logDryCycle}
-        disabled={saving === 'dry'}
+        disabled={saving !== null}
       >
         <Text style={[styles.smallButtonText, { color: c.text }]}>
           {saving === 'dry' ? '…' : 'Log dry cycle'}

--- a/packages/mobile/src/app/filament/[id].tsx
+++ b/packages/mobile/src/app/filament/[id].tsx
@@ -70,6 +70,7 @@ function buildDetailRows(f: Filament): { label: string; value: string }[] {
 function usePendingSync(api: Api | null, setReloadKey: React.Dispatch<React.SetStateAction<number>>): number {
   const [pending, setPending] = useState(0);
   const prevPending = useRef(0);
+  const reloadTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Read initial count after mount (async IIFE — state set after await, not
   // synchronously). Then track changes: a DROP means a flush applied writes —
@@ -87,13 +88,20 @@ function usePendingSync(api: Api | null, setReloadKey: React.Dispatch<React.SetS
       }
     })();
     const unsub = subscribePending((count) => {
-      if (count < prevPending.current) setReloadKey((k) => k + 1);
+      // A multi-item flush drops the count once per entry; DEBOUNCE the refetch
+      // so a reconnect with many queued writes coalesces into a single reload
+      // after the flush settles, not one API burst per item (Codex P2).
+      if (count < prevPending.current) {
+        if (reloadTimer.current) clearTimeout(reloadTimer.current);
+        reloadTimer.current = setTimeout(() => setReloadKey((k) => k + 1), 500);
+      }
       prevPending.current = count;
       setPending(count);
     });
     return () => {
       active = false;
       unsub();
+      if (reloadTimer.current) clearTimeout(reloadTimer.current);
     };
   }, [setReloadKey]);
 

--- a/packages/mobile/src/app/filament/[id].tsx
+++ b/packages/mobile/src/app/filament/[id].tsx
@@ -116,6 +116,8 @@ export default function FilamentDetailScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  // Show retired spools too (so the Un-retire action is reachable, Codex P2).
+  const [showRetired, setShowRetired] = useState(false);
   // GH #595/#693: arrived via a spool deep-link QR (`?spool=<id>`) — briefly
   // highlight that spool's card once the filament (with its spools) loads.
   const [highlightSpoolId, setHighlightSpoolId] = useState<string | null>(null);
@@ -227,13 +229,19 @@ export default function FilamentDetailScreen() {
   const hasColor = !!filament.color || (filament.secondaryColors?.length ?? 0) > 0;
   const swatchColor = filament.color || filament.secondaryColors?.[0] || '#808080';
 
-  // Feature A: if the deep-linked spool is retired and not in activeSpools, include it.
+  // Which spools to render: active ones, plus retired ones when the user has
+  // toggled them on (so Un-retire is reachable, Codex P2), plus a retired
+  // deep-link target even when the toggle is off (Feature A).
   const deepLinkedSpool = spoolParam ? allSpools.find((s) => s._id === spoolParam) : undefined;
   const deepLinkedIsRetiredExtra =
-    deepLinkedSpool?.retired && !activeSpools.some((s) => s._id === spoolParam);
-  const spoolsToRender: Spool[] = deepLinkedIsRetiredExtra
-    ? [...activeSpools, deepLinkedSpool as Spool]
-    : activeSpools;
+    !showRetired &&
+    deepLinkedSpool?.retired &&
+    !activeSpools.some((s) => s._id === spoolParam);
+  const spoolsToRender: Spool[] = showRetired
+    ? allSpools
+    : deepLinkedIsRetiredExtra
+      ? [...activeSpools, deepLinkedSpool as Spool]
+      : activeSpools;
 
   // The spool PUT returns the RAW (unresolved) filament — for a variant that
   // inherits density / temps / weights from its parent, those come back null.
@@ -334,6 +342,17 @@ export default function FilamentDetailScreen() {
           );
         })
       )}
+
+      {retiredCount > 0 && (
+        <Pressable
+          style={[styles.retiredToggle, { borderColor: c.border }]}
+          onPress={() => setShowRetired((v) => !v)}
+        >
+          <Text style={[styles.retiredToggleText, { color: c.muted }]}>
+            {showRetired ? 'Hide retired' : `Show ${retiredCount} retired`}
+          </Text>
+        </Pressable>
+      )}
     </ScrollView>
   );
 }
@@ -367,28 +386,30 @@ function SpoolRow({
   // Feature B: log usage input state.
   const [usageGrams, setUsageGrams] = useState('');
 
-  /** Feature C: route every spool mutation through the offline write queue. */
-  /** Returns true when the write went through or was queued; false on a real
-   * server error (so callers can keep the user's input to retry). */
+  /** Feature C: route every spool mutation through the offline write queue.
+   * Returns `{ ok }` — false on a real server error so callers can keep the
+   * user's input to retry — and the server's `filament` when it went through
+   * live (callers refresh from the authoritative state rather than props). */
   async function runWrite(
     saveKey: string,
     label: string,
     write: WriteOp,
     optimisticPatch: Partial<Spool>,
-  ): Promise<boolean> {
+  ): Promise<{ ok: boolean; filament?: Filament }> {
     setSaving(saveKey);
     try {
       const result = await submitWrite(api, { filamentId, spoolId: spool._id, label, write });
       if (result.queued) {
         onLocalPatch(spool._id, optimisticPatch);
         Alert.alert('Saved offline', 'This change will sync when the server is reachable.');
-      } else {
-        onUpdated(result.result as Filament);
+        return { ok: true };
       }
-      return true;
+      const f = result.result as Filament;
+      onUpdated(f);
+      return { ok: true, filament: f };
     } catch (e) {
       Alert.alert('Update failed', (e as Error).message);
-      return false;
+      return { ok: false };
     } finally {
       setSaving(null);
     }
@@ -439,19 +460,23 @@ function SpoolRow({
       spool.totalWeight == null ? undefined : Math.max(0, spool.totalWeight - g);
     const optimisticPatch: Partial<Spool> =
       optimisticTotalWeight !== undefined ? { totalWeight: optimisticTotalWeight } : {};
-    const ok = await runWrite(
+    const res = await runWrite(
       'usage',
       `Use ${g} g`,
       { kind: 'logUsage', grams: g },
       optimisticPatch,
     );
-    if (ok) {
+    if (res.ok) {
       setUsageGrams('');
-      // Reflect the decrement in the remaining-weight field too — otherwise it
-      // keeps the pre-usage value and a later Save writes it back, undoing the
-      // usage (Codex P2). Usage is online-only (not queued), so `remaining`
-      // here minus g equals the server's new remaining.
-      if (remaining != null) setGrams(String(Math.max(0, remaining - g)));
+      // Refresh the remaining-weight field from the SERVER's authoritative
+      // spool, not the pre-request value — the weight may have changed
+      // server-side since this screen loaded (another device / print history),
+      // and a stale value would be written back on a later Save (Codex P2).
+      // Usage is online-only (never queued), so res.filament is present.
+      const updated = res.filament?.spools?.find((sp) => sp._id === spool._id);
+      if (updated?.totalWeight != null) {
+        setGrams(String(Math.max(0, Math.round(updated.totalWeight - tare))));
+      }
     }
   }
 
@@ -474,7 +499,10 @@ function SpoolRow({
       ]}
       onLayout={onLayoutY ? (e) => onLayoutY(e.nativeEvent.layout.y) : undefined}
     >
-      <Text style={[styles.cardTitle, { color: c.text }]}>{spool.label || 'Spool'}</Text>
+      <Text style={[styles.cardTitle, { color: c.text }]}>
+        {spool.label || 'Spool'}
+        {spool.retired ? <Text style={{ color: c.muted, fontWeight: '400' }}> · retired</Text> : null}
+      </Text>
 
       <Text style={[styles.fieldLabel, { color: c.muted }]}>Remaining filament (g)</Text>
       <View style={styles.row}>
@@ -641,6 +669,15 @@ const styles = StyleSheet.create({
   },
   chipText: { fontSize: 14 },
   disabled: { opacity: 0.5 },
+  retiredToggle: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    alignSelf: 'flex-start',
+    marginTop: 14,
+  },
+  retiredToggleText: { fontSize: 14, fontWeight: '600' },
   pendingPill: {
     borderWidth: 1,
     borderRadius: 12,

--- a/packages/mobile/src/app/scan-qr.tsx
+++ b/packages/mobile/src/app/scan-qr.tsx
@@ -44,15 +44,32 @@ export default function ScanQrScreen() {
       // Filament DB labels encode either a deep-link URL (/filaments/{id}, with an
       // optional ?spool=<id> for spool-specific labels — GH #595) or a bare
       // instanceId. Parse the URL form first; otherwise resolve via match.
+      const api = createApi({ baseUrl, apiKey });
       const parsed = parseFilamentDeepLink(data);
       if (parsed) {
+        // Spool deep-link: resolve the spool server-side (the single-spool
+        // endpoint) so the filament id comes authoritatively from the spool,
+        // falling back to the id embedded in the URL when the server can't
+        // resolve it (an older server without the endpoint, or a transient
+        // error — the URL still carries a usable filament id).
+        if (parsed.spool) {
+          try {
+            const { filament } = await api.getSpool(parsed.spool);
+            router.replace({
+              pathname: '/filament/[id]',
+              params: { id: filament._id, spool: parsed.spool },
+            });
+            return;
+          } catch {
+            // fall through to the URL-embedded filament id below
+          }
+        }
         router.replace({
           pathname: '/filament/[id]',
           params: parsed.spool ? { id: parsed.id, spool: parsed.spool } : { id: parsed.id },
         });
         return;
       }
-      const api = createApi({ baseUrl, apiKey });
       const res = await api.matchByInstanceId(data.trim());
       if (res.match?._id) {
         router.replace({ pathname: '/filament/[id]', params: { id: res.match._id } });

--- a/packages/mobile/src/lib/api.ts
+++ b/packages/mobile/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   Location,
   MatchResult,
   NfcDecodeResponse,
+  Spool,
 } from './types';
 
 /**
@@ -109,12 +110,40 @@ export function createApi(cfg: ApiConfig) {
         method: 'POST',
         body: JSON.stringify({ tagData, overrides, spoolRemainingGrams }),
       }),
-    /** Update a spool — location and/or remaining weight (server converts). */
+    /** Update a spool — location, remaining weight, and/or retired (server converts). */
     updateSpool: (filamentId: string, spoolId: string, patch: Record<string, unknown>) =>
       request<Filament>(
         cfg,
         `/api/filaments/${encodeURIComponent(filamentId)}/spools/${encodeURIComponent(spoolId)}`,
         { method: 'PUT', body: JSON.stringify(patch) },
+      ),
+    /**
+     * Resolve a single spool by id to its (inheritance-resolved) filament + the
+     * spool itself. Powers spool-level deep links — a label QR's `?spool=` link
+     * opens straight to that spool without knowing the parent filament up front.
+     */
+    getSpool: (spoolId: string) =>
+      request<{ filament: Filament; spool: Spool }>(
+        cfg,
+        `/api/spools/${encodeURIComponent(spoolId)}`,
+      ),
+    /** Log filament usage — decrements the spool's remaining weight by `grams`. */
+    logUsage: (filamentId: string, spoolId: string, grams: number, jobLabel?: string) =>
+      request<Filament>(
+        cfg,
+        `/api/filaments/${encodeURIComponent(filamentId)}/spools/${encodeURIComponent(spoolId)}/usage`,
+        { method: 'POST', body: JSON.stringify({ grams, ...(jobLabel ? { jobLabel } : {}) }) },
+      ),
+    /** Log a dry-box cycle for a spool (temperature / duration / notes). */
+    logDryCycle: (
+      filamentId: string,
+      spoolId: string,
+      cycle: { tempC?: number; durationMin?: number; notes?: string },
+    ) =>
+      request<Filament>(
+        cfg,
+        `/api/filaments/${encodeURIComponent(filamentId)}/spools/${encodeURIComponent(spoolId)}/dry-cycles`,
+        { method: 'POST', body: JSON.stringify(cycle) },
       ),
   };
 }

--- a/packages/mobile/src/lib/serverConfig.tsx
+++ b/packages/mobile/src/lib/serverConfig.tsx
@@ -1,6 +1,8 @@
 import * as SecureStore from 'expo-secure-store';
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 
+import { clearQueue } from './writeQueue';
+
 /**
  * The server connection (base URL + optional API key), persisted in the OS
  * secure store (iOS Keychain / Android Keystore) — never plain storage, since
@@ -57,6 +59,13 @@ export function ServerConfigProvider({ children }: { children: ReactNode }) {
       throw new Error('Enter a full http:// or https:// address, e.g. http://192.168.1.50:3456');
     }
     const key = cfg.apiKey?.trim() || null;
+    // If the server address changes, drop any queued offline writes — they were
+    // made against the previous server and must not replay to a different
+    // Filament DB instance (Codex P2 on #709). Validation above has passed, so
+    // we only clear on a genuine, accepted change of address.
+    if (url !== baseUrl) {
+      await clearQueue();
+    }
     if (url) await SecureStore.setItemAsync(BASE_URL_KEY, url);
     else await SecureStore.deleteItemAsync(BASE_URL_KEY);
     if (key) await SecureStore.setItemAsync(API_KEY_KEY, key);

--- a/packages/mobile/src/lib/writeQueue.ts
+++ b/packages/mobile/src/lib/writeQueue.ts
@@ -178,6 +178,13 @@ export async function submitWrite(
   // e.g. queued remaining=100 then a live remaining=50, or a queued SET that
   // replays over a live usage decrement).
   if ((await pendingCount()) > 0) {
+    // First try to drain — the server may be reachable now even though no
+    // mount/focus/foreground flush has fired, so we shouldn't enqueue/block
+    // unnecessarily and leave the user stuck (Codex P2). A concurrent flush
+    // (the guard) no-ops here; we then re-check below.
+    await flushQueue(api).catch(() => {});
+  }
+  if ((await pendingCount()) > 0) {
     if (isQueueable(entry.write)) {
       // Idempotent — enqueue it to drain in order behind the pending writes.
       await enqueue(entry);

--- a/packages/mobile/src/lib/writeQueue.ts
+++ b/packages/mobile/src/lib/writeQueue.ts
@@ -114,12 +114,20 @@ export function applyWrite(api: Api, q: QueuedWrite): Promise<unknown> {
   }
 }
 
+// True for the duration of a flushQueue run. Read by enqueue's cap-trim so it
+// never evicts the in-flight head (index 0) that a flush is mid-request on.
+let flushing = false;
+
 async function enqueue(entry: Omit<QueuedWrite, 'id' | 'createdAt'>): Promise<void> {
   await withLock(async () => {
     const list = await readQueue();
     list.push({ ...entry, id: nextId(), createdAt: Date.now() });
-    // Drop the oldest if over the cap.
-    while (list.length > MAX_QUEUE) list.shift();
+    // Drop the oldest over the cap — but never index 0 while a flush is in
+    // flight (that entry is mid-request; removing it would lose it). Drop the
+    // next-oldest instead in that window.
+    while (list.length > MAX_QUEUE) {
+      list.splice(flushing && list.length > 1 ? 1 : 0, 1);
+    }
     await writeQueueRaw(list);
     notify(list.length);
   });
@@ -171,54 +179,63 @@ export interface FlushResult {
   remaining: number;
 }
 
-let flushing = false;
+/**
+ * Whether an error status is transient/recoverable (keep the queued write and
+ * retry later) vs a permanent rejection of the request (drop it, else it wedges
+ * the FIFO queue). Auth (401/403) is transient — the user can fix a stale API
+ * key and the edit must survive until then (Codex P1). Network (0), timeout
+ * (408), rate-limit (429) and server errors (5xx) are transient too. Other 4xx
+ * (400/404/409/410/422…) mean the request is bad/gone — drop.
+ */
+function isTransient(status: number): boolean {
+  return (
+    status === 0 ||
+    status === 401 ||
+    status === 403 ||
+    status === 408 ||
+    status === 429 ||
+    status >= 500
+  );
+}
 
 /**
- * Replay queued writes FIFO. Stops at the first network failure (still
- * offline); drops a write the server rejects (4xx/5xx — it would never
- * succeed). Safe to call repeatedly; a concurrent call is a no-op. Only
- * idempotent ops are ever in the queue (see submitWrite), so the at-least-once
- * replay that a lost-but-committed response causes is harmless.
+ * Replay queued writes FIFO. The head is PEEKED, not removed, before its
+ * network call: if the app is killed mid-request the entry survives in storage
+ * and is retried next flush (safe because only idempotent ops are queued — a
+ * lost-but-committed response just re-applies harmlessly; Codex P2). enqueue's
+ * cap-trim skips the in-flight head so a concurrent enqueue can't evict it. A
+ * transient error (network / auth / server) stops the flush and KEEPS the head;
+ * a permanent client error drops it so it can't wedge the queue. Concurrent
+ * calls are a no-op.
  */
 export async function flushQueue(api: Api): Promise<FlushResult> {
   if (flushing) return { flushed: 0, dropped: 0, remaining: await pendingCount() };
   flushing = true;
   let flushed = 0;
   let dropped = 0;
+  const removeById = (id: string) =>
+    withLock(async () => {
+      const list = await readQueue();
+      const idx = list.findIndex((e) => e.id === id);
+      if (idx >= 0) {
+        list.splice(idx, 1);
+        await writeQueueRaw(list);
+        notify(list.length);
+      }
+    });
   try {
     for (;;) {
-      // CLAIM the head — remove it under lock BEFORE the network call — so a
-      // concurrent enqueue at the cap can't evict the in-flight entry from the
-      // front and silently lose it (Codex P3). It's restored below if the
-      // server is still unreachable.
-      const head = await withLock(async () => {
-        const list = await readQueue();
-        const h = list.shift();
-        if (h) {
-          await writeQueueRaw(list);
-          notify(list.length);
-        }
-        return h ?? null;
-      });
+      // Peek the head WITHOUT removing it — durability across a crash/kill.
+      const head = await withLock(async () => (await readQueue())[0] ?? null);
       if (!head) break;
       try {
         await applyWrite(api, head);
         flushed++;
+        await removeById(head.id);
       } catch (e) {
-        if (e instanceof ApiError && e.status === 0) {
-          // Still offline — put the claimed head back at the front and stop.
-          // If concurrent enqueues filled the queue while it was in flight,
-          // trim from the NEWEST end so the restored (oldest) head survives.
-          await withLock(async () => {
-            const list = await readQueue();
-            list.unshift(head);
-            while (list.length > MAX_QUEUE) list.pop();
-            await writeQueueRaw(list);
-            notify(list.length);
-          });
-          break;
-        }
-        dropped++; // server rejected it (already removed) — drop so it can't wedge the queue
+        if (e instanceof ApiError && isTransient(e.status)) break; // keep it, stop
+        dropped++; // permanent rejection — drop so it can't wedge the queue
+        await removeById(head.id);
       }
     }
   } finally {

--- a/packages/mobile/src/lib/writeQueue.ts
+++ b/packages/mobile/src/lib/writeQueue.ts
@@ -102,6 +102,18 @@ export async function pendingCount(): Promise<number> {
   return withLock(async () => (await readQueue()).length);
 }
 
+/**
+ * Drop all queued writes. Called when the configured server changes — queued
+ * edits were made against the previous server and must NOT replay to a
+ * different Filament DB instance (wrong spools / 404s). Codex P2 on #709.
+ */
+export async function clearQueue(): Promise<void> {
+  await withLock(async () => {
+    await writeQueueRaw([]);
+    notify(0);
+  });
+}
+
 /** Dispatch one queued write to the matching API call. */
 export function applyWrite(api: Api, q: QueuedWrite): Promise<unknown> {
   switch (q.write.kind) {
@@ -161,14 +173,21 @@ export async function submitWrite(
   api: Api,
   entry: Omit<QueuedWrite, 'id' | 'createdAt'>,
 ): Promise<SubmitResult> {
-  // FIFO ordering: if queueable writes are already pending, enqueue this one
-  // too instead of sending it live. Going live now would let an OLDER queued
-  // write replay on top of this newer value on the next flush and overwrite it
-  // (Codex P1, e.g. queued remaining=100 then a live remaining=50). The pending
-  // writes drain in order on the next flush, this one after them.
-  if (isQueueable(entry.write) && (await pendingCount()) > 0) {
-    await enqueue(entry);
-    return { queued: true };
+  // FIFO ordering: while any write is already pending, a live write would let
+  // an OLDER queued write replay on top of it on the next flush (Codex P1/P2,
+  // e.g. queued remaining=100 then a live remaining=50, or a queued SET that
+  // replays over a live usage decrement).
+  if ((await pendingCount()) > 0) {
+    if (isQueueable(entry.write)) {
+      // Idempotent — enqueue it to drain in order behind the pending writes.
+      await enqueue(entry);
+      return { queued: true };
+    }
+    // Non-idempotent (usage / dry cycle) can't be queued safely, so it must
+    // wait for the queue to drain rather than apply out of order.
+    throw new Error(
+      'You have unsynced offline changes. Let them sync first, then log usage or a dry cycle.',
+    );
   }
   try {
     const result = await applyWrite(api, { ...entry, id: 'live', createdAt: 0 });

--- a/packages/mobile/src/lib/writeQueue.ts
+++ b/packages/mobile/src/lib/writeQueue.ts
@@ -248,15 +248,16 @@ export async function flushQueue(api: Api): Promise<FlushResult> {
   flushing = true;
   let flushed = 0;
   let dropped = 0;
-  const removeById = (id: string) =>
+  // Remove a processed entry by id; returns false if it was no longer present.
+  const removeById = (id: string): Promise<boolean> =>
     withLock(async () => {
       const list = await readQueue();
       const idx = list.findIndex((e) => e.id === id);
-      if (idx >= 0) {
-        list.splice(idx, 1);
-        await writeQueueRaw(list);
-        notify(list.length);
-      }
+      if (idx < 0) return false;
+      list.splice(idx, 1);
+      await writeQueueRaw(list);
+      notify(list.length);
+      return true;
     });
   try {
     for (;;) {
@@ -266,12 +267,15 @@ export async function flushQueue(api: Api): Promise<FlushResult> {
       try {
         await applyWrite(api, head);
         flushed++;
-        await removeById(head.id);
       } catch (e) {
         if (e instanceof ApiError && isTransient(e.status)) break; // keep it, stop
-        dropped++; // permanent rejection — drop so it can't wedge the queue
-        await removeById(head.id);
+        dropped++; // permanent rejection — fall through and remove
       }
+      // Remove the processed head. If it's already gone, the queue was cleared
+      // under us (a server change called clearQueue) and may now hold entries
+      // for a DIFFERENT server — stop rather than replay them via this now-stale
+      // api (Codex P2).
+      if (!(await removeById(head.id))) break;
     }
   } finally {
     flushing = false;

--- a/packages/mobile/src/lib/writeQueue.ts
+++ b/packages/mobile/src/lib/writeQueue.ts
@@ -161,6 +161,15 @@ export async function submitWrite(
   api: Api,
   entry: Omit<QueuedWrite, 'id' | 'createdAt'>,
 ): Promise<SubmitResult> {
+  // FIFO ordering: if queueable writes are already pending, enqueue this one
+  // too instead of sending it live. Going live now would let an OLDER queued
+  // write replay on top of this newer value on the next flush and overwrite it
+  // (Codex P1, e.g. queued remaining=100 then a live remaining=50). The pending
+  // writes drain in order on the next flush, this one after them.
+  if (isQueueable(entry.write) && (await pendingCount()) > 0) {
+    await enqueue(entry);
+    return { queued: true };
+  }
   try {
     const result = await applyWrite(api, { ...entry, id: 'live', createdAt: 0 });
     return { queued: false, result };

--- a/packages/mobile/src/lib/writeQueue.ts
+++ b/packages/mobile/src/lib/writeQueue.ts
@@ -1,0 +1,228 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ApiError, type Api } from './api';
+
+/**
+ * Offline write queue (mobile Phase 3).
+ *
+ * Spool edits (move location, set remaining weight, retire, log usage / dry
+ * cycle) are mutations. When the server is unreachable, instead of failing the
+ * edit we persist it here and replay it FIFO once the server is reachable
+ * again — so a scan-and-update on a flaky shop network isn't lost.
+ *
+ * Design:
+ *   - Only IDEMPOTENT ops are queued — currently `updateSpool` (remaining
+ *     weight / location / retire), which are absolute SETs, so replaying one is
+ *     a no-op. logUsage / logDryCycle DECREMENT / APPEND, so replaying them
+ *     after a committed-but-lost response (e.g. a slow LAN past the 15s
+ *     request timeout) would double-apply — they therefore require live
+ *     connectivity and are never queued (Codex review). Offline support for
+ *     them would need a server-side idempotency key; deferred.
+ *   - Network failures (ApiError status 0 — see api.ts) queue a queueable op.
+ *     A real server rejection (4xx/5xx) is NOT queued: it would never succeed,
+ *     so it surfaces to the user immediately (submitWrite) or is dropped on
+ *     flush.
+ *   - flushQueue CLAIMS the head (removes it) before the network call so a
+ *     concurrent enqueue at the cap can't evict the in-flight entry; the head
+ *     is restored at the front if the server is still unreachable.
+ *   - All queue reads/writes funnel through a tiny async mutex so a flush and
+ *     an enqueue can't interleave their load→save and clobber each other.
+ *   - Persisted in AsyncStorage (NOT SecureStore — it's not a credential, and
+ *     SecureStore caps values at ~2KB on Android, too small for a queue).
+ */
+
+const QUEUE_KEY = 'filamentdb.writeQueue.v1';
+// Bound the queue so a phone left offline indefinitely can't grow it without
+// limit. Oldest entries are dropped first if the cap is exceeded.
+const MAX_QUEUE = 200;
+
+export type WriteOp =
+  | { kind: 'updateSpool'; patch: Record<string, unknown> }
+  | { kind: 'logUsage'; grams: number; jobLabel?: string }
+  | { kind: 'logDryCycle'; cycle: { tempC?: number; durationMin?: number; notes?: string } };
+
+export interface QueuedWrite {
+  id: string;
+  createdAt: number;
+  filamentId: string;
+  spoolId: string;
+  /** Human-readable summary for the pending-writes UI. */
+  label: string;
+  write: WriteOp;
+}
+
+// ── async mutex: serialize all load→modify→save sequences ──────────────────
+let lock: Promise<unknown> = Promise.resolve();
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const run = lock.then(fn, fn);
+  // Keep the chain alive even if `fn` rejects, but don't leak the rejection.
+  lock = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+let seq = 0;
+function nextId(): string {
+  // Date.now() is fine in RN (the no-Date rule is workflow-script-only); the
+  // seq counter disambiguates writes enqueued within the same millisecond.
+  return `${Date.now()}-${seq++}`;
+}
+
+async function readQueue(): Promise<QueuedWrite[]> {
+  const raw = await AsyncStorage.getItem(QUEUE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as QueuedWrite[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeQueueRaw(list: QueuedWrite[]): Promise<void> {
+  if (list.length === 0) await AsyncStorage.removeItem(QUEUE_KEY);
+  else await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(list));
+}
+
+// ── change subscription so the UI can show a live pending count ────────────
+type Listener = (count: number) => void;
+const listeners = new Set<Listener>();
+function notify(count: number): void {
+  for (const l of listeners) l(count);
+}
+export function subscribePending(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export async function pendingCount(): Promise<number> {
+  return withLock(async () => (await readQueue()).length);
+}
+
+/** Dispatch one queued write to the matching API call. */
+export function applyWrite(api: Api, q: QueuedWrite): Promise<unknown> {
+  switch (q.write.kind) {
+    case 'updateSpool':
+      return api.updateSpool(q.filamentId, q.spoolId, q.write.patch);
+    case 'logUsage':
+      return api.logUsage(q.filamentId, q.spoolId, q.write.grams, q.write.jobLabel);
+    case 'logDryCycle':
+      return api.logDryCycle(q.filamentId, q.spoolId, q.write.cycle);
+  }
+}
+
+async function enqueue(entry: Omit<QueuedWrite, 'id' | 'createdAt'>): Promise<void> {
+  await withLock(async () => {
+    const list = await readQueue();
+    list.push({ ...entry, id: nextId(), createdAt: Date.now() });
+    // Drop the oldest if over the cap.
+    while (list.length > MAX_QUEUE) list.shift();
+    await writeQueueRaw(list);
+    notify(list.length);
+  });
+}
+
+export interface SubmitResult {
+  /** true when the write was queued because the server was unreachable. */
+  queued: boolean;
+  /** The server's response when it went through synchronously. */
+  result?: unknown;
+}
+
+/**
+ * Whether an op is safe to queue + replay. Only idempotent ops qualify:
+ * replaying an `updateSpool` (absolute SET) is a no-op, but logUsage /
+ * logDryCycle decrement / append and would double-apply if a committed write's
+ * response was lost (Codex review). Non-queueable ops require live connectivity.
+ */
+function isQueueable(write: WriteOp): boolean {
+  return write.kind === 'updateSpool';
+}
+
+/**
+ * Perform a write, queueing it if the server is unreachable AND the op is
+ * idempotent (safe to replay). A real server error (4xx/5xx) — or a network
+ * failure on a non-idempotent op (usage / dry cycle) — is re-thrown so the
+ * caller surfaces it: queueing a request the server rejected would fail
+ * forever, and replaying a decrement/append could double-apply.
+ */
+export async function submitWrite(
+  api: Api,
+  entry: Omit<QueuedWrite, 'id' | 'createdAt'>,
+): Promise<SubmitResult> {
+  try {
+    const result = await applyWrite(api, { ...entry, id: 'live', createdAt: 0 });
+    return { queued: false, result };
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 0 && isQueueable(entry.write)) {
+      await enqueue(entry);
+      return { queued: true };
+    }
+    throw e;
+  }
+}
+
+export interface FlushResult {
+  flushed: number;
+  dropped: number;
+  remaining: number;
+}
+
+let flushing = false;
+
+/**
+ * Replay queued writes FIFO. Stops at the first network failure (still
+ * offline); drops a write the server rejects (4xx/5xx — it would never
+ * succeed). Safe to call repeatedly; a concurrent call is a no-op. Only
+ * idempotent ops are ever in the queue (see submitWrite), so the at-least-once
+ * replay that a lost-but-committed response causes is harmless.
+ */
+export async function flushQueue(api: Api): Promise<FlushResult> {
+  if (flushing) return { flushed: 0, dropped: 0, remaining: await pendingCount() };
+  flushing = true;
+  let flushed = 0;
+  let dropped = 0;
+  try {
+    for (;;) {
+      // CLAIM the head — remove it under lock BEFORE the network call — so a
+      // concurrent enqueue at the cap can't evict the in-flight entry from the
+      // front and silently lose it (Codex P3). It's restored below if the
+      // server is still unreachable.
+      const head = await withLock(async () => {
+        const list = await readQueue();
+        const h = list.shift();
+        if (h) {
+          await writeQueueRaw(list);
+          notify(list.length);
+        }
+        return h ?? null;
+      });
+      if (!head) break;
+      try {
+        await applyWrite(api, head);
+        flushed++;
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 0) {
+          // Still offline — put the claimed head back at the front and stop.
+          // If concurrent enqueues filled the queue while it was in flight,
+          // trim from the NEWEST end so the restored (oldest) head survives.
+          await withLock(async () => {
+            const list = await readQueue();
+            list.unshift(head);
+            while (list.length > MAX_QUEUE) list.pop();
+            await writeQueueRaw(list);
+            notify(list.length);
+          });
+          break;
+        }
+        dropped++; // server rejected it (already removed) — drop so it can't wedge the queue
+      }
+    }
+  } finally {
+    flushing = false;
+  }
+  return { flushed, dropped, remaining: await pendingCount() };
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -4709,6 +4709,52 @@
         }
       }
     },
+    "/api/spools/{spoolId}": {
+      "get": {
+        "tags": [
+          "Spools"
+        ],
+        "summary": "Resolve a single spool by id (v1.43)",
+        "description": "Resolve a spool's subdocument id to its owning filament (inheritance-resolved for variants) plus the spool itself. Powers the mobile scanner's spool-level deep links — the label QR's ?spool=<spoolId> link resolves here so the phone can open the filament detail with that spool highlighted without knowing the parent filament id up front.",
+        "parameters": [
+          {
+            "name": "spoolId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The spool subdocument _id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The owning filament + the spool",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "filament": {
+                      "type": "object"
+                    },
+                    "spool": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed spool id"
+          },
+          "404": {
+            "description": "No spool with that id (or its owning filament is trashed)"
+          }
+        }
+      }
+    },
     "/api/spools/by-location": {
       "get": {
         "tags": [

--- a/src/app/api/spools/[spoolId]/route.ts
+++ b/src/app/api/spools/[spoolId]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import mongoose from "mongoose";
+import dbConnect from "@/lib/mongodb";
+import Filament from "@/models/Filament";
+import { resolveFilament } from "@/lib/resolveFilament";
+import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+
+/**
+ * GET /api/spools/{spoolId}
+ *
+ * Resolve a single spool by its subdocument id to the filament that owns it
+ * plus the spool itself. Powers the mobile scanner's spool-level deep links
+ * (the label QR's `?spool=<spoolId>` link, GH #595): the phone scans the QR,
+ * resolves the spool here, and opens the filament detail with that spool
+ * highlighted — without having to know the parent filament id up front.
+ *
+ * The filament is inheritance-resolved (variants get their parent's values)
+ * so the response is a complete view, mirroring `GET /api/filaments/{id}`.
+ * Read-only, so no trusted-origin guard (matches the other GET routes).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ spoolId: string }> },
+) {
+  try {
+    await dbConnect();
+    const { spoolId } = await params;
+
+    if (!mongoose.isValidObjectId(spoolId)) {
+      return errorResponse("Invalid spool id", 400);
+    }
+
+    const filament = await Filament.findOne({
+      "spools._id": spoolId,
+      _deletedAt: null,
+    }).lean();
+    if (!filament) {
+      return errorResponse("Spool not found", 404);
+    }
+
+    // The matched spool subdocument (the query guarantees one exists).
+    const spool = (filament.spools ?? []).find(
+      (s) => String(s._id) === String(spoolId),
+    );
+    if (!spool) {
+      return errorResponse("Spool not found", 404);
+    }
+
+    // Resolve inheritance for variants so the caller gets a complete view.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let resolved: any = filament;
+    if (filament.parentId) {
+      const parent = await Filament.findOne({
+        _id: filament.parentId,
+        _deletedAt: null,
+      }).lean();
+      resolved = resolveFilament(filament, parent);
+    }
+
+    return NextResponse.json({ filament: resolved, spool });
+  } catch (err) {
+    return errorResponseFromCaught(err, "Failed to resolve spool");
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1084,6 +1084,7 @@ export default function Home() {
                 <div className="px-4 py-1">
                   <span className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">{t("spools.export")}</span>
                 </div>
+                {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- a CSV download endpoint, not a page; the new dynamic /api/spools/[spoolId] route makes the linter match this static export-csv path as a "page" */}
                 <a
                   href="/api/spools/export-csv"
                   className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"

--- a/tests/spool-by-id-route.test.ts
+++ b/tests/spool-by-id-route.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/spools/[spoolId]/route";
+
+/**
+ * GET /api/spools/{spoolId} — single-spool resolution (mobile Phase 3
+ * spool-level deep links). Resolves a spool subdocument id to its owning
+ * filament (inheritance-resolved for variants) + the spool itself.
+ */
+describe("GET /api/spools/{spoolId}", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let Filament: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    const filMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
+    Filament = mongoose.models.Filament;
+  });
+
+  function call(spoolId: string) {
+    return GET(new NextRequest(`http://localhost/api/spools/${spoolId}`), {
+      params: Promise.resolve({ spoolId }),
+    });
+  }
+
+  it("resolves a spool to its filament + the spool subdoc", async () => {
+    const f = await Filament.create({
+      name: "Deep Link PLA",
+      vendor: "Acme",
+      type: "PLA",
+      spoolWeight: 200,
+      spools: [
+        { label: "A", totalWeight: 900 },
+        { label: "B", totalWeight: 1200 },
+      ],
+    });
+    const spoolId = String(f.spools[1]._id);
+
+    const res = await call(spoolId);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.filament._id).toBe(String(f._id));
+    expect(body.filament.name).toBe("Deep Link PLA");
+    expect(body.spool._id).toBe(spoolId);
+    expect(body.spool.label).toBe("B");
+    expect(body.spool.totalWeight).toBe(1200);
+  });
+
+  it("resolves inherited fields when the spool's filament is a variant", async () => {
+    const parent = await Filament.create({
+      name: "Parent PLA",
+      vendor: "Acme",
+      type: "PLA",
+      spoolWeight: 250,
+      netFilamentWeight: 1000,
+    });
+    const variant = await Filament.create({
+      name: "Variant Red",
+      vendor: "Acme",
+      type: "PLA",
+      parentId: parent._id,
+      // vendor/type/spoolWeight/netFilamentWeight left to inherit
+      spools: [{ label: "", totalWeight: 1250 }],
+    });
+    const spoolId = String(variant.spools[0]._id);
+
+    const res = await call(spoolId);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.filament._id).toBe(String(variant._id));
+    // inherited from parent
+    expect(body.filament.spoolWeight).toBe(250);
+    expect(body.filament.netFilamentWeight).toBe(1000);
+    expect(body.spool.totalWeight).toBe(1250);
+  });
+
+  it("400 for a malformed spool id", async () => {
+    const res = await call("not-an-objectid");
+    expect(res.status).toBe(400);
+  });
+
+  it("404 for a valid but absent spool id", async () => {
+    const res = await call(String(new mongoose.Types.ObjectId()));
+    expect(res.status).toBe(404);
+  });
+
+  it("404 when the owning filament is soft-deleted", async () => {
+    const f = await Filament.create({
+      name: "Trashed PLA",
+      vendor: "Acme",
+      type: "PLA",
+      spools: [{ label: "", totalWeight: 500 }],
+      _deletedAt: new Date(),
+    });
+    const spoolId = String(f.spools[0]._id);
+
+    const res = await call(spoolId);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Mobile scanner — Phase 3

Three of the four Phase 3 "niceties" from `docs/mobile-app-plan.md` §8. **mDNS auto-discovery follows in its own PR** so its native config (Electron Bonjour advertisement + iOS `NSBonjourServices`/local-network permission + the `react-native-zeroconf` module) can be built and verified on a real device rather than shipped unverified.

### A — Spool-level deep links + single-spool endpoint
- **New `GET /api/spools/{spoolId}`** (`src/app/api/spools/[spoolId]/route.ts`): resolves a spool subdocument id to its owning filament (inheritance-resolved for variants) + the spool. Route test (`tests/spool-by-id-route.test.ts`, 5 cases) + OpenAPI entry.
- The scanner resolves a label's `?spool=` deep link **through** that endpoint (authoritative filament from the spool), with a fallback to the filament id embedded in the URL for older servers / transient errors.
- The detail screen **scrolls to** and shows the deep-linked spool — including when it's **retired** (previously filtered out).

### B — In-app inventory actions
Each spool card gains **retire / un-retire**, **log usage** (grams), and **log dry cycle** — new `api.ts` methods over the existing `/usage`, `/dry-cycles`, and spool-PUT routes.

### C — Offline write queue
- Spool edits made while the server is unreachable are persisted in AsyncStorage and replayed FIFO on reconnect (flush on detail-screen focus + on app foreground), with optimistic local updates and a **"N changes pending sync"** pill.
- **Only idempotent `updateSpool` ops** (weight / location / retire) are queued. `logUsage`/`logDryCycle` decrement/append, so replaying one after a committed-but-lost response would double-apply — they require live connectivity instead. Offline support for them would need a server-side idempotency key (deferred).
- `flushQueue` claims the head **before** its network call so a concurrent cap-eviction can't drop the in-flight entry.

### Verification
- `src/` route: `tsc`, `eslint`, and the new route test pass; OpenAPI documented.
- `packages/mobile`: `tsc` and `expo lint` clean (the mobile package has no unit-test runner — same as Phases 1–2).
- Ran an adversarial multi-dimension review over the queue / detail screen / endpoint before opening this PR; the two confirmed findings (non-idempotent replay; cap-eviction of the in-flight head) are fixed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)