### PR TITLE
fix(mobile): iOS NFC via ISO 15693 tag session — drop the NDEF entitlement (App Store 90778)

### DIFF
--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -45,7 +45,11 @@ if (nfcEnabled) {
     {
       nfcPermission:
         'Filament DB reads NFC filament spool tags (OpenPrintTag) to look them up in your database.',
-      includeNdefEntitlement: true,
+      // Entitlement is `['TAG']` only — NOT `NDEF`. Apple's iOS 26 SDK rejects
+      // the `NDEF` reader-format value at App Store submission (error 90778).
+      // We read OpenPrintTag (ISO 15693) through a TAG session on iOS, which
+      // needs only `TAG` (see src/lib/nfc.ts).
+      includeNdefEntitlement: false,
     },
   ]);
 }

--- a/packages/mobile/src/lib/nfc.ts
+++ b/packages/mobile/src/lib/nfc.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import NfcManager, { NfcTech } from 'react-native-nfc-manager';
 import { bytesToAscii, bytesToBase64 } from './base64';
 
@@ -5,6 +6,15 @@ import { bytesToAscii, bytesToBase64 } from './base64';
  * NFC reading for Phase 1 — OpenPrintTag only (ISO 15693 / NFC-V), which reads
  * on both iOS and Android. The tag is NDEF-wrapped CBOR; we read the NDEF
  * record, base64 its payload, and let `POST /api/nfc/decode` do the decoding.
+ *
+ * iOS reads via an ISO 15693 **tag** session (NFCTagReaderSession) +
+ * getNdefMessage(), NOT NfcTech.Ndef. An NFCISO15693Tag conforms to NFCNDEFTag,
+ * so a tag session can still read the NDEF — and it needs only the `TAG`
+ * reader-format entitlement. Apple's iOS 26 SDK rejects the `NDEF` format value
+ * at App Store submission (error 90778), so the app no longer ships it
+ * (app.config.ts: includeNdefEntitlement: false → entitlement is `['TAG']`).
+ * Android has no NFC entitlement and its Ndef tech reads the NDEF directly, so
+ * it keeps using NfcTech.Ndef.
  *
  * Bambu (MIFARE Classic) is Phase 2 and Android-only — iPhone's Core NFC can't
  * read MIFARE Classic at all (see docs/mobile-app-plan.md §2).
@@ -44,10 +54,15 @@ export interface OpenPrintTagScan {
  */
 export async function readOpenPrintTag(): Promise<OpenPrintTagScan> {
   await ensureStarted();
-  await NfcManager.requestTechnology(NfcTech.Ndef);
+  const isIOS = Platform.OS === 'ios';
+  // iOS: ISO 15693 tag session → getNdefMessage() (TAG entitlement only).
+  // Android: Ndef tech → getTag().ndefMessage (no entitlement). See file docblock.
+  await NfcManager.requestTechnology(isIOS ? NfcTech.Iso15693IOS : NfcTech.Ndef);
   try {
-    const tag = await NfcManager.getTag();
-    const records = tag?.ndefMessage ?? [];
+    const event = isIOS
+      ? await NfcManager.ndefHandler.getNdefMessage()
+      : await NfcManager.getTag();
+    const records = event?.ndefMessage ?? [];
     // nfc-manager types record `type`/`payload` as `string | number[]`; we only
     // handle the byte-array form (what a Type 5 / NDEF read yields).
     const opt = records.find(


### PR DESCRIPTION
Re-opens the NFC fix that was reverted in #729 (it had merged before the required Codex review). **Held for a clean Codex review of this HEAD before merging.**

## Why
App Store / TestFlight upload fails validation with **error 90778** — Apple's iOS 26 SDK no longer allows the `NDEF` value in `com.apple.developer.nfc.readersession.formats`. The app read tags with `NfcTech.Ndef` (NFCNDEFReaderSession), which requires that entitlement.

## Fix
OpenPrintTag is an **ISO 15693** tag, and `NFCISO15693Tag` conforms to `NFCNDEFTag` — so a **tag session** (`NFCTagReaderSession`) reads the same NDEF using only the **`TAG`** entitlement (confirmed in `react-native-nfc-manager` v3.17.2's iOS `getNdefMessage`, which reads NDEF off `tagSession.connectedTag`).

- **`src/lib/nfc.ts`** — iOS: `requestTechnology(NfcTech.Iso15693IOS)` + `ndefHandler.getNdefMessage()`. Android: unchanged (`NfcTech.Ndef` + `getTag()`). MIME-record match + base64 payload + `/api/nfc/decode` flow identical.
- **`app.config.ts`** — `includeNdefEntitlement: false` → entitlement `['TAG']`, which passes App Store validation.

## Verification
- ✅ **On-device verified**: scanned a real OpenPrintTag on iOS with this exact change (local build, `['TAG']` entitlement) — the lookup works.
- `tsc` + `expo lint` clean. API confirmed against the installed library source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)