### PR TITLE
test: retry MongoMemoryServer startup on random-port collision (#808)

### DIFF
--- a/tests/mongoRetry.test.ts
+++ b/tests/mongoRetry.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { isPortInUseError, startWithRetry } from "./mongoRetry";
+
+/**
+ * GH #808 — the shared Mongo startup must survive a random-port collision by
+ * retrying with a fresh server, but must not mask genuine startup failures.
+ */
+describe("isPortInUseError", () => {
+  it("matches the mongodb-memory-server port-in-use message", () => {
+    expect(isPortInUseError(new Error('Port "57343" already in use'))).toBe(true);
+    expect(isPortInUseError(new Error("listen EADDRINUSE: address already in use"))).toBe(true);
+  });
+
+  it("matches a raw EADDRINUSE code", () => {
+    expect(isPortInUseError({ code: "EADDRINUSE" })).toBe(true);
+  });
+
+  it("does NOT match unrelated startup failures", () => {
+    expect(isPortInUseError(new Error("Instance failed to start within 60000ms"))).toBe(false);
+    expect(isPortInUseError(new Error("spawn mongod ENOENT"))).toBe(false);
+    expect(isPortInUseError(null)).toBe(false);
+  });
+});
+
+describe("startWithRetry", () => {
+  const noSleep = () => Promise.resolve();
+
+  it("retries past port collisions and returns the eventual success", async () => {
+    let calls = 0;
+    const create = vi.fn(async () => {
+      calls++;
+      if (calls < 3) throw new Error('Port "57343" already in use');
+      return "server";
+    });
+    const onRetry = vi.fn();
+    const result = await startWithRetry(create, { delayMs: 0, sleep: noSleep, onRetry });
+    expect(result).toBe("server");
+    expect(create).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows a non-port error immediately without retrying", async () => {
+    const create = vi.fn(async () => {
+      throw new Error("Instance failed to start within 60000ms");
+    });
+    await expect(startWithRetry(create, { delayMs: 0, sleep: noSleep })).rejects.toThrow(
+      /failed to start/,
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after maxAttempts and throws the last port error", async () => {
+    const create = vi.fn(async () => {
+      throw new Error('Port "5000" already in use');
+    });
+    await expect(
+      startWithRetry(create, { maxAttempts: 3, delayMs: 0, sleep: noSleep }),
+    ).rejects.toThrow(/already in use/);
+    expect(create).toHaveBeenCalledTimes(3);
+  });
+
+  it("succeeds on the first try without invoking the retry callback", async () => {
+    const create = vi.fn(async () => "ok");
+    const onRetry = vi.fn();
+    expect(await startWithRetry(create, { onRetry })).toBe("ok");
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mongoRetry.ts
+++ b/tests/mongoRetry.ts
@@ -1,0 +1,60 @@
+/**
+ * GH #808 — retry helper for the shared MongoMemoryServer startup.
+ *
+ * mongodb-memory-server picks a random port; if that port is already held by
+ * another local process (Steam, another dev server, a prior test run not yet
+ * reaped), it throws `StdoutInstanceError: Port "57343" already in use` and the
+ * WHOLE vitest run fails before a single suite executes — a flaky, unrelated
+ * red build. Retrying with a fresh server picks a new random port.
+ *
+ * Dependency-injected (`create` is passed in) so it's unit-testable without
+ * spawning real mongod. Lives in tests/ (not src/lib) since it's test infra and
+ * isn't subject to the src coverage thresholds.
+ */
+
+/** Is this a "the port I randomly picked is taken" error — i.e. retryable by
+ *  just trying a fresh port? Matches mongodb-memory-server's
+ *  `StdoutInstanceError` message and the raw EADDRINUSE shape. Genuine startup
+ *  failures (missing binary, launch timeout) do NOT match, so they surface. */
+export function isPortInUseError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/already in use/i.test(msg) || /EADDRINUSE/i.test(msg)) return true;
+  return (err as { code?: string } | null)?.code === "EADDRINUSE";
+}
+
+export interface StartWithRetryOptions {
+  maxAttempts?: number;
+  delayMs?: number;
+  /** Called before each retry (not before the first attempt, not after the
+   *  final failure) — used to warn() so CI shows the flake happened. */
+  onRetry?: (attempt: number, err: unknown) => void;
+  /** Injectable sleep for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Run `create()`, retrying only on a port-collision error with a fresh call
+ * each time, up to `maxAttempts`. Non-retryable errors throw immediately; the
+ * last attempt's error propagates so a genuine failure stays visible.
+ */
+export async function startWithRetry<T>(
+  create: () => Promise<T>,
+  opts: StartWithRetryOptions = {},
+): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? 5;
+  const delayMs = opts.delayMs ?? 250;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await create();
+    } catch (err) {
+      lastErr = err;
+      if (!isPortInUseError(err) || attempt === maxAttempts) throw err;
+      opts.onRetry?.(attempt, err);
+      if (delayMs > 0) await sleep(delayMs);
+    }
+  }
+  // Unreachable (the loop either returns or throws), but satisfies the compiler.
+  throw lastErr;
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,7 @@
 import { MongoMemoryServer } from "mongodb-memory-server";
 import mongoose from "mongoose";
 import { beforeAll, afterAll, afterEach } from "vitest";
+import { startWithRetry } from "./mongoRetry";
 
 // Allow a generous startup budget — Windows CI runners have been observed
 // downloading/extracting the mongodb binary and failing the default 10s
@@ -25,9 +26,27 @@ const MONGO_INSTANCE_LAUNCH_TIMEOUT_MS = 60_000;
 let mongoServer: MongoMemoryServer | null = null;
 
 beforeAll(async () => {
-  mongoServer = await MongoMemoryServer.create({
-    instance: { launchTimeout: MONGO_INSTANCE_LAUNCH_TIMEOUT_MS },
-  });
+  // GH #808: mongodb-memory-server picks a random port; if it collides with
+  // another local process it throws "Port … already in use" and fails the
+  // ENTIRE run before any suite executes. Retry with a fresh server (new random
+  // port) on that specific error only — genuine startup failures still surface.
+  // Port collisions fail fast, so a handful of retries fit inside the budget.
+  mongoServer = await startWithRetry(
+    () =>
+      MongoMemoryServer.create({
+        instance: { launchTimeout: MONGO_INSTANCE_LAUNCH_TIMEOUT_MS },
+      }),
+    {
+      maxAttempts: 5,
+      delayMs: 250,
+      onRetry: (attempt, err) =>
+        console.warn(
+          `[tests/setup] MongoMemoryServer port collision (attempt ${attempt}/5); retrying with a fresh port: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+    },
+  );
   const uri = mongoServer.getUri();
   process.env.MONGODB_URI = uri;
   await mongoose.connect(uri);


### PR DESCRIPTION
Fixes [#808](https://github.com/hyiger/filament-db/issues/808).

A full `npm test` run could fail **before any suite executed** when `mongodb-memory-server` picked a random port already held by another local process (the report saw `steam_osx` on `:57343`), throwing `StdoutInstanceError: Port "57343" already in use`. The target suite passed on its own when rerun — a classic flaky, unrelated red build.

### Fix
`tests/setup.ts`'s shared `beforeAll` now starts Mongo through a new [`startWithRetry`](tests/mongoRetry.ts) helper:
- up to **5 attempts**, a **fresh `MongoMemoryServer`** (new random port) per attempt;
- retries **only** on the port-in-use / `EADDRINUSE` error — genuine startup failures (missing binary, launch timeout) rethrow immediately so they stay visible;
- `console.warn` on each retry so CI shows the flake happened;
- port collisions fail fast, so the retries fit comfortably inside the existing 120s start budget.

The helper is dependency-injected (`create` + `sleep`), so it's unit-tested without spawning real mongod — `tests/mongoRetry.test.ts` covers retry-then-succeed, immediate rethrow of a non-port error, give-up after `maxAttempts`, and the `isPortInUseError` classifier.

`tsc` + `lint` green; the retry tests pass and DB-backed suites still start correctly through the new wiring.

Fixes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)