### PR TITLE
fix(list): show all of a parent's variants so the count chip matches (#786)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "remark-gfm": "^4.0.1",
         "swagger-ui-react": "^5.32.1",
         "tar": "^7.5.16",
-        "undici": "^6.25.0",
+        "undici": "^6.27.0",
         "yaml": "^2.8.3"
       },
       "devDependencies": {
@@ -15993,9 +15993,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -48,11 +48,12 @@
     "remark-gfm": "^4.0.1",
     "swagger-ui-react": "^5.32.1",
     "tar": "^7.5.16",
-    "undici": "^6.25.0",
+    "undici": "^6.27.0",
     "yaml": "^2.8.3"
   },
   "overrides": {
     "postcss": "^8.5.10",
+    "undici": "^6.27.0",
     "exceljs": {
       "uuid": "^11.1.1"
     },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import type { FilamentSummary } from "@/types/filament";
 import { getRemainingGrams, getRemainingPct, getSpoolCount } from "@/lib/inventoryStats";
 import { compareFilaments, nextSortState, type SortKey, type SortDir } from "@/lib/sortFilamentList";
+import { buildFilamentGroups } from "@/lib/groupFilaments";
 
 type Filament = FilamentSummary;
 
@@ -431,12 +432,22 @@ export default function Home() {
     (f: Filament) => getSpoolCount(f) > 0 || parentsWithStock.has(f._id),
     [parentsWithStock],
   );
-  // Count of hidden inventory rows (standalone + variants with no active spool;
-  // parents are grouping headers, not stock) — drives the toggle's badge.
-  const outOfStockCount = useMemo(
-    () => filaments.filter((f) => !f.hasVariants && getSpoolCount(f) === 0).length,
-    [filaments],
-  );
+  // Count of hidden inventory rows — drives the toggle's badge. Parents are
+  // grouping headers (not stock). A variant of a STOCKED family is now always
+  // rendered under its parent (#786), so it isn't "hidden" even with no spool
+  // of its own — only standalone rows and variants of a fully-out-of-stock
+  // family are actually hidden by the default filter.
+  const outOfStockCount = useMemo(() => {
+    const shownParents = new Set(
+      filaments.filter((f) => f.hasVariants && inStock(f)).map((f) => f._id),
+    );
+    return filaments.filter((f) => {
+      if (f.hasVariants) return false;
+      if (getSpoolCount(f) > 0) return false;
+      if (f.parentId && shownParents.has(f.parentId)) return false;
+      return true;
+    }).length;
+  }, [filaments, inStock]);
 
   const visibleFilaments = useMemo(() => {
     // The "all" view keeps parents in the dataset so the list renders them as
@@ -489,32 +500,9 @@ export default function Home() {
     return map;
   }, [filaments]);
 
-  // True variant count per parent, derived from the FULL fetched list (#744).
-  // The collapsed parent's "N color(s)" chip must reflect every variant in the
-  // family, not just those left in `visibleFilaments` after the #712
-  // out-of-stock hide — otherwise a parent with out-of-stock variants
-  // under-counts vs. its own detail page. `filaments` holds every non-deleted
-  // variant (out-of-stock filtering is applied only when deriving
-  // `visibleFilaments`); when a server-side search/type/vendor filter is
-  // active `filaments` is already that filtered set, so the chip then reflects
-  // the filtered family, matching the rows shown.
-  const variantCountByParent = useMemo(() => {
-    const m = new Map<string, number>();
-    for (const f of filaments) {
-      if (f.parentId) m.set(f.parentId, (m.get(f.parentId) ?? 0) + 1);
-    }
-    return m;
-  }, [filaments]);
-
   const groupedFilaments = useMemo(() => {
-    const parentMap = new Map<string, GroupedFilament>();
-    const standalone: Filament[] = [];
-    const variantsByParent = new Map<string, Filament[]>();
-
-    // Apply parent-field fallbacks to a variant. Used both for the
-    // grouped-under-parent and orphaned-variant paths so the same
-    // inheritance is visible regardless of whether the parent row
-    // happens to be in the current filter result set.
+    // Apply parent-field fallbacks to a variant so inherited nozzle/bed/cost/
+    // density/spool values render even when the variant left them blank.
     const enrichVariant = (v: Filament, parent: Filament | undefined): Filament => {
       if (!parent) return v;
       return {
@@ -530,45 +518,18 @@ export default function Home() {
       };
     };
 
-    // First pass: collect variants
-    for (const f of visibleFilaments) {
-      if (f.parentId) {
-        const variants = variantsByParent.get(f.parentId) || [];
-        variants.push(f);
-        variantsByParent.set(f.parentId, variants);
-      }
-    }
+    // #744 / #786: a shown parent's group carries EVERY variant from the full
+    // fetched list, not just those left in `visibleFilaments` after the #712
+    // out-of-stock hide. The chip below renders `group.variants.length`, so the
+    // count and the variant rows/swatches are the same array and can't drift.
+    // `filaments` is already the server-filtered set when a search/type/vendor
+    // filter is active, so filtered views still match.
+    const { groups, standalone } = buildFilamentGroups(filaments, visibleFilaments, {
+      enrichVariant,
+      parentLookup,
+    });
 
-    // Second pass: build groups, resolving inherited fields for variants
-    for (const f of visibleFilaments) {
-      if (f.parentId) continue; // variants are handled by their parent
-      const variants = (variantsByParent.get(f._id) || []).map((v) =>
-        enrichVariant(v, f),
-      );
-      if (variants.length > 0) {
-        parentMap.set(f._id, { parent: f, variants });
-      } else {
-        standalone.push(f);
-      }
-    }
-
-    // Also include orphaned variants (parent not in current filter
-    // results). Enrich from `parentLookup` so the inheritance still
-    // applies — the parent existing-but-filtered-out shouldn't change
-    // what the variant renders.
-    for (const [parentId, variants] of variantsByParent) {
-      if (!parentMap.has(parentId)) {
-        const parent = parentLookup.get(parentId);
-        standalone.push(...variants.map((v) => enrichVariant(v, parent)));
-      }
-    }
-
-    // Combine and sort
-    const all: (Filament | GroupedFilament)[] = [
-      ...parentMap.values(),
-      ...standalone.map((f) => f),
-    ];
-
+    const all: (Filament | GroupedFilament)[] = [...groups, ...standalone];
     const cmp = compareFilaments(sortKey, sortDir);
     all.sort((a, b) => {
       const fa = "parent" in a ? a.parent : a;
@@ -577,7 +538,7 @@ export default function Home() {
     });
 
     return all;
-  }, [visibleFilaments, parentLookup, sortKey, sortDir]);
+  }, [filaments, visibleFilaments, parentLookup, sortKey, sortDir]);
 
   const toggleExpanded = (parentId: string) => {
     setExpandedParents((prev) => {
@@ -1067,7 +1028,7 @@ export default function Home() {
             </Link>
             <span className="ml-1.5 text-[10px] text-gray-500 bg-gray-200 dark:bg-gray-800 px-1 py-0.5 rounded">
               {t("filaments.colorCount", {
-                count: variantCountByParent.get(f._id) ?? group.variants.length,
+                count: group.variants.length,
               })}
             </span>
           </td>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -518,13 +518,21 @@ export default function Home() {
       };
     };
 
-    // #744 / #786: a shown parent's group carries EVERY variant from the full
-    // fetched list, not just those left in `visibleFilaments` after the #712
-    // out-of-stock hide. The chip below renders `group.variants.length`, so the
-    // count and the variant rows/swatches are the same array and can't drift.
-    // `filaments` is already the server-filtered set when a search/type/vendor
-    // filter is active, so filtered views still match.
-    const { groups, standalone } = buildFilamentGroups(filaments, visibleFilaments, {
+    // #744 / #786: in the unfiltered "all" view a shown parent's group carries
+    // EVERY variant from the full fetched list, not just those left after the
+    // #712 out-of-stock hide — there the hide is a visibility declutter, not a
+    // content filter, so a shown family shows all its colors and the chip
+    // (rendered as group.variants.length below) counts them all.
+    //
+    // Under a CONTENT filter the variants must respect it, so source from
+    // `visibleFilaments` instead (Codex P2 on #788): otherwise a parent visible
+    // under `hasSpools` (its own spool) would pull in no-spool variants the
+    // filter excluded, and expand → select-all would then include them.
+    // (`lowStock`/`noCalibration` drop parents entirely, so they have no group
+    // either way.) When a server-side search/type/vendor filter is active,
+    // `quickFilter` is "all" but `filaments` is already that filtered set.
+    const variantSource = quickFilter === "all" ? filaments : visibleFilaments;
+    const { groups, standalone } = buildFilamentGroups(variantSource, visibleFilaments, {
       enrichVariant,
       parentLookup,
     });
@@ -538,7 +546,7 @@ export default function Home() {
     });
 
     return all;
-  }, [filaments, visibleFilaments, parentLookup, sortKey, sortDir]);
+  }, [filaments, visibleFilaments, parentLookup, quickFilter, sortKey, sortDir]);
 
   const toggleExpanded = (parentId: string) => {
     setExpandedParents((prev) => {

--- a/src/lib/groupFilaments.ts
+++ b/src/lib/groupFilaments.ts
@@ -1,0 +1,88 @@
+/**
+ * Group filaments into parent families + standalone rows for the main list.
+ *
+ * The crux (GH #744 / #786): a parent's "N colors" chip and the variant
+ * rows/swatches rendered under it MUST come from the same set, or they drift.
+ * #712 hides out-of-stock filaments by removing them from `visibleFilaments`;
+ * when a shown parent's variants were sourced from that filtered set, the chip
+ * — counted from the full list — over-counted the variants actually displayed.
+ * tonysurma's report: chip says 6, the list shows fewer.
+ *
+ * Fix: a shown parent's group carries ALL of its variants from `allFilaments`
+ * (the full fetched set, which is already server-filtered when a search /
+ * type / vendor filter is active). The list then renders the chip as
+ * `group.variants.length`, so the count and the displayed variants are the
+ * SAME array — they cannot disagree.
+ *
+ * `visibleFilaments` still decides which TOP-LEVEL rows appear, so a
+ * fully-out-of-stock family stays hidden; it just no longer prunes the
+ * variants of a family that is shown.
+ */
+export interface VariantGroup<F> {
+  parent: F;
+  variants: F[];
+}
+
+export interface GroupResult<F> {
+  groups: VariantGroup<F>[];
+  standalone: F[];
+}
+
+type Groupable = { _id: string; parentId?: string | null };
+
+export function buildFilamentGroups<F extends Groupable>(
+  /** The full fetched list (server-filtered when a search/type/vendor filter
+   *  is active). Source of truth for a shown family's variants + the chip. */
+  allFilaments: F[],
+  /** The post-filter set that decides which top-level rows are shown. */
+  visibleFilaments: F[],
+  opts: {
+    /** Apply parent→variant field inheritance for display. Identity by default. */
+    enrichVariant?: (variant: F, parent: F | undefined) => F;
+    /** Parent lookup for enriching orphaned variants whose parent row was
+     *  filtered out of `visibleFilaments`. */
+    parentLookup?: Map<string, F>;
+  } = {},
+): GroupResult<F> {
+  const enrich = opts.enrichVariant ?? ((v) => v);
+  const parentLookup = opts.parentLookup;
+
+  // Every variant of each parent, from the full set — this is exactly the set
+  // the chip counts, so a rendered group must match it one-for-one.
+  const allVariantsByParent = new Map<string, F[]>();
+  for (const f of allFilaments) {
+    if (f.parentId) {
+      const arr = allVariantsByParent.get(f.parentId);
+      if (arr) arr.push(f);
+      else allVariantsByParent.set(f.parentId, [f]);
+    }
+  }
+
+  const groups: VariantGroup<F>[] = [];
+  const groupedParentIds = new Set<string>();
+  const standalone: F[] = [];
+
+  // A visible non-variant row becomes a group iff the FULL set has variants for
+  // it; the group then carries every one of them (in- and out-of-stock alike).
+  for (const f of visibleFilaments) {
+    if (f.parentId) continue; // variants handled via their parent
+    const variants = allVariantsByParent.get(f._id);
+    if (variants && variants.length > 0) {
+      groups.push({ parent: f, variants: variants.map((v) => enrich(v, f)) });
+      groupedParentIds.add(f._id);
+    } else {
+      standalone.push(f);
+    }
+  }
+
+  // Orphaned variants: a visible variant whose parent is NOT a shown group
+  // (e.g. the parent was filtered out server-side). Render it standalone, still
+  // enriched from its (possibly-hidden) parent so inherited fields resolve.
+  for (const f of visibleFilaments) {
+    if (!f.parentId) continue;
+    if (groupedParentIds.has(f.parentId)) continue; // already inside its group
+    standalone.push(enrich(f, parentLookup?.get(f.parentId)));
+  }
+
+  return { groups, standalone };
+}

--- a/tests/groupFilaments.test.ts
+++ b/tests/groupFilaments.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { buildFilamentGroups } from "@/lib/groupFilaments";
+
+type F = {
+  _id: string;
+  parentId?: string | null;
+  name?: string;
+  cost?: number | null;
+};
+
+const parent = (id: string, extra: Partial<F> = {}): F => ({ _id: id, ...extra });
+const variant = (id: string, parentId: string, extra: Partial<F> = {}): F => ({
+  _id: id,
+  parentId,
+  ...extra,
+});
+
+describe("buildFilamentGroups", () => {
+  it("groups a parent with its variants and keeps standalones separate", () => {
+    const all = [parent("p"), variant("v1", "p"), variant("v2", "p"), parent("s")];
+    const { groups, standalone } = buildFilamentGroups(all, all);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].parent._id).toBe("p");
+    expect(groups[0].variants.map((v) => v._id)).toEqual(["v1", "v2"]);
+    expect(standalone.map((f) => f._id)).toEqual(["s"]);
+  });
+
+  // The #744 / #786 invariant: the chip count (group.variants.length) equals the
+  // number of variants in the FULL list, even when the out-of-stock filter has
+  // dropped some variants from `visibleFilaments`.
+  it("includes out-of-stock variants of a shown family (chip == displayed)", () => {
+    const all = [
+      parent("p"),
+      variant("v1", "p"),
+      variant("v2", "p"), // out of stock — filtered from visible
+      variant("v3", "p"), // out of stock — filtered from visible
+    ];
+    // Simulate #712: the parent is shown (a sibling is in stock) but two
+    // variants were stripped from the visible set.
+    const visible = [parent("p"), variant("v1", "p")];
+
+    const { groups } = buildFilamentGroups(all, visible);
+
+    expect(groups).toHaveLength(1);
+    const fullCount = all.filter((f) => f.parentId === "p").length;
+    expect(groups[0].variants).toHaveLength(fullCount); // 3, not 1
+    expect(groups[0].variants.map((v) => v._id)).toEqual(["v1", "v2", "v3"]);
+  });
+
+  it("keeps a parent shown via its own spool but with all variants out of stock", () => {
+    const all = [parent("p"), variant("v1", "p"), variant("v2", "p")];
+    // Parent itself is visible (own spool) but no variant survived the filter.
+    const visible = [parent("p")];
+
+    const { groups, standalone } = buildFilamentGroups(all, visible);
+
+    expect(standalone).toHaveLength(0); // not demoted to a standalone row
+    expect(groups).toHaveLength(1);
+    expect(groups[0].variants.map((v) => v._id)).toEqual(["v1", "v2"]);
+  });
+
+  it("renders a visible variant standalone when its parent is filtered out", () => {
+    const all = [parent("p"), variant("v1", "p")];
+    // Server-side search matched the variant but not the parent row.
+    const visible = [variant("v1", "p")];
+
+    const { groups, standalone } = buildFilamentGroups(all, visible, {
+      parentLookup: new Map([["p", parent("p", { cost: 25 })]]),
+      enrichVariant: (v, p) => (p ? { ...v, cost: v.cost ?? p.cost } : v),
+    });
+
+    expect(groups).toHaveLength(0);
+    expect(standalone.map((f) => f._id)).toEqual(["v1"]);
+    expect(standalone[0].cost).toBe(25); // enriched from the hidden parent
+  });
+
+  it("does not double-render an in-stock variant that's both visible and grouped", () => {
+    const all = [parent("p"), variant("v1", "p"), variant("v2", "p")];
+    const visible = [parent("p"), variant("v1", "p")]; // v1 in stock + parent shown
+
+    const { groups, standalone } = buildFilamentGroups(all, visible);
+
+    expect(standalone).toHaveLength(0);
+    expect(groups[0].variants.map((v) => v._id)).toEqual(["v1", "v2"]);
+    // v1 appears exactly once (inside the group, not also as a standalone)
+    const allRendered = [
+      ...groups.flatMap((g) => g.variants.map((v) => v._id)),
+      ...standalone.map((f) => f._id),
+    ];
+    expect(allRendered.filter((id) => id === "v1")).toHaveLength(1);
+  });
+
+  it("applies enrichVariant to grouped variants", () => {
+    const all = [parent("p", { cost: 30 }), variant("v1", "p", { cost: null })];
+    const { groups } = buildFilamentGroups(all, all, {
+      enrichVariant: (v, p) => (p ? { ...v, cost: v.cost ?? p.cost } : v),
+    });
+    expect(groups[0].variants[0].cost).toBe(30);
+  });
+});

--- a/tests/groupFilaments.test.ts
+++ b/tests/groupFilaments.test.ts
@@ -90,6 +90,20 @@ describe("buildFilamentGroups", () => {
     expect(allRendered.filter((id) => id === "v1")).toHaveLength(1);
   });
 
+  // Codex P2 on #788: the FIRST arg (source) controls membership, so the
+  // caller can pass a content-filtered set (e.g. the `hasSpools` quick filter)
+  // and the group will only carry variants that pass the filter — it must NOT
+  // reach past the source into a wider list.
+  it("limits a group's variants to the provided source set", () => {
+    const all = [parent("p"), variant("v1", "p"), variant("v2", "p")];
+    // hasSpools-style: only the parent + v1 survive the content filter.
+    const filtered = [parent("p"), variant("v1", "p")];
+    const { groups } = buildFilamentGroups(filtered, filtered);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].variants.map((v) => v._id)).toEqual(["v1"]); // v2 excluded
+    expect(all.length).toBe(3); // sanity: v2 exists, just not in the source
+  });
+
   it("applies enrichVariant to grouped variants", () => {
     const all = [parent("p", { cost: 30 }), variant("v1", "p", { cost: null })];
     const { groups } = buildFilamentGroups(all, all, {


### PR DESCRIPTION
Reopens #744 (tonysurma). Fixes #786.

### The bug
The parent "**N colors**" chip and the variant rows/swatches rendered under it came from **different sets**:
- **Chip** → counted from the full fetched list (all variants) — fixed in #750.
- **Displayed variants** → sourced from `visibleFilaments`, which the #712 out-of-stock hide strips.

So after #750 the chip says e.g. 6 but the list shows fewer — in both the collapsed color-dots and the expanded rows. The `inStock` predicate kept a variant only if it had its *own* spool, dropping out-of-stock variants even when their family was shown.

It only reproduces when a family has **out-of-stock variants**, which is why it was hard to confirm (a fully-stocked database — like the maintainer's — never shows it).

### The fix
- Extract the grouping into a pure, unit-tested helper `buildFilamentGroups` (`src/lib/groupFilaments.ts`). A shown parent's group now carries **every** variant from the full list (already server-filtered when a search/type/vendor filter is active).
- Render the chip as `group.variants.length` — so the count and the displayed variants are the **same array** and can't drift again (removes the separate `variantCountByParent` memo).
- `visibleFilaments` still decides which **top-level** rows appear, so a fully-out-of-stock family stays hidden; once a family is shown, all its colors show.
- `outOfStockCount` (the "Show out of stock (N)" badge) no longer counts variants that are now visible under a stocked family.

**Behavior note:** in the default hide-out-of-stock view, out-of-stock *color variants* now appear under a stocked family (the only way to match the "all variants" chip from #750). The toggle still governs standalone rows and fully-out-of-stock families.

### Tests / verification
- New `tests/groupFilaments.test.ts` (6 cases) pins the invariant *displayed variant count == full variant count* even when the visible set is filtered — this is the regression guard that was missing.
- Full suite green locally (2279 tests).
- Verified in a browser against a **seeded scratch DB** (in-memory Mongo, Atlas untouched): a parent with 1 in-stock + 2 out-of-stock variants renders the chip "3 color(s)" and all 3 rows/swatches; the badge correctly shows "Show out of stock (1)" (the standalone only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)