### PR TITLE
fix(openprinttag): render drying time as hours+minutes, not raw minutes (#807)

### DIFF
--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -6,6 +6,7 @@ import { List, type RowComponentProps } from "react-window";
 import { useToast } from "@/components/Toast";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { safeHttpUrl } from "@/lib/safeRenderUrl";
+import { formatMinutesAsHm } from "@/lib/formatDuration";
 
 // Row layout constants — the virtualized List needs known heights so it
 // can compute the absolute scroll position of every row without mounting
@@ -213,7 +214,10 @@ function MaterialDetail({ m }: { m: OPTMaterial }) {
               <DetailField label={t("openprinttag.detail.chamberTemp")} value={m.chamberTemp} unit="°C" />
               <DetailField label={t("openprinttag.detail.preheatTemp")} value={m.preheatTemp} unit="°C" />
               <DetailField label={t("openprinttag.detail.dryingTemp")} value={m.dryingTemp} unit="°C" />
-              <DetailField label={t("openprinttag.detail.dryingTime")} value={m.dryingTime} unit="h" />
+              {/* GH #807: dryingTime is stored in MINUTES (OPT spec key
+                  drying_time). Render as "Xh Ym" — was wrongly suffixing the raw
+                  minutes with "h" (480 → "480 h" instead of "8h 0m"). */}
+              <DetailField label={t("openprinttag.detail.dryingTime")} value={formatMinutesAsHm(m.dryingTime)} />
             </>
           ) : (
             <p className="text-xs text-gray-400 dark:text-gray-500 italic py-1">{t("openprinttag.detail.noProperties")}</p>

--- a/src/lib/formatDuration.ts
+++ b/src/lib/formatDuration.ts
@@ -1,0 +1,19 @@
+/**
+ * GH #807 — format a duration given in MINUTES (the app's canonical drying-time
+ * unit) as a human "Xh Ym" / "Ym" string:
+ *   480 → "8h 0m"   90 → "1h 30m"   45 → "45m"   0 → "0m"
+ *
+ * The OpenPrintTag browser was rendering the raw minutes value with an `h`
+ * suffix (so `drying_time: 480` showed as "480 h"); this matches the minutes
+ * interpretation the form, NFC read dialog, and compare page already use.
+ *
+ * Pure + null-safe. Returns null for null/non-finite input so callers can hide
+ * the field entirely.
+ */
+export function formatMinutesAsHm(minutes: number | null | undefined): string | null {
+  if (minutes == null || !Number.isFinite(minutes)) return null;
+  const total = Math.max(0, Math.round(minutes));
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}

--- a/tests/formatDuration.test.ts
+++ b/tests/formatDuration.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { formatMinutesAsHm } from "@/lib/formatDuration";
+
+/**
+ * GH #807 — drying time is stored in minutes; the OpenPrintTag browser must
+ * render it as hours+minutes, not raw minutes with an "h" suffix.
+ */
+describe("formatMinutesAsHm", () => {
+  it("formats whole hours with explicit 0 minutes", () => {
+    expect(formatMinutesAsHm(480)).toBe("8h 0m");
+    expect(formatMinutesAsHm(60)).toBe("1h 0m");
+  });
+
+  it("formats hours + minutes", () => {
+    expect(formatMinutesAsHm(90)).toBe("1h 30m");
+    expect(formatMinutesAsHm(135)).toBe("2h 15m");
+  });
+
+  it("drops the hours part under an hour", () => {
+    expect(formatMinutesAsHm(45)).toBe("45m");
+    expect(formatMinutesAsHm(0)).toBe("0m");
+  });
+
+  it("rounds and clamps stray values", () => {
+    expect(formatMinutesAsHm(89.6)).toBe("1h 30m");
+    expect(formatMinutesAsHm(-5)).toBe("0m");
+  });
+
+  it("returns null for null / non-finite (so the field can hide)", () => {
+    expect(formatMinutesAsHm(null)).toBeNull();
+    expect(formatMinutesAsHm(undefined)).toBeNull();
+    expect(formatMinutesAsHm(Number.NaN)).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes [#807](https://github.com/hyiger/filament-db/issues/807).

The OpenPrintTag database browser rendered `dryingTime` — stored in **minutes** (OPT spec key `drying_time`, e.g. `480`) — with a literal `h` suffix, so it displayed as **"480 h"** instead of **"8h 0m"**. Anyone browsing or importing community materials saw drying cycles 60× too long.

### Fix
New pure [`formatMinutesAsHm()`](src/lib/formatDuration.ts): `480 → "8h 0m"`, `90 → "1h 30m"`, `45 → "45m"`, `null → null`. This matches the minutes interpretation the filament form (`Drying Time (min)`), the NFC read dialog, and the compare page already use. The browser's drying-time field now formats through it and drops the bogus `h` unit.

Display-only — import/parse semantics are unchanged (the parser already stored minutes correctly).

5 unit tests for the formatter (`tsc` + `lint` green).

Fixes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)