### PR TITLE
revert: NFC ISO 15693 change (#728) — re-review before re-landing

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -45,11 +45,7 @@ if (nfcEnabled) {
     {
       nfcPermission:
         'Filament DB reads NFC filament spool tags (OpenPrintTag) to look them up in your database.',
-      // Entitlement is `['TAG']` only — NOT `NDEF`. Apple's iOS 26 SDK rejects
-      // the `NDEF` reader-format value at App Store submission (error 90778).
-      // We read OpenPrintTag (ISO 15693) through a TAG session on iOS, which
-      // needs only `TAG` (see src/lib/nfc.ts).
-      includeNdefEntitlement: false,
+      includeNdefEntitlement: true,
     },
   ]);
 }

--- a/packages/mobile/src/lib/nfc.ts
+++ b/packages/mobile/src/lib/nfc.ts
@@ -1,4 +1,3 @@
-import { Platform } from 'react-native';
 import NfcManager, { NfcTech } from 'react-native-nfc-manager';
 import { bytesToAscii, bytesToBase64 } from './base64';
 
@@ -6,15 +5,6 @@ import { bytesToAscii, bytesToBase64 } from './base64';
  * NFC reading for Phase 1 — OpenPrintTag only (ISO 15693 / NFC-V), which reads
  * on both iOS and Android. The tag is NDEF-wrapped CBOR; we read the NDEF
  * record, base64 its payload, and let `POST /api/nfc/decode` do the decoding.
- *
- * iOS reads via an ISO 15693 **tag** session (NFCTagReaderSession) +
- * getNdefMessage(), NOT NfcTech.Ndef. An NFCISO15693Tag conforms to NFCNDEFTag,
- * so a tag session can still read the NDEF — and it needs only the `TAG`
- * reader-format entitlement. Apple's iOS 26 SDK rejects the `NDEF` format value
- * at App Store submission (error 90778), so the app no longer ships it
- * (app.config.ts: includeNdefEntitlement: false → entitlement is `['TAG']`).
- * Android has no NFC entitlement and its Ndef tech reads the NDEF directly, so
- * it keeps using NfcTech.Ndef.
  *
  * Bambu (MIFARE Classic) is Phase 2 and Android-only — iPhone's Core NFC can't
  * read MIFARE Classic at all (see docs/mobile-app-plan.md §2).
@@ -54,15 +44,10 @@ export interface OpenPrintTagScan {
  */
 export async function readOpenPrintTag(): Promise<OpenPrintTagScan> {
   await ensureStarted();
-  const isIOS = Platform.OS === 'ios';
-  // iOS: ISO 15693 tag session → getNdefMessage() (TAG entitlement only).
-  // Android: Ndef tech → getTag().ndefMessage (no entitlement). See file docblock.
-  await NfcManager.requestTechnology(isIOS ? NfcTech.Iso15693IOS : NfcTech.Ndef);
+  await NfcManager.requestTechnology(NfcTech.Ndef);
   try {
-    const event = isIOS
-      ? await NfcManager.ndefHandler.getNdefMessage()
-      : await NfcManager.getTag();
-    const records = event?.ndefMessage ?? [];
+    const tag = await NfcManager.getTag();
+    const records = tag?.ndefMessage ?? [];
     // nfc-manager types record `type`/`payload` as `string | number[]`; we only
     // handle the byte-array form (what a Type 5 / NDEF read yields).
     const opt = records.find(


### PR DESCRIPTION
Reverts #728. It was merged prematurely (before the requested Codex review); this takes it back off `main`.

The NFC ISO 15693 / drop-NDEF-entitlement change itself is fine and on-device-verified (the OpenPrintTag scan works), but it will be **re-opened as a fresh PR and re-merged only after Codex reviews it**.

No behavior change beyond restoring `main` to its pre-#728 state. Mobile-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)