### PR TITLE
fix(proxy): raise proxyClientMaxBodySize to 52mb so large snapshot restores aren't truncated (#878)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,20 @@ const nextConfig: NextConfig = {
   env: {
     APP_VERSION: pkg.version,
   },
+  experimental: {
+    // GH #878: `src/proxy.ts` runs on every `/api/*` request, and Next buffers
+    // the request body so it can be read in both the proxy and the route. That
+    // buffer defaults to 10MB — over which Next silently keeps only the first
+    // 10MB and lets the request continue with a PARTIAL body (it does not error).
+    // `POST /api/snapshot` accepts up to 50MB (MAX_SNAPSHOT_SIZE), so a valid
+    // 10–50MB backup was truncated before the handler, parsed as partial JSON,
+    // and rejected with a misleading "Invalid JSON in snapshot file" instead of
+    // restoring (or returning the route's real 413). Raise the cap above the
+    // largest accepted route body (50MB) with headroom for the multipart
+    // envelope, so legitimate bodies reach the handler and the route's own size
+    // guard stays authoritative. Keep this >= MAX_SNAPSHOT_SIZE.
+    proxyClientMaxBodySize: "52mb",
+  },
   async headers() {
     // GH #225 — Content-Security-Policy:
     //

--- a/tests/next-config-proxy-size.test.ts
+++ b/tests/next-config-proxy-size.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import nextConfig from "../next.config";
+
+/**
+ * GH #878: `src/proxy.ts` matches every `/api/*` request, so Next buffers the
+ * request body (default 10MB) and SILENTLY truncates anything larger to a
+ * partial body — the request continues, it doesn't error. `POST /api/snapshot`
+ * accepts up to 50MB (`MAX_SNAPSHOT_SIZE` in src/app/api/snapshot/route.ts), so
+ * without raising the proxy cap a valid 10–50MB backup is truncated before the
+ * handler and fails as "Invalid JSON" instead of restoring.
+ *
+ * This invariant pins the proxy buffer >= the largest accepted route body, so a
+ * future change can't silently drop the cap (or raise the snapshot cap past it)
+ * and reintroduce the truncation. The route-level handler tests can't catch this
+ * — they bypass the proxy layer entirely.
+ *
+ * Keep MAX_SNAPSHOT_SIZE in sync with the route if it ever changes.
+ */
+const MAX_SNAPSHOT_SIZE = 50 * 1024 * 1024; // src/app/api/snapshot/route.ts
+
+function parseSize(v: unknown): number {
+  if (typeof v === "number") return v;
+  if (typeof v !== "string") return 0;
+  const m = /^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?$/i.exec(v.trim());
+  if (!m) return 0;
+  const mult: Record<string, number> = { b: 1, kb: 1024, mb: 1024 ** 2, gb: 1024 ** 3 };
+  return parseFloat(m[1]) * mult[(m[2] || "b").toLowerCase()];
+}
+
+describe("#878 — proxy body limit covers the largest API route body", () => {
+  it("experimental.proxyClientMaxBodySize is set and >= MAX_SNAPSHOT_SIZE", () => {
+    const experimental = nextConfig.experimental as Record<string, unknown> | undefined;
+    const cap = parseSize(experimental?.proxyClientMaxBodySize);
+    expect(cap).toBeGreaterThanOrEqual(MAX_SNAPSHOT_SIZE);
+  });
+});

--- a/tests/next-config-proxy-size.test.ts
+++ b/tests/next-config-proxy-size.test.ts
@@ -46,12 +46,20 @@ function snapshotRouteCapBytes(): number {
   return expr.split("*").reduce((acc, part) => acc * parseFloat(part.trim()), 1);
 }
 
-describe("#878 — proxy body limit covers the largest API route body", () => {
-  it("experimental.proxyClientMaxBodySize is set and >= the snapshot route's MAX_SNAPSHOT_SIZE", () => {
+// The backup UI restores via multipart/form-data, so the proxy buffer must hold
+// MAX_SNAPSHOT_SIZE PLUS the multipart envelope (boundary + part headers — well
+// under a few KB for a single file field). Require a clear margin above the route
+// cap rather than allowing equality, so a near-limit snapshot can't be truncated
+// and a future proxyCap == routeCap (or a route-cap raised to match the proxy
+// cap) fails this test instead of silently reintroducing #878 (Codex P3).
+const MULTIPART_HEADROOM = 1024 * 1024; // 1 MiB — generous vs the real envelope
+
+describe("#878 — proxy body limit covers the largest API route body + multipart overhead", () => {
+  it("experimental.proxyClientMaxBodySize exceeds the snapshot route's MAX_SNAPSHOT_SIZE with headroom", () => {
     const experimental = nextConfig.experimental as Record<string, unknown> | undefined;
     const proxyCap = parseSize(experimental?.proxyClientMaxBodySize);
     const routeCap = snapshotRouteCapBytes();
     expect(routeCap).toBeGreaterThan(0); // sanity: the derivation actually parsed
-    expect(proxyCap).toBeGreaterThanOrEqual(routeCap);
+    expect(proxyCap).toBeGreaterThanOrEqual(routeCap + MULTIPART_HEADROOM);
   });
 });

--- a/tests/next-config-proxy-size.test.ts
+++ b/tests/next-config-proxy-size.test.ts
@@ -1,23 +1,20 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
 import nextConfig from "../next.config";
 
 /**
  * GH #878: `src/proxy.ts` matches every `/api/*` request, so Next buffers the
  * request body (default 10MB) and SILENTLY truncates anything larger to a
  * partial body — the request continues, it doesn't error. `POST /api/snapshot`
- * accepts up to 50MB (`MAX_SNAPSHOT_SIZE` in src/app/api/snapshot/route.ts), so
- * without raising the proxy cap a valid 10–50MB backup is truncated before the
- * handler and fails as "Invalid JSON" instead of restoring.
+ * accepts up to `MAX_SNAPSHOT_SIZE` (src/app/api/snapshot/route.ts), so without
+ * raising the proxy cap a valid 10–50MB backup is truncated before the handler
+ * and fails as "Invalid JSON" instead of restoring.
  *
  * This invariant pins the proxy buffer >= the largest accepted route body, so a
  * future change can't silently drop the cap (or raise the snapshot cap past it)
- * and reintroduce the truncation. The route-level handler tests can't catch this
- * — they bypass the proxy layer entirely.
- *
- * Keep MAX_SNAPSHOT_SIZE in sync with the route if it ever changes.
+ * and reintroduce the truncation. Route-level handler tests can't catch this —
+ * they bypass the proxy layer entirely.
  */
-const MAX_SNAPSHOT_SIZE = 50 * 1024 * 1024; // src/app/api/snapshot/route.ts
-
 function parseSize(v: unknown): number {
   if (typeof v === "number") return v;
   if (typeof v !== "string") return 0;
@@ -27,10 +24,34 @@ function parseSize(v: unknown): number {
   return parseFloat(m[1]) * mult[(m[2] || "b").toLowerCase()];
 }
 
+/**
+ * Derive the snapshot route's cap from its source rather than hard-coding it, so
+ * raising `MAX_SNAPSHOT_SIZE` without also raising the proxy cap fails this test
+ * (Codex P3) instead of silently passing. The handler defines it as a local
+ * const (not exported), and importing the route would pull in mongoose/db deps —
+ * so read the literal arithmetic and evaluate it safely (digits / `*` only).
+ */
+function snapshotRouteCapBytes(): number {
+  const src = readFileSync("src/app/api/snapshot/route.ts", "utf-8");
+  const m = /MAX_SNAPSHOT_SIZE\s*=\s*([\d.\s*]+?)\s*;/.exec(src);
+  if (!m) {
+    throw new Error(
+      "Could not find MAX_SNAPSHOT_SIZE in src/app/api/snapshot/route.ts — update this test",
+    );
+  }
+  const expr = m[1].trim();
+  if (!/^[\d.\s*]+$/.test(expr)) {
+    throw new Error(`Unexpected MAX_SNAPSHOT_SIZE expression: ${expr}`);
+  }
+  return expr.split("*").reduce((acc, part) => acc * parseFloat(part.trim()), 1);
+}
+
 describe("#878 — proxy body limit covers the largest API route body", () => {
-  it("experimental.proxyClientMaxBodySize is set and >= MAX_SNAPSHOT_SIZE", () => {
+  it("experimental.proxyClientMaxBodySize is set and >= the snapshot route's MAX_SNAPSHOT_SIZE", () => {
     const experimental = nextConfig.experimental as Record<string, unknown> | undefined;
-    const cap = parseSize(experimental?.proxyClientMaxBodySize);
-    expect(cap).toBeGreaterThanOrEqual(MAX_SNAPSHOT_SIZE);
+    const proxyCap = parseSize(experimental?.proxyClientMaxBodySize);
+    const routeCap = snapshotRouteCapBytes();
+    expect(routeCap).toBeGreaterThan(0); // sanity: the derivation actually parsed
+    expect(proxyCap).toBeGreaterThanOrEqual(routeCap);
   });
 });


### PR DESCRIPTION
Fixes #878.

## Root cause
`src/proxy.ts` matches every `/api/*` request, so Next 16 buffers the request body to allow reads in both the proxy and the route. That buffer defaults to **10MB**, and per [the Next docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/proxyClientMaxBodySize), over the limit it **keeps only the first 10MB and lets the request continue with a partial body — it does not error**. `next.config.ts` set no `experimental.proxyClientMaxBodySize`, so the 10MB default was in effect.

`POST /api/snapshot` accepts up to **50MB** (`MAX_SNAPSHOT_SIZE`), and the backup UI posts a multipart snapshot there. A valid 10–50MB backup was therefore truncated *before* the handler: `file.size` read ~10MB (< 50MB, so the route's 413 never fired), `file.text()` returned truncated JSON, `JSON.parse` threw, and the user saw a misleading **"Invalid JSON in snapshot file"**. The 10MB import routes (`MAX_UPLOAD_SIZE`) sat right at the same boundary.

## Fix
Set `experimental.proxyClientMaxBodySize = "52mb"` — above the 50MB route cap with headroom for the multipart envelope, so legitimate bodies reach the handler and each route's own size guard stays authoritative (a 50–52MB file now gets the route's real 413 instead of a truncation-induced 400).

## Tests
Added `tests/next-config-proxy-size.test.ts` pinning the invariant **proxy cap ≥ `MAX_SNAPSHOT_SIZE`** — the truncation is a proxy-layer behavior route-handler unit tests can't reproduce, so this guards against a future change silently dropping the cap or raising the snapshot cap past it. `tsc` + lint clean.

## Notes
- Affects desktop too — Electron embeds the standalone Next server, so this is the primary backup/restore UX.
- A full end-to-end check (POST a 10–50MB snapshot to a running server) would belong in the CI `smoke` job; flagging that as a possible follow-up rather than bundling a large fixture here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)