### PR TITLE
Bump version to 1.44.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.44.0",
+      "version": "1.44.1",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.44.0",
+  "version": "1.44.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.44.0",
+    "version": "1.44.1",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Automated version bump produced by the Release Bump workflow.

Updates package.json, package-lock.json, and public/openapi.json to **1.44.1**.

Auto-merge is enabled — this will land as soon as CI passes.

## After merge
```bash
git checkout main
git pull
git tag v1.44.1
git push origin v1.44.1
```
The tag push triggers the existing `release.yml` build matrix.