### PR TITLE
feat(ui): distinguish same-Ø nozzles + hardened gate for abrasive (#872 item 4)

### DIFF
--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -620,14 +620,19 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
   }, [printers, nozzles, form.compatibleNozzles]);
 
   // #872: an abrasive filament needs a hardened nozzle, so the compatible-nozzle
-  // picker hard-filters to hardened ones when `abrasive` is set. Already-selected
-  // nozzles stay visible (even if soft) so the user can still deselect them —
-  // they're flagged in the list; only NEW soft nozzles are hidden.
+  // picker hard-filters to hardened ones when abrasive. The abrasive marker can
+  // come from EITHER the form boolean (settings.filament_abrasive) OR optTags tag 4
+  // (e.g. OpenPrintTag/Atlas data) — mirror the Material Tags checkbox's effective
+  // state (form.optTags.includes(4) || form.abrasive) so the gate isn't silently
+  // bypassed when only the tag is set (Codex P2). Already-selected nozzles stay
+  // visible (even if soft) so the user can still deselect them — they're flagged;
+  // only NEW soft nozzles are hidden.
+  const isAbrasive = form.abrasive || form.optTags.includes(4);
   const visibleNozzles = useMemo(() => {
-    if (!form.abrasive) return nozzles;
+    if (!isAbrasive) return nozzles;
     return nozzles.filter((n) => n.hardened || form.compatibleNozzles.includes(n._id));
-  }, [nozzles, form.abrasive, form.compatibleNozzles]);
-  const hiddenSoftNozzleCount = form.abrasive ? nozzles.length - visibleNozzles.length : 0;
+  }, [nozzles, isAbrasive, form.compatibleNozzles]);
+  const hiddenSoftNozzleCount = isAbrasive ? nozzles.length - visibleNozzles.length : 0;
 
   // Derive the effective selection rather than syncing it via an effect.
   // When the user removes a compatible nozzle that was the only reason
@@ -2323,7 +2328,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
                   )}
                   {/* #872: a soft nozzle that is still selected on an abrasive
                       filament is flagged so the user knows to swap it out. */}
-                  {form.abrasive && !n.hardened && (
+                  {isAbrasive && !n.hardened && (
                     <span className="ml-1 px-1.5 py-0.5 bg-red-200 dark:bg-red-900 text-red-800 dark:text-red-200 rounded text-xs">
                       {t("form.nozzle.notHardened")}
                     </span>

--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -7,6 +7,7 @@ import CollapsibleSection, { expandAndScrollToSection } from "@/components/Colla
 import FormToc, { FormTocMobileButton, type TocEntry } from "@/components/FormToc";
 import FilamentSwatch from "@/components/FilamentSwatch";
 import { snapToStep } from "@/lib/snapToStep";
+import { nozzleTypeLabel } from "@/lib/nozzleTypes";
 import {
   filterColorSuggestions,
   lookupCssNamedColor,
@@ -137,6 +138,7 @@ interface NozzleOption {
   diameter: number;
   type: string;
   highFlow: boolean;
+  hardened: boolean;
   printers?: { _id: string; name: string }[];
 }
 
@@ -616,6 +618,16 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
     }
     return printers.filter((p) => relevantIds.has(p._id));
   }, [printers, nozzles, form.compatibleNozzles]);
+
+  // #872: an abrasive filament needs a hardened nozzle, so the compatible-nozzle
+  // picker hard-filters to hardened ones when `abrasive` is set. Already-selected
+  // nozzles stay visible (even if soft) so the user can still deselect them —
+  // they're flagged in the list; only NEW soft nozzles are hidden.
+  const visibleNozzles = useMemo(() => {
+    if (!form.abrasive) return nozzles;
+    return nozzles.filter((n) => n.hardened || form.compatibleNozzles.includes(n._id));
+  }, [nozzles, form.abrasive, form.compatibleNozzles]);
+  const hiddenSoftNozzleCount = form.abrasive ? nozzles.length - visibleNozzles.length : 0;
 
   // Derive the effective selection rather than syncing it via an effect.
   // When the user removes a compatible nozzle that was the only reason
@@ -2254,7 +2266,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
           <div className="flex gap-2 mb-2">
             <button
               type="button"
-              onClick={() => setForm({ ...form, compatibleNozzles: nozzles.map((n) => n._id) })}
+              onClick={() => setForm({ ...form, compatibleNozzles: visibleNozzles.map((n) => n._id) })}
               className="text-xs text-blue-600 hover:underline"
             >
               {t("form.selectAll")}
@@ -2273,9 +2285,15 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
             {t("form.noNozzlesDefined")} <a href="/nozzles/new" className="text-blue-600 hover:underline">{t("form.addOneFirst")}</a>
           </p>
         )}
