### PR TITLE
feat(mobile+desktop): mDNS auto-discovery of the desktop app on the LAN

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -901,11 +901,18 @@ ipcMain.handle("save-config", async (event, config: {
     if (!isDev) {
       // Restart the production server with the new URI
       await stopServer();
+      let serverRestarted = false;
       try {
         await startProductionServer(uri || undefined);
+        serverRestarted = true;
       } catch (err) {
         console.error("Failed to start server after config save:", err);
       }
+      // Refresh LAN auto-discovery so a stale advert doesn't point at a server
+      // that just restarted (or failed to). syncMdnsAdvertisement() no-ops when
+      // exposeToLan is off; stop outright if the restart failed.
+      if (serverRestarted) syncMdnsAdvertisement();
+      else stopMdnsAdvertisement();
     }
 
     // Reload the window on a connection change so the renderer picks up
@@ -1621,8 +1628,10 @@ app.whenReady().then(async () => {
     // Always start the server — even without mongoUri, the setup page needs it.
     // Crash-restart is handled inside startProductionServer (GH #315), so
     // every spawned process — including restarts — gets the handler.
+    let serverStarted = false;
     try {
       await startProductionServer(mongoUri || undefined);
+      serverStarted = true;
     } catch (err) {
       console.error("Failed to start server:", err);
       dialog.showErrorBox(
@@ -1630,9 +1639,12 @@ app.whenReady().then(async () => {
         `The embedded web server failed to start. The app may not work correctly.\n\n${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    // Advertise over mDNS if "Share on local network" is on, so the mobile app
-    // can auto-discover this instance from a cold start.
-    syncMdnsAdvertisement();
+    // Advertise over mDNS (if "Share on local network" is on) only when the
+    // server actually came up — otherwise the phone would discover a server it
+    // can't reach. The catch above SWALLOWS the error, so a plain post-try call
+    // would advertise regardless; the flag is load-bearing.
+    if (serverStarted) syncMdnsAdvertisement();
+    else stopMdnsAdvertisement();
   }
 
   // Create the window. NFC init is deferred to the window's "show" event

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -531,11 +531,15 @@ async function startProductionServer(mongoUri?: string): Promise<void> {
       if (isQuitting || thisProc !== serverProcess) return;
       if (code === 0 || code === null) return; // clean exit, not a crash
 
+      // The current server crashed unexpectedly. Stop advertising it over mDNS
+      // for the entire down/restart window so a mobile scan can't discover and
+      // save a dead URL — it's re-published only after a healthy restart below
+      // (Codex #723). Covers both the backoff window and a failed restart;
+      // the retry-cap branch inherits this too.
+      stopMdnsAdvertisement();
+
       if (serverRestartCount >= MAX_SERVER_RESTARTS) {
         diag(`server crash-restart cap reached (${MAX_SERVER_RESTARTS})`);
-        // The server is dead for good — stop advertising it over mDNS so the
-        // mobile app doesn't keep discovering a host it can't reach (Codex #723).
-        stopMdnsAdvertisement();
         dialog.showErrorBox(
           "Server Crashed",
           `The embedded web server crashed repeatedly (${MAX_SERVER_RESTARTS} restart attempts) and has been left stopped.`,
@@ -562,6 +566,8 @@ async function startProductionServer(mongoUri?: string): Promise<void> {
         startProductionServer((store.get("mongodbUri") as string) || undefined)
           .then(() => {
             diag("server restarted successfully after crash");
+            // Server healthy again — re-publish mDNS (no-op if exposeToLan off).
+            syncMdnsAdvertisement();
             mainWindow?.reload();
           })
           .catch((restartErr) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -533,6 +533,9 @@ async function startProductionServer(mongoUri?: string): Promise<void> {
 
       if (serverRestartCount >= MAX_SERVER_RESTARTS) {
         diag(`server crash-restart cap reached (${MAX_SERVER_RESTARTS})`);
+        // The server is dead for good — stop advertising it over mDNS so the
+        // mobile app doesn't keep discovering a host it can't reach (Codex #723).
+        stopMdnsAdvertisement();
         dialog.showErrorBox(
           "Server Crashed",
           `The embedded web server crashed repeatedly (${MAX_SERVER_RESTARTS} restart attempts) and has been left stopped.`,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -971,8 +971,11 @@ ipcMain.handle("save-config", async (event, config: {
   }
 
   // Start/stop LAN auto-discovery to match the new "Share on local network"
-  // state once the server's bind has settled.
-  if (exposeToLanChanged) syncMdnsAdvertisement();
+  // state once the server's bind has settled. Only for the exposeToLan-ONLY
+  // path: when connectionChanged ran it already synced/stopped mDNS based on
+  // its own restart outcome, so re-syncing here would re-advertise a dead
+  // server if that restart failed while turning LAN sharing on (Codex #723).
+  if (exposeToLanChanged && !connectionChanged) syncMdnsAdvertisement();
   return { success: true };
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import { NfcService } from "./nfc-service";
 import { listLabelPrinters, printLabel as printLabelToDevice } from "./label-printer";
 import { isLoopbackHostname } from "../src/lib/loopbackHost";
 import { listLanIpv4 } from "../src/lib/getLanIp";
+import { startMdnsAdvertisement, stopMdnsAdvertisement } from "./mdns-service";
 import { startLocalMongo, stopLocalMongo } from "./local-mongo";
 import { SyncService, SyncStatus, getDbNameFromUri } from "./sync-service";
 import { initAutoUpdater } from "./auto-updater";
@@ -628,6 +629,21 @@ function stopServer(): Promise<void> {
 }
 
 /**
+ * Advertise (or stop advertising) the embedded server over mDNS so the mobile
+ * app can auto-discover it on the LAN. Only when packaged AND "Share on local
+ * network" is enabled — in dev the renderer is served by a separate `next dev`,
+ * and when exposeToLan is off the server is loopback-only (nothing to reach).
+ * Idempotent; call it after the server's bind state settles.
+ */
+function syncMdnsAdvertisement(): void {
+  if (!isDev && store.get("exposeToLan")) {
+    startMdnsAdvertisement(PORT, app.getVersion());
+  } else {
+    stopMdnsAdvertisement();
+  }
+}
+
+/**
  * Resolve which MongoDB URI to use based on connection mode.
  * For offline/hybrid, starts local MongoDB.
  * For hybrid, also initializes sync service.
@@ -938,10 +954,15 @@ ipcMain.handle("save-config", async (event, config: {
       } catch (recoveryErr) {
         console.error("Failed to restore server after LAN-share toggle failure:", recoveryErr);
       }
+      // Reflect the reverted bind state in the mDNS advertisement too.
+      syncMdnsAdvertisement();
       return { success: false };
     }
   }
 
+  // Start/stop LAN auto-discovery to match the new "Share on local network"
+  // state once the server's bind has settled.
+  if (exposeToLanChanged) syncMdnsAdvertisement();
   return { success: true };
 });
 
@@ -1609,6 +1630,9 @@ app.whenReady().then(async () => {
         `The embedded web server failed to start. The app may not work correctly.\n\n${err instanceof Error ? err.message : String(err)}`,
       );
     }
+    // Advertise over mDNS if "Share on local network" is on, so the mobile app
+    // can auto-discover this instance from a cold start.
+    syncMdnsAdvertisement();
   }
 
   // Create the window. NFC init is deferred to the window's "show" event
@@ -1643,6 +1667,7 @@ app.on("before-quit", (event) => {
   isQuitting = true;
   event.preventDefault();
   void stopServer();
+  stopMdnsAdvertisement();
   if (syncService) syncService.destroy();
   if (nfcService) nfcService.destroy();
 

--- a/electron/mdns-service.ts
+++ b/electron/mdns-service.ts
@@ -39,21 +39,25 @@ export function startMdnsAdvertisement(port: number, version: string): void {
   }
 }
 
-/** Stop advertising and tear down the responder. Safe to call when not running. */
+/** Stop advertising and tear down the responder. Safe to call when not running.
+ *  Module refs are cleared FIRST, before the (async-goodbye) teardown, so a
+ *  re-entrant start/stop can never reuse a stale handle. */
 export function stopMdnsAdvertisement(): void {
+  const svc = service;
+  const responder = bonjour;
+  service = null;
+  bonjour = null;
   try {
-    service?.stop?.();
+    svc?.stop?.();
   } catch (err) {
     console.error("Failed to stop mDNS service:", err);
   }
-  service = null;
   try {
-    bonjour?.unpublishAll?.();
-    bonjour?.destroy?.();
+    responder?.unpublishAll?.();
+    responder?.destroy?.();
   } catch (err) {
     console.error("Failed to destroy mDNS responder:", err);
   }
-  bonjour = null;
 }
 
 /** Whether an advertisement is currently published. */

--- a/electron/mdns-service.ts
+++ b/electron/mdns-service.ts
@@ -1,0 +1,62 @@
+import { Bonjour, type Service } from "bonjour-service";
+
+/**
+ * mDNS / Bonjour advertisement for LAN auto-discovery.
+ *
+ * Advertises this desktop instance as `_filamentdb._tcp` on the local network
+ * so the Filament DB mobile scanner app can find it without the user typing an
+ * IP address. Only advertised while "Share on local network" is enabled — the
+ * embedded server is loopback-only otherwise, so there'd be nothing for a phone
+ * to reach (see syncMdnsAdvertisement in electron/main.ts).
+ *
+ * Uses `bonjour-service` (pure JS, no native dependency — consistent with the
+ * post-#588 "no native modules beyond pcsclite" stance).
+ */
+const SERVICE_TYPE = "filamentdb"; // → `_filamentdb._tcp`
+const SERVICE_NAME = "Filament DB";
+
+let bonjour: Bonjour | null = null;
+let service: Service | null = null;
+
+/** Start (or restart) advertising the server on `port`. Idempotent and
+ *  best-effort — a failure to advertise must never crash the app. */
+export function startMdnsAdvertisement(port: number, version: string): void {
+  stopMdnsAdvertisement();
+  try {
+    bonjour = new Bonjour();
+    service = bonjour.publish({
+      name: SERVICE_NAME,
+      type: SERVICE_TYPE,
+      port,
+      txt: { app: "filament-db", version },
+    });
+    service.on("error", (err: unknown) => {
+      console.error("mDNS service error:", err);
+    });
+  } catch (err) {
+    console.error("Failed to start mDNS advertisement:", err);
+    stopMdnsAdvertisement();
+  }
+}
+
+/** Stop advertising and tear down the responder. Safe to call when not running. */
+export function stopMdnsAdvertisement(): void {
+  try {
+    service?.stop?.();
+  } catch (err) {
+    console.error("Failed to stop mDNS service:", err);
+  }
+  service = null;
+  try {
+    bonjour?.unpublishAll?.();
+    bonjour?.destroy?.();
+  } catch (err) {
+    console.error("Failed to destroy mDNS responder:", err);
+  }
+  bonjour = null;
+}
+
+/** Whether an advertisement is currently published. */
+export function isMdnsAdvertising(): boolean {
+  return service !== null;
+}

--- a/electron/mdns-service.ts
+++ b/electron/mdns-service.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { Bonjour, type Service } from "bonjour-service";
 
 /**
@@ -18,6 +19,23 @@ const SERVICE_NAME = "Filament DB";
 let bonjour: Bonjour | null = null;
 let service: Service | null = null;
 
+/**
+ * A per-machine instance name. mDNS instance names must be unique on a LAN —
+ * two desktops publishing the bare "Filament DB" would collide and bonjour-
+ * service would suppress the second on probe, hiding it from discovery
+ * (Codex #723). Suffix the hostname so each host is distinct and recognisable
+ * in the mobile picker.
+ */
+function instanceName(): string {
+  let host = "";
+  try {
+    host = os.hostname().replace(/\.local$/i, "").trim();
+  } catch {
+    host = "";
+  }
+  return host ? `${SERVICE_NAME} (${host})` : SERVICE_NAME;
+}
+
 /** Start (or restart) advertising the server on `port`. Idempotent and
  *  best-effort — a failure to advertise must never crash the app. */
 export function startMdnsAdvertisement(port: number, version: string): void {
@@ -25,7 +43,7 @@ export function startMdnsAdvertisement(port: number, version: string): void {
   try {
     bonjour = new Bonjour();
     service = bonjour.publish({
-      name: SERVICE_NAME,
+      name: instanceName(),
       type: SERVICE_TYPE,
       port,
       txt: { app: "filament-db", version },

--- a/electron/mdns-service.ts
+++ b/electron/mdns-service.ts
@@ -41,7 +41,14 @@ function instanceName(): string {
 export function startMdnsAdvertisement(port: number, version: string): void {
   stopMdnsAdvertisement();
   try {
-    bonjour = new Bonjour();
+    // Pass an errorCallback so the underlying responder routes async multicast
+    // send/respond errors here instead of its default (which THROWS when no
+    // callback is given) — a transient socket error must not crash the main
+    // process for a best-effort advertiser (Codex #723). service.on("error")
+    // below only covers publish errors, not responder-level ones.
+    bonjour = new Bonjour(undefined, (err: unknown) => {
+      console.error("mDNS responder error:", err);
+    });
     service = bonjour.publish({
       name: instanceName(),
       type: SERVICE_TYPE,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",
+        "bonjour-service": "^1.4.1",
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",
         "exceljs": "^4.4.0",
@@ -808,7 +809,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1652,7 +1652,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1675,7 +1674,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1698,7 +1696,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1715,7 +1712,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1732,7 +1728,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1749,7 +1744,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1766,7 +1760,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1783,7 +1776,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1800,7 +1792,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1817,7 +1808,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1834,7 +1824,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1851,7 +1840,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1868,7 +1856,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1891,7 +1878,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1914,7 +1900,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1937,7 +1922,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1960,7 +1944,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1983,7 +1966,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2006,7 +1988,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2029,7 +2010,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2052,7 +2032,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2072,7 +2051,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2092,7 +2070,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2112,7 +2089,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2186,6 +2162,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
@@ -5823,6 +5805,16 @@
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
     },
+    "node_modules/bonjour-service": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.1.tgz",
+      "integrity": "sha512-9KM4QMPKnaJqaja1v7gYO/+TXZGLtzPA05NmUTqDAJjcsWeVoOXKMvU9g0gfuuoYTQqJZ924hivICd5R/bCJbA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -7026,6 +7018,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -12299,6 +12303,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
     "node_modules/nan": {
       "version": "2.27.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
@@ -15427,6 +15444,12 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@pokusew/pcsclite": "^0.6.0",
+    "bonjour-service": "^1.4.1",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.8.3",
     "exceljs": "^4.4.0",

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -73,10 +73,26 @@ const config: ExpoConfig = {
         NSAllowsArbitraryLoads: false,
         NSAllowsLocalNetworking: true,
       },
+      // mDNS auto-discovery (react-native-zeroconf). iOS 14+ requires every
+      // Bonjour service type the app browses to be declared here, plus a
+      // local-network usage description for the permission prompt. The desktop
+      // app advertises `_filamentdb._tcp` when "Share on local network" is on.
+      NSBonjourServices: ['_filamentdb._tcp'],
+      NSLocalNetworkUsageDescription:
+        'Filament DB looks for your Filament DB desktop app on this network so you can connect without typing its address.',
     },
   },
   android: {
     package: 'com.filamentdb.scanner',
+    // mDNS auto-discovery (react-native-zeroconf / NsdManager). INTERNET is
+    // added by default; the multicast + network/wifi-state perms are needed to
+    // browse Bonjour services on the LAN. `android.permissions` is additive.
+    permissions: [
+      'android.permission.INTERNET',
+      'android.permission.ACCESS_NETWORK_STATE',
+      'android.permission.ACCESS_WIFI_STATE',
+      'android.permission.CHANGE_WIFI_MULTICAST_STATE',
+    ],
     adaptiveIcon: {
       backgroundColor: '#E6F4FE',
       foregroundImage: './assets/images/android-icon-foreground.png',

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -36,7 +36,8 @@
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-web": "~0.21.0",
-        "react-native-worklets": "0.8.3"
+        "react-native-worklets": "0.8.3",
+        "react-native-zeroconf": "^0.14.0"
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
@@ -5627,6 +5628,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expo": {
       "version": "56.0.11",
       "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.11.tgz",
@@ -9802,6 +9812,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-native-zeroconf": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-native-zeroconf/-/react-native-zeroconf-0.14.0.tgz",
+      "integrity": "sha512-TqjORroaVZrBYLzk3YtviQy8lUl/iiMacknxixRYlmGaqgsv4LJXIYafpnvPa3y2SC4/qu2mvF8D1/VTTxylgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60"
       }
     },
     "node_modules/react-native/node_modules/commander": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -31,7 +31,8 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-web": "~0.21.0",
-    "react-native-worklets": "0.8.3"
+    "react-native-worklets": "0.8.3",
+    "react-native-zeroconf": "^0.14.0"
   },
   "devDependencies": {
     "@types/react": "~19.2.2",

--- a/packages/mobile/src/app/settings.tsx
+++ b/packages/mobile/src/app/settings.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import {
+  ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   Platform,
@@ -9,16 +10,19 @@ import {
   StyleSheet,
   Text,
   TextInput,
+  View,
 } from 'react-native';
 
 import { useServerConfig } from '@/lib/serverConfig';
 import { useColors } from '@/lib/theme';
+import { useServerDiscovery } from '@/lib/zeroconf';
 
 export default function SettingsScreen() {
   const { baseUrl, apiKey, save } = useServerConfig();
   const [url, setUrl] = useState(baseUrl ?? '');
   const [key, setKey] = useState(apiKey ?? '');
   const [saving, setSaving] = useState(false);
+  const { servers, scanning, supported, scan } = useServerDiscovery();
   const router = useRouter();
   const c = useColors();
 
@@ -45,7 +49,46 @@ export default function SettingsScreen() {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
-        <Text style={[styles.label, { color: c.text }]}>Server address</Text>
+        {supported && (
+          <>
+            <View style={styles.discoverHeader}>
+              <Text style={[styles.label, { color: c.text }]}>Find on your network</Text>
+              <Pressable onPress={scan} hitSlop={8} disabled={scanning}>
+                <View style={styles.scanAction}>
+                  {scanning && <ActivityIndicator size="small" color={c.tint} />}
+                  <Text style={[styles.scanText, { color: c.tint }]}>
+                    {scanning ? 'Scanning…' : servers.length > 0 ? 'Rescan' : 'Scan'}
+                  </Text>
+                </View>
+              </Pressable>
+            </View>
+            {servers.map((s) => {
+              const selected = s.url === url;
+              return (
+                <Pressable
+                  key={s.id}
+                  onPress={() => setUrl(s.url)}
+                  style={[
+                    styles.serverRow,
+                    { borderColor: selected ? c.tint : c.border, backgroundColor: c.inputBg },
+                  ]}
+                >
+                  <Text style={[styles.serverName, { color: c.text }]}>{s.name}</Text>
+                  <Text style={[styles.serverUrl, { color: c.muted }]}>{s.url}</Text>
+                </Pressable>
+              );
+            })}
+            <Text style={[styles.hint, { color: c.muted }]}>
+              {servers.length > 0
+                ? 'Tap a server to use its address, then Save.'
+                : scanning
+                  ? 'Looking for Filament DB on this network…'
+                  : 'Make sure “Share on local network” is on in the desktop app and this phone is on the same Wi-Fi, then Scan.'}
+            </Text>
+            <Text style={[styles.label, styles.spaced, { color: c.text }]}>Server address</Text>
+          </>
+        )}
+        {!supported && <Text style={[styles.label, { color: c.text }]}>Server address</Text>}
         <TextInput
           style={inputStyle}
           value={url}
@@ -95,6 +138,22 @@ const styles = StyleSheet.create({
   container: { padding: 20, gap: 6 },
   label: { fontSize: 15, fontWeight: '600' },
   spaced: { marginTop: 18 },
+  discoverHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  scanAction: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  scanText: { fontSize: 15, fontWeight: '600' },
+  serverRow: {
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    marginTop: 8,
+    gap: 2,
+  },
+  serverName: { fontSize: 16, fontWeight: '600' },
+  serverUrl: { fontSize: 13 },
   input: {
     borderWidth: 1,
     borderRadius: 10,

--- a/packages/mobile/src/lib/zeroconf.ts
+++ b/packages/mobile/src/lib/zeroconf.ts
@@ -98,13 +98,26 @@ export interface ServerDiscovery {
  * (e.g. on the settings screen) and the returned `servers` list fills in as
  * instances resolve. Scanning stops on unmount.
  */
+/** Bound the scanning window. Android's default NSD backend can fail SILENTLY
+ *  (no 'resolved' and no 'error' — react-native-zeroconf 0.14 documents this),
+ *  so neither the resolved handler nor the error handler would ever clear
+ *  `scanning`, stranding the UI on "Scanning…". A hard timeout guarantees the
+ *  Scan button re-enables; servers found during the window stay listed and the
+ *  user can Rescan. (Codex #723.) */
+const SCAN_TIMEOUT_MS = 15_000;
+
 export function useServerDiscovery(): ServerDiscovery {
   const [servers, setServers] = useState<DiscoveredServer[]>([]);
   const [scanning, setScanning] = useState(false);
   const [supported, setSupported] = useState(true);
   const zcRef = useRef<ZeroconfInstance | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const stop = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     const zc = zcRef.current;
     zcRef.current = null;
     if (zc) {
@@ -152,6 +165,8 @@ export function useServerDiscovery(): ServerDiscovery {
     });
     try {
       zc.scan('filamentdb', 'tcp', 'local.');
+      // Hard stop after the window so a silent native failure can't hang the UI.
+      timeoutRef.current = setTimeout(stop, SCAN_TIMEOUT_MS);
     } catch (err) {
       console.warn('zeroconf scan failed', err);
       setSupported(false);

--- a/packages/mobile/src/lib/zeroconf.ts
+++ b/packages/mobile/src/lib/zeroconf.ts
@@ -145,6 +145,10 @@ export function useServerDiscovery(): ServerDiscovery {
     });
     zc.on('error', (err) => {
       console.warn('zeroconf error', err);
+      // Tear down so `scanning` clears and the Scan button re-enables — an async
+      // error (denied iOS Local Network permission, Android NSD failure) would
+      // otherwise strand the UI in a permanent "Scanning…" state (Codex #723).
+      stop();
     });
     try {
       zc.scan('filamentdb', 'tcp', 'local.');

--- a/packages/mobile/src/lib/zeroconf.ts
+++ b/packages/mobile/src/lib/zeroconf.ts
@@ -29,21 +29,38 @@ export interface ZeroconfService {
 
 const IPV4_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
 
+/** RFC1918 private ranges — the addresses a phone on the same Wi-Fi can route
+ *  to. Sorted ahead of anything else so the likely-LAN candidate leads. */
+function isPrivateIpv4(ip: string): boolean {
+  if (ip.startsWith('192.168.')) return true;
+  if (ip.startsWith('10.')) return true;
+  const m = /^172\.(\d{1,3})\./.exec(ip);
+  return m ? Number(m[1]) >= 16 && Number(m[1]) <= 31 : false;
+}
+
 /**
- * Build a Filament DB server entry from a resolved zeroconf service. Prefers an
- * IPv4 address over the `.local` hostname — phones reach a raw LAN IP reliably,
- * whereas `.local` resolution over HTTP is flaky on some networks. Returns null
- * when the service carries no usable address or port. Pure + unit-testable.
+ * Build the candidate server entries from a resolved zeroconf service.
+ *
+ * A desktop with several non-loopback interfaces (Wi-Fi + Docker/VM/VPN) is
+ * advertised with multiple IPv4 addresses, and only some are reachable from the
+ * phone. Rather than guess one (Codex #723), return EVERY usable IPv4 as its own
+ * entry — RFC1918 private addresses first — so the user can pick the one that
+ * connects. Falls back to the `.local` hostname only when no IPv4 is offered.
+ * Returns [] when the service has no usable address/port. Pure + unit-testable.
  */
-export function discoveredServerFromService(
+export function discoveredServersFromService(
   svc: ZeroconfService | null | undefined,
-): DiscoveredServer | null {
-  if (!svc || !svc.port) return null;
-  const ipv4 = (svc.addresses ?? []).find((a) => IPV4_RE.test(a));
-  const host = ipv4 ?? (svc.host ? svc.host.replace(/\.$/, '') : null);
-  if (!host) return null;
-  const url = `http://${host}:${svc.port}`;
-  return { id: url, name: svc.name?.trim() || host, url };
+): DiscoveredServer[] {
+  if (!svc || !svc.port) return [];
+  const name = svc.name?.trim() ?? '';
+  const ipv4s = (svc.addresses ?? [])
+    .filter((a) => IPV4_RE.test(a) && !a.startsWith('169.254.')) // skip link-local APIPA
+    .sort((a, b) => (isPrivateIpv4(a) ? 0 : 1) - (isPrivateIpv4(b) ? 0 : 1));
+  const hosts = ipv4s.length > 0 ? ipv4s : svc.host ? [svc.host.replace(/\.$/, '')] : [];
+  return hosts.map((host) => {
+    const url = `http://${host}:${svc.port}`;
+    return { id: url, name: name || host, url };
+  });
 }
 
 interface ZeroconfInstance {
@@ -116,9 +133,15 @@ export function useServerDiscovery(): ServerDiscovery {
     setServers([]);
     setScanning(true);
     zc.on('resolved', (svc) => {
-      const server = discoveredServerFromService(svc);
-      if (!server) return;
-      setServers((prev) => (prev.some((s) => s.id === server.id) ? prev : [...prev, server]));
+      const found = discoveredServersFromService(svc);
+      if (found.length === 0) return;
+      setServers((prev) => {
+        const next = [...prev];
+        for (const s of found) {
+          if (!next.some((p) => p.id === s.id)) next.push(s);
+        }
+        return next;
+      });
     });
     zc.on('error', (err) => {
       console.warn('zeroconf error', err);

--- a/packages/mobile/src/lib/zeroconf.ts
+++ b/packages/mobile/src/lib/zeroconf.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * mDNS / Bonjour discovery of Filament DB desktop instances on the LAN.
+ *
+ * The desktop app advertises `_filamentdb._tcp` when "Share on local network"
+ * is enabled; this lets the phone find it and fill in the server address
+ * without the user typing an IP. Uses react-native-zeroconf (a native module,
+ * present in dev/standalone builds — gracefully no-ops where it isn't, e.g.
+ * web / Expo Go, via `supported: false`).
+ */
+
+export interface DiscoveredServer {
+  /** Stable id (the URL) for dedupe + list keys. */
+  id: string;
+  /** Advertised instance name, e.g. "Filament DB". */
+  name: string;
+  /** Full base URL to use as the server address, e.g. http://192.168.1.50:3456 */
+  url: string;
+}
+
+/** Subset of react-native-zeroconf's resolved-service object that we read. */
+export interface ZeroconfService {
+  name?: string;
+  host?: string;
+  port?: number;
+  addresses?: string[];
+}
+
+const IPV4_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+
+/**
+ * Build a Filament DB server entry from a resolved zeroconf service. Prefers an
+ * IPv4 address over the `.local` hostname — phones reach a raw LAN IP reliably,
+ * whereas `.local` resolution over HTTP is flaky on some networks. Returns null
+ * when the service carries no usable address or port. Pure + unit-testable.
+ */
+export function discoveredServerFromService(
+  svc: ZeroconfService | null | undefined,
+): DiscoveredServer | null {
+  if (!svc || !svc.port) return null;
+  const ipv4 = (svc.addresses ?? []).find((a) => IPV4_RE.test(a));
+  const host = ipv4 ?? (svc.host ? svc.host.replace(/\.$/, '') : null);
+  if (!host) return null;
+  const url = `http://${host}:${svc.port}`;
+  return { id: url, name: svc.name?.trim() || host, url };
+}
+
+interface ZeroconfInstance {
+  on(event: 'resolved', listener: (service: ZeroconfService) => void): void;
+  on(event: 'error', listener: (error: unknown) => void): void;
+  scan(type: string, protocol: string, domain: string): void;
+  stop(): void;
+  removeDeviceListeners(): void;
+}
+
+/** Lazily construct a Zeroconf instance. `require` (not a top-level import) so a
+ *  build without the native module — web / Expo Go — doesn't crash on load. */
+function loadZeroconf(): ZeroconfInstance | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('react-native-zeroconf');
+    const Ctor = (mod?.default ?? mod) as { new (): ZeroconfInstance };
+    return new Ctor();
+  } catch {
+    return null;
+  }
+}
+
+export interface ServerDiscovery {
+  servers: DiscoveredServer[];
+  scanning: boolean;
+  /** False when the native module isn't available (web / Expo Go). */
+  supported: boolean;
+  scan: () => void;
+  stop: () => void;
+}
+
+/**
+ * Hook: scan the LAN for Filament DB desktop instances. Call `scan()` to start
+ * (e.g. on the settings screen) and the returned `servers` list fills in as
+ * instances resolve. Scanning stops on unmount.
+ */
+export function useServerDiscovery(): ServerDiscovery {
+  const [servers, setServers] = useState<DiscoveredServer[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [supported, setSupported] = useState(true);
+  const zcRef = useRef<ZeroconfInstance | null>(null);
+
+  const stop = useCallback(() => {
+    const zc = zcRef.current;
+    zcRef.current = null;
+    if (zc) {
+      try {
+        zc.stop();
+      } catch {
+        // ignore — best effort
+      }
+      try {
+        zc.removeDeviceListeners();
+      } catch {
+        // ignore
+      }
+    }
+    setScanning(false);
+  }, []);
+
+  const scan = useCallback(() => {
+    stop();
+    const zc = loadZeroconf();
+    if (!zc) {
+      setSupported(false);
+      return;
+    }
+    zcRef.current = zc;
+    setServers([]);
+    setScanning(true);
+    zc.on('resolved', (svc) => {
+      const server = discoveredServerFromService(svc);
+      if (!server) return;
+      setServers((prev) => (prev.some((s) => s.id === server.id) ? prev : [...prev, server]));
+    });
+    zc.on('error', (err) => {
+      console.warn('zeroconf error', err);
+    });
+    try {
+      zc.scan('filamentdb', 'tcp', 'local.');
+    } catch (err) {
+      console.warn('zeroconf scan failed', err);
+      setSupported(false);
+      stop();
+    }
+  }, [stop]);
+
+  useEffect(() => () => stop(), [stop]);
+
+  return { servers, scanning, supported, scan, stop };
+}


### PR DESCRIPTION
## Summary
Completes the deferred fourth Phase 3 nicety: the mobile app can now **auto-discover** the desktop Filament DB on the LAN instead of the user typing its IP. The desktop advertises itself over mDNS/Bonjour; the phone browses for it.

This pairs with **Share on local network** (v1.45.0): the desktop only advertises when that toggle is on (it's loopback-only otherwise, so there'd be nothing to reach).

## Desktop (Electron)
- **`electron/mdns-service.ts`** — advertises `_filamentdb._tcp` on port 3456 via `bonjour-service` (pure JS, no native dependency — consistent with the post-#588 stance). `start`/`stop` are idempotent and best-effort (a failure never crashes the app).
- **`main.ts`** — `syncMdnsAdvertisement()` publishes only when **packaged AND `exposeToLan`** is on. Wired into: the boot path (after the server starts), the `exposeToLan` save-config toggle (including the revert-on-failure path), and `before-quit` (stop).

## Mobile (Expo / RN)
- **`react-native-zeroconf`** added. `app.config.ts` gains the iOS `NSBonjourServices` (`_filamentdb._tcp`) + `NSLocalNetworkUsageDescription`, and the additive Android perms (`INTERNET`, `ACCESS_NETWORK_STATE`, `ACCESS_WIFI_STATE`, `CHANGE_WIFI_MULTICAST_STATE`). Autolinks via prebuild — no config plugin (confirmed against Expo v56 docs + the lib README).
- **`src/lib/zeroconf.ts`** — `useServerDiscovery()` hook + pure `discoveredServerFromService()` (prefers an IPv4 address over the `.local` name, strips a trailing dot, dedupes by URL). Lazy `require` so a build without the native module (web / Expo Go) degrades to `supported: false` rather than crashing.
- **`settings.tsx`** — a "Find on your network" section above the manual address field: a Scan button + live list of discovered servers; tapping one fills the address (then Save).

## Verification
- `bonjour-service` bundles cleanly via esbuild; **root tsc + electron eslint + mobile tsc + expo lint all pass; npm audit 0 vulns.**
- Checked the behavior against the Expo v56 config reference (`android.permissions` is additive; `ios.infoPlist` takes arbitrary keys) and the react-native-zeroconf README (permission + API surface).

## ⚠️ Needs on-device verification
The end-to-end phone↔desktop discovery can only be confirmed on real hardware — it needs the native zeroconf module in a dev/standalone build + the iOS Local Network permission grant. This is exactly why the item was deferred. The desktop-advertising half is structurally verifiable (bundles, gated correctly); the phone-discovery half is for the maintainer to confirm on a device after a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)