### PR TITLE
fix(analytics): readable "Usage by day" chart — scale bars + Y axis (#716)

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useCurrency } from "@/hooks/useCurrency";
 import { Skeleton, SkeletonRegion } from "@/components/Skeleton";
+import { niceAxisScale } from "@/lib/chartScale";
 
 interface AnalyticsData {
   since: string;
@@ -64,6 +65,10 @@ export default function AnalyticsPage() {
     if (!data) return 0;
     return data.usageByDay.reduce((max, d) => Math.max(max, d.grams), 0);
   }, [data]);
+
+  // #716: a rounded axis scale + tick values so the "Usage by day" bars are
+  // readable against gridlines instead of guessing magnitudes by eye.
+  const dayScale = useMemo(() => niceAxisScale(maxDayGrams), [maxDayGrams]);
 
   const maxByFilament = useMemo(() => {
     if (!data) return 0;
@@ -185,24 +190,54 @@ export default function AnalyticsPage() {
               <p className="text-sm text-gray-500">{t("analytics.noData")}</p>
             ) : (
               <div className="border border-gray-200 dark:border-gray-700 rounded p-3">
-                <div className="flex items-end gap-0.5 h-40">
-                  {data.usageByDay.map((d) => {
-                    const pct = maxDayGrams > 0 ? (d.grams / maxDayGrams) * 100 : 0;
-                    return (
-                      <div
-                        key={d.date}
-                        className="flex-1 flex flex-col items-center justify-end"
-                        title={`${d.date}: ${d.grams} g`}
+                <div className="flex">
+                  {/* Y axis: tick labels positioned to line up with the
+                      gridlines (bottom = tick/max). */}
+                  <div className="relative h-40 w-10 shrink-0 mr-2" aria-hidden="true">
+                    {dayScale.ticks.map((tick) => (
+                      <span
+                        key={tick}
+                        className="absolute right-0 -translate-y-1/2 text-[10px] tabular-nums text-gray-400 dark:text-gray-500"
+                        style={{ bottom: `${dayScale.max > 0 ? (tick / dayScale.max) * 100 : 0}%` }}
                       >
-                        <div
-                          className={`w-full ${d.grams > 0 ? "bg-blue-500" : "bg-transparent"} rounded-sm`}
-                          style={{ height: `${pct}%`, minHeight: d.grams > 0 ? "2px" : "0" }}
-                        />
-                      </div>
-                    );
-                  })}
+                        {tick}
+                      </span>
+                    ))}
+                  </div>
+                  {/* Plot: gridlines behind, bars in front. Bars scale against
+                      dayScale.max so the tallest aligns under the top gridline.
+                      The column wrappers are h-full so the % bar height
+                      resolves against a definite height (the prior bug: a
+                      `flex items-end` row doesn't stretch its children, so
+                      `height: N%` collapsed every bar to its 2px minHeight). */}
+                  <div className="relative flex-1 h-40">
+                    {dayScale.ticks.map((tick) => (
+                      <div
+                        key={tick}
+                        className="absolute inset-x-0 border-t border-gray-200 dark:border-gray-800"
+                        style={{ bottom: `${dayScale.max > 0 ? (tick / dayScale.max) * 100 : 0}%` }}
+                      />
+                    ))}
+                    <div className="absolute inset-0 flex items-end gap-0.5">
+                      {data.usageByDay.map((d) => {
+                        const pct = dayScale.max > 0 ? (d.grams / dayScale.max) * 100 : 0;
+                        return (
+                          <div
+                            key={d.date}
+                            className="flex-1 h-full flex flex-col items-center justify-end"
+                            title={`${d.date}: ${d.grams} g`}
+                          >
+                            <div
+                              className={`w-full ${d.grams > 0 ? "bg-blue-500" : "bg-transparent"} rounded-sm`}
+                              style={{ height: `${pct}%`, minHeight: d.grams > 0 ? "2px" : "0" }}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
                 </div>
-                <div className="flex justify-between text-xs text-gray-500 mt-2">
+                <div className="flex justify-between text-xs text-gray-500 mt-2 pl-12">
                   <span>{data.usageByDay[0]?.date}</span>
                   <span>
                     {data.usageByDay[data.usageByDay.length - 1]?.date}

--- a/src/lib/chartScale.ts
+++ b/src/lib/chartScale.ts
@@ -1,0 +1,48 @@
+/**
+ * Compute a "nice" axis scale for a small bar chart — a rounded maximum plus
+ * evenly-spaced tick values — so users can read magnitudes off gridlines
+ * instead of guessing from bar heights (GH #717... see issue #716: the
+ * "Usage by day" chart had no Y-axis at all).
+ *
+ * Returns `{ max, ticks }` where `ticks` ascends from 0 to `max` inclusive.
+ * Bars should be scaled against `max` (not the raw data max) so the tallest
+ * bar aligns under the top gridline.
+ *
+ * Pure + unit-tested (tests/chartScale.test.ts).
+ */
+export interface AxisScale {
+  max: number;
+  ticks: number[];
+}
+
+/** Round a positive value to a "nice" step: 1, 2, 2.5, 5 (× 10ⁿ). */
+function niceStep(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) return 1;
+  const exp = Math.floor(Math.log10(raw));
+  const pow = Math.pow(10, exp);
+  const frac = raw / pow; // [1, 10)
+  let nice: number;
+  if (frac <= 1) nice = 1;
+  else if (frac <= 2) nice = 2;
+  else if (frac <= 2.5) nice = 2.5;
+  else if (frac <= 5) nice = 5;
+  else nice = 10;
+  return nice * pow;
+}
+
+export function niceAxisScale(rawMax: number, targetTicks = 4): AxisScale {
+  if (!Number.isFinite(rawMax) || rawMax <= 0) {
+    return { max: 0, ticks: [0] };
+  }
+  const intervals = Math.max(1, Math.floor(targetTicks));
+  const step = niceStep(rawMax / intervals);
+  const max = Math.ceil(rawMax / step) * step;
+  const ticks: number[] = [];
+  // Iterate by index (not `v += step`) to avoid floating-point drift, then
+  // round each tick to a sane precision so 0.1 × 3 doesn't render 0.30000004.
+  const count = Math.round(max / step);
+  for (let i = 0; i <= count; i++) {
+    ticks.push(Math.round(step * i * 1e6) / 1e6);
+  }
+  return { max, ticks };
+}

--- a/tests/chartScale.test.ts
+++ b/tests/chartScale.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { niceAxisScale } from "@/lib/chartScale";
+
+describe("niceAxisScale", () => {
+  it("returns a zero scale for non-positive / invalid input", () => {
+    expect(niceAxisScale(0)).toEqual({ max: 0, ticks: [0] });
+    expect(niceAxisScale(-5)).toEqual({ max: 0, ticks: [0] });
+    expect(niceAxisScale(NaN)).toEqual({ max: 0, ticks: [0] });
+    expect(niceAxisScale(Infinity)).toEqual({ max: 0, ticks: [0] });
+  });
+
+  it("rounds the reported issue's max (103) to a clean scale", () => {
+    // raw step 103/4 ≈ 25.75 → nice step 50 → max 150
+    const { max, ticks } = niceAxisScale(103);
+    expect(max).toBe(150);
+    expect(ticks).toEqual([0, 50, 100, 150]);
+  });
+
+  it("keeps the data max at or below the axis max", () => {
+    for (const v of [1, 6, 23, 50, 59, 103, 247, 999, 1234]) {
+      expect(niceAxisScale(v).max).toBeGreaterThanOrEqual(v);
+    }
+  });
+
+  it("always starts ticks at 0 and ends at max", () => {
+    for (const v of [6, 50, 103, 500]) {
+      const { max, ticks } = niceAxisScale(v);
+      expect(ticks[0]).toBe(0);
+      expect(ticks[ticks.length - 1]).toBe(max);
+    }
+  });
+
+  it("produces evenly-spaced ascending ticks", () => {
+    const { ticks } = niceAxisScale(103);
+    const step = ticks[1] - ticks[0];
+    for (let i = 1; i < ticks.length; i++) {
+      expect(ticks[i] - ticks[i - 1]).toBeCloseTo(step, 9);
+      expect(ticks[i]).toBeGreaterThan(ticks[i - 1]);
+    }
+  });
+
+  it("handles small maxima with clean integer ticks", () => {
+    expect(niceAxisScale(6)).toEqual({ max: 6, ticks: [0, 2, 4, 6] });
+    // 7/4 = 1.75 → step 2 → max 8
+    expect(niceAxisScale(7)).toEqual({ max: 8, ticks: [0, 2, 4, 6, 8] });
+  });
+
+  it("scales up cleanly for large maxima", () => {
+    // 1234/4 = 308.5 → nice step 500 → max 1500
+    const { max, ticks } = niceAxisScale(1234);
+    expect(max).toBe(1500);
+    expect(ticks).toEqual([0, 500, 1000, 1500]);
+  });
+
+  it("respects a custom target tick count", () => {
+    const { max, ticks } = niceAxisScale(100, 5);
+    // 100/5 = 20 → step 20 → max 100
+    expect(max).toBe(100);
+    expect(ticks).toEqual([0, 20, 40, 60, 80, 100]);
+  });
+
+  it("avoids floating-point drift in tick values", () => {
+    const { ticks } = niceAxisScale(1);
+    // 1/4 = 0.25 → step 0.25 → ticks must be exact, not 0.30000000004 etc.
+    expect(ticks).toEqual([0, 0.25, 0.5, 0.75, 1]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #716 — the **Usage by day** bar chart was unreadable: bars rendered as thin flat lines at the bottom and there was no Y-axis to read magnitudes off.

## Root cause
The bars used `height: <pct>%` inside a `flex items-end` row. `align-items: flex-end` does **not** stretch flex children, so each bar's column had `height: auto` — a percentage height against an auto-height parent resolves to ~0, collapsing every bar to its `minHeight: 2px`. So all bars looked identical regardless of value (the data was correct, only the rendering was broken).

## Fix
- **`src/lib/chartScale.ts`** (pure, unit-tested) — `niceAxisScale(rawMax)` returns a rounded axis max + evenly-spaced ticks (1/2/2.5/5 ×10ⁿ steps). `103 → { max: 150, ticks: [0,50,100,150] }`.
- **Analytics chart** — bars now sit in an `absolute inset-0 flex items-end` overlay with `h-full` columns inside a `relative h-40` plot, so `height: <pct>%` resolves against a definite height. Bars scale against the nice max; a Y-axis (tick labels) + horizontal gridlines are drawn behind them, positioned by `bottom: tick/max`.

## Verification
- `niceAxisScale`: 9 unit tests (boundary maxima, FP-drift, custom tick counts).
- **Dark-mode browser preview** with representative data (59/103/23/50g): bars render at proportional heights (63/110/25/53 px) under a `0/50/100/150` axis with gridlines; no console errors. tsc + eslint clean.

| before | after |
|---|---|
| flat 2px lines, no scale | proportional bars, Y-axis + gridlines |

🤖 Generated with [Claude Code](https://claude.com/claude-code)