### PR TITLE
fix(web): dark-mode <select> popups rendering light-on-white (#711)

### DIFF
--- a/src/app/bed-types/BedTypeForm.tsx
+++ b/src/app/bed-types/BedTypeForm.tsx
@@ -82,6 +82,10 @@ export default function BedTypeForm({ initialData, onSubmit, onDirtyChange }: Pr
 
   const inputClass =
     "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm dark:text-gray-100 bg-transparent";
+  // GH #711: a <select> needs an explicit dark background so its native option
+  // popup follows dark mode — a transparent bg makes the popup render
+  // light-on-white. Text inputs keep bg-transparent (they have no popup).
+  const selectClass = inputClass.replace("bg-transparent", "bg-white dark:bg-gray-900");
   const labelClass = "block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1";
 
   return (
@@ -100,7 +104,7 @@ export default function BedTypeForm({ initialData, onSubmit, onDirtyChange }: Pr
       <div>
         <label className={labelClass}>{t("bedTypes.form.material")} *</label>
         <select
-          className={inputClass}
+          className={selectClass}
           value={form.material}
           onChange={(e) => updateForm({ material: e.target.value })}
         >

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -914,6 +914,10 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
 
   const inputClass =
     "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-transparent text-gray-900 dark:text-gray-100";
+  // GH #711: a <select> needs an explicit dark background so its native option
+  // popup follows dark mode — a transparent bg makes the popup render
+  // light-on-white. Text inputs keep bg-transparent (they have no popup).
+  const selectClass = inputClass.replace("bg-transparent", "bg-white dark:bg-gray-900");
   const labelClass = "block text-sm font-medium mb-1 text-gray-900 dark:text-gray-100";
 
   // Single source of truth for the submit button label so the duplicate at
@@ -2100,7 +2104,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
         </div>
         <div>
           <label className={labelClass}>{t("form.spoolType")}</label>
-          <select className={inputClass} value={form.spoolType}
+          <select className={selectClass} value={form.spoolType}
             onChange={(e) => setForm({ ...form, spoolType: e.target.value })}>
             <option value="">—</option>
             <option value="plastic">{t("form.spoolType.plastic")}</option>

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -2225,7 +2225,7 @@ function SpoolCard({
       <div className="mt-3 flex items-center gap-2 text-xs">
         <label className="text-gray-500">{t("detail.spool.location")}:</label>
         <select
-          className="px-2 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-transparent"
+          className="px-2 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
           value={spool.locationId ?? ""}
           onChange={(e) => onUpdateLocation(e.target.value || null)}
         >
@@ -2278,7 +2278,7 @@ function SpoolCard({
           <span className="text-gray-400">{t("detail.spool.noPrinterSlots")}</span>
         ) : (
           <select
-            className="px-2 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-transparent disabled:opacity-50"
+            className="px-2 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 disabled:opacity-50"
             value=""
             disabled={spool.retired}
             title={spool.retired ? t("detail.spool.retiredCannotAssign") : undefined}

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -427,7 +427,7 @@ export default function InventoryPage() {
             id="inv-kind"
             value={kind}
             onChange={(e) => setKind(e.target.value)}
-            className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-transparent"
+            className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
           >
             <option value="">{t("inventory.filter.allKinds")}</option>
             <option value="shelf">{t("locations.kind.shelf")}</option>
@@ -940,7 +940,7 @@ function SpoolEditRow({
             }}
             aria-label={t("inventory.moveTo")}
             title={t("inventory.moveTo")}
-            className="text-xs px-1 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-transparent disabled:opacity-50"
+            className="text-xs px-1 py-0.5 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 disabled:opacity-50"
           >
             <option value="">{t("inventory.moveTo")}</option>
             <option value="__none">{t("inventory.noLocation")}</option>

--- a/src/app/locations/LocationForm.tsx
+++ b/src/app/locations/LocationForm.tsx
@@ -83,6 +83,10 @@ export default function LocationForm({ initialData, onSubmit, onDirtyChange }: P
 
   const inputClass =
     "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm dark:text-gray-100 bg-transparent";
+  // GH #711: a <select> needs an explicit dark background so its native option
+  // popup follows dark mode — a transparent bg makes the popup render
+  // light-on-white. Text inputs keep bg-transparent (they have no popup).
+  const selectClass = inputClass.replace("bg-transparent", "bg-white dark:bg-gray-900");
   const labelClass =
     "block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1";
 
@@ -102,7 +106,7 @@ export default function LocationForm({ initialData, onSubmit, onDirtyChange }: P
       <div>
         <label className={labelClass}>{t("locations.form.kind")}</label>
         <select
-          className={inputClass}
+          className={selectClass}
           value={form.kind}
           onChange={(e) => updateForm({ kind: e.target.value })}
         >

--- a/src/app/nozzles/NozzleForm.tsx
+++ b/src/app/nozzles/NozzleForm.tsx
@@ -121,6 +121,10 @@ export default function NozzleForm({ initialData, onSubmit, onDirtyChange }: Pro
 
   const inputClass =
     "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm dark:text-gray-100 bg-transparent";
+  // GH #711: a <select> needs an explicit dark background so its native option
+  // popup follows dark mode — a transparent bg makes the popup render
+  // light-on-white. Text inputs keep bg-transparent (they have no popup).
+  const selectClass = inputClass.replace("bg-transparent", "bg-white dark:bg-gray-900");
   const labelClass = "block text-sm font-medium text-gray-900 dark:text-gray-100 mb-1";
 
   return (
@@ -160,7 +164,7 @@ export default function NozzleForm({ initialData, onSubmit, onDirtyChange }: Pro
         <div>
           <label className={labelClass}>{t("nozzles.form.type")} *</label>
           <select
-            className={inputClass}
+            className={selectClass}
             value={form.type}
             onChange={(e) => updateForm({ type: e.target.value })}
           >

--- a/src/app/printers/PrinterForm.tsx
+++ b/src/app/printers/PrinterForm.tsx
@@ -525,6 +525,10 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
 
   const inputClass =
     "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-transparent text-gray-900 dark:text-gray-100";
+  // GH #711: a <select> needs an explicit dark background so its native option
+  // popup follows dark mode — a transparent bg makes the popup render
+  // light-on-white. Text inputs keep bg-transparent (they have no popup).
+  const selectClass = inputClass.replace("bg-transparent", "bg-white dark:bg-gray-900");
   const labelClass = "block text-sm font-medium mb-1 text-gray-900 dark:text-gray-100";
 
   return (
@@ -691,7 +695,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
                     })}
                   />
                   <select
-                    className={`col-span-5 ${inputClass}`}
+                    className={`col-span-5 ${selectClass}`}
                     value={slot.filamentId ?? ""}
                     onChange={(e) =>
                       updateSlot(slot._uid, {
@@ -711,7 +715,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
                     ))}
                   </select>
                   <select
-                    className={`col-span-3 ${inputClass}`}
+                    className={`col-span-3 ${selectClass}`}
                     value={slot.spoolId ?? ""}
                     onChange={(e) =>
                       updateSlot(slot._uid, { spoolId: e.target.value || null })


### PR DESCRIPTION
## Summary
Fixes #711 — in dark mode the native option popup of several `<select>` controls rendered **light-on-white** (unreadable), reported on the Spool Inventory **Kind** filter.

## Root cause
`globals.css` sets `color-scheme: dark` on `html.dark` (GH #598), which makes OS-drawn popups follow dark mode. **But** a `<select>` with an author-set *transparent* background (`bg-transparent`, no `dark:bg-*`) makes Chromium/Electron draw the option popup with light defaults *regardless* of `color-scheme`. The inherited light text then lands on a white popup → the screenshot in the issue.

The home-page filter selects never had this bug because they carry an explicit `bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100`.

## Fix
Apply that proven pattern to every affected select:
- **4 inline selects** updated directly: inventory Kind filter + per-row move-to; spool location + assign-slot on the filament detail page.
- **5 shared-`inputClass` forms** (Nozzle, Filament `spoolType`, Printer ×2, Location, BedType) get a derived `selectClass = inputClass.replace("bg-transparent", "bg-white dark:bg-gray-900")`, so **text/number inputs keep their transparent fill** (they have no popup) — only `<select>` changes.

## Scope / verification
- Audited **all 20 `<select>` elements** app-wide — the other 11 already had explicit dark backgrounds; **none missed**.
- Audited date/color/datalist controls (also `bg-transparent`): their OS pickers follow `color-scheme`, **not** the host background, so they're not the #711 failure mode and need no change.
- `tsc` clean, `eslint` clean. No test asserts on these classNames. Pure presentational change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)