### PR TITLE
docs: fix mobile links, usage endpoint shape, and dryingTime units (#809)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1009,14 +1009,14 @@ Returns:
       "bed": 60
     },
     "dryingTemperature": 55,
-    "dryingTime": 4,
+    "dryingTime": 240,
     "glassTempTransition": 60,
     "heatDeflectionTemp": 52
   }
 }
 ```
 
-Extracted fields include: name, vendor, type, density, diameter, temperatures (nozzle, bed, ranges), drying temperature/time, glass transition (Tg), heat deflection (HDT), shore hardness (A/D), volumetric speed, print speed ranges, and weights. Fields not found in the TDS are omitted from the response.
+Extracted fields include: name, vendor, type, density, diameter, temperatures (nozzle, bed, ranges), drying temperature/time, glass transition (Tg), heat deflection (HDT), shore hardness (A/D), volumetric speed, print speed ranges, and weights. Fields not found in the TDS are omitted from the response. **`dryingTime` is in minutes** (e.g. `240` = 4 hours, `480` = 8 hours) — the app's canonical unit for that field.
 
 **SSRF / redirect handling**: the URL fetcher uses the shared `assertExternalUrl` guard (no `file:` / `gopher:` schemes; rejects loopback / RFC1918 / link-local / cloud-metadata IPs). Redirects are followed manually with the same guard re-applied on every hop, capped at 5 redirects — so a public host cannot 30x-redirect into private space (matches the `embed-check` route's pattern). The `tdsUrl` field on `Filament` is also schema-validated to http(s) on both create and every update path.
 

--- a/docs/de/api.md
+++ b/docs/de/api.md
@@ -928,14 +928,14 @@ Liefert:
       "bed": 60
     },
     "dryingTemperature": 55,
-    "dryingTime": 4,
+    "dryingTime": 240,
     "glassTempTransition": 60,
     "heatDeflectionTemp": 52
   }
 }
 ```
 
-Extrahierte Felder umfassen: Name, Hersteller, Typ, Dichte, Durchmesser, Temperaturen (Düse, Druckbett, Bereiche), Trocknungstemperatur/-zeit, Glasübergang (Tg), Heat Deflection (HDT), Shore-Härte (A/D), volumetrische Geschwindigkeit, Druckgeschwindigkeits-Bereiche und Gewichte. Felder, die im TDS nicht gefunden werden, werden aus der Antwort weggelassen.
+Extrahierte Felder umfassen: Name, Hersteller, Typ, Dichte, Durchmesser, Temperaturen (Düse, Druckbett, Bereiche), Trocknungstemperatur/-zeit, Glasübergang (Tg), Heat Deflection (HDT), Shore-Härte (A/D), volumetrische Geschwindigkeit, Druckgeschwindigkeits-Bereiche und Gewichte. Felder, die im TDS nicht gefunden werden, werden aus der Antwort weggelassen. **`dryingTime` ist in Minuten** (z. B. `240` = 4 Stunden, `480` = 8 Stunden) — die kanonische Einheit der App für dieses Feld.
 
 **SSRF-/Redirect-Handling**: Der URL-Fetcher nutzt den geteilten `assertExternalUrl`-Guard (keine `file:`-/`gopher:`-Schemata; lehnt Loopback-/RFC1918-/Link-Local-/Cloud-Metadata-IPs ab). Redirects werden manuell verfolgt, wobei der gleiche Guard bei jedem Hop erneut angewendet wird, gedeckelt auf 5 Redirects — so kann ein öffentlicher Host nicht per 30x in privaten Raum umleiten (entspricht dem Muster der `embed-check`-Route). Das `tdsUrl`-Feld am `Filament` wird zusätzlich schema-validiert auf http(s) bei Erstellung und auf jedem Update-Pfad.
 

--- a/docs/de/setup.md
+++ b/docs/de/setup.md
@@ -112,7 +112,7 @@ Das Vertrauensmodell von Filament DB ist **localhost / Einzelnutzer**: Standardm
 
 Es gibt zwei Wege, eine exponierte Instanz abzusichern — je nachdem, **wer** sie erreichen muss:
 
