### PR TITLE
fix(label-printer): friendly Windows spooler-down (1722) message + BiDi crash warning

### DIFF
--- a/electron/label-printer.ts
+++ b/electron/label-printer.ts
@@ -88,6 +88,12 @@ export interface LabelPrinterDevice {
   /** True when the target matches a PT-series printer — the picker badges
    *  / pre-selects the obvious choice. */
   looksLikePrinter: boolean;
+  /** Windows only: the queue has bidirectional support (EnableBIDI) turned on.
+   *  Some drivers (the PT-P710BT among them) crash the Print Spooler when the
+   *  spooler's bidi status query runs at schedule time, so the picker warns the
+   *  user to disable it. `undefined` on macOS/Linux and whenever the bidi state
+   *  couldn't be read — only an explicit `true` should trigger the warning. */
+  bidiEnabled?: boolean;
 }
 
 function isCups(): boolean {
@@ -202,10 +208,21 @@ function prettifyUsbUri(uri: string): string {
 }
 
 async function listWindowsPrinters(): Promise<LabelPrinterDevice[]> {
-  // ConvertTo-Json yields a single object for one printer and an array for
-  // many; @(...) forces an array so the shape is predictable.
+  // Keep `Get-Printer` as the source of the device list (same printer set +
+  // names as before) and enrich each row with EnableBIDI from Win32_Printer —
+  // `Get-Printer` doesn't surface the bidi flag, but the WMI/CIM class does.
+  // The CIM query is best-effort (wrapped in try/catch in PS): if it fails the
+  // bidi map stays empty and EnableBIDI reports false for every printer, but
+  // the listing itself still works. ConvertTo-Json yields a single object for
+  // one printer and an array for many; @(...) forces an array so the shape is
+  // predictable.
   const script =
-    "@(Get-Printer | Select-Object Name) | ConvertTo-Json -Compress";
+    "$bidi=@{}; " +
+    "try { Get-CimInstance Win32_Printer -ErrorAction Stop | " +
+    "ForEach-Object { $bidi[$_.Name] = [bool]$_.EnableBIDI } } catch {}; " +
+    "@(Get-Printer | ForEach-Object { " +
+    "[pscustomobject]@{ Name = $_.Name; EnableBIDI = [bool]$bidi[$_.Name] } }) | " +
+    "ConvertTo-Json -Compress";
   const { stdout } = await execFileP(
     windowsPowershellPath(),
     ["-NoProfile", "-NonInteractive", "-Command", script],
@@ -221,12 +238,16 @@ async function listWindowsPrinters(): Promise<LabelPrinterDevice[]> {
   }
   const rows = Array.isArray(parsed) ? parsed : [parsed];
   return rows
-    .map((r) => (r && typeof r === "object" ? (r as { Name?: string }).Name : undefined))
-    .filter((n): n is string => typeof n === "string" && n.length > 0)
-    .map((name) => ({
+    .filter((r): r is { Name?: unknown; EnableBIDI?: unknown } => !!r && typeof r === "object")
+    .map((r) => ({ name: r.Name, bidi: r.EnableBIDI }))
+    .filter((r): r is { name: string; bidi: unknown } => typeof r.name === "string" && r.name.length > 0)
+    .map(({ name, bidi }) => ({
       path: name,
       friendlyName: name,
       looksLikePrinter: PRINTER_PATTERN.test(name),
+      // Only a definite `true` warns; a missing/non-boolean value stays
+      // undefined so a failed CIM probe doesn't show a spurious warning.
+      bidiEnabled: typeof bidi === "boolean" ? bidi : undefined,
     }));
 }
 
@@ -343,6 +364,51 @@ async function ensureManagedQueue(uri: string): Promise<void> {
   }
 }
 
+/** win32 `RPC_S_SERVER_UNAVAILABLE`. The winspool APIs are RPC calls to the
+ *  Print Spooler service, so when it's stopped or has crashed `OpenPrinter`
+ *  (and every later winspool call) fails with this code. */
+const WIN32_RPC_S_SERVER_UNAVAILABLE = 1722;
+
+/** Actionable, renderer-ready message for the spooler-down case. Shared by the
+ *  PowerShell `OpenPrinter` throw (interpolated into {@link WINDOWS_RAW_PRINT_PS1})
+ *  and the {@link printWindows} catch, so the toast text is identical whichever
+ *  layer first surfaces it. Kept ASCII-only on purpose: it's embedded in a C#
+ *  string literal inside a PowerShell here-string that's written to disk and
+ *  re-read, where non-ASCII (em dashes, arrows) can be mangled by the host code
+ *  page. Exported for the unit test. */
+export const SPOOLER_DOWN_MESSAGE =
+  "The Windows Print Spooler service isn't running - restart it (open services.msc, select Print Spooler, and click Start), then try printing again.";
+
+/** Flatten an execFile rejection (its message + any captured stderr) into one
+ *  string for pattern matching. PowerShell writes the C# exception to stderr;
+ *  execFile also attaches it to the rejection. */
+function windowsPrintErrorText(err: unknown): string {
+  if (err && typeof err === "object") {
+    const e = err as { message?: unknown; stderr?: unknown };
+    const msg = typeof e.message === "string" ? e.message : "";
+    const stderr = typeof e.stderr === "string" ? e.stderr : "";
+    return `${msg}\n${stderr}`;
+  }
+  return String(err);
+}
+
+/**
+ * Map a raw Windows print-subprocess failure to an actionable message, or
+ * `null` when nothing specific applies (caller keeps the original error).
+ *
+ * Detects the spooler-down case both as the friendly message the PowerShell
+ * child already emits for an `OpenPrinter` 1722 AND as the bare win32 code
+ * `1722`, which can still surface from a later winspool call or be buried in
+ * .NET/PowerShell error noise. Exported for the unit test.
+ */
+export function mapWindowsPrintError(raw: string): string | null {
+  if (!raw) return null;
+  if (raw.includes(SPOOLER_DOWN_MESSAGE)) return SPOOLER_DOWN_MESSAGE;
+  // Word-boundaried so it matches "(1722)" / "error 1722" but not 17220 etc.
+  if (/\b1722\b/.test(raw)) return SPOOLER_DOWN_MESSAGE;
+  return null;
+}
+
 async function printWindows(printerName: string, bytes: Uint8Array): Promise<void> {
   // The spooler RAW datatype needs the bytes as a file; pass it + the printer
   // name to a P/Invoke script that calls winspool WritePrinter. Use a unique
@@ -366,6 +432,12 @@ async function printWindows(printerName: string, bytes: Uint8Array): Promise<voi
       ],
       { timeout: WINDOWS_PRINT_TIMEOUT_MS },
     );
+  } catch (err) {
+    // Replace cryptic winspool failures (notably the Print Spooler being down,
+    // win32 1722) with an actionable message so the renderer toast is clear;
+    // anything we don't recognise rethrows verbatim.
+    const friendly = mapWindowsPrintError(windowsPrintErrorText(err));
+    throw friendly ? new Error(friendly) : err;
   } finally {
     await rm(dir, { recursive: true, force: true }).catch(() => {});
   }
@@ -404,7 +476,12 @@ public static class FdbRawPrinter {
   [DllImport("winspool.drv", SetLastError=true)] public static extern bool WritePrinter(IntPtr h, byte[] buf, int count, out int written);
   public static void Print(string printer, byte[] data) {
     IntPtr h;
-    if (!OpenPrinter(printer, out h, IntPtr.Zero)) throw new Exception("OpenPrinter failed (" + Marshal.GetLastWin32Error() + ")");
+    if (!OpenPrinter(printer, out h, IntPtr.Zero)) {
+      int err = Marshal.GetLastWin32Error();
+      // win32 1722 (RPC_S_SERVER_UNAVAILABLE) = the Print Spooler service is
+      // down - surface the actionable hint instead of the bare code.
+      throw new Exception(err == ${WIN32_RPC_S_SERVER_UNAVAILABLE} ? "${SPOOLER_DOWN_MESSAGE}" : "OpenPrinter failed (" + err + ")");
+    }
     try {
       DOCINFO di = new DOCINFO(); di.pDocName = "Filament DB Label"; di.pDataType = "RAW";
       if (!StartDocPrinter(h, 1, ref di)) throw new Exception("StartDocPrinter failed (" + Marshal.GetLastWin32Error() + ")");

--- a/src/components/LabelPrinterSettings.tsx
+++ b/src/components/LabelPrinterSettings.tsx
@@ -271,6 +271,11 @@ export default function LabelPrinterSettings() {
                   <code className="text-xs text-gray-500 dark:text-gray-400 font-mono">
                     {d.path}
                   </code>
+                  {d.bidiEnabled && (
+                    <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+                      {t("settings.labelPrinter.bidiWarning")}
+                    </p>
+                  )}
                 </div>
               </label>
             );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -897,6 +897,7 @@
   "settings.labelPrinter.noDevices": "Keine Drucker gefunden. Verbinden Sie den PT-P710BT per USB (fügen Sie ihn bei Bedarf in den Systemeinstellungen für Drucker hinzu) und klicken Sie dann auf Aktualisieren.",
   "settings.labelPrinter.refresh": "Aktualisieren",
   "settings.labelPrinter.looksLikePrinter": "PT-Touch",
+  "settings.labelPrinter.bidiWarning": "Die bidirektionale Unterstützung ist für diesen Drucker aktiviert. Manche Treiber bringen den Windows-Druckwarteschlangendienst zum Absturz, wenn mit aktiviertem BiDi gedruckt wird. Falls der Etikettendruck fehlschlägt, öffnen Sie Druckereigenschaften → Anschlüsse und deaktivieren Sie „Bidirektionale Unterstützung aktivieren“.",
   "settings.labelPrinter.deviceSaved": "Etikettendrucker-Gerät gespeichert.",
   "settings.labelPrinter.deviceSaveFailed": "Gerät konnte nicht gespeichert werden: {error}",
   "settings.labelPrinter.deviceCleared": "Etikettendrucker-Auswahl entfernt.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -897,6 +897,7 @@
   "settings.labelPrinter.noDevices": "No printers found. Connect the PT-P710BT via USB (add it in your system print settings if needed), then click Refresh.",
   "settings.labelPrinter.refresh": "Refresh",
   "settings.labelPrinter.looksLikePrinter": "PT-Touch",
+  "settings.labelPrinter.bidiWarning": "Bidirectional support is on for this printer. Some drivers crash the Windows Print Spooler when printing with BiDi enabled. If labels fail to print, open Printer Properties → Ports and uncheck \"Enable bidirectional support\".",
   "settings.labelPrinter.deviceSaved": "Label printer device saved.",
   "settings.labelPrinter.deviceSaveFailed": "Couldn't save device: {error}",
   "settings.labelPrinter.deviceCleared": "Label printer device cleared.",

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -103,6 +103,11 @@ export interface LabelPrinterDevice {
   /** True when the path/manufacturer/friendly name matches a PT-series
    *  printer — the picker pre-selects the obvious choice. */
   looksLikePrinter: boolean;
+  /** Windows only: the queue has bidirectional support (EnableBIDI) on. Some
+   *  drivers crash the Print Spooler with BiDi enabled, so the picker warns.
+   *  `undefined` on macOS/Linux and when the state couldn't be read — only an
+   *  explicit `true` triggers the warning. */
+  bidiEnabled?: boolean;
 }
 
 export interface UpdateStatus {

--- a/tests/label-printer.test.ts
+++ b/tests/label-printer.test.ts
@@ -71,6 +71,8 @@ import {
   listLabelPrinters,
   printLabel,
   windowsPowershellPath,
+  mapWindowsPrintError,
+  SPOOLER_DOWN_MESSAGE,
   WINDOWS_RAW_PRINT_PS1,
   WINDOWS_PRINT_TIMEOUT_MS,
 } from "../electron/label-printer";
@@ -88,6 +90,22 @@ beforeEach(() => {
 // Skip on Windows — that branch uses a different (PowerShell) transport.
 const cups = process.platform !== "win32";
 const d = cups ? describe : describe.skip;
+
+/**
+ * Run `fn` with `process.platform` forced to "win32" so the Windows branch is
+ * reachable on the CUPS test host. execFile is mocked, so nothing is spawned;
+ * the fs calls printWindows makes (mkdtemp/writeFile/rm) are real but
+ * platform-agnostic. Restores the original descriptor even if `fn` throws.
+ */
+async function runAsWin32(fn: () => Promise<void> | void): Promise<void> {
+  const desc = Object.getOwnPropertyDescriptor(process, "platform")!;
+  Object.defineProperty(process, "platform", { ...desc, value: "win32" });
+  try {
+    await fn();
+  } finally {
+    Object.defineProperty(process, "platform", desc);
+  }
+}
 
 d("listLabelPrinters (CUPS)", () => {
   it("surfaces installed queues and available usb devices, badging PT printers", async () => {
@@ -294,5 +312,118 @@ describe("Windows raw-print job lifecycle (GH #759)", () => {
   it("gives the Windows print a longer subprocess timeout than the 15s listing timeout, under the 30s IPC wrapper", () => {
     expect(WINDOWS_PRINT_TIMEOUT_MS).toBeGreaterThan(15_000);
     expect(WINDOWS_PRINT_TIMEOUT_MS).toBeLessThan(30_000);
+  });
+});
+
+describe("Windows spooler-down error mapping (win32 1722)", () => {
+  // win32 1722 = RPC_S_SERVER_UNAVAILABLE — the winspool calls are RPC to the
+  // Print Spooler service, so a stopped/crashed spooler fails OpenPrinter with
+  // 1722. The cryptic "OpenPrinter failed (1722)" becomes an actionable hint.
+
+  it("SPOOLER_DOWN_MESSAGE names the service and how to restart it, ASCII-only", () => {
+    expect(SPOOLER_DOWN_MESSAGE).toMatch(/Print Spooler/i);
+    expect(SPOOLER_DOWN_MESSAGE).toMatch(/services\.msc/i);
+    // ASCII-only: it's embedded in the PS1 here-string that's written to disk
+    // and re-read under the host code page, where non-ASCII can be mangled.
+    expect(/^[\x00-\x7F]*$/.test(SPOOLER_DOWN_MESSAGE)).toBe(true);
+  });
+
+  describe("the PowerShell template special-cases 1722 on OpenPrinter", () => {
+    it("branches on win32 1722 and embeds the friendly message", () => {
+      expect(WINDOWS_RAW_PRINT_PS1).toMatch(/err == 1722/);
+      expect(WINDOWS_RAW_PRINT_PS1).toContain(SPOOLER_DOWN_MESSAGE);
+    });
+    it("keeps the generic 'OpenPrinter failed (N)' for every other code", () => {
+      expect(WINDOWS_RAW_PRINT_PS1).toContain('"OpenPrinter failed (" + err + ")"');
+    });
+    it("the whole template stays ASCII (host-code-page safe)", () => {
+      expect(/^[\x00-\x7F]*$/.test(WINDOWS_RAW_PRINT_PS1)).toBe(true);
+    });
+  });
+
+  describe("mapWindowsPrintError", () => {
+    it("maps the bare 'OpenPrinter failed (1722)' text to the friendly hint", () => {
+      expect(mapWindowsPrintError("OpenPrinter failed (1722)")).toBe(SPOOLER_DOWN_MESSAGE);
+    });
+    it("maps a 1722 buried in .NET/PowerShell noise (later winspool call)", () => {
+      const noise =
+        "Exception calling \"Print\": \"WritePrinter failed (1722)\"\n    at <ScriptBlock>";
+      expect(mapWindowsPrintError(noise)).toBe(SPOOLER_DOWN_MESSAGE);
+    });
+    it("passes through the friendly message the PS child already emitted", () => {
+      expect(mapWindowsPrintError(`boom\n${SPOOLER_DOWN_MESSAGE}\n`)).toBe(SPOOLER_DOWN_MESSAGE);
+    });
+    it("returns null for unrelated win32 codes", () => {
+      expect(mapWindowsPrintError("OpenPrinter failed (5)")).toBeNull(); // access denied
+      expect(mapWindowsPrintError("WritePrinter failed (1784)")).toBeNull();
+    });
+    it("does not match 1722 as a substring of a larger number", () => {
+      expect(mapWindowsPrintError("code 17220")).toBeNull();
+      expect(mapWindowsPrintError("error 21722")).toBeNull();
+    });
+    it("returns null for empty input", () => {
+      expect(mapWindowsPrintError("")).toBeNull();
+    });
+  });
+
+  describe("printWindows surfaces the mapping to the renderer", () => {
+    it("rewrites a 1722 print failure to the actionable spooler-down message", async () => {
+      await runAsWin32(async () => {
+        h.state.execImpl = () => ({
+          error: new Error("Command failed: powershell.exe ..."),
+          stderr: "OpenPrinter failed (1722)",
+        });
+        await expect(printLabel("Brother PT-P710BT", BYTES)).rejects.toThrow(/Print Spooler/i);
+      });
+    });
+
+    it("passes unrelated print failures through unchanged", async () => {
+      await runAsWin32(async () => {
+        h.state.execImpl = () => ({
+          error: new Error("WritePrinter failed (5)"),
+          stderr: "",
+        });
+        await expect(printLabel("Brother PT-P710BT", BYTES)).rejects.toThrow(
+          /WritePrinter failed \(5\)/,
+        );
+      });
+    });
+  });
+});
+
+describe("listWindowsPrinters — bidirectional-support detection", () => {
+  // Some drivers (the PT-P710BT among them) crash the spooler when BiDi is on;
+  // the picker reads EnableBIDI from Win32_Printer to warn the user. Get-Printer
+  // stays the source of the device list — Win32_Printer only supplies the flag.
+
+  it("keeps Get-Printer as the device source and reads EnableBIDI from Win32_Printer", async () => {
+    await runAsWin32(async () => {
+      h.state.execImpl = () => ({ stdout: '[{"Name":"Brother PT-P710BT","EnableBIDI":true}]' });
+      await listLabelPrinters();
+      const script = h.state.execCalls[0].args[3];
+      expect(script).toContain("Get-Printer");
+      expect(script).toContain("Win32_Printer");
+      expect(script).toContain("EnableBIDI");
+    });
+  });
+
+  it("flags printers with BiDi on and leaves it false when off", async () => {
+    await runAsWin32(async () => {
+      h.state.execImpl = () => ({
+        stdout:
+          '[{"Name":"Brother PT-P710BT","EnableBIDI":true},{"Name":"HP DeskJet","EnableBIDI":false}]',
+      });
+      const devices = await listLabelPrinters();
+      expect(devices.find((x) => x.path === "Brother PT-P710BT")?.bidiEnabled).toBe(true);
+      expect(devices.find((x) => x.path === "HP DeskJet")?.bidiEnabled).toBe(false);
+    });
+  });
+
+  it("leaves bidiEnabled undefined when the flag is absent (CIM probe failed)", async () => {
+    await runAsWin32(async () => {
+      h.state.execImpl = () => ({ stdout: '[{"Name":"Brother PT-P710BT"}]' });
+      const devices = await listLabelPrinters();
+      expect(devices[0].bidiEnabled).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## What

Hardens Windows label printing after the first on-hardware Windows test (Brother PT-P710BT, Win11 24H2) surfaced a Print Spooler crash.

### The bug
With a queue's **bidirectional support (`EnableBIDI`)** enabled, the spooler's bidi status query at schedule time fast-fails `localspl.dll` (`0xc0000409`) on **every** RAW job — wedging the job in the queue and returning a cryptic `OpenPrinter failed (1722)` on each retry until the queue is cleared. Disabling BiDi on the queue is the fix (hardware-confirmed: a real raster label then prints and cuts cleanly, spooler stays up).

### Changes
- **Friendly spooler-down message.** Map win32 `1722` (`RPC_S_SERVER_UNAVAILABLE` → spooler down) to an actionable `SPOOLER_DOWN_MESSAGE`, emitted from the PowerShell `OpenPrinter` throw **and** re-mapped in `printWindows()` via the pure `mapWindowsPrintError()`, so the renderer toast is identical whichever layer surfaces it first. ASCII-only on purpose (it rides a PowerShell here-string written to disk and re-read).
- **BiDi warning in Settings.** `listWindowsPrinters()` reads `EnableBIDI` from `Win32_Printer` (`Get-Printer` stays the device source) into `LabelPrinterDevice.bidiEnabled`; the picker shows an amber warning (`settings.labelPrinter.bidiWarning`, EN+DE) pointing the user to Printer Properties → Ports → uncheck "Enable bidirectional support".

### Tests
`tests/label-printer.test.ts`: 1722 mapping (incl. buried-in-noise and word-boundary `17220`/`21722` negatives), `printWindows` passthrough of unrelated win32 errors, and BiDi detection (on / off / absent-when-CIM-probe-failed).

Follow-up to #759. macOS/Linux transport paths are untouched.

## Test plan
- [ ] CI green: `test (20)`, `test (22)`, `smoke`
- [x] Verified on hardware: with BiDi disabled, a real RAW raster job prints + cuts and the spooler stays running; the queue drains cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
