### PR TITLE
feat(prusaslicer): compatible_printers_condition from nozzle diameters (#872 item 6)

### DIFF
--- a/src/app/api/filaments/export/route.ts
+++ b/src/app/api/filaments/export/route.ts
@@ -15,6 +15,7 @@ export async function GET() {
       .populate("calibrations.nozzle")
       .populate("calibrations.printer")
       .populate("calibrations.bedType")
+      .populate("compatibleNozzles") // #872: diameters for compatible_printers_condition
       .lean();
 
     // Build a parent lookup for resolving variants

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -56,6 +56,7 @@ export async function GET(request: NextRequest) {
       .populate("calibrations.nozzle")
       .populate("calibrations.printer")
       .populate("calibrations.bedType")
+      .populate("compatibleNozzles") // #872: diameters for compatible_printers_condition
       .lean();
 
     // Build parent lookup for resolving variants
@@ -82,6 +83,7 @@ export async function GET(request: NextRequest) {
         .populate("calibrations.nozzle")
         .populate("calibrations.printer")
         .populate("calibrations.bedType")
+        .populate("compatibleNozzles") // #872
         .lean();
       for (const parent of missingParents) {
         parentMap.set(parent._id.toString(), parent);

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -146,13 +146,14 @@ export function filamentToSlicerKeys(
   // round-tripped user-pinned condition (already in the settings bag) wins, and
   // only applied when we actually have populated diameters — otherwise the empty
   // "no restriction" default below still applies.
-  // An EMPTY string counts as "no restriction" (the default), NOT a user pin —
-  // round-tripped PrusaSlicer imports store `compatible_printers_condition = ` as
-  // "" in the settings bag, so deriving must override it. Only a NON-EMPTY value
-  // is treated as a user-pinned restriction to preserve (Codex P2).
-  const pinnedCondition = keys.compatible_printers_condition;
+  // Derive only when the key is ABSENT or an EMPTY STRING — both mean "no
+  // restriction" (a round-tripped `compatible_printers_condition = ` stores "").
+  // A NON-EMPTY string is a user pin, and `null` is PrusaSlicer's `nil`
+  // inheritance marker (parseIniFilaments → null, writeSection re-emits it as
+  // `nil`) — BOTH must be preserved, not overwritten by the derivation (Codex P2).
   if (
-    (pinnedCondition == null || pinnedCondition === "") &&
+    (!("compatible_printers_condition" in keys) ||
+      keys.compatible_printers_condition === "") &&
     Array.isArray(filament.compatibleNozzles)
   ) {
     const diameters = Array.from(

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -146,8 +146,13 @@ export function filamentToSlicerKeys(
   // round-tripped user-pinned condition (already in the settings bag) wins, and
   // only applied when we actually have populated diameters — otherwise the empty
   // "no restriction" default below still applies.
+  // An EMPTY string counts as "no restriction" (the default), NOT a user pin —
+  // round-tripped PrusaSlicer imports store `compatible_printers_condition = ` as
+  // "" in the settings bag, so deriving must override it. Only a NON-EMPTY value
+  // is treated as a user-pinned restriction to preserve (Codex P2).
+  const pinnedCondition = keys.compatible_printers_condition;
   if (
-    !("compatible_printers_condition" in keys) &&
+    (pinnedCondition == null || pinnedCondition === "") &&
     Array.isArray(filament.compatibleNozzles)
   ) {
     const diameters = Array.from(

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -140,6 +140,36 @@ export function filamentToSlicerKeys(
   if (!("compatible_printers" in keys)) {
     keys.compatible_printers = "";
   }
+  // #872: derive compatible_printers_condition from the filament's compatible
+  // nozzle diameters, e.g. `nozzle_diameter[0]==0.4 or nozzle_diameter[0]==0.6`,
+  // so a synced preset only shows up for printers whose nozzle matches. Gated so a
+  // round-tripped user-pinned condition (already in the settings bag) wins, and
+  // only applied when we actually have populated diameters — otherwise the empty
+  // "no restriction" default below still applies.
+  if (
+    !("compatible_printers_condition" in keys) &&
+    Array.isArray(filament.compatibleNozzles)
+  ) {
+    const diameters = Array.from(
+      new Set(
+        filament.compatibleNozzles
+          .map((n: unknown) =>
+            n != null &&
+            typeof n === "object" &&
+            typeof (n as { diameter?: unknown }).diameter === "number"
+              ? (n as { diameter: number }).diameter
+              : null,
+          )
+          .filter((d): d is number => typeof d === "number" && d > 0),
+      ),
+    ).sort((a, b) => a - b);
+    if (diameters.length > 0) {
+      keys.compatible_printers_condition = diameters
+        .map((d) => `nozzle_diameter[0]==${d}`)
+        .join(" or ");
+    }
+  }
+
   if (!("compatible_printers_condition" in keys)) {
     keys.compatible_printers_condition = "";
   }

--- a/src/lib/singleFilamentExport.ts
+++ b/src/lib/singleFilamentExport.ts
@@ -26,6 +26,9 @@ const POPULATE_PATHS = [
   "calibrations.nozzle",
   "calibrations.printer",
   "calibrations.bedType",
+  // #872: needed so the PrusaSlicer export can build a
+  // compatible_printers_condition from the compatible nozzle diameters.
+  "compatibleNozzles",
 ] as const;
 
 /**

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -157,6 +157,47 @@ describe("filamentToSlicerKeys", () => {
     expect(keys.compatible_printers_condition).toBe("");
   });
 
+  it("#872: derives compatible_printers_condition from compatible nozzle diameters (deduped + sorted)", () => {
+    const keys = filamentToSlicerKeys({
+      name: "PA12-CF",
+      vendor: "X",
+      type: "PA",
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+      compatibleNozzles: [{ diameter: 0.6 }, { diameter: 0.4 }, { diameter: 0.4 }],
+    });
+    expect(keys.compatible_printers_condition).toBe(
+      "nozzle_diameter[0]==0.4 or nozzle_diameter[0]==0.6",
+    );
+  });
+
+  it("#872: a user-pinned compatible_printers_condition wins over the nozzle-diameter derivation", () => {
+    const keys = filamentToSlicerKeys({
+      name: "Pinned",
+      vendor: "X",
+      type: "PLA",
+      diameter: 1.75,
+      temperatures: {},
+      settings: { compatible_printers_condition: "printer_model==MK4" },
+      compatibleNozzles: [{ diameter: 0.4 }],
+    });
+    expect(keys.compatible_printers_condition).toBe("printer_model==MK4");
+  });
+
+  it("#872: no compatible nozzles → empty condition (no restriction)", () => {
+    const keys = filamentToSlicerKeys({
+      name: "Bare",
+      vendor: "X",
+      type: "PLA",
+      diameter: 1.75,
+      temperatures: {},
+      settings: {},
+      compatibleNozzles: [],
+    });
+    expect(keys.compatible_printers_condition).toBe("");
+  });
+
   it("preserves a user-set compatible_printers from the settings bag", () => {
     // If a previous import (or hand-edit) pinned the preset to a
     // specific printer, the default-blanking must NOT clobber that.

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -199,6 +199,20 @@ describe("filamentToSlicerKeys", () => {
     expect(keys.compatible_printers_condition).toBe("nozzle_diameter[0]==0.4");
   });
 
+  it("#872: a NULL (nil/inherit) settings condition is preserved, not derived over", () => {
+    const keys = filamentToSlicerKeys({
+      name: "Inherited",
+      vendor: "X",
+      type: "PLA",
+      diameter: 1.75,
+      temperatures: {},
+      // PrusaSlicer `nil` round-trips through parseIniFilaments as null (inherit).
+      settings: { compatible_printers_condition: null },
+      compatibleNozzles: [{ diameter: 0.4 }],
+    });
+    expect(keys.compatible_printers_condition).toBeNull();
+  });
+
   it("#872: no compatible nozzles → empty condition (no restriction)", () => {
     const keys = filamentToSlicerKeys({
       name: "Bare",

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -185,6 +185,20 @@ describe("filamentToSlicerKeys", () => {
     expect(keys.compatible_printers_condition).toBe("printer_model==MK4");
   });
 
+  it("#872: an EMPTY settings condition (round-tripped default) is overridden by the nozzle derivation", () => {
+    const keys = filamentToSlicerKeys({
+      name: "RoundTripped",
+      vendor: "X",
+      type: "PLA",
+      diameter: 1.75,
+      temperatures: {},
+      // PrusaSlicer round-trip stores `compatible_printers_condition = ` as "".
+      settings: { compatible_printers_condition: "" },
+      compatibleNozzles: [{ diameter: 0.4 }],
+    });
+    expect(keys.compatible_printers_condition).toBe("nozzle_diameter[0]==0.4");
+  });
+
   it("#872: no compatible nozzles → empty condition (no restriction)", () => {
     const keys = filamentToSlicerKeys({
       name: "Bare",


### PR DESCRIPTION
Part of #872 (item 6 of 6).

## Problem
PrusaSlicer exports set `compatible_printers_condition` empty ('no restriction'), so a synced preset appeared for every printer regardless of nozzle.

## Fix
Derive the condition from the filament's **compatible-nozzle diameters**:
`nozzle_diameter[0]==0.4 or nozzle_diameter[0]==0.6` (deduped + sorted). So a preset only shows for printers whose installed nozzle matches.
- **User pin wins**: a round-tripped `compatible_printers_condition` already in the settings bag is preserved (never clobbered).
- **Empty stays empty**: with no compatible nozzles, the empty 'no restriction' default still applies.
- Populated `compatibleNozzles` in the bundle route + single-filament export populate chain (incl. the inheriting-variant parent fetch) so diameters are reachable.

## Tests
derive/dedupe/sort, user-pin precedence, empty-nozzles → empty. Full bundle suite + tsc + lint green.

Per your decision (nozzle-diameter gate). Closes the last of the #872 work alongside items 1–4; item 5 (multi-nozzle preset naming) is a design note for your approval first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)