### PR TITLE
ci(electron): type-check electron/ in CI + fix CardReader never-type bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      # The root tsconfig excludes electron/ (esbuild bundles it without type
+      # checking), so type-check the Electron main/preload/services separately
+      # or ~5.6k lines ship unchecked. (#816)
+      - name: Type check (Electron)
+        run: npm run electron:typecheck
+
       - name: Run tests with coverage
         run: npm run test:coverage
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -398,9 +398,9 @@ async function resolveSrvUri(uri: string): Promise<string> {
     await client.connect();
     // Extract the resolved topology from the client's options
     const options = client.options;
-    const hosts = options.hosts.map((h: { host: string; port: number }) =>
-      `${h.host}:${h.port}`
-    ).join(",");
+    // `options.hosts` is the driver's HostAddress[] (host/port optional); let
+    // the element type infer rather than asserting a narrower shape (#816).
+    const hosts = options.hosts.map((h) => `${h.host}:${h.port}`).join(",");
 
     // Parse the original URI to preserve credentials and options
     const parsed = new URL(uri.replace("mongodb+srv://", "http://"));
@@ -1203,7 +1203,7 @@ ipcMain.handle("label-printer-get-device-path", (event) => {
   // the rest of the app uses — see the get-config handler above. Kept
   // as a separate handler so the renderer doesn't have to read the
   // whole config object just to render the Print Label dialog.
-  return (store as Store<Record<string, unknown>>).get("labelPrinterDevicePath", null);
+  return (store as unknown as Store<Record<string, unknown>>).get("labelPrinterDevicePath", null);
 });
 
 ipcMain.handle("label-printer-set-device-path", (event, devicePath: string | null) => {
@@ -1212,7 +1212,7 @@ ipcMain.handle("label-printer-set-device-path", (event, devicePath: string | nul
     throw new Error("devicePath must be a string or null");
   }
   if (devicePath == null) {
-    (store as Store<Record<string, unknown>>).delete("labelPrinterDevicePath");
+    (store as unknown as Store<Record<string, unknown>>).delete("labelPrinterDevicePath");
   } else {
     // GH #623: only accept the shapes listLabelPrinters ever surfaces —
     // a `usb://…` device URI (the one scheme the CUPS lister emits) or an
@@ -1228,7 +1228,7 @@ ipcMain.handle("label-printer-set-device-path", (event, devicePath: string | nul
         "devicePath must be a usb:// device URI or an installed printer/queue name",
       );
     }
-    (store as Store<Record<string, unknown>>).set("labelPrinterDevicePath", devicePath);
+    (store as unknown as Store<Record<string, unknown>>).set("labelPrinterDevicePath", devicePath);
   }
   return { ok: true };
 });
@@ -1244,7 +1244,7 @@ ipcMain.handle("label-printer-set-device-path", (event, devicePath: string | nul
 // otherwise. (Codex P2 on PR #487.)
 ipcMain.handle("label-printer-get-public-url", (event) => {
   assertTrustedSender(event, "label-printer-get-public-url");
-  return (store as Store<Record<string, unknown>>).get("labelPrinterPublicUrl", null);
+  return (store as unknown as Store<Record<string, unknown>>).get("labelPrinterPublicUrl", null);
 });
 
 ipcMain.handle("label-printer-set-public-url", (event, url: string | null) => {
@@ -1253,7 +1253,7 @@ ipcMain.handle("label-printer-set-public-url", (event, url: string | null) => {
     throw new Error("url must be a string or null");
   }
   if (url == null || url.trim() === "") {
-    (store as Store<Record<string, unknown>>).delete("labelPrinterPublicUrl");
+    (store as unknown as Store<Record<string, unknown>>).delete("labelPrinterPublicUrl");
     return { ok: true };
   }
   // Validate shape: must parse + must be http(s) + must not be the
@@ -1292,7 +1292,7 @@ ipcMain.handle("label-printer-set-public-url", (event, url: string | null) => {
   // Strip trailing slash so callers can safely concat `${url}/filaments/...`
   // without producing double slashes.
   const normalized = url.replace(/\/+$/, "");
-  (store as Store<Record<string, unknown>>).set("labelPrinterPublicUrl", normalized);
+  (store as unknown as Store<Record<string, unknown>>).set("labelPrinterPublicUrl", normalized);
   return { ok: true };
 });
 
@@ -1329,7 +1329,7 @@ ipcMain.handle("label-printer-print", async (event, bytes: number[]) => {
       throw new Error("bytes must contain only integers in [0, 255]");
     }
   }
-  const target = (store as Store<Record<string, unknown>>).get(
+  const target = (store as unknown as Store<Record<string, unknown>>).get(
     "labelPrinterDevicePath",
     null,
   ) as string | null;

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -46,8 +46,20 @@ export interface NfcStatus {
 
 type PCSCLite = ReturnType<typeof pcsclite>;
 
-/** Extract the CardReader type from the pcsclite "reader" event listener. */
-type CardReader = Parameters<Extract<Parameters<PCSCLite["on"]>[1], (reader: unknown) => void>>[0];
+/**
+ * Extract the (non-exported) CardReader type from the pcsclite "reader" event
+ * overload. `@pokusew/pcsclite` does `export = pcsc`, so the CardReader
+ * interface isn't importable directly. The previous `Parameters<Extract<…>>`
+ * form collapsed to `never` (the listener overload isn't assignable to
+ * `(reader: unknown) => void` under contravariant parameter checking), which
+ * silently turned every reader access into a `never` — only caught once
+ * electron/ started being type-checked (#816). Infer the parameter from the
+ * specific "reader" overload instead.
+ */
+type CardReader =
+  PCSCLite extends { on(type: "reader", listener: (reader: infer R) => void): unknown }
+    ? R
+    : never;
 
 /** Status payload from CardReader "status" event. */
 interface CardReaderStatus {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "electron:compile": "esbuild electron/main.ts --bundle --platform=node --outfile=electron-dist/main.js --external:electron --external:@pokusew/pcsclite --external:mongodb-memory-server-core --external:mongodb && esbuild electron/preload.ts --bundle --platform=node --outfile=electron-dist/preload.js --external:electron",
+    "electron:typecheck": "tsc -p tsconfig.electron.json",
     "electron:rebuild": "electron-rebuild -f -o @pokusew/pcsclite",
     "electron:dev": "npm run electron:rebuild && npm run electron:compile && concurrently \"next dev -p 3456\" \"wait-on http://localhost:3456 && electron .\"",
     "electron:build": "npm run build && npm run electron:fixlinks && npm run electron:rebuild && npm run electron:compile && npm run electron:pack",

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,14 +1,17 @@
 {
+  // Type-check-only config for the Electron main/preload/services. The root
+  // tsconfig EXCLUDES electron/ (it's bundled by esbuild, which strips types
+  // without checking), so without this pass the ~5.6k lines of Electron TS ship
+  // unchecked. Extending the root config (rather than hand-rolling module /
+  // moduleResolution) is what lets electron-store's pure-ESM `exports.types`
+  // condition resolve, so its .get/.set typings are present. noEmit keeps this a
+  // pure check that writes nothing; incremental is off so it shares no build
+  // state with the root pass. (#816)
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "strict": true,
-    "outDir": "electron-dist",
-    "rootDir": "electron",
-    "skipLibCheck": true,
-    "resolveJsonModule": true
+    "noEmit": true,
+    "incremental": false
   },
-  "include": ["electron/**/*.ts"]
+  "include": ["electron/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
From the audit triage (#816, P2).

`tsconfig.electron.json` was **orphaned** (referenced by no npm script or workflow) and **broken** (88 errors when run), so the only CI typecheck (`npx tsc --noEmit` against the root config, which **excludes** `electron/`) never covered the ~5.6k lines of Electron TypeScript. `electron:compile` uses esbuild, which strips types without checking. A type error anywhere in the main process, IPC handlers, NFC service, label printer, sync service, or auto-updater shipped green.

## Changes
- **`tsconfig.electron.json`** rewritten to `extends` the root config (`noEmit`, `incremental: false`). Extending fixes the `TS6059` rootDir violations from the `../src/*` re-export shims and switches to `bundler` resolution so `electron-store`'s pure-ESM `exports.types` condition resolves (restoring its `.get/.set` typings) — clearing the bulk of the 88 errors.
- **Real source bug it masked (`electron/nfc-service.ts`):** `CardReader` was derived via `Parameters<Extract<…, (reader: unknown) => void>>`, which collapses to `never` (the listener overload isn't assignable to `(reader: unknown) => void` under contravariant parameter checking). Every reader access was silently `never`. Replaced with a conditional-`infer` on the specific pcsclite `"reader"` overload. The package does `export = pcsc` so `CardReader` can't be imported directly.
- **`electron/main.ts`:** cast the off-schema label-printer store keys through `unknown` (the cast the compiler error itself recommends); drop a too-narrow inline annotation on the resolved-hosts `.map` (the driver's `HostAddress.host/port` are optional).
- **CI wiring:** new `electron:typecheck` npm script + a "Type check (Electron)" step in `test.yml`.

## Verification
- `npm run electron:typecheck` → **0 errors** (was 88).
- Root `tsc --noEmit` still clean; `npm run electron:compile` (esbuild) unaffected — all changes are type-only except the equivalent-behavior `.map` annotation drop.

Fixes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)