### PR TITLE
fix(deps): bump dompurify to ^3.4.11 (GHSA-cmwh-pvxp-8882)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7048,9 +7048,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "joi": "^18.2.1",
     "esbuild": "^0.28.1",
     "@babel/core": "^7.29.1",
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0",
     "vite": "^8.0.16"


### PR DESCRIPTION
## Why
A newly-published **moderate** advisory — [GHSA-cmwh-pvxp-8882](https://github.com/advisories/GHSA-cmwh-pvxp-8882) (DOMPurify permanent `ALLOWED_ATTR` pollution via `setConfig()`, an incomplete fix of the 3.4.7 hook-pollution patch) — covers `dompurify <=3.4.10`. The existing `dompurify: ^3.4.9` override resolved to **3.4.10**, so `npm audit --audit-level=moderate` (the `test.yml` gate) started **failing on every PR and on main**, e.g. [#772](https://github.com/hyiger/filament-db/pull/772). Not introduced by any code change — purely a fresh upstream advisory.

## Fix
`dompurify` is a transitive dep of `swagger-ui-react` (which wants `^3.3.2`). **3.4.11** is the patched release and satisfies that range. Bump the existing override `^3.4.9` → `^3.4.11`. Same approach as the `tmp` override in [#392](https://github.com/hyiger/filament-db/pull/392).

## Verification
- `npm install` → `node_modules/dompurify` now **3.4.11**
- `npm audit --audit-level=moderate` → **found 0 vulnerabilities**

Once this lands, rebasing the other open PRs (incl. #772) clears their failing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)