-- **Nur Nicht-Browser-Clients** (die [mobile Begleit-App](mobile.md), PrusaSlicer/OrcaSlicer-Integrationen, Skripte) — setze `FILAMENTDB_API_KEY` auf einen starken Zufallswert. Jede `/api/*`-Anfrage muss dann `Authorization: Bearer <key>` senden; die Mobile-App und die Slicer-Integrationen unterstützen das. **Erzeuge den Schlüssel einmal, speichere ihn und verwende genau diesen Wert wieder** — deine Clients brauchen ihn, und er muss über Neustarts hinweg gleich bleiben (nicht inline erzeugen, sonst ändert er sich bei jedem Start und nichts kann sich mehr authentifizieren):
+- **Nur Nicht-Browser-Clients** (die [mobile Begleit-App](../../packages/mobile/README.md), PrusaSlicer/OrcaSlicer-Integrationen, Skripte) — setze `FILAMENTDB_API_KEY` auf einen starken Zufallswert. Jede `/api/*`-Anfrage muss dann `Authorization: Bearer <key>` senden; die Mobile-App und die Slicer-Integrationen unterstützen das. **Erzeuge den Schlüssel einmal, speichere ihn und verwende genau diesen Wert wieder** — deine Clients brauchen ihn, und er muss über Neustarts hinweg gleich bleiben (nicht inline erzeugen, sonst ändert er sich bei jedem Start und nichts kann sich mehr authentifizieren):
 
   ```bash
   # 1. Schlüssel einmal erzeugen und kopieren (in die Mobile-App / den Slicer einfügen):

--- a/docs/mobile-app-plan.md
+++ b/docs/mobile-app-plan.md
@@ -139,8 +139,9 @@ keep on the server. Add an optional **`remainingWeight`** field to the PUT body;
 `totalWeight = remainingWeight + effectiveSpoolWeight` using the same `$lookup` the inventory
 aggregation already uses (`/api/spools/by-location`, `/api/locations?stats=true`).
 
-The existing `POST /api/filaments/{id}/spools/{spoolId}/usage?grams=X` already covers the "I used X
-grams" delta case (with a ledger entry) — use it for relative decrements.
+The existing `POST /api/filaments/{id}/spools/{spoolId}/usage` (JSON body
+`{ grams, jobLabel?, date? }`) already covers the "I used X grams" delta case
+(with a ledger entry) — use it for relative decrements.
 
 ### 4.4 Create-from-decoded-tag (reuse existing mapper)
 
@@ -208,7 +209,7 @@ fall back to QR / manual entry with a clear message.
 | Filament detail + spools | `GET /api/filaments/{id}` | exists |
 | Browse / search list (lightweight) | `GET /api/filaments?search=&type=&vendor=` | exists |
 | Update spool location | `PUT /api/filaments/{id}/spools/{spoolId}` `{locationId}` | exists |
-| Log filament used (delta + ledger) | `POST /api/filaments/{id}/spools/{spoolId}/usage?grams=X` | exists |
+| Log filament used (delta + ledger) | `POST /api/filaments/{id}/spools/{spoolId}/usage` `{grams, jobLabel?, date?}` | exists |
 | Location picker / create | `GET` + `POST /api/locations` | exists |
 | Create from OpenPrintTag slug | `POST /api/openprinttag/import` | exists |
 | Create from Bambu Studio preset | `POST /api/filaments/bambustudio` | exists |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -110,7 +110,7 @@ Filament DB's trust model is **localhost / single-user**: by default the API is 
 
 You have two ways to secure an exposed instance, depending on **who** needs to reach it:
 
-- **Non-browser clients only** (the [mobile companion app](mobile.md), PrusaSlicer/OrcaSlicer integrations, scripts) — set `FILAMENTDB_API_KEY` to a strong random value. Every `/api/*` request must then send `Authorization: Bearer <key>`; the mobile app and the slicer integrations support this. **Generate the key once, save it, and reuse that exact value** — your clients need it, and it must stay the same across restarts (don't generate it inline, or it changes every run and nothing can authenticate):
+- **Non-browser clients only** (the [mobile companion app](../packages/mobile/README.md), PrusaSlicer/OrcaSlicer integrations, scripts) — set `FILAMENTDB_API_KEY` to a strong random value. Every `/api/*` request must then send `Authorization: Bearer <key>`; the mobile app and the slicer integrations support this. **Generate the key once, save it, and reuse that exact value** — your clients need it, and it must stay the same across restarts (don't generate it inline, or it changes every run and nothing can authenticate):
 
   ```bash
   # 1. Generate a key once and copy it (paste this into the mobile app / slicer):


### PR DESCRIPTION
Fixes [#809](https://github.com/hyiger/filament-db/issues/809). Three independent doc-drift fixes from the audit — docs-only, no code/API change.

1. **Broken mobile links.** `docs/setup.md` and `docs/de/setup.md` linked `[mobile companion app](mobile.md)`, but there is no `docs/mobile.md`. Retargeted to the existing mobile README — `../packages/mobile/README.md` from `docs/`, `../../packages/mobile/README.md` from `docs/de/` (verified both resolve).
2. **Stale usage endpoint.** `docs/mobile-app-plan.md` described manual usage logging as `POST …/usage?grams=X` (prose + status table), but the route takes a JSON body `{ grams, jobLabel?, date? }` (as `docs/api.md`, the route handler, and the mobile client all use). Updated both occurrences.
3. **`dryingTime` units.** `docs/api.md` and `docs/de/api.md` TDS examples showed `"dryingTime": 4` (looks like 4 hours), but the field is **minutes** everywhere in code (`tdsExtractor` prompt, OPT encoder, form label). Changed to `240` (= 4h) and added prose that the field is in minutes — consistent with the #807 fix.

Verified: no remaining `](mobile.md)`, `usage?grams`, or `"dryingTime": 4` references in `docs/`.

(The issue also floated adding a CI Markdown link-check; left as a separate enhancement.)

Fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)