### PR TITLE
fix(docker): install tzdata so the TZ env var works (#796)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@ ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
+# GH #796: the node:22-alpine base ships no zoneinfo DB, so a `TZ=America/...`
+# env var can't be resolved and musl silently falls back to UTC. Install tzdata
+# (as root, before the USER switch below) so the documented TZ env var works.
+# ~3MB; the container stays UTC unless TZ is set.
+RUN apk add --no-cache tzdata
+
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -97,6 +97,7 @@ volumes:
 | `MONGODB_URI` | Yes | MongoDB connection string |
 | `PORT` | No | Server port inside the container (default: `3000`) |
 | `HOSTNAME` | No | Interface the server binds inside the container (default: `0.0.0.0`). Reachability is governed by the `docker run -p` mapping, not this. |
+| `TZ` | No | IANA timezone for the container clock, e.g. `America/Los_Angeles` (defaults to UTC). The image bundles `tzdata`, so a zone name resolves correctly. |
 | `FILAMENTDB_API_KEY` | No | Bearer-token gate on **every** `/api/*` request. See [Securing a network-exposed instance](#securing-a-network-exposed-instance). **Note:** it disables the browser web UI — use it only for non-browser clients (mobile app, slicers, scripts). |
 | `GEMINI_API_KEY` | No | Google Gemini API key for TDS extraction |
 | `ANTHROPIC_API_KEY` | No | Anthropic Claude API key for TDS extraction |


### PR DESCRIPTION
Fixes [#796](https://github.com/hyiger/filament-db/issues/796).

The `node:22-alpine` runtime stage shipped without a zoneinfo database, so `TZ=America/Los_Angeles` (or any zone) couldn't be resolved — musl **silently falls back to UTC**, and the documented env var had no effect.

- **Dockerfile**: `RUN apk add --no-cache tzdata` in the runner stage, as root, before the `USER nextjs` switch. The container stays UTC unless `TZ` is set; ~3MB image bump.
- **docs/setup.md**: added a `TZ` row to the environment-variable table.

**Verification** (no Docker build in CI): `docker run --rm -e TZ=America/Los_Angeles <img> date` now shows local time; `docker run --rm <img> date` (no TZ) stays UTC.

Fixes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)