### PR TITLE
fix(label-printer): commit the Windows spool job so it doesn't reprint (#759)

### DIFF
--- a/electron/label-printer.ts
+++ b/electron/label-printer.ts
@@ -38,10 +38,19 @@ const PRINTER_PATTERN = /pt-?p710bt|p-?touch|brother/i;
  *  letters, digits and underscores. */
 const MANAGED_QUEUE = "FilamentDB_Label";
 
-/** Per-subprocess timeout. Listing and a single 24mm label both complete
- *  well under this; the IPC handler wraps the whole print in its own 30s
- *  timeout on top. */
+/** Per-subprocess timeout for listing + the CUPS `lp` print. Listing and a
+ *  single 24mm label both complete well under this; the IPC handler wraps the
+ *  whole print in its own 30s timeout on top. */
 const EXEC_TIMEOUT_MS = 15_000;
+
+/** GH #759 — the Windows winspool print gets a LONGER subprocess timeout than
+ *  the 15s listing timeout. `EndDocPrinter` blocks until the spooler drains the
+ *  RAW bytes to the (slow, USB) label printer, which can take several seconds;
+ *  at 15s a busy/recovering spooler could be SIGKILLed mid-`EndDocPrinter`,
+ *  leaving the job open + a leaked printer handle (the "2nd print sticks, 3rd
+ *  errors" cascade). Kept under the IPC handler's 30s wrapper so the user still
+ *  gets a bounded failure. Exported for the regression test. */
+export const WINDOWS_PRINT_TIMEOUT_MS = 25_000;
 
 /** On Linux a GUI app's PATH often omits /usr/sbin where lpadmin/lpinfo
  *  live, so we try the bare name first then the sbin path. (The CUPS tools
@@ -355,7 +364,7 @@ async function printWindows(printerName: string, bytes: Uint8Array): Promise<voi
         "-PrinterName", printerName,
         "-FilePath", dataPath,
       ],
-      { timeout: EXEC_TIMEOUT_MS },
+      { timeout: WINDOWS_PRINT_TIMEOUT_MS },
     );
   } finally {
     await rm(dir, { recursive: true, force: true }).catch(() => {});
@@ -365,8 +374,19 @@ async function printWindows(printerName: string, bytes: Uint8Array): Promise<voi
 /** PowerShell that sends a file's bytes to a printer with the spooler RAW
  *  datatype via winspool.drv WritePrinter — the Windows equivalent of
  *  `lp -o raw`. Bypasses the driver's rendering so the Brother raster
- *  stream reaches the print head verbatim. */
-const WINDOWS_RAW_PRINT_PS1 = `param([Parameter(Mandatory=$true)][string]$PrinterName,
+ *  stream reaches the print head verbatim.
+ *
+ *  GH #759 — `EndPagePrinter`/`EndDocPrinter` are the calls that COMMIT the
+ *  spool job as "printed". The pre-fix code discarded their bool returns, so a
+ *  job that physically printed (WritePrinter succeeded) but failed to commit
+ *  still exited 0 → the renderer saw success while the spooler held an
+ *  uncommitted job that re-spooled on reboot and blocked the next print. We now
+ *  check both returns and throw — but ONLY when the protected body succeeded
+ *  (`pageOk`/`docOk` guard the throw), so a teardown after a real WritePrinter
+ *  failure doesn't mask the original error. EndPage/EndDoc/Close are still
+ *  ALWAYS called in their finallys, so a failed write tears the job down
+ *  instead of leaking it open. Exported for the regression test. */
+export const WINDOWS_RAW_PRINT_PS1 = `param([Parameter(Mandatory=$true)][string]$PrinterName,
       [Parameter(Mandatory=$true)][string]$FilePath)
 $ErrorActionPreference = "Stop"
 $code = @"
@@ -388,13 +408,24 @@ public static class FdbRawPrinter {
     try {
       DOCINFO di = new DOCINFO(); di.pDocName = "Filament DB Label"; di.pDataType = "RAW";
       if (!StartDocPrinter(h, 1, ref di)) throw new Exception("StartDocPrinter failed (" + Marshal.GetLastWin32Error() + ")");
+      bool docOk = false;
       try {
         if (!StartPagePrinter(h)) throw new Exception("StartPagePrinter failed (" + Marshal.GetLastWin32Error() + ")");
-        int written;
-        if (!WritePrinter(h, data, data.Length, out written)) throw new Exception("WritePrinter failed (" + Marshal.GetLastWin32Error() + ")");
-        if (written != data.Length) throw new Exception("WritePrinter wrote " + written + " of " + data.Length + " bytes");
-        EndPagePrinter(h);
-      } finally { EndDocPrinter(h); }
+        bool pageOk = false;
+        try {
+          int written;
+          if (!WritePrinter(h, data, data.Length, out written)) throw new Exception("WritePrinter failed (" + Marshal.GetLastWin32Error() + ")");
+          if (written != data.Length) throw new Exception("WritePrinter wrote " + written + " of " + data.Length + " bytes");
+          pageOk = true;
+        } finally {
+          bool endPage = EndPagePrinter(h);
+          if (pageOk && !endPage) throw new Exception("EndPagePrinter failed (" + Marshal.GetLastWin32Error() + ")");
+        }
+        docOk = true;
+      } finally {
+        bool endDoc = EndDocPrinter(h);
+        if (docOk && !endDoc) throw new Exception("EndDocPrinter failed (" + Marshal.GetLastWin32Error() + ")");
+      }
     } finally { ClosePrinter(h); }
   }
 }

