### PR TITLE
fix(openprinttag): don't freeze the app on a cold OpenPrintTag fetch (#743)

### DIFF
--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -401,12 +401,17 @@ export default function OpenPrintTagBrowser() {
     async (refresh = false) => {
       setLoading(true);
       setError(null);
-      // #743: bound the request so a stalled/slow cold fetch on the server
-      // surfaces a retryable error instead of an infinite spinner ("never
-      // returns"). The server caches the result, so a retry after a timeout
-      // picks up the in-progress single-flight load once it completes.
+      // #743: a backstop against a truly-stuck request (the real "whole app
+      // hangs" cause — a synchronous parse blocking the event loop — is fixed
+      // server-side). This MUST exceed the server's worst-case window so it
+      // never pre-empts the legitimate slow paths: the server retries the
+      // GitHub fetch up to 3×60s + backoff (~183s) and then serves a stale
+      // cached DB (GH #225) — a cached user on a flaky network must still get
+      // that stale data, not a premature timeout (Codex P2). 240s clears the
+      // ~183s server window with margin; the single-flight means a retry after
+      // a timeout joins the in-progress load rather than duplicating it.
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 90_000);
+      const timeout = setTimeout(() => controller.abort(), 240_000);
       try {
         // GH #427: refresh moved from `GET ?refresh=true` to POST so
         // the cache-mutation isn't a GET-with-side-effect.

--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -401,12 +401,18 @@ export default function OpenPrintTagBrowser() {
     async (refresh = false) => {
       setLoading(true);
       setError(null);
+      // #743: bound the request so a stalled/slow cold fetch on the server
+      // surfaces a retryable error instead of an infinite spinner ("never
+      // returns"). The server caches the result, so a retry after a timeout
+      // picks up the in-progress single-flight load once it completes.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 90_000);
       try {
         // GH #427: refresh moved from `GET ?refresh=true` to POST so
         // the cache-mutation isn't a GET-with-side-effect.
         const res = refresh
-          ? await fetch("/api/openprinttag", { method: "POST" })
-          : await fetch("/api/openprinttag");
+          ? await fetch("/api/openprinttag", { method: "POST", signal: controller.signal })
+          : await fetch("/api/openprinttag", { signal: controller.signal });
         if (!res.ok) {
           const data = await res.json().catch(() => ({}));
           throw new Error(data.error || `HTTP ${res.status}`);
@@ -414,9 +420,14 @@ export default function OpenPrintTagBrowser() {
         const data: OPTDatabase = await res.json();
         setDb(data);
       } catch (err) {
-        setError(String(err));
-        toast(t("openprinttag.failedToLoad"), "error");
+        const timedOut = err instanceof DOMException && err.name === "AbortError";
+        setError(timedOut ? t("openprinttag.loadTimeout") : String(err));
+        toast(
+          timedOut ? t("openprinttag.loadTimeout") : t("openprinttag.failedToLoad"),
+          "error",
+        );
       } finally {
+        clearTimeout(timeout);
         setLoading(false);
       }
     },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -711,6 +711,7 @@
   "openprinttag.fetchingDescription": "Ca. 11.000 Materialdateien werden von GitHub heruntergeladen und verarbeitet.\nDies kann beim ersten Laden 10–30 Sekunden dauern (danach 1 Stunde gecacht).",
   "openprinttag.failedToLoadDatabase": "Datenbank konnte nicht geladen werden",
   "openprinttag.failedToLoad": "OpenPrintTag-Datenbank konnte nicht geladen werden",
+  "openprinttag.loadTimeout": "Zeitüberschreitung beim Laden — die Datenbank wird möglicherweise noch auf dem Server heruntergeladen. Warte einen Moment und versuche es erneut.",
   "openprinttag.retry": "Erneut versuchen",
   "openprinttag.importFailed": "Import fehlgeschlagen",
   "openprinttag.importFailedNetwork": "Import fehlgeschlagen: Netzwerkfehler",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -711,6 +711,7 @@
   "openprinttag.fetchingDescription": "Downloading and parsing ~11,000 material files from GitHub.\nThis may take 10–30 seconds on first load (cached for 1 hour after).",
   "openprinttag.failedToLoadDatabase": "Failed to load database",
   "openprinttag.failedToLoad": "Failed to load OpenPrintTag database",
+  "openprinttag.loadTimeout": "Loading timed out — the database may still be downloading on the server. Wait a moment and try again.",
   "openprinttag.retry": "Retry",
   "openprinttag.importFailed": "Import failed",
   "openprinttag.importFailedNetwork": "Import failed: network error",

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -13,7 +13,8 @@
  */
 
 import { parse as parseYaml } from "yaml";
-import { mkdtempSync, readFileSync, rmSync, readdirSync, statSync } from "fs";
+import { mkdtempSync, rmSync } from "fs";
+import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import { Readable } from "node:stream";
@@ -405,14 +406,17 @@ export function mapToFilamentPayload(
 
 /**
  * Walk a directory recursively, yielding file paths.
+ *
+ * #743: async (fs/promises) rather than readdirSync/statSync so the recursive
+ * walk over the OpenPrintTag tree (~11k material files) doesn't block the
+ * embedded server's single event loop on a cold parse.
  */
-function walkDir(dir: string): string[] {
+async function walkDir(dir: string): Promise<string[]> {
   const results: string[] = [];
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    const stat = statSync(full);
-    if (stat.isDirectory()) {
-      results.push(...walkDir(full));
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walkDir(full)));
     } else {
       results.push(full);
     }
@@ -441,6 +445,23 @@ export async function fetchOpenPrintTagDatabase(): Promise<OPTDatabase> {
     return cachedDatabase;
   }
 
+  // #743: single-flight. On a fresh install the cache is empty, and the page
+  // auto-fetches on mount — a reload / re-navigation / second tab would each
+  // otherwise kick off an independent GitHub download + tar extract + ~11k-file
+  // parse, piling up on the one embedded-server event loop and compounding the
+  // freeze. Share ONE in-progress load; clear it in `finally` (success OR
+  // failure) so a failed cold load doesn't leave a rejected promise that every
+  // later caller awaits forever.
+  if (inFlightFetch) return inFlightFetch;
+  inFlightFetch = runFetchWithRetries();
+  try {
+    return await inFlightFetch;
+  } finally {
+    inFlightFetch = null;
+  }
+}
+
+async function runFetchWithRetries(): Promise<OPTDatabase> {
   const MAX_ATTEMPTS = 3;
   let lastError: unknown = null;
 
@@ -565,7 +586,7 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     );
 
     // The tarball extracts to a subdirectory like OpenPrintTag-openprinttag-database-<sha>/
-    const extracted = readdirSync(tmpDir);
+    const extracted = await readdir(tmpDir);
     if (extracted.length === 0) throw new Error("Tarball extraction produced no files");
     const repoRoot = join(tmpDir, extracted[0]);
 
@@ -573,9 +594,9 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     const brandMap = new Map<string, { name: string; country?: string }>();
     const brandsDir = join(repoRoot, "data", "brands");
     try {
-      for (const file of readdirSync(brandsDir)) {
+      for (const file of await readdir(brandsDir)) {
         if (!file.endsWith(".yaml")) continue;
-        const content = readFileSync(join(brandsDir, file), "utf-8");
+        const content = await readFile(join(brandsDir, file), "utf-8");
         const brand = parseBrandYaml(content);
         if (brand) brandMap.set(brand.slug, { name: brand.name, country: brand.country });
       }
@@ -583,16 +604,25 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
       // brands dir may not exist in some edge cases
     }
 
-    // Parse materials
+    // Parse materials. #743: async file reads + a periodic event-loop yield so
+    // this ~11k-file parse doesn't block the embedded server's single event
+    // loop (which would freeze the WHOLE app — every other tab/route — on a
+    // cold fetch, the reported symptom). parseYaml itself is synchronous, so we
+    // also yield via setImmediate every YIELD_EVERY files to break up CPU bursts.
     const materials: OPTMaterial[] = [];
     let totalSLA = 0;
     const materialsDir = join(repoRoot, "data", "materials");
-    const allFiles = walkDir(materialsDir);
+    const allFiles = await walkDir(materialsDir);
 
+    const YIELD_EVERY = 256;
+    let seen = 0;
     for (const filePath of allFiles) {
       if (!filePath.endsWith(".yaml")) continue;
+      if (++seen % YIELD_EVERY === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
       try {
-        const content = readFileSync(filePath, "utf-8");
+        const content = await readFile(filePath, "utf-8");
         const raw = parseYaml(content) as Record<string, unknown>;
         if (!raw || !raw.class) continue;
 
@@ -654,6 +684,8 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 let cachedDatabase: OPTDatabase | null = null;
 let cacheTimestamp = 0;
+// #743: in-progress fetch shared by concurrent callers (single-flight).
+let inFlightFetch: Promise<OPTDatabase> | null = null;
 
 /**
  * Clear the cached database (useful for forcing a refresh).
@@ -661,4 +693,5 @@ let cacheTimestamp = 0;
 export function clearCache(): void {
   cachedDatabase = null;
   cacheTimestamp = 0;
+  inFlightFetch = null;
 }

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -689,9 +689,17 @@ let inFlightFetch: Promise<OPTDatabase> | null = null;
 
 /**
  * Clear the cached database (useful for forcing a refresh).
+ *
+ * #743 (Codex P1): clears ONLY the cached result — NOT `inFlightFetch`. The
+ * refresh-POST path calls this and then re-fetches; if a cold load is still
+ * running, forgetting (not cancelling) the in-flight promise would let the
+ * refetch start a SECOND download+parse instead of joining the running one,
+ * and the older load's `finally` could later clobber the newer in-flight/cache
+ * state — reintroducing the duplicate cold parses this fix prevents. Leaving
+ * `inFlightFetch` intact means a refresh joins any in-progress load (which is
+ * itself a fresh download), or starts a clean one when none is running.
  */
 export function clearCache(): void {
   cachedDatabase = null;
   cacheTimestamp = 0;
-  inFlightFetch = null;
 }

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -901,4 +901,24 @@ type: Resin
     const db = await fetchOpenPrintTagDatabase();
     expect(db.totalFFF).toBe(1);
   });
+
+  it("#743: clearCache during an in-flight load doesn't start a duplicate fetch", async () => {
+    // Codex P1: a refresh (clearCache + refetch) while a cold load is still
+    // running must JOIN that load, not start a second download+parse. clearCache
+    // therefore must NOT forget the in-flight promise.
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-cc/data/brands/.gitkeep": "",
+      "OpenPrintTag-cc/data/materials/m.yaml":
+        "uuid: m\nslug: m\nbrand:\n  slug: x\nname: M\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    const p1 = fetchOpenPrintTagDatabase(); // starts the load (sets inFlightFetch)
+    clearCache(); // refresh clears the cached RESULT mid-flight
+    const p2 = fetchOpenPrintTagDatabase(); // must join the running load
+    const [a, b] = await Promise.all([p1, p2]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1); // joined, not duplicated
+    expect(a).toBe(b);
+  });
 });

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -858,4 +858,47 @@ type: Resin
       /404|Not Found|GitHub tarball/,
     );
   });
+
+  it("#743: single-flight — concurrent callers share ONE fetch", async () => {
+    // On a fresh install the cache is empty and the page auto-fetches; a
+    // reload / second tab must not each kick off an independent
+    // download+extract+parse. Concurrent calls share one in-flight load.
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-sf/data/brands/.gitkeep": "",
+      "OpenPrintTag-sf/data/materials/m.yaml":
+        "uuid: m\nslug: m\nbrand:\n  slug: x\nname: M\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    const [a, b] = await Promise.all([
+      fetchOpenPrintTagDatabase(),
+      fetchOpenPrintTagDatabase(),
+    ]);
+
+    // Without single-flight this would be 2 (each call fetches independently).
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b); // both callers get the same resolved object
+  });
+
+  it("#743: a failed cold load doesn't wedge later calls (in-flight cleared on reject)", async () => {
+    // Every attempt fails and there's no cache to fall back on (clean install),
+    // so the first call rejects. The in-flight promise must be cleared so a
+    // later call RE-ATTEMPTS rather than awaiting the dead rejected promise.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 503, statusText: "Service Unavailable" }),
+    );
+    await expect(fetchOpenPrintTagDatabase()).rejects.toThrow();
+
+    // Now the server recovers — a subsequent call must succeed, not hang on a
+    // stale rejected promise.
+    vi.restoreAllMocks();
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-recover/data/brands/.gitkeep": "",
+      "OpenPrintTag-recover/data/materials/m.yaml":
+        "uuid: m\nslug: m\nbrand:\n  slug: x\nname: M\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+    const db = await fetchOpenPrintTagDatabase();
+    expect(db.totalFFF).toBe(1);
+  });
 });


