### PR TITLE
Bump version to 1.51.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.50.0",
+      "version": "1.51.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.50.0",
+    "version": "1.51.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"
@@ -1444,15 +1444,25 @@
                       "nullable": true,
                       "description": "The spool whose instanceId matched the tag (#732), or null when the hit was filament-level or heuristic.",
                       "properties": {
-                        "_id": { "type": "string" },
-                        "instanceId": { "type": "string" },
-                        "label": { "type": "string" }
+                        "_id": {
+                          "type": "string"
+                        },
+                        "instanceId": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
                       }
                     },
                     "matchedBy": {
                       "type": "string",
                       "nullable": true,
-                      "enum": ["instanceId", "heuristic", null],
+                      "enum": [
+                        "instanceId",
+                        "heuristic",
+                        null
+                      ],
                       "description": "\"instanceId\" when the tag's spool_uid matched a per-spool spools[].instanceId (matchedSpool set) or the filament-level instanceId; \"heuristic\" for a name / vendor+type match; null when nothing matched."
                     },
                     "candidates": {
@@ -1542,9 +1552,15 @@
                       "nullable": true,
                       "description": "The spool whose instanceId matched the query (#732), or null when the hit was filament-level or heuristic.",
                       "properties": {
-                        "_id": { "type": "string" },
-                        "instanceId": { "type": "string" },
-                        "label": { "type": "string" }
+                        "_id": {
+                          "type": "string"
+                        },
+                        "instanceId": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
                       }
                     },
                     "candidates": {


### PR DESCRIPTION
Automated version bump produced by the Release Bump workflow.

Updates package.json, package-lock.json, and public/openapi.json to **1.51.0**.

Auto-merge is enabled — this will land as soon as CI passes.

## After merge
```bash
git checkout main
git pull
git tag v1.51.0
git push origin v1.51.0
```
The tag push triggers the existing `release.yml` build matrix.