+        {/* #872: when abrasive hides soft nozzles, say so (and why). */}
+        {hiddenSoftNozzleCount > 0 && (
+          <p className="text-xs text-amber-700 dark:text-amber-300 mb-2">
+            {t("form.nozzle.hardenedOnly", { count: hiddenSoftNozzleCount })}
+          </p>
+        )}
         {nozzles.length > 0 && (
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {nozzles.map((n) => (
+            {visibleNozzles.map((n) => (
               <label
                 key={n._id}
                 className={`flex items-center gap-2 p-2 rounded border cursor-pointer text-sm ${
@@ -2292,9 +2310,22 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange }: P
                 />
                 <span>
                   {n.name}
+                  {/* #872: always show diameter + type so same-diameter nozzles
+                      (e.g. 0.4 Brass vs 0.4 Diamondback) are distinguishable
+                      regardless of how the nozzle was named. */}
+                  <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
+                    · {n.diameter}mm{nozzleTypeLabel(n.type, t) ? ` ${nozzleTypeLabel(n.type, t)}` : ""}
+                  </span>
                   {n.highFlow && (
                     <span className="ml-1 px-1.5 py-0.5 bg-amber-200 dark:bg-amber-900 text-amber-800 dark:text-amber-200 rounded text-xs">
                       HF
+                    </span>
+                  )}
+                  {/* #872: a soft nozzle that is still selected on an abrasive
+                      filament is flagged so the user knows to swap it out. */}
+                  {form.abrasive && !n.hardened && (
+                    <span className="ml-1 px-1.5 py-0.5 bg-red-200 dark:bg-red-900 text-red-800 dark:text-red-200 rounded text-xs">
+                      {t("form.nozzle.notHardened")}
                     </span>
                   )}
                   {n.printers && n.printers.length > 0 && (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1338,6 +1338,8 @@
   "form.tag.biodegradable": "Biologisch abbaubar",
   "form.tag.foodSafe": "Lebensmittelecht",
   "form.section.compatibleNozzles": "Kompatible Düsen",
+  "form.nozzle.hardenedOnly": "Abrasives Filament — nur gehärtete Düsen werden angezeigt ({count} ausgeblendet).",
+  "form.nozzle.notHardened": "nicht gehärtet",
   "form.loadingNozzles": "Düsen werden geladen…",
   "form.selectAll": "Alle auswählen",
   "form.clearAll": "Alle leeren",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1338,6 +1338,8 @@
   "form.tag.biodegradable": "Biodegradable",
   "form.tag.foodSafe": "Food Safe",
   "form.section.compatibleNozzles": "Compatible Nozzles",
+  "form.nozzle.hardenedOnly": "Abrasive filament — showing hardened nozzles only ({count} hidden).",
+  "form.nozzle.notHardened": "not hardened",
   "form.loadingNozzles": "Loading nozzles...",
   "form.selectAll": "Select All",
   "form.clearAll": "Clear All",


### PR DESCRIPTION
Part of #872 (item 4 of 6).

## Problem
You defined nozzles like '0.4mm' (Brass) and '0.4mm' (Diamondback) — **named by diameter** — so the compatible-nozzle picker (which showed only `nozzle.name`) rendered two identical '0.4mm' options you couldn't tell apart. (Confirmed against your data: two 0.4mm nozzles, one Brass/soft, one Diamondback/hardened.)

## Fix
- **Always show `· <Ø>mm <Type>`** after the name, so same-diameter nozzles are distinguishable regardless of how they're named (e.g. '0.4mm · 0.4mm Brass' vs '0.4mm · 0.4mm Diamondback').
- **Hardened gate**: when the filament's `abrasive` tag is set, the picker hard-filters to **hardened** nozzles. *Select all* respects it, and a note reports how many were hidden. An already-selected soft nozzle stays visible with a 'not hardened' flag so it can still be removed.
- Added `hardened` to the form's `NozzleOption` type (the `/api/nozzles` response already includes it).

## Verified (preview)
- The two '0.4mm' nozzles now read 'Brass' vs 'Diamondback'.
- Toggling **Abrasive** drops the picker 8 → 6 nozzles with the note *'Abrasive filament — showing hardened nozzles only (2 hidden).'*
- tsc + lint + i18n-parity green.

i18n: `form.nozzle.hardenedOnly` + `form.nozzle.notHardened` (en + de).

🤖 Generated with [Claude Code](https://claude.com/claude-code)