### PR TITLE
fix(api): PrusaSlicer sync no longer 400s on a legacy out-of-range stored temp (#859)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -460,10 +460,18 @@ export async function POST(
     if (config.filament_soluble) update.soluble = config.filament_soluble === "1";
     if (config.filament_abrasive) update.abrasive = config.filament_abrasive === "1";
 
-    // Merge temperatures into existing
-    if (Object.keys(temps).length > 0) {
-      const existing = (filament.temperatures as Record<string, unknown>) || {};
-      update.temperatures = { ...existing, ...temps };
+    // #859: write ONLY the temperature keys PrusaSlicer actually sent, as
+    // dotted paths — never a $set of the whole `temperatures` object. #645 added
+    // `runValidators` to the sync write below; Mongoose update-validators check
+    // every path in the $set, so the previous `{ ...existing, ...temps }` merge
+    // dragged the filament's STORED temps into the validated payload. A single
+    // legacy out-of-range value (e.g. a nozzle temp > 600 saved before the
+    // validators existed) then failed validation and 400'd the ENTIRE sync —
+    // silently dropping EM + maxVolumetricSpeed too ("no longer syncs back").
+    // Dotted paths leave untouched siblings unchanged AND unvalidated, while a
+    // genuinely-bad INCOMING value is still rejected (preserves #645's intent).
+    for (const [key, value] of Object.entries(temps)) {
+      update[`temperatures.${key}`] = value;
     }
 
     // GH #265 / Codex P1: per-nozzle calibration sync must respect

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -350,6 +350,60 @@ describe("API route correctness", () => {
     expect(freshVariant.calibrations ?? []).toHaveLength(0);
   });
 
+  it("#859 — slicer sync persists EM + maxVolumetricSpeed despite a legacy out-of-range stored temp", async () => {
+    const nozzle = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "brass" });
+    // Seed RAW (bypassing Mongoose validators) a filament whose STORED nozzle
+    // temp is out of the schema range (max 600) — legacy data saved before the
+    // #645 sync-write validators existed.
+    const ins = await mongoose.connection.collection("filaments").insertOne({
+      name: "Legacy PETG",
+      vendor: "Prusa",
+      type: "PETG",
+      diameter: 1.75,
+      compatibleNozzles: [nozzle._id],
+      temperatures: { nozzle: 700, bed: 80 }, // 700 > schema max 600
+      calibrations: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const id = ins.insertedId;
+
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${id}?nozzle_diameter=0.4`, {
+        config: {
+          extrusion_multiplier: "1.08",
+          filament_max_volumetric_speed: "15",
+          bed_temperature: "60",
+        },
+      }),
+      { params: Promise.resolve({ id: String(id) }) },
+    );
+    // Pre-#859 the whole-`temperatures` $set re-validated the legacy nozzle:700
+    // and 400'd the ENTIRE sync; now only the incoming `temperatures.bed` is
+    // written + validated, so the sync succeeds and EM + maxVolumetricSpeed land.
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(id);
+    expect(fresh.maxVolumetricSpeed).toBe(15);
+    expect(fresh.temperatures.bed).toBe(60);
+    // The untouched legacy value is preserved (dotted paths don't replace siblings).
+    expect(fresh.temperatures.nozzle).toBe(700);
+    expect(fresh.calibrations).toHaveLength(1);
+    expect(fresh.calibrations[0].extrusionMultiplier).toBe(1.08);
+  });
+
+  it("#859 — a genuinely bad INCOMING temperature is still rejected (preserves #645)", async () => {
+    const f = await Filament.create({ name: "Clean PLA", vendor: "Prusa", type: "PLA" });
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}`, {
+        config: { temperature: "700" }, // 700 > max 600, and it's the INCOMING value
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(400);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.temperatures?.nozzle ?? null).toBe(null);
+  });
+
   it("#265 — calibration sync on a variant that OVERRIDES calibrations writes to the variant", async () => {
     // Codex P1: a variant with its own non-empty calibrations array
     // owns its calibrations (resolveFilament uses them, not the


### PR DESCRIPTION
From the triage of #859. **Most likely** root cause, empirically reproduced (mongoose + mongodb-memory-server).

## Root cause (a regression)
#645 (commit `80de848d`) added `runValidators: true` to the slicer per-id sync write — **but** the handler re-`$set`s the **whole `temperatures` object** (`{ ...existing, ...incoming }`, `route.ts:463-467`), and PrusaSlicer always sends temp keys. So the filament's **stored** temps ride into the validated `$set`, and a single **legacy out-of-range value** (e.g. a `temperatures.nozzle` > 600 saved before the validators existed) fails validation → **400 → nothing writes**, silently dropping EM *and* max-volumetric-flow. Before #645 the write had no validators, so legacy data was tolerated — hence *"no longer syncs back."*

## Fix
Write only the temperature keys PrusaSlicer actually sent, as **dotted paths** (`temperatures.bed`, …), instead of `$set`-ing the whole object. Update-validators then check **only the incoming values** — a bad incoming value is still rejected (preserves #645's intent), but a legacy value the sync isn't touching is left alone and unvalidated.

## Verification
- New regression test: a legacy-out-of-range doc (seeded raw to bypass validators) now syncs EM + `maxVolumetricSpeed` (**200**, was **400** on the old route — confirmed by reverting); a genuinely-bad *incoming* temperature still **400s**.
- Full `api-route-correctness.test.ts` → **28 passing** (incl. the existing #265 sync tests). `tsc` + eslint clean.

## Why "Addresses" not "Fixes"
This is the most likely cause but **medium confidence for this user's exact case** — the decisive evidence (the sync POST request/response) isn't in the issue. I'm asking the reporter to capture it; a **403** would instead point at the CSRF guard (a separate, security-sensitive change), a **404** at a renamed preset (client-side). The fix here is a genuine robustness bug worth landing regardless. **#859 stays open until confirmed.**

Addresses #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)