### PR TITLE
fix(nfc): ignore virtual/contact PC/SC readers + surface reader name (#847)

### DIFF
--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -20,6 +20,7 @@ import {
   classifyNfcError as classifyNfcErrorImpl,
   type NfcErrorCode,
 } from "../src/lib/nfcErrorClassify";
+import { isLikelyContactlessReader } from "../src/lib/nfcReaderFilter";
 
 export type { NfcErrorCode };
 /** Re-export the classifier so the existing call-sites in this file
@@ -115,6 +116,16 @@ export class NfcService extends EventEmitter {
     this.pcsc = pcsclite();
 
     this.pcsc.on("reader", (reader: CardReader) => {
+      // GH #847: ignore virtual/system + contact-only PC/SC "readers" the OS
+      // enumerates (Windows Hello / UICC / TPM virtual smart cards, built-in
+      // contact slots). On Windows a virtual card's "present" bit otherwise
+      // drove a false "Tag detected" + an auto-read popup with no NFC hardware
+      // installed. The name is still logged so a misfiltered real reader can be
+      // spotted (and it's surfaced in the status tooltip).
+      if (!isLikelyContactlessReader(reader.name)) {
+        console.log(`[NFC] Ignoring non-contactless reader: ${reader.name}`);
+        return;
+      }
       this.readers.set(reader.name, reader);
       this.lastReaderDiscoveredAt = Date.now();
       console.log(`[NFC] Reader discovered: ${reader.name} (${this.readers.size} total)`);

--- a/src/components/NfcStatus.tsx
+++ b/src/components/NfcStatus.tsx
@@ -78,11 +78,18 @@ export default function NfcStatus() {
   // Tooltip surfaces the raw error message when we have one (PR-Q #476)
   // — useful for diagnostics even if the classified hint already
   // explains what to do.
-  const tooltip = status.lastError
+  const baseTooltip = status.lastError
     ? `${label}\n\n${status.lastError.message}`
     : hint
       ? `${label}\n\n${hint}`
       : label;
+  // #847: append the connected reader's name so the user can see WHICH device
+  // the app picked up — invaluable when a non-NFC reader (e.g. a Windows
+  // virtual smart-card reader) is mistaken for a tag source.
+  const tooltip =
+    status.readerConnected && status.readerName
+      ? `${baseTooltip}\n\n${t("nfc.status.readerNameTooltip", { name: status.readerName })}`
+      : baseTooltip;
 
   // GH #451 follow-up (Codex P2 on PR #475): when an NFC scan has
   // landed but the dialog is currently dismissed (either auto-suppressed

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -621,6 +621,7 @@
   "nfc.status.readyPlaceTag": "Bereit — Tag auflegen",
   "nfc.status.readyPlaceTagHint": "Lege einen Tag auf den Reader, um ihn zu lesen — das Ergebnis erscheint überall in der App. Liegt bereits ein Tag auf dem Reader, hebe ihn an und lege ihn erneut auf.",
   "nfc.status.tagDetected": "Tag erkannt",
+  "nfc.status.readerNameTooltip": "Lesegerät: {name}",
   "nfc.status.tagDetectedWithUid": "Tag erkannt ({uid})",
   "nfc.status.tagLoaded": "Geladen: {name}",
   "atlas.import.title": "Aus MongoDB Atlas importieren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -621,6 +621,7 @@
   "nfc.status.readyPlaceTag": "Ready — place tag",
   "nfc.status.readyPlaceTagHint": "Place a tag on the reader to read it — the result opens anywhere in the app. A tag already resting on the reader may need to be lifted and placed again.",
   "nfc.status.tagDetected": "Tag detected",
+  "nfc.status.readerNameTooltip": "Reader: {name}",
   "nfc.status.tagDetectedWithUid": "Tag detected ({uid})",
   "nfc.status.tagLoaded": "Loaded: {name}",
   "atlas.import.title": "Import from MongoDB Atlas",

--- a/src/lib/nfcReaderFilter.ts
+++ b/src/lib/nfcReaderFilter.ts
@@ -1,0 +1,39 @@
+/**
+ * Heuristic: does a PC/SC reader name look like a real contactless (NFC)
+ * reader, vs a virtual/system or contact-only smart-card "reader" the OS
+ * enumerates?
+ *
+ * GH #847: On Windows 11, the PC/SC stack routinely enumerates readers that
+ * aren't NFC hardware at all — virtual smart cards (Windows Hello for Business,
+ * UICC/eSIM, TPM) and built-in CONTACT smart-card slots. A virtual/idle card's
+ * "present" bit (or a driver phantom) drove a false "Tag detected" in the
+ * header and an auto-read popup on a machine with no NFC reader installed.
+ *
+ * Posture: a DENYLIST, not an allowlist — reject names that clearly identify a
+ * virtual/system/contact reader, and let everything else through, so an
+ * unlisted-but-real contactless reader still works (an allowlist would risk
+ * silently breaking a reader from a vendor we didn't think of). When a real
+ * reader is still misidentified, the reader name is surfaced in the NFC status
+ * tooltip so it can be reported and a pattern added here.
+ *
+ * Matching is case-insensitive. `\bcontacted\b` matches the built-in
+ * "...Contacted SmartCard..." slots but NOT "contactless".
+ */
+const NON_CONTACTLESS_READER_PATTERNS: RegExp[] = [
+  /virtual smart card/i,
+  /windows hello/i,
+  /\bUICC\b/i,
+  /\bTPM\b/i,
+  /\bVSC\b/i,
+  /microsoft.*virtual/i,
+  /\bcontacted\b/i,
+];
+
+export function isLikelyContactlessReader(
+  name: string | null | undefined,
+): boolean {
+  if (!name) return false;
+  const trimmed = name.trim();
+  if (!trimmed) return false;
+  return !NON_CONTACTLESS_READER_PATTERNS.some((re) => re.test(trimmed));
+}

--- a/tests/nfcReaderFilter.test.ts
+++ b/tests/nfcReaderFilter.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { isLikelyContactlessReader } from "@/lib/nfcReaderFilter";
+
+describe("isLikelyContactlessReader (#847)", () => {
+  it("accepts real contactless NFC readers", () => {
+    for (const name of [
+      "ACS ACR1552 1S CL Reader",
+      "ACS ACR122U PICC Interface",
+      "ACS ACR1252 1S CL Reader",
+      "Sony FeliCa Port/PaSoRi 3.0 (RC-S380)",
+      "Identiv uTrust 3700 F CL Reader",
+      "HID Global OMNIKEY 5022 Smart Card Reader",
+      "SCM Microsystems Inc. Contactless Reader",
+    ]) {
+      expect(isLikelyContactlessReader(name)).toBe(true);
+    }
+  });
+
+  it("rejects Windows virtual / system smart-card readers", () => {
+    for (const name of [
+      "Microsoft Virtual Smart Card 0",
+      "Windows Hello for Business",
+      "Microsoft UICC ISO Reader 0",
+      "Identity Device (Microsoft Generic profile)\\TPM Virtual Smart Card",
+      "Some VSC Reader",
+      "Microsoft Base Smart Card Crypto Provider (virtual)",
+    ]) {
+      expect(isLikelyContactlessReader(name)).toBe(false);
+    }
+  });
+
+  it("rejects built-in CONTACT smart-card slots (not contactless)", () => {
+    expect(isLikelyContactlessReader("Broadcom Corp Contacted SmartCard 0")).toBe(false);
+    // …but does not reject a contactless reader whose name contains "contact".
+    expect(isLikelyContactlessReader("Vendor Contactless SmartCard 0")).toBe(true);
+  });
+
+  it("rejects empty / missing names", () => {
+    expect(isLikelyContactlessReader("")).toBe(false);
+    expect(isLikelyContactlessReader("   ")).toBe(false);
+    expect(isLikelyContactlessReader(null)).toBe(false);
+    expect(isLikelyContactlessReader(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
From the triage of #847 (bug 1 of 2 — false tag detection).

## Problem
On Windows 11 with **no NFC hardware installed**, the app showed "Tag detected" and popped an unknown-filament dialog. The NFC service trusted **every** PC/SC reader the OS enumerates (`electron/nfc-service.ts:118`, no name/type filter), and Windows routinely enumerates *virtual* readers (Windows Hello, UICC/eSIM, TPM virtual smart cards) and built-in **contact** smart-card slots. A virtual/idle card's "present" bit (or a driver phantom) flipped `tagPresent` → the header pill + the present-edge auto-read → the popup.

## Fix (chosen option: denylist + surface reader name)
- **`src/lib/nfcReaderFilter.ts`** (new, pure, unit-tested) — `isLikelyContactlessReader()` rejects virtual/system/contact reader names (Windows Hello / UICC / TPM / VSC / Microsoft virtual / `Contacted`) and lets everything else through (denylist, not allowlist, so an unlisted real reader still works).
- **`electron/nfc-service.ts`** — skips a non-contactless reader at enumeration (logs the name); it never sets `readerConnected` or fires an auto-read.
- **`NfcStatus.tsx`** — surfaces the connected reader's **name** in the tooltip (the reporter's explicit ask + the diagnostic to extend the denylist).

## Scope note (decode-gate deliberately deferred)
The chosen option also listed a "decode-gate" (don't show "Tag detected"/popup until a successful decode). The code analysis showed it's **redundant after filtering** (the reader is dropped at enumeration, so nothing downstream fires) and a decode-gate on the deliberate present-edge read would **contradict the #572 design** (a deliberate placement is *meant* to surface errors) and regress real-reader feedback — which I can't verify without Windows NFC hardware. If an unlisted reader still trips it, the now-visible reader name pins exactly which pattern to add. Happy to add a decode-gate if you'd rather.

## Verification
- `tsc` + **electron typecheck** (0 errors) + eslint clean.
- `tests/nfcReaderFilter.test.ts` (5 cases: accepts ACS/Sony/Identiv/Omnikey, rejects Windows virtual + `Contacted`, rejects empty); i18n parity 1593/1593; coverage test passes.
- **On-hardware (Windows) confirmation owed** — no Windows NFC host in CI.

Part of **#847** — the All-filter half is #848; #847 stays open until both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)