### PR TITLE
fix(list): make the parent expand caret larger + clearer

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1000,7 +1000,7 @@ export default function Home() {
               <button
                 type="button"
                 onClick={() => toggleExpanded(f._id)}
-                className="text-gray-400 hover:text-gray-600 text-xs w-4 flex-shrink-0"
+                className="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100 text-base leading-none w-5 flex-shrink-0"
                 title={isExpanded ? t("filaments.collapseVariants") : t("filaments.expandVariants")}
                 // GH #416: a SR user could neither read the chevron glyph
                 // nor tell whether it was expanded. The translated label


### PR DESCRIPTION
The collapse/expand chevron (▸/▾) on parent rows in the main filament list rendered at `text-xs` in a faint gray, so on some displays it looked like a **dot** rather than an arrow (user report with screenshot).

Bumped it from `text-xs` → `text-base` (12px → 16px), widened the control to `w-5`, and raised contrast with explicit dark-mode colors (`text-gray-500`/`dark:text-gray-300`). Purely a styling tweak — no behavior change; the a11y label / `aria-expanded` are untouched.

Verified in a browser against a seeded scratch DB: the caret renders at 16px and is clearly an arrow on a parent row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)