### PR TITLE
fix(list): parent color-count counts all variants, not just in-stock (#744)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -489,6 +489,23 @@ export default function Home() {
     return map;
   }, [filaments]);
 
+  // True variant count per parent, derived from the FULL fetched list (#744).
+  // The collapsed parent's "N color(s)" chip must reflect every variant in the
+  // family, not just those left in `visibleFilaments` after the #712
+  // out-of-stock hide — otherwise a parent with out-of-stock variants
+  // under-counts vs. its own detail page. `filaments` holds every non-deleted
+  // variant (out-of-stock filtering is applied only when deriving
+  // `visibleFilaments`); when a server-side search/type/vendor filter is
+  // active `filaments` is already that filtered set, so the chip then reflects
+  // the filtered family, matching the rows shown.
+  const variantCountByParent = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const f of filaments) {
+      if (f.parentId) m.set(f.parentId, (m.get(f.parentId) ?? 0) + 1);
+    }
+    return m;
+  }, [filaments]);
+
   const groupedFilaments = useMemo(() => {
     const parentMap = new Map<string, GroupedFilament>();
     const standalone: Filament[] = [];
@@ -1049,7 +1066,9 @@ export default function Home() {
               {f.name}
             </Link>
             <span className="ml-1.5 text-[10px] text-gray-500 bg-gray-200 dark:bg-gray-800 px-1 py-0.5 rounded">
-              {t("filaments.colorCount", { count: group.variants.length })}
+              {t("filaments.colorCount", {
+                count: variantCountByParent.get(f._id) ?? group.variants.length,
+              })}
             </span>
           </td>
           <td className="py-2 px-2">{f.vendor}</td>


### PR DESCRIPTION
Fixes #744.

## Problem
On the main filament list, a collapsed parent's **"N color(s)"** chip showed too few colors — fewer than the parent's own detail page reports — when some variants were out of stock.

## Cause
The chip rendered `group.variants.length` (`src/app/page.tsx`), but `group.variants` is built from `visibleFilaments`, which **drops out-of-stock variants** under the #712 default "hide out-of-stock" filter. So the count reflected only in-stock variants, while the detail page (unfiltered) showed the true total — the mismatch the reporter saw.

## Fix
Derive the chip count from the **full fetched `filaments` list** (which holds every non-deleted variant; out-of-stock filtering is applied only when deriving `visibleFilaments`):

```ts
const variantCountByParent = useMemo(() => {
  const m = new Map<string, number>();
  for (const f of filaments) if (f.parentId) m.set(f.parentId, (m.get(f.parentId) ?? 0) + 1);
  return m;
}, [filaments]);
```
…and the chip uses `variantCountByParent.get(f._id) ?? group.variants.length`. When a server-side search/type/vendor filter is active, `filaments` is already that filtered set, so the chip then matches the filtered family (and the rows shown).

## Verification
`tsc` + `eslint` clean. Read-only client change (no API/data writes). CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)