### PR TITLE
fix(api): 400 (not 500) on a malformed id for the OpenPrintTag binary route (#854)

### DIFF
--- a/src/app/api/filaments/[id]/openprinttag/route.ts
+++ b/src/app/api/filaments/[id]/openprinttag/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import "@/models/Nozzle";
@@ -13,6 +14,12 @@ export async function GET(
   try {
     await dbConnect();
     const { id } = await params;
+    // A non-ObjectId id makes Mongoose throw a CastError that the generic
+    // catch maps to 500; reject it up front as a 400 like the sibling routes
+    // (check/sync/link). (#854, follow-up to #818)
+    if (!mongoose.isValidObjectId(id)) {
+      return NextResponse.json({ error: "Invalid filament id" }, { status: 400 });
+    }
 
     const filament = await Filament.findOne({ _id: id, _deletedAt: null }).lean();
     if (!filament) {

--- a/tests/openprinttag-route.test.ts
+++ b/tests/openprinttag-route.test.ts
@@ -30,6 +30,14 @@ describe("GET /api/filaments/[id]/openprinttag — spool-scoped spool_uid (#732)
     return decodeOpenPrintTagBinary(buf).spoolUid;
   }
 
+  it("returns 400 (not 500) for a malformed filament id (#854)", async () => {
+    const res = await openprinttag(req("not-an-object-id"), {
+      params: Promise.resolve({ id: "not-an-object-id" }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid filament id/i);
+  });
+
   it("defaults to the first non-retired spool's instanceId", async () => {
     const f = await Filament.create({
       name: "Spooled PLA",


### PR DESCRIPTION
Follow-up to #818/#839 — that PR added a `mongoose.isValidObjectId` 400 guard to the OpenPrintTag `check`/`sync`/`link` routes but **missed the binary download route** `GET /api/filaments/{id}/openprinttag`.

A non-ObjectId `id` (e.g. `/api/filaments/not-an-object-id/openprinttag`) made Mongoose throw a `CastError` before the 404 branch, which the generic catch mapped to **500** with the raw driver detail in `detail`.

**Fix:** add the identical guard after `const { id } = await params;` — returns **400 "Invalid filament id"** before the query, byte-identical to the sibling routes. Plus a route test asserting 400 (not 500) for a malformed id.

## Verification
- `tsc` + eslint clean; `tests/openprinttag-route.test.ts` → 7 passing (added the malformed-id case).

Fixes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)