### PR TITLE
docs(security): scope FILAMENTDB_API_KEY to non-browser clients; loopback Docker defaults (#766, #767)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,15 @@ MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/filament-d
 # Comma-separated list of hostnames allowed to access the dev server (e.g. myhost.local)
 ALLOWED_DEV_ORIGINS=
 
+# Optional bearer-token gate on every /api/* request, for securing a
+# network-exposed instance. WARNING: it's all-or-nothing and DISABLES the
+# first-party browser web UI (the UI doesn't send the key) — set it only for
+# non-browser clients (the mobile app, PrusaSlicer/OrcaSlicer, scripts). For
+# browser-UI access over a LAN, keep the port on loopback or use an
+# authenticating reverse proxy instead. See docs/setup.md "Securing a
+# network-exposed instance". Generate with: openssl rand -hex 32
+FILAMENTDB_API_KEY=
+
 # AI provider for TDS extraction (choose one)
 GEMINI_API_KEY=
 ANTHROPIC_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Filament DB
 
-A desktop and web application for managing 3D printing filament profiles. Import filament configurations from PrusaSlicer, store them in MongoDB or MongoDB Atlas, and manage them through a clean interface. The desktop app reads and writes [OpenPrintTag](https://openprinttag.org/) NFC tags (NFC-V / ISO 15693) and reads Bambu Lab MIFARE Classic spool tags via an ACR1552U reader, so you can scan a spool to autofill a profile or write your own per-spool tags. Available as an installable desktop app for macOS, Windows, and Linux, or run as a local web app. The desktop app supports offline mode with an embedded local database, hybrid mode with automatic cloud sync, or direct Atlas cloud mode. The API is unauthenticated by default and intended for single-user localhost use; do not expose to untrusted networks without adding an auth layer. For exposed/headless deployments (e.g. the mobile companion app talking to it over the LAN), set the `FILAMENTDB_API_KEY` environment variable — every `/api` request must then send `Authorization: Bearer <key>`. Leave it unset for localhost/desktop use, where it stays a no-op.
+A desktop and web application for managing 3D printing filament profiles. Import filament configurations from PrusaSlicer, store them in MongoDB or MongoDB Atlas, and manage them through a clean interface. The desktop app reads and writes [OpenPrintTag](https://openprinttag.org/) NFC tags (NFC-V / ISO 15693) and reads Bambu Lab MIFARE Classic spool tags via an ACR1552U reader, so you can scan a spool to autofill a profile or write your own per-spool tags. Available as an installable desktop app for macOS, Windows, and Linux, or run as a local web app. The desktop app supports offline mode with an embedded local database, hybrid mode with automatic cloud sync, or direct Atlas cloud mode. The API is unauthenticated by default and intended for single-user localhost use; do not expose to untrusted networks without adding an auth layer. For exposed/headless deployments (e.g. the mobile companion app talking to it over the LAN), set the `FILAMENTDB_API_KEY` environment variable — every `/api` request must then send `Authorization: Bearer <key>`. Note the gate is all-or-nothing and **disables the first-party browser web UI** (which doesn't send the key), so it's for non-browser clients (mobile app, slicers, scripts); for browser-UI access on a LAN, keep the port on loopback or use an authenticating reverse proxy (see [Securing a network-exposed instance](docs/setup.md#securing-a-network-exposed-instance)). Leave it unset for localhost/desktop use, where it stays a no-op.
 
 ![Filament DB](docs/images/filament-db-screenshot.png)
 
@@ -94,10 +94,10 @@ Download the latest release for your platform from [GitHub Releases](https://git
 ### Docker
 
 ```bash
-docker run -p 3456:3000 -e MONGODB_URI="mongodb+srv://..." ghcr.io/hyiger/filament-db
+docker run -p 127.0.0.1:3456:3000 -e MONGODB_URI="mongodb+srv://..." ghcr.io/hyiger/filament-db
 ```
 
-Open http://localhost:3456. See the [Setup Guide](docs/setup.md#option-2-docker) for Docker Compose and configuration options.
+Open http://localhost:3456. The `127.0.0.1:` prefix binds the port to this machine only — a bare `-p 3456:3000` exposes the (unauthenticated) API to your whole LAN. See [Securing a network-exposed instance](docs/setup.md#securing-a-network-exposed-instance) before exposing it, and the [Setup Guide](docs/setup.md#option-2-docker) for Docker Compose and configuration options.
 
 ### From Source
 

--- a/docs/de/desktop.md
+++ b/docs/de/desktop.md
@@ -51,7 +51,7 @@ Standardmäßig bindet der eingebettete Next.js-Server an `localhost` und ist so
 
 Seit v1.47.0 kündigt sich der Desktop zusätzlich per **mDNS** an (`_filamentdb._tcp`, über `electron/mdns-service.ts` / `bonjour-service`) – **nur solange „Im lokalen Netzwerk freigeben" aktiv ist** –, sodass der **Im Netzwerk suchen**-Scan der mobilen App ihn ohne URL-Eingabe automatisch findet.
 
-> **Eine im LAN freigegebene Instanz absichern:** Setze die Umgebungsvariable `FILAMENTDB_API_KEY`, um bei jeder `/api/*`-Anfrage ein Bearer-Token zu verlangen (`src/lib/apiAuth.ts`). Bleibt sie ungesetzt, bleibt die API unauthentifiziert (Standard).
+> **Eine im LAN freigegebene Instanz absichern:** Setze die Umgebungsvariable `FILAMENTDB_API_KEY`, um bei jeder `/api/*`-Anfrage ein Bearer-Token zu verlangen (`src/lib/apiAuth.ts`). Bleibt sie ungesetzt, bleibt die API unauthentifiziert (Standard). Das Gate ist Alles-oder-Nichts und **deaktiviert die Browser-Web-UI** (die den Schlüssel nicht sendet) — es ist für Nicht-Browser-Clients (Mobile-App, Slicer); für Browser-UI-Zugriff im LAN nutze Loopback + die Desktop-App oder einen authentifizierenden Reverse-Proxy — siehe [Eine netzwerkexponierte Instanz absichern](setup.md#eine-netzwerkexponierte-instanz-absichern).
 
 ## Auto-Update *(v1.11)*
 

--- a/docs/de/setup.md
+++ b/docs/de/setup.md
@@ -112,12 +112,16 @@ Das Vertrauensmodell von Filament DB ist **localhost / Einzelnutzer**: Standardm
 
 Es gibt zwei Wege, eine exponierte Instanz abzusichern — je nachdem, **wer** sie erreichen muss:
 
-- **Nur Nicht-Browser-Clients** (die [mobile Begleit-App](mobile.md), PrusaSlicer/OrcaSlicer-Integrationen, Skripte) — setze `FILAMENTDB_API_KEY` auf einen starken Zufallswert. Jede `/api/*`-Anfrage muss dann `Authorization: Bearer <key>` senden; die Mobile-App und die Slicer-Integrationen unterstützen das. Erzeuge einen Wert z. B. mit `openssl rand -hex 32`.
+- **Nur Nicht-Browser-Clients** (die [mobile Begleit-App](mobile.md), PrusaSlicer/OrcaSlicer-Integrationen, Skripte) — setze `FILAMENTDB_API_KEY` auf einen starken Zufallswert. Jede `/api/*`-Anfrage muss dann `Authorization: Bearer <key>` senden; die Mobile-App und die Slicer-Integrationen unterstützen das. **Erzeuge den Schlüssel einmal, speichere ihn und verwende genau diesen Wert wieder** — deine Clients brauchen ihn, und er muss über Neustarts hinweg gleich bleiben (nicht inline erzeugen, sonst ändert er sich bei jedem Start und nichts kann sich mehr authentifizieren):
 
   ```bash
+  # 1. Schlüssel einmal erzeugen und kopieren (in die Mobile-App / den Slicer einfügen):
+  openssl rand -hex 32
+
+  # 2. Mit diesem gespeicherten Wert starten:
   docker run -p 3456:3000 \
     -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/filament-db" \
-    -e FILAMENTDB_API_KEY="$(openssl rand -hex 32)" \
+    -e FILAMENTDB_API_KEY="<erzeugten-schlüssel-einfügen>" \
     ghcr.io/hyiger/filament-db
   ```
 

--- a/docs/de/setup.md
+++ b/docs/de/setup.md
@@ -127,7 +127,7 @@ Es gibt zwei Wege, eine exponierte Instanz abzusichern — je nachdem, **wer** s
 
   > **Das Bearer-Gate ist Alles-oder-Nichts und deaktiviert die Browser-Web-UI.** Die Web-UI sendet einfache Same-Origin-Anfragen ohne den Schlüssel, daher lädt die UI zwar, aber jeder Aufruf liefert `401`. Es gibt bewusst keine Same-Origin-Ausnahme (diese Signale sind fälschbar). Nutze den Schlüssel nur, wenn der Zugriff auf diese Instanz nicht über die Browser-UI erfolgt.
 
-- **Browser-Web-UI-Zugriff über das LAN** — verlasse dich **nicht** auf `FILAMENTDB_API_KEY` (er bricht die UI, siehe oben). Binde stattdessen den Port an Loopback und nutze die Desktop-App, oder stelle Filament DB hinter einen **authentifizierenden Reverse-Proxy** (nginx/Caddy/Authelia mit Basic-Auth, SSO oder mTLS), der die Authentifizierung übernimmt, bevor die Anfrage die App erreicht.
+- **Browser-Web-UI-Zugriff über das LAN** — verlasse dich **nicht** auf `FILAMENTDB_API_KEY` (er bricht die UI, siehe oben). Binde stattdessen den Port an Loopback und nutze die Desktop-App, oder stelle Filament DB hinter einen **authentifizierenden Reverse-Proxy** (nginx/Caddy/Authelia mit Basic-Auth, SSO oder mTLS), der die Authentifizierung übernimmt, bevor die Anfrage die App erreicht. Wenn du einen Reverse-Proxy nutzt, **binde Filament DB selbst an Loopback** (`-p 127.0.0.1:3456:3000` bei Docker, `HOSTNAME=127.0.0.1` beim systemd-Dienst) oder sperre den direkten Port per Firewall — sonst bleibt die App unter `http://<host>:3456` erreichbar und Browser-Nutzer umgehen den Proxy direkt zur nicht authentifizierten API. Der Proxy muss der einzige Zugang sein.
 
 ### Aus Quellen bauen
 
@@ -289,7 +289,7 @@ sudo chmod 600 "/opt/Filament DB/.env"
 
 `HOSTNAME=0.0.0.0` sorgt dafür, dass der Server auf allen Netzwerkschnittstellen lauscht, sodass andere Geräte im Netz ihn erreichen können.
 
-> **Sicherheit:** Das Binden an `0.0.0.0` gibt die **nicht authentifizierte** `/api`-Oberfläche für alle im Netz frei. Lies vorher [Eine netzwerkexponierte Instanz absichern](#eine-netzwerkexponierte-instanz-absichern) — setze `FILAMENTDB_API_KEY`, wenn nur Nicht-Browser-Clients (Mobile-App, Slicer) Zugriff brauchen, oder stelle den Dienst hinter einen authentifizierenden Reverse-Proxy, wenn du die Browser-UI im LAN willst (der Schlüssel deaktiviert die Web-UI).
+> **Sicherheit:** Das Binden an `0.0.0.0` gibt die **nicht authentifizierte** `/api`-Oberfläche für alle im Netz frei. Lies vorher [Eine netzwerkexponierte Instanz absichern](#eine-netzwerkexponierte-instanz-absichern) — setze `FILAMENTDB_API_KEY`, wenn nur Nicht-Browser-Clients (Mobile-App, Slicer) Zugriff brauchen, oder stelle den Dienst hinter einen authentifizierenden Reverse-Proxy, wenn du die Browser-UI im LAN willst (der Schlüssel deaktiviert die Web-UI). Beim Reverse-Proxy-Weg setze hier `HOSTNAME=127.0.0.1` (nicht `0.0.0.0`) — oder sperre Port 3456 per Firewall — damit die App nur über den Proxy erreichbar ist; sonst können Browser-Nutzer `http://<host>:3456` direkt aufrufen und ihn umgehen.
 
 ### 2. Dienst anlegen
 

--- a/docs/de/setup.md
+++ b/docs/de/setup.md
@@ -31,12 +31,14 @@ Filament DB als Docker-Container betreiben. Das Image ist ~72 MB groß, basiert 
 ### Schnellstart
 
 ```bash
-docker run -p 3456:3000 \
+docker run -p 127.0.0.1:3456:3000 \
   -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/filament-db" \
   ghcr.io/hyiger/filament-db
 ```
 
 Öffne http://localhost:3456.
+
+> **Sicherheit:** Das Präfix `127.0.0.1:` bindet den Port **nur an diese Maschine**. Ein bloßes `-p 3456:3000` veröffentlicht auf **allen** Host-Schnittstellen und gibt damit die API von Filament DB im gesamten LAN frei — und die API ist **standardmäßig nicht authentifiziert**. Lass das `127.0.0.1:`-Präfix nur weg, wenn du den Dienst von anderen Geräten aus erreichen willst, und lies zuerst [Eine netzwerkexponierte Instanz absichern](#eine-netzwerkexponierte-instanz-absichern).
 
 ### Docker Compose
 
@@ -47,7 +49,10 @@ services:
   filament-db:
     image: ghcr.io/hyiger/filament-db
     ports:
-      - "3456:3000"
+      # Nur Loopback — von diesem Host erreichbar. Für den Zugriff von anderen
+      # Geräten "3456:3000" verwenden und "Eine netzwerkexponierte Instanz
+      # absichern" lesen.
+      - "127.0.0.1:3456:3000"
     environment:
       - MONGODB_URI=mongodb+srv://user:pass@cluster.mongodb.net/filament-db
       # Optional: AI-Provider für TDS-Extraktion (eine wählen)
@@ -70,7 +75,8 @@ services:
   filament-db:
     image: ghcr.io/hyiger/filament-db
     ports:
-      - "3456:3000"
+      # Nur Loopback (siehe Hinweis oben). "3456:3000" für LAN-Freigabe.
+      - "127.0.0.1:3456:3000"
     environment:
       - MONGODB_URI=mongodb://mongo:27017/filament-db
     depends_on:
@@ -93,10 +99,31 @@ volumes:
 |----------|----------|-------------|
 | `MONGODB_URI` | Ja | MongoDB-Verbindungszeichenfolge |
 | `PORT` | Nein | Serverport im Container (Standard: `3000`) |
+| `HOSTNAME` | Nein | Schnittstelle, an die der Server im Container bindet (Standard: `0.0.0.0`). Die Erreichbarkeit steuert das `docker run -p`-Mapping, nicht diese Variable. |
+| `FILAMENTDB_API_KEY` | Nein | Bearer-Token-Gate für **jede** `/api/*`-Anfrage. Siehe [Eine netzwerkexponierte Instanz absichern](#eine-netzwerkexponierte-instanz-absichern). **Hinweis:** deaktiviert die Browser-Web-UI — nur für Nicht-Browser-Clients (Mobile-App, Slicer, Skripte) verwenden. |
 | `GEMINI_API_KEY` | Nein | Google-Gemini-API-Key für TDS-Extraktion |
 | `ANTHROPIC_API_KEY` | Nein | Anthropic-Claude-API-Key für TDS-Extraktion |
 | `OPENAI_API_KEY` | Nein | OpenAI-API-Key für TDS-Extraktion |
 | `ALLOWED_DEV_ORIGINS` | Nein | Komma-separierte Hostnamen, die auf den Dev-Server zugreifen dürfen (z. B. `myhost.local`) |
+
+### Eine netzwerkexponierte Instanz absichern
+
+Das Vertrauensmodell von Filament DB ist **localhost / Einzelnutzer**: Standardmäßig ist die API **nicht authentifiziert**, was in Ordnung ist, solange der Port an Loopback (`127.0.0.1:`) gebunden ist oder du die Desktop-App nutzt. Eine Freigabe ins LAN (ein bloßes `-p 3456:3000` oder ein Headless-Dienst, der an `0.0.0.0` bindet) gibt die gesamte `/api`-Oberfläche für jedes Gerät im Netz frei.
+
+Es gibt zwei Wege, eine exponierte Instanz abzusichern — je nachdem, **wer** sie erreichen muss:
+
+- **Nur Nicht-Browser-Clients** (die [mobile Begleit-App](mobile.md), PrusaSlicer/OrcaSlicer-Integrationen, Skripte) — setze `FILAMENTDB_API_KEY` auf einen starken Zufallswert. Jede `/api/*`-Anfrage muss dann `Authorization: Bearer <key>` senden; die Mobile-App und die Slicer-Integrationen unterstützen das. Erzeuge einen Wert z. B. mit `openssl rand -hex 32`.
+
+  ```bash
+  docker run -p 3456:3000 \
+    -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/filament-db" \
+    -e FILAMENTDB_API_KEY="$(openssl rand -hex 32)" \
+    ghcr.io/hyiger/filament-db
+  ```
+
+  > **Das Bearer-Gate ist Alles-oder-Nichts und deaktiviert die Browser-Web-UI.** Die Web-UI sendet einfache Same-Origin-Anfragen ohne den Schlüssel, daher lädt die UI zwar, aber jeder Aufruf liefert `401`. Es gibt bewusst keine Same-Origin-Ausnahme (diese Signale sind fälschbar). Nutze den Schlüssel nur, wenn der Zugriff auf diese Instanz nicht über die Browser-UI erfolgt.
+
+- **Browser-Web-UI-Zugriff über das LAN** — verlasse dich **nicht** auf `FILAMENTDB_API_KEY` (er bricht die UI, siehe oben). Binde stattdessen den Port an Loopback und nutze die Desktop-App, oder stelle Filament DB hinter einen **authentifizierenden Reverse-Proxy** (nginx/Caddy/Authelia mit Basic-Auth, SSO oder mTLS), der die Authentifizierung übernimmt, bevor die Anfrage die App erreicht.
 
 ### Aus Quellen bauen
 
@@ -104,7 +131,7 @@ volumes:
 git clone https://github.com/hyiger/filament-db.git
 cd filament-db
 docker build -t filament-db .
-docker run -p 3456:3000 -e MONGODB_URI="mongodb+srv://..." filament-db
+docker run -p 127.0.0.1:3456:3000 -e MONGODB_URI="mongodb+srv://..." filament-db
 ```
 
 ---
@@ -257,6 +284,8 @@ sudo chmod 600 "/opt/Filament DB/.env"
 ```
 
 `HOSTNAME=0.0.0.0` sorgt dafür, dass der Server auf allen Netzwerkschnittstellen lauscht, sodass andere Geräte im Netz ihn erreichen können.
+
+> **Sicherheit:** Das Binden an `0.0.0.0` gibt die **nicht authentifizierte** `/api`-Oberfläche für alle im Netz frei. Lies vorher [Eine netzwerkexponierte Instanz absichern](#eine-netzwerkexponierte-instanz-absichern) — setze `FILAMENTDB_API_KEY`, wenn nur Nicht-Browser-Clients (Mobile-App, Slicer) Zugriff brauchen, oder stelle den Dienst hinter einen authentifizierenden Reverse-Proxy, wenn du die Browser-UI im LAN willst (der Schlüssel deaktiviert die Web-UI).
 
 ### 2. Dienst anlegen
 

--- a/docs/de/smart-filament-workflow-guide.md
+++ b/docs/de/smart-filament-workflow-guide.md
@@ -182,6 +182,7 @@ Atlas (Cloud), Hybrid (Lokal + Cloud) und Offline (Nur lokal).
 > `docker run -p 3456:3000 -e MONGODB_URI="mongodb+srv://..." ghcr.io/hyiger/filament-db`.
 > Mappt Host-Port `3456` (passend zur Desktop-App) auf Container-Port `3000`, sodass PrusaSlicers
 > `http://localhost:3456` für beide funktioniert.
+> (Läuft PrusaSlicer auf **derselben** Maschine wie der Container, verwende `-p 127.0.0.1:3456:3000`, um ihn vom LAN fernzuhalten; das bloße `-p 3456:3000` oben ist nur nötig, wenn PrusaSlicer auf einer anderen Maschine läuft — das gibt die nicht authentifizierte API frei, siehe [Eine netzwerkexponierte Instanz absichern](setup.md#eine-netzwerkexponierte-instanz-absichern).)
 > Die Docker-/Web-Version kann den USB-NFC-Reader nicht nutzen — Tag-Lesen und -Schreiben benötigt
 > die **Desktop**-App.
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -49,7 +49,7 @@ By default the embedded Next.js server binds to `localhost`, so it's reachable o
 
 Since v1.47.0 the desktop also advertises itself over **mDNS** (`_filamentdb._tcp`, via `electron/mdns-service.ts` / `bonjour-service`) **only while "Share on local network" is on**, so the mobile app's **Find on your network** scan can auto-discover it without typing a URL.
 
-> **Securing a LAN-exposed instance:** set the `FILAMENTDB_API_KEY` environment variable to require a bearer token on every `/api/*` request (`src/lib/apiAuth.ts`). Leaving it unset keeps the API unauthenticated (the default).
+> **Securing a LAN-exposed instance:** set the `FILAMENTDB_API_KEY` environment variable to require a bearer token on every `/api/*` request (`src/lib/apiAuth.ts`). Leaving it unset keeps the API unauthenticated (the default). The gate is all-or-nothing and **disables the browser web UI** (which doesn't attach the key), so it's for non-browser clients (the mobile app, slicers); for browser-UI access on a LAN, use loopback + the desktop app or an authenticating reverse proxy — see [Securing a network-exposed instance](setup.md#securing-a-network-exposed-instance).
 
 ## Auto-Update *(v1.11)*
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -29,12 +29,14 @@ Run Filament DB as a Docker container. The image is ~72MB, built on `node:22-alp
 ### Quick Start
 
 ```bash
-docker run -p 3456:3000 \
+docker run -p 127.0.0.1:3456:3000 \
   -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/filament-db" \
   ghcr.io/hyiger/filament-db
 ```
 
 Open http://localhost:3456.
+
+> **Security:** the `127.0.0.1:` prefix binds the port to **this machine only**. A bare `-p 3456:3000` publishes on **all** host interfaces, exposing Filament DB's API to your whole LAN — and the API is **unauthenticated by default**. Only drop the `127.0.0.1:` prefix if you intend to reach it from other devices, and read [Securing a network-exposed instance](#securing-a-network-exposed-instance) first.
 
 ### Docker Compose
 
@@ -45,7 +47,9 @@ services:
   filament-db:
     image: ghcr.io/hyiger/filament-db
     ports:
-      - "3456:3000"
+      # Loopback-only — reachable from this host. To reach it from other
+      # devices, use "3456:3000" and read "Securing a network-exposed instance".
+      - "127.0.0.1:3456:3000"
     environment:
       - MONGODB_URI=mongodb+srv://user:pass@cluster.mongodb.net/filament-db
       # Optional: AI provider for TDS extraction (choose one)
@@ -68,7 +72,8 @@ services:
   filament-db:
     image: ghcr.io/hyiger/filament-db
     ports:
-      - "3456:3000"
+      # Loopback-only (see the note above). Use "3456:3000" to expose on the LAN.
+      - "127.0.0.1:3456:3000"
     environment:
       - MONGODB_URI=mongodb://mongo:27017/filament-db
     depends_on:
@@ -91,10 +96,31 @@ volumes:
 |----------|----------|-------------|
 | `MONGODB_URI` | Yes | MongoDB connection string |
 | `PORT` | No | Server port inside the container (default: `3000`) |
+| `HOSTNAME` | No | Interface the server binds inside the container (default: `0.0.0.0`). Reachability is governed by the `docker run -p` mapping, not this. |
+| `FILAMENTDB_API_KEY` | No | Bearer-token gate on **every** `/api/*` request. See [Securing a network-exposed instance](#securing-a-network-exposed-instance). **Note:** it disables the browser web UI — use it only for non-browser clients (mobile app, slicers, scripts). |
 | `GEMINI_API_KEY` | No | Google Gemini API key for TDS extraction |
 | `ANTHROPIC_API_KEY` | No | Anthropic Claude API key for TDS extraction |
 | `OPENAI_API_KEY` | No | OpenAI API key for TDS extraction |
 | `ALLOWED_DEV_ORIGINS` | No | Comma-separated hostnames allowed to access the dev server (e.g. `myhost.local`) |
+
+### Securing a network-exposed instance
+
+Filament DB's trust model is **localhost / single-user**: by default the API is **unauthenticated**, which is fine when the port is bound to loopback (`127.0.0.1:`) or you're using the desktop app. Publishing it to the LAN (a bare `-p 3456:3000`, or a headless service binding `0.0.0.0`) exposes the full `/api` surface to every device on the network.
+
+You have two ways to secure an exposed instance, depending on **who** needs to reach it:
+
+- **Non-browser clients only** (the [mobile companion app](mobile.md), PrusaSlicer/OrcaSlicer integrations, scripts) — set `FILAMENTDB_API_KEY` to a strong random value. Every `/api/*` request must then send `Authorization: Bearer <key>`; the mobile app and the slicer integrations support this. Generate one with e.g. `openssl rand -hex 32`.
+
+  ```bash
+  docker run -p 3456:3000 \
+    -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/filament-db" \
+    -e FILAMENTDB_API_KEY="$(openssl rand -hex 32)" \
+    ghcr.io/hyiger/filament-db
+  ```
+
+  > **The bearer gate is all-or-nothing and disables the first-party browser web UI.** The web UI makes plain same-origin requests and does not attach the key, so with `FILAMENTDB_API_KEY` set the UI loads but every call returns `401`. There is deliberately no same-origin exemption (those request signals are forgeable). Use the key only when the browser UI isn't how you'll access this instance.
+
+- **Browser web-UI access over the LAN** — do **not** rely on `FILAMENTDB_API_KEY` (it breaks the UI, above). Instead either keep the port on loopback and use the desktop app, or put Filament DB behind an **authenticating reverse proxy** (nginx/Caddy/Authelia with basic-auth, SSO, or mTLS) that terminates auth before the request reaches the app.
 
 ### Building from Source
 
@@ -102,7 +128,7 @@ volumes:
 git clone https://github.com/hyiger/filament-db.git
 cd filament-db
 docker build -t filament-db .
-docker run -p 3456:3000 -e MONGODB_URI="mongodb+srv://..." filament-db
+docker run -p 127.0.0.1:3456:3000 -e MONGODB_URI="mongodb+srv://..." filament-db
 ```
 
 ---
@@ -255,6 +281,8 @@ sudo chmod 600 "/opt/Filament DB/.env"
 ```
 
 `HOSTNAME=0.0.0.0` makes the server listen on all network interfaces so other devices on your network can reach it.
+
+> **Security:** binding `0.0.0.0` exposes the **unauthenticated** `/api` surface to everyone on your network. Before doing this, read [Securing a network-exposed instance](#securing-a-network-exposed-instance) — set `FILAMENTDB_API_KEY` if only non-browser clients (the mobile app, slicers) need access, or front the service with an authenticating reverse proxy if you want the browser UI on the LAN (the key disables the web UI).
 
 > **Note:** If you're running the desktop app instead of a headless service, you don't need to set `HOSTNAME` by hand — flip on the **Share on local network** toggle in Settings (electron-store key `exposeToLan`, off by default) and the embedded server binds `0.0.0.0` for you. It pairs with mDNS auto-discovery, so the mobile companion app can find your instance on the network without typing a URL.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,7 +124,7 @@ You have two ways to secure an exposed instance, depending on **who** needs to r
 
   > **The bearer gate is all-or-nothing and disables the first-party browser web UI.** The web UI makes plain same-origin requests and does not attach the key, so with `FILAMENTDB_API_KEY` set the UI loads but every call returns `401`. There is deliberately no same-origin exemption (those request signals are forgeable). Use the key only when the browser UI isn't how you'll access this instance.
 
-- **Browser web-UI access over the LAN** — do **not** rely on `FILAMENTDB_API_KEY` (it breaks the UI, above). Instead either keep the port on loopback and use the desktop app, or put Filament DB behind an **authenticating reverse proxy** (nginx/Caddy/Authelia with basic-auth, SSO, or mTLS) that terminates auth before the request reaches the app.
+- **Browser web-UI access over the LAN** — do **not** rely on `FILAMENTDB_API_KEY` (it breaks the UI, above). Instead either keep the port on loopback and use the desktop app, or put Filament DB behind an **authenticating reverse proxy** (nginx/Caddy/Authelia with basic-auth, SSO, or mTLS) that terminates auth before the request reaches the app. When you use a reverse proxy, **bind Filament DB itself to loopback** (`-p 127.0.0.1:3456:3000` for Docker, `HOSTNAME=127.0.0.1` for the systemd service) or firewall its direct port — otherwise the app stays reachable at `http://<host>:3456` and browser users bypass the proxy straight to the unauthenticated API. The proxy must be the only way in.
 
 ### Building from Source
 
@@ -286,7 +286,7 @@ sudo chmod 600 "/opt/Filament DB/.env"
 
 `HOSTNAME=0.0.0.0` makes the server listen on all network interfaces so other devices on your network can reach it.
 
-> **Security:** binding `0.0.0.0` exposes the **unauthenticated** `/api` surface to everyone on your network. Before doing this, read [Securing a network-exposed instance](#securing-a-network-exposed-instance) — set `FILAMENTDB_API_KEY` if only non-browser clients (the mobile app, slicers) need access, or front the service with an authenticating reverse proxy if you want the browser UI on the LAN (the key disables the web UI).
+> **Security:** binding `0.0.0.0` exposes the **unauthenticated** `/api` surface to everyone on your network. Before doing this, read [Securing a network-exposed instance](#securing-a-network-exposed-instance) — set `FILAMENTDB_API_KEY` if only non-browser clients (the mobile app, slicers) need access, or front the service with an authenticating reverse proxy if you want the browser UI on the LAN (the key disables the web UI). If you go the reverse-proxy route, set `HOSTNAME=127.0.0.1` here (not `0.0.0.0`) — or firewall port 3456 — so the app is reachable only through the proxy; otherwise browser users can hit `http://<host>:3456` directly and bypass it.
 
 > **Note:** If you're running the desktop app instead of a headless service, you don't need to set `HOSTNAME` by hand — flip on the **Share on local network** toggle in Settings (electron-store key `exposeToLan`, off by default) and the embedded server binds `0.0.0.0` for you. It pairs with mDNS auto-discovery, so the mobile companion app can find your instance on the network without typing a URL.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -109,12 +109,16 @@ Filament DB's trust model is **localhost / single-user**: by default the API is 
 
 You have two ways to secure an exposed instance, depending on **who** needs to reach it:
 
-- **Non-browser clients only** (the [mobile companion app](mobile.md), PrusaSlicer/OrcaSlicer integrations, scripts) — set `FILAMENTDB_API_KEY` to a strong random value. Every `/api/*` request must then send `Authorization: Bearer <key>`; the mobile app and the slicer integrations support this. Generate one with e.g. `openssl rand -hex 32`.
+- **Non-browser clients only** (the [mobile companion app](mobile.md), PrusaSlicer/OrcaSlicer integrations, scripts) — set `FILAMENTDB_API_KEY` to a strong random value. Every `/api/*` request must then send `Authorization: Bearer <key>`; the mobile app and the slicer integrations support this. **Generate the key once, save it, and reuse that exact value** — your clients need it, and it must stay the same across restarts (don't generate it inline, or it changes every run and nothing can authenticate):
 
   ```bash
+  # 1. Generate a key once and copy it (paste this into the mobile app / slicer):
+  openssl rand -hex 32
+
+  # 2. Run with that saved value:
   docker run -p 3456:3000 \
     -e MONGODB_URI="mongodb+srv://user:pass@cluster.mongodb.net/filament-db" \
-    -e FILAMENTDB_API_KEY="$(openssl rand -hex 32)" \
+    -e FILAMENTDB_API_KEY="<paste-the-generated-key>" \
     ghcr.io/hyiger/filament-db
   ```
 

--- a/docs/smart-filament-workflow-guide.md
+++ b/docs/smart-filament-workflow-guide.md
@@ -177,6 +177,7 @@ from Step 5 (with the real password filled in). The three modes are Atlas (Cloud
 > **Note — Docker alternative:** You can run Filament DB as a container instead:
 > `docker run -p 3456:3000 -e MONGODB_URI="mongodb+srv://..." ghcr.io/hyiger/filament-db`.
 > Maps host port `3456` (matching the desktop app) to container port `3000`, so PrusaSlicer's `http://localhost:3456` works for both.
+> (If PrusaSlicer runs on the **same** machine as the container, use `-p 127.0.0.1:3456:3000` to keep it off the LAN; the bare `-p 3456:3000` above is needed only when PrusaSlicer is on a different machine — that exposes the unauthenticated API, so see [Securing a network-exposed instance](setup.md#securing-a-network-exposed-instance).)
 > The Docker/web version cannot use the USB NFC reader — tag reading and writing needs the
 > **desktop** app.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -612,7 +612,7 @@ By default the desktop app's database is reachable only from the computer it run
 1. In **Settings**, find **Share on local network** and toggle it on. The embedded server rebinds to your LAN address (instead of localhost), and Settings shows the URL other devices can use.
 2. With sharing on, the app also advertises itself over Bonjour/mDNS (`_filamentdb._tcp`), so the mobile app can find it without you typing an IP.
 
-> **Securing a shared instance:** set the `FILAMENTDB_API_KEY` environment variable to require a bearer token on every API request. Unset, a LAN-exposed instance is unauthenticated.
+> **Securing a shared instance:** set the `FILAMENTDB_API_KEY` environment variable to require a bearer token on every API request. Unset, a LAN-exposed instance is unauthenticated. The gate is all-or-nothing and **disables the browser web UI** (it doesn't send the key) — use it for non-browser clients (mobile app, slicers); for browser-UI access on a LAN, use loopback or an authenticating reverse proxy. See [Securing a network-exposed instance](setup.md#securing-a-network-exposed-instance).
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -686,7 +686,7 @@ Settings → **Share on local network** lets other devices on your LAN reach thi
 
 Turn it on and the server re-binds to `0.0.0.0` (all interfaces), and the settings panel shows the LAN URL to point another device at (e.g. `http://192.168.1.50:3456`). This is what the mobile scanner app connects to.
 
-**Securing a shared instance**: set the `FILAMENTDB_API_KEY` environment variable on the desktop host (or server) to put a bearer-token gate in front of every `/api/*` request — clients must then send a matching API key. Leaving it unset (the default) leaves the API unauthenticated, which is fine for a trusted home network but not for an exposed one.
+**Securing a shared instance**: set the `FILAMENTDB_API_KEY` environment variable on the desktop host (or server) to put a bearer-token gate in front of every `/api/*` request — clients must then send a matching API key. Leaving it unset (the default) leaves the API unauthenticated, which is fine for a trusted home network but not for an exposed one. Note the gate is all-or-nothing and **disables the browser web UI** (which doesn't send the key), so it's for non-browser clients (the mobile app, slicers, scripts); for browser-UI access on a LAN, use loopback + the desktop app or an authenticating reverse proxy — see [Securing a network-exposed instance](setup.md#securing-a-network-exposed-instance).
 
 ## Find on Your Network — mDNS Auto-Discovery *(v1.47)*
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,9 +7,16 @@ import { decideApiAuth } from "@/lib/apiAuth";
  *
  * Enforces the optional API-key gate on `/api/*`. When `FILAMENTDB_API_KEY` is
  * unset (the default, and how the desktop/Electron app runs) this is a no-op.
- * When set, off-device callers must present `Authorization: Bearer <key>`;
- * the same-origin first-party web UI is unaffected. Logic + rationale live in
- * src/lib/apiAuth.ts (pure + unit-tested).
+ * When set, the gate is ALL-OR-NOTHING: every `/api/*` request — including the
+ * first-party browser UI's same-origin fetches — must present
+ * `Authorization: Bearer <key>` or it gets a 401. There is deliberately no
+ * same-origin exemption (Origin/Sec-Fetch headers are forgeable by non-browser
+ * callers). The web UI does NOT attach the key, so setting it is for non-browser
+ * clients (the mobile companion, PrusaSlicer/OrcaSlicer, curl); a browser-UI
+ * deployment should instead bind loopback (and use the desktop app) or sit
+ * behind an authenticating reverse proxy — see docs/setup.md "Securing a
+ * network-exposed instance". Logic + rationale live in src/lib/apiAuth.ts
+ * (pure + unit-tested).
  */
 export function proxy(request: NextRequest): NextResponse {
   const decision = decideApiAuth(process.env.FILAMENTDB_API_KEY, {


### PR DESCRIPTION
Resolves [#766](https://github.com/hyiger/filament-db/issues/766) and [#767](https://github.com/hyiger/filament-db/issues/767) together — they're coupled (the docs must not recommend the key for a browser-UI deployment that it breaks). Per the triage decision, #767 takes **option (b)**: document the key as API/mobile/headless-only; no app auth code.

## #767 — the key breaks the first-party web UI
`src/proxy.ts` gates **every** `/api/*` all-or-nothing on the bearer; the browser UI does plain same-origin `fetch("/api/...")` with no `Authorization` header, so a deployment with `FILAMENTDB_API_KEY` set loads the shell and 401s every UI call. (`npm run dev` + the packaged Electron app are unaffected — Electron never injects the key.)
- **Fixed the stale `src/proxy.ts` comment** that claimed "the same-origin first-party web UI is unaffected" — it now accurately describes the all-or-nothing gate and the deliberate no-same-origin-exemption rationale, and points to the new docs section. No app auth code added; `tests/apiAuth.test.ts` already pins this behavior (12 pass).

## #766 — docs steered users into exposed unauthenticated deployments
`-p 3456:3000` binds all host interfaces; systemd `HOSTNAME=0.0.0.0`; `.env.example` + the env table omitted the key.
- **Loopback defaults:** README + `docs/setup.md` (+ German) localhost Docker examples now use `-p 127.0.0.1:3456:3000` with a note that a bare mapping exposes the unauthenticated API. Both Compose blocks + build-from-source updated.
- **New "Securing a network-exposed instance" section (EN + DE):** the two supported paths — `FILAMENTDB_API_KEY` for non-browser clients (mobile/slicers/scripts) vs. loopback + desktop app or an authenticating reverse proxy for browser-UI LAN access — with the all-or-nothing + web-UI-break caveat spelled out.
- **Env table** gains `FILAMENTDB_API_KEY` + `HOSTNAME` rows; **`.env.example`** gains a commented `FILAMENTDB_API_KEY` with the caveat.
- systemd block gains a security callout; the smart-filament workflow guides (EN + DE) get a loopback-vs-expose note; the key-recommending notes in `desktop.md`/`usage.md`/`tutorial.md` (+ `de/desktop.md`) gain the web-UI caveat so they don't send users into the #767 trap.

Docs + one code-comment; `tsc`, `lint`, and `tests/apiAuth.test.ts` all green.

Fixes #766
Fixes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)