### PR TITLE
fix(list): show all filaments under "All" when a catalog has no spools (#847)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -494,6 +494,12 @@ export default function Home() {
     }).length;
   }, [filaments, inStock]);
 
+  // #847: when NOTHING is in stock (e.g. a catalog with 0 spools), the "all"
+  // view falls back to showing every filament, so the "Show out of stock"
+  // toggle would be a no-op — suppress it unless at least one filament is
+  // actually in stock (i.e. the hide is genuinely hiding something).
+  const hasAnyInStock = useMemo(() => filaments.some(inStock), [filaments, inStock]);
+
   const visibleFilaments = useMemo(() => {
     // The "all" view keeps parents in the dataset so the list renders them as
     // grouping headers above their color variants. By default it hides
@@ -505,7 +511,14 @@ export default function Home() {
     // (Codex P2 on #712).
     if (quickFilter === "all") {
       const filterActive = !!debouncedSearch || !!typeFilter || !!vendorFilter;
-      return showOutOfStock || filterActive ? filaments : filaments.filter(inStock);
+      if (showOutOfStock || filterActive) return filaments;
+      const inStockList = filaments.filter(inStock);
+      // #847: don't let the default out-of-stock hide empty the unfiltered "All"
+      // view. A catalog with nothing in stock (e.g. filaments but 0 spools)
+      // would otherwise render "No filaments match" under "All (N)". Show
+      // everything when there's nothing to declutter to; the #712 hide still
+      // applies whenever at least one filament IS stocked.
+      return inStockList.length === 0 ? filaments : inStockList;
     }
     // #552: "Has spools" resolves against the full list (parents
     // included) because a parent carrying its own spool genuinely has
@@ -1258,7 +1271,7 @@ export default function Home() {
             onChange={setQuickFilter}
             counts={quickFilterCounts}
           />
-          {quickFilter === "all" && !debouncedSearch && !typeFilter && !vendorFilter && outOfStockCount > 0 && (
+          {quickFilter === "all" && !debouncedSearch && !typeFilter && !vendorFilter && outOfStockCount > 0 && hasAnyInStock && (
             <button
               onClick={() => setShowOutOfStock((s) => !s)}
               aria-pressed={showOutOfStock}


### PR DESCRIPTION
From the triage of #847 (bug 2 of 2 — the filter behaviour).

## Problem
A catalog with filaments but **0 spools** rendered "No filaments match the current filters" under the selected **`All (120)`** chip. The #712 "hide out-of-stock by default" feature hides filaments with no active spool — with 0 spools *nothing* is in stock, so it hid all 120 — while the chip count is computed **pre-hide**, giving the contradiction "All (120)" with zero rows. The same 120 appeared under "Show out of stock (120)" / "No calibration (120)".

## Fix
- When the unfiltered `All` view would hide **everything** (the in-stock list is empty), fall back to showing all filaments (`src/app/page.tsx`). The #712 declutter still applies whenever ≥1 filament is stocked, so this only ever shows **more** rows — it can't regress the stocked case.
- Suppress the now-no-op "Show out of stock (N)" toggle when nothing is in stock (the items are already shown), gating it on a new `hasAnyInStock`.

The triage's secondary "toggle-aware empty state" message is **intentionally not added**: this fix makes `All` non-empty whenever filaments exist, so that branch is unreachable for `All`, and showing an out-of-stock hint on a genuine search/filter no-match would mislead.

## Verification
- `tsc --noEmit` + eslint clean.
- Reproduction is data-dependent (filaments + 0 spools); the change is a small, self-contained conditional (show all when the in-stock subset is empty). The live preview shares the production DB, so I didn't reproduce the 0-spool state there.

Part of **#847** — the false-tag-detection half is a separate PR; #847 stays open until both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)