### PR TITLE
fix(mobile): clear uuid<11.1.1 advisories + add a mobile CI gate (#764, #765)

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,61 @@
+# CI gate for the Expo mobile app (packages/mobile) — GH #765.
+#
+# The root test.yml only exercises the web/Electron package: root tsconfig and
+# eslint exclude packages/, and packages/mobile carries its own package-lock.json
+# (it is NOT an npm workspace member), so root `npm ci`/lint/tsc/audit never touch
+# it. This job runs the mobile package's own lint + typecheck + production audit
+# so a PR can't break the scanner app or introduce mobile-only advisories while
+# the required root checks stay green.
+#
+# Scoped with a paths filter so it only runs when the mobile package (or this
+# workflow) changes — the mobile app is touched far less often than the web app
+# and its install is heavy. NOTE: if this is ever added to branch protection as a
+# REQUIRED check, drop the paths filter (or use a "skipped = success" shim) to
+# avoid the required-check + path-filter "pending forever" deadlock.
+name: Mobile
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/mobile/**"
+      - ".github/workflows/mobile.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/mobile/**"
+      - ".github/workflows/mobile.yml"
+
+jobs:
+  mobile:
+    name: lint · typecheck · audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/mobile
+    steps:
+      - uses: actions/checkout@v4
+
+      # node 20 matches the EAS build environment (eas-build-mobile.yml); a
+      # single version is enough for a lint/tsc/audit gate.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: packages/mobile/package-lock.json
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      # No `typecheck` script in packages/mobile — invoke tsc directly.
+      - name: Type check
+        run: npx tsc --noEmit
+
+      # Production-dependency audit. Blocking: the uuid<11.1.1 advisories (GH
+      # #764) are resolved by the `overrides` block in packages/mobile/package.json
+      # shipped in the same PR, so this passes today. If a future Expo bump
+      # re-introduces a transitive advisory, this fails the PR — the intended gate.
+      - name: Security audit (production deps)
+        run: npm audit --audit-level=moderate --omit=dev

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -11347,13 +11347,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -46,5 +46,8 @@
     "web": "expo start --web",
     "lint": "expo lint"
   },
+  "overrides": {
+    "uuid": "^11.1.1"
+  },
   "private": true
 }


### PR DESCRIPTION
Resolves [#764](https://github.com/hyiger/filament-db/issues/764) and [#765](https://github.com/hyiger/filament-db/issues/765) together (the CI gate is only blockable once the advisories are fixed).

## #764 — mobile npm audit (12 moderate → 0)
All 12 advisories traced to **one** root: `uuid@7.0.3` (GHSA-w5hq-g745-h8pq), pulled in solely by `xcode@3.0.1` (Expo prebuild/CNG tooling) → `@expo/config-plugins` → expo / expo-splash-screen / react-native-nfc-manager. It's **build-time only** (runs on EAS during `expo prebuild`; no `uuid` in the shipped bundle, and `xcode` only calls `uuid.v4()`, unchanged in v11).
- `npm audit fix` would force a **major Expo downgrade** — not used.
- Added `"overrides": { "uuid": "^11.1.1" }` to `packages/mobile/package.json` (mirrors the root `exceljs.uuid` precedent) + regenerated the lockfile (uuid dedupes to 11.1.1).
- `cd packages/mobile && npm audit --omit=dev --audit-level=moderate` → **found 0 vulnerabilities**; `npx tsc --noEmit` still passes.

## #765 — mobile CI gate
`packages/mobile` had no automated checks: root `test.yml` is root-only, root tsconfig/eslint exclude `packages/`, and the mobile package has its own lockfile (not an npm workspace).
- New `.github/workflows/mobile.yml` — PR + push to `main`, paths-filtered to `packages/mobile/**`, node 20 (matches the EAS env): `npm ci` · `npm run lint` (`expo lint`) · `npx tsc --noEmit` · `npm audit --audit-level=moderate --omit=dev`.
- The audit step is **blocking from day one** because #764's override lands in the same PR (passes now); a future Expo bump that re-introduces an advisory will fail the gate.
- Not added to branch protection here (maintainer/admin action); the workflow comment notes the path-filter + required-check caveat if you do.

Fixes #764
Fixes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)