--- a/tests/label-printer.test.ts
+++ b/tests/label-printer.test.ts
@@ -67,7 +67,13 @@ vi.mock("node:child_process", () => {
   return { execFile, spawn };
 });
 
-import { listLabelPrinters, printLabel, windowsPowershellPath } from "../electron/label-printer";
+import {
+  listLabelPrinters,
+  printLabel,
+  windowsPowershellPath,
+  WINDOWS_RAW_PRINT_PS1,
+  WINDOWS_PRINT_TIMEOUT_MS,
+} from "../electron/label-printer";
 
 const BYTES = new Uint8Array([0x1b, 0x40, 0x41, 0x42]);
 const BROTHER_URI = "usb://Brother/PT-P710BT?serial=000M5G671606";
@@ -264,5 +270,29 @@ describe("printLabel — legacy serial targets (GH #589)", () => {
     await expect(printLabel(target, BYTES)).rejects.toThrow(/select your printer again/i);
     expect(h.state.spawnCalls.some((c) => c.cmd === "lp")).toBe(false);
     expect(h.state.execCalls.some((c) => c.cmd === "lpadmin")).toBe(false);
+  });
+});
+
+describe("Windows raw-print job lifecycle (GH #759)", () => {
+  // The win32 print path can't be executed without a Windows host + printer
+  // (see the file header), so these are string-level guards on the generated
+  // PowerShell template + the dedicated timeout — pinning the #759 fix so a
+  // future edit can't silently re-introduce the "job never commits" bug.
+  it("surfaces EndPagePrinter/EndDocPrinter failures instead of completing silently", () => {
+    // The throw-strings only exist if the bool returns of the two commit calls
+    // are checked — discarding them again (the original bug) removes both.
+    expect(WINDOWS_RAW_PRINT_PS1).toMatch(/EndPagePrinter failed/);
+    expect(WINDOWS_RAW_PRINT_PS1).toMatch(/EndDocPrinter failed/);
+    // Still RAW datatype (the Brother raster must bypass driver rendering).
+    expect(WINDOWS_RAW_PRINT_PS1).toContain('di.pDataType = "RAW"');
+    // The guard flags that keep a teardown-after-write-failure from masking
+    // the original WritePrinter error.
+    expect(WINDOWS_RAW_PRINT_PS1).toMatch(/bool pageOk = false/);
+    expect(WINDOWS_RAW_PRINT_PS1).toMatch(/bool docOk = false/);
+  });
+
+  it("gives the Windows print a longer subprocess timeout than the 15s listing timeout, under the 30s IPC wrapper", () => {
+    expect(WINDOWS_PRINT_TIMEOUT_MS).toBeGreaterThan(15_000);
+    expect(WINDOWS_PRINT_TIMEOUT_MS).toBeLessThan(30_000);
   });
 });


### PR DESCRIPTION
Fixes [#759](https://github.com/hyiger/filament-db/issues/759) — on Windows (USB Brother PT-P710BT) a label prints correctly but the spooler job never reports "completed", so it re-spools on reboot/re-plug (printing twice) and blocks the next print (2nd sticks at "unknown status", 3rd errors). macOS/Linux (CUPS) are unaffected.

## Root cause
The winspool RAW path (`electron/label-printer.ts`) drove the Win32 sequence in the correct order, but **discarded the bool returns of `EndPagePrinter`/`EndDocPrinter`** — the two calls that *commit* the spool job as printed. The bytes reach the head (so the label prints), but if `EndDocPrinter` returns false the C# still returns normally → PowerShell exits 0 → the renderer sees `{ ok: true }` while the spooler holds an uncommitted job. That uncommitted job re-spools on reboot and keeps the port busy.

A too-aggressive 15s subprocess timeout (shared with *listing*) can also `SIGKILL` PowerShell mid-`EndDocPrinter` once the spooler is slow/busy — the amplifier behind "2nd sticks, 3rd errors".

## Fix (Windows branch only — CUPS path untouched)
- **Check `EndPagePrinter`/`EndDocPrinter` returns and throw on failure** — a job that can't be committed now surfaces a real error instead of a false success. `pageOk`/`docOk` flags guard the throw so a teardown after a genuine `WritePrinter` failure doesn't mask the original error; the End*/Close calls still **always** run in their finallys, tearing a failed job down instead of leaking it open.
- **Dedicated `WINDOWS_PRINT_TIMEOUT_MS` (25s, under the 30s IPC wrapper)** instead of the 15s listing timeout, so a slow USB-label spooler isn't killed mid-commit.

## Testing
- `electron/` is out of the Vitest/tsconfig scope and the win32 path can't run without a Windows host + printer, so `tests/label-printer.test.ts` gains **string-level guards** on the generated PowerShell (End* failure checks present, RAW datatype, the timeout bounds) to pin the fix against regression. Full `npm test`/`lint` green.
- ⚠️ **On-hardware confirmation is OWED** (this is a blind patch, as discussed on the issue): verify on Windows that the job completes in the queue, doesn't reprint on reboot, and that 2nd/3rd prints succeed.

## Fallback (if needed)
If hardware testing shows `EndDocPrinter` returns *true* yet the job still hangs, the deeper fix is printing through the installed Brother driver queue (OS owns lifecycle, like CUPS) rather than raw winspool — a separate, larger change to decide after testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)