### PR DESCRIPTION
Fixes #743.

## Problem
On a **fresh Electron install** (reporter: x64 Windows), clicking **Browse** on the OpenPrintTag page spun forever **and wedged the whole app** — other tabs/pages stopped loading too. Worked in a blank Docker container and on a machine that already had the data, so it's the **first cold fetch+parse** on a fresh install.

## Root cause
The embedded Next standalone server runs as a **single Node event loop**. The OpenPrintTag load parsed **~11k YAML files fully synchronously** (`readFileSync` + `parseYaml` in a tight loop; recursive `readdirSync`/`statSync` walk), blocking that loop so **every other request stalled** — the "whole app hangs" symptom. Compounding it: **no single-flight guard** (a reload / second tab each started an independent download+extract+parse that piled up) and **no client-side fetch timeout** (infinite spinner).

## Fix
- **Single-flight** (`openprinttagBrowser.ts`): concurrent callers share one in-progress load (`inFlightFetch`), cleared in `finally` so a failed cold load doesn't leave a rejected promise that later callers await forever.
- **Non-blocking parse**: `walkDir` + the brands/materials reads now use `fs/promises` (async) and yield via `setImmediate` every 256 files — the big parse no longer blocks the embedded server's event loop.
- **Client timeout** (`openprinttag/page.tsx`): a 90s `AbortController` surfaces a retryable error (`openprinttag.loadTimeout`, en+de) instead of an infinite spinner.

## Tests
`openprinttagBrowser.test.ts`: single-flight (concurrent calls → **one** fetch, same object) + rejection-doesn't-wedge (a fully-failed load lets the next call re-attempt). All existing OPT + i18n-parity tests pass.

## Caveat
Can't fully reproduce the Windows-specific cold-FS + Defender amplification without a Windows host. But the single-flight + async-parse changes are platform-independent and directly remove the event-loop block that produces the app-wide freeze; the client timeout removes the "never returns" UX. Worth an on-Windows confirmation after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)