### PR TITLE
fix(api): PrusaSlicer EM/PA sync falls back to the global nozzle catalog (#859)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -578,6 +578,33 @@ export async function POST(
             };
           }
         }
+
+        // #859 follow-up: when the filament has no matching COMPATIBLE nozzle
+        // (commonly because `compatibleNozzles` is empty on a filament imported
+        // / synced from Filament DB), fall back to the GLOBAL nozzle catalog and
+        // attach the calibration to the UNIQUE nozzle at this diameter (+
+        // high_flow). Mirrors the Bambu/OrcaSlicer sync routes; only when
+        // EXACTLY ONE catalog nozzle matches, so we never guess. Without this,
+        // PrusaSlicer's EM / pressure-advance edits were silently dropped for any
+        // filament with no compatible nozzles set.
+        if (!calibrationWrite) {
+          const highFlowParam = request.nextUrl.searchParams.get("high_flow");
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const globalQuery: Record<string, any> = {
+            diameter: nozzleDiameter,
+            _deletedAt: null,
+          };
+          if (highFlowParam !== null) {
+            globalQuery.highFlow = highFlowParam === "1";
+          }
+          const globalMatches = await Nozzle.find(globalQuery).limit(2).lean();
+          if (globalMatches.length === 1) {
+            calibrationWrite = {
+              nozzleId: String(globalMatches[0]._id),
+              fields: calFields,
+            };
+          }
+        }
       }
     }
 

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -404,6 +404,43 @@ describe("API route correctness", () => {
     expect(fresh.temperatures?.nozzle ?? null).toBe(null);
   });
 
+  it("#859/PrusaSlicer — EM sync falls back to a UNIQUE global-catalog nozzle when the filament has no compatible nozzles", async () => {
+    const hf = await Nozzle.create({ name: "0.4 HF", diameter: 0.4, type: "brass", highFlow: true });
+    // A same-diameter standard nozzle exists too, so the high_flow filter must disambiguate.
+    await Nozzle.create({ name: "0.4 std", diameter: 0.4, type: "brass", highFlow: false });
+    // compatibleNozzles intentionally empty — the common case for a synced/imported filament.
+    const f = await Filament.create({ name: "No-Compat PCTG", vendor: "CHCKX", type: "PCTG" });
+
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}?nozzle_diameter=0.4&high_flow=1`, {
+        config: { extrusion_multiplier: "1.07" },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    // Pre-fix: 0 calibrations (the block was skipped on empty compatibleNozzles).
+    expect(fresh.calibrations).toHaveLength(1);
+    expect(fresh.calibrations[0].extrusionMultiplier).toBe(1.07);
+    expect(String(fresh.calibrations[0].nozzle)).toBe(String(hf._id));
+  });
+
+  it("#859/PrusaSlicer — EM fallback does NOT guess when multiple global nozzles match", async () => {
+    await Nozzle.create({ name: "0.4 HF A", diameter: 0.4, type: "brass", highFlow: true });
+    await Nozzle.create({ name: "0.4 HF B", diameter: 0.4, type: "hardened", highFlow: true });
+    const f = await Filament.create({ name: "Ambiguous PCTG", vendor: "X", type: "PCTG" });
+
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}?nozzle_diameter=0.4&high_flow=1`, {
+        config: { extrusion_multiplier: "1.07" },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.calibrations ?? []).toHaveLength(0); // ambiguous → don't guess
+  });
+
   it("#265 — calibration sync on a variant that OVERRIDES calibrations writes to the variant", async () => {
     // Codex P1: a variant with its own non-empty calibrations array
     // owns its calibrations (resolveFilament uses them, not the


### PR DESCRIPTION
Found while live-debugging a PrusaSlicer 2.9.5 (Filament-Edition 1.9.2) ↔ Filament DB 1.57.3 sync.

## Root cause
The sync endpoint is **healthy** — replaying PrusaSlicer's exact request (name-based `POST /api/filaments/{name}?nozzle_diameter=0.4&high_flow=1`, no `Origin`) returns **200** and the top-level `maxVolumetricSpeed` persists. But the **extrusion multiplier never landed**: EM/pressure-advance write to a **per-nozzle calibration**, and the matching only searched the filament's `compatibleNozzles` with **no fallback** when that list is empty (`if (compatIds.length > 0) { … }`, no `else`).

A filament synced/imported from Filament DB typically has `compatibleNozzles: []`, so the block was skipped and **EM was silently dropped** — even though a unique matching nozzle (e.g. a `0.4mm HF`) was sitting in the global catalog. The **Bambu and OrcaSlicer** routes already fall back to a unique catalog nozzle; the **PrusaSlicer** route didn't.

## Fix
When no compatible nozzle matches, fall back to the **global nozzle catalog** and attach the calibration to the **unique** nozzle at this diameter (+ `high_flow`) — only when exactly one matches, so it never guesses. Mirrors the Bambu/Orca logic.

## Verification
- New tests: a no-compatible-nozzle filament now lands EM on the unique `0.4mm-HF` catalog nozzle; an ambiguous case (two matching catalog nozzles) writes no calibration. `tests/api-route-correctness.test.ts` → **30 passing**. `tsc` + eslint clean.
- Confirmed live against the running 1.57.3 server that the *endpoint* returns 200 for the real request shape; the running app predates this fix, so the test suite is the validation.

Addresses **#859** (the EM-sync half — kept open until verified end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)