### PR TITLE
chore: refresh bundled reference snapshot (#853 pre-tag ritual)

### DIFF
--- a/src/content/referenceContent.ts
+++ b/src/content/referenceContent.ts
@@ -9,8 +9,8 @@
  * Docker / web bundle this committed snapshot as-is.
  */
 
-export const REFERENCE_WIKI_SHA = "7b0cf11";
-export const REFERENCE_SYNCED_AT = "2026-06-09";
+export const REFERENCE_WIKI_SHA = "6c24943";
+export const REFERENCE_SYNCED_AT = "2026-06-12";
 
 /** Chapter id (e.g. "ch6") -> the chapter's markdown, sliced from the wiki.
  *  Imported ONLY by the lazily-loaded ReferenceChapterBody chunk so it never

--- a/src/content/referenceIndex.ts
+++ b/src/content/referenceIndex.ts
@@ -9,8 +9,8 @@
  * Docker / web bundle this committed snapshot as-is.
  */
 
-export const REFERENCE_WIKI_SHA = "7b0cf11";
-export const REFERENCE_SYNCED_AT = "2026-06-09";
+export const REFERENCE_WIKI_SHA = "6c24943";
+export const REFERENCE_SYNCED_AT = "2026-06-12";
 
 /** Chapter ids present in the bundled content (empty only in the --stub build).
  *  Lets the detail page gate the Technical Reference panel without importing


### PR DESCRIPTION
The first exercise of the #853 process: with the per-build `fetch-reference` removed, the release ships the committed `src/content/` snapshot — so it should be current before tagging. The drift check flagged the provenance was behind: `REFERENCE_WIKI_SHA` `7b0cf11` → `6c24943`, `REFERENCE_SYNCED_AT` `2026-06-09` → `2026-06-12`.

**Provenance-only** — the extracted material-chapter content (ch6–21) is byte-identical; only the SHA/date stamp updates so support/debugging can rely on one `REFERENCE_WIKI_SHA` for 1.57.2.

Generated by `npm run fetch:reference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)