### PR TITLE
fix(mobile): throttle QR re-scan + gate NFC button on device availability

### DIFF
--- a/packages/mobile/src/app/index.tsx
+++ b/packages/mobile/src/app/index.tsx
@@ -1,11 +1,11 @@
 import { Link, useRouter } from 'expo-router';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ApiError, createApi } from '@/lib/api';
 import { NFC_ENABLED } from '@/lib/features';
-import { readOpenPrintTag } from '@/lib/nfc';
+import { isNfcAvailable, readOpenPrintTag } from '@/lib/nfc';
 import { setPendingScan } from '@/lib/pendingScan';
 import { useServerConfig } from '@/lib/serverConfig';
 import { useColors } from '@/lib/theme';
@@ -15,6 +15,27 @@ export default function ScanScreen() {
   const router = useRouter();
   const c = useColors();
   const [busy, setBusy] = useState(false);
+  // null = still probing; false short-circuits when the build disabled NFC.
+  // Gate the NFC button on real device capability, not just the build-time
+  // NFC_ENABLED flag, so a device without NFC hardware (or with it switched off)
+  // shows a disabled button + hint instead of a cryptic native error on tap.
+  // (#824)
+  const [nfcAvailable, setNfcAvailable] = useState<boolean | null>(NFC_ENABLED ? null : false);
+
+  useEffect(() => {
+    if (!NFC_ENABLED) return;
+    let active = true;
+    isNfcAvailable()
+      .then((ok) => {
+        if (active) setNfcAvailable(ok);
+      })
+      .catch(() => {
+        if (active) setNfcAvailable(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   if (loading) {
     return (
@@ -43,6 +64,12 @@ export default function ScanScreen() {
   const api = createApi({ baseUrl, apiKey });
 
   async function scanNfc() {
+    // Defense-in-depth: the button is disabled when NFC is unavailable, but
+    // guard the handler too so a stray tap can't reach the native reader. (#824)
+    if (nfcAvailable === false) {
+      Alert.alert('NFC unavailable', 'This device has no NFC, or NFC is turned off in Settings.');
+      return;
+    }
     setBusy(true);
     try {
       const scan = await readOpenPrintTag();
@@ -90,14 +117,20 @@ export default function ScanScreen() {
         </Pressable>
         {NFC_ENABLED && (
           <Pressable
-            style={[styles.bigButton, { backgroundColor: c.tint }, busy && styles.disabled]}
+            style={[
+              styles.bigButton,
+              { backgroundColor: c.tint },
+              (busy || nfcAvailable === false) && styles.disabled,
+            ]}
             onPress={scanNfc}
-            disabled={busy}
+            disabled={busy || nfcAvailable === false}
           >
             <Text style={[styles.bigButtonText, { color: c.onTint }]}>
               {busy ? 'Scanning…' : 'Scan NFC tag'}
             </Text>
-            <Text style={styles.bigButtonHint}>OpenPrintTag</Text>
+            <Text style={styles.bigButtonHint}>
+              {nfcAvailable === false ? 'NFC unavailable on this device' : 'OpenPrintTag'}
+            </Text>
           </Pressable>
         )}
       </View>

--- a/packages/mobile/src/app/scan-qr.tsx
+++ b/packages/mobile/src/app/scan-qr.tsx
@@ -1,6 +1,6 @@
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { useRouter } from 'expo-router';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { ApiError, createApi } from '@/lib/api';
@@ -13,7 +13,22 @@ export default function ScanQrScreen() {
   const router = useRouter();
   const c = useColors();
   const handled = useRef(false);
+  // expo-camera fires onBarcodeScanned on every frame a code is visible. On a
+  // failed resolve we must re-arm so a later scan works, but re-arming
+  // synchronously hammers the server with back-to-back match requests while an
+  // unmatched code is held in frame (or the server is down). Re-arm on a
+  // cooldown instead, and dedupe the same code within a window so a held code is
+  // only tried once. (#815)
+  const rearmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastScan = useRef<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(
+    () => () => {
+      if (rearmTimer.current) clearTimeout(rearmTimer.current);
+    },
+    [],
+  );
 
   if (!permission) {
     return (
@@ -36,9 +51,24 @@ export default function ScanQrScreen() {
     );
   }
 
+  // Re-arm the scanner after a cooldown so a held unmatched code isn't retried
+  // every frame. Clearing lastScan lets re-scanning the SAME code retry once the
+  // window passes (e.g. after the server comes back). (#815)
+  function rearmAfterCooldown() {
+    if (rearmTimer.current) clearTimeout(rearmTimer.current);
+    rearmTimer.current = setTimeout(() => {
+      handled.current = false;
+      lastScan.current = null;
+      rearmTimer.current = null;
+    }, 1500);
+  }
+
   async function onScanned(data: string) {
-    if (handled.current || !baseUrl) return;
+    const code = data.trim();
+    // Ignore the same code while it's still in frame (it re-fires per frame).
+    if (handled.current || !baseUrl || code === lastScan.current) return;
     handled.current = true;
+    lastScan.current = code;
     setError(null);
     try {
       // Filament DB labels encode either a deep-link URL (/filaments/{id}, with an
@@ -70,7 +100,7 @@ export default function ScanQrScreen() {
         });
         return;
       }
-      const res = await api.matchByInstanceId(data.trim());
+      const res = await api.matchByInstanceId(code);
       if (res.match?._id) {
         // #732: if the code resolved to a specific spool, deep-link to it so the
         // detail screen highlights that spool (older servers omit matchedSpool).
@@ -81,11 +111,11 @@ export default function ScanQrScreen() {
         });
       } else {
         setError('No filament matched that code.');
-        handled.current = false;
+        rearmAfterCooldown();
       }
     } catch (e) {
       setError(e instanceof ApiError ? e.message : (e as Error).message);
-      handled.current = false;
+      rearmAfterCooldown();
     }
   }
 


### PR DESCRIPTION
From the audit triage. Two mobile-scanner fixes in `packages/mobile`.

## #815 — QR scanner request storm (P2)
`scan-qr.tsx` re-armed its once-only `handled` guard **synchronously** on both failure paths, while `expo-camera` fires `onBarcodeScanned` on every frame a code is visible. Holding an unmatched QR in frame (or scanning while the server is unreachable) produced a continuous stream of `GET /api/filaments/match` requests — one per round-trip — plus a flickering error overlay.

**Fix:** re-arm on a **1.5 s cooldown** instead of synchronously, with same-code dedupe (`lastScan` ref) so a held code is tried once. Clearing `lastScan` in the cooldown lets the *same* code retry after the window (e.g. once the server is back). `useEffect` cleanup clears a pending timer on unmount.

## #824 — NFC button not gated on device availability (P3)
The "Scan NFC tag" button was gated only on the build-time `NFC_ENABLED` flag; `isNfcAvailable()` was unused dead code. On a device with no NFC (e.g. iPad) or NFC turned off, tapping surfaced a raw native error.

**Fix:** probe real device NFC availability on mount (lazy-init `false` when `NFC_ENABLED` is off, to satisfy `react-hooks/set-state-in-effect`), disable the button + show an "NFC unavailable on this device" hint when absent/off, and guard `scanNfc()` as defense-in-depth.

## Verification
- `packages/mobile`: `tsc --noEmit` clean, `eslint` clean on both files.
- No automated harness exists for the mobile screens (`packages/` is excluded from root Vitest/tsc), so behavior was verified by reading the camera/handler flow. On-device manual checks (request storm throttled, NFC button disabled without hardware) are owed.

Fixes #815
Fixes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)