### PR TITLE
fix(ui): align the "show out of stock" pill with the quick-filter chips

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1265,28 +1265,28 @@ export default function Home() {
       )}
 
       <div className="flex items-center justify-between gap-3 mb-2 flex-wrap">
-        <div className="flex items-center gap-2 flex-wrap">
-          <QuickFilterChips
-            active={quickFilter}
-            onChange={setQuickFilter}
-            counts={quickFilterCounts}
-          />
-          {quickFilter === "all" && !debouncedSearch && !typeFilter && !vendorFilter && outOfStockCount > 0 && hasAnyInStock && (
-            <button
-              onClick={() => setShowOutOfStock((s) => !s)}
-              aria-pressed={showOutOfStock}
-              className={`px-3 py-1 rounded-full text-sm border transition-colors ${
-                showOutOfStock
-                  ? "bg-gray-700 text-white border-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:border-gray-200"
-                  : "bg-transparent text-gray-600 border-gray-300 hover:bg-gray-100 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-700"
-              }`}
-            >
-              {showOutOfStock
-                ? t("filaments.hideOutOfStock")
-                : t("filaments.showOutOfStock", { count: outOfStockCount })}
-            </button>
-          )}
-        </div>
+        <QuickFilterChips
+          active={quickFilter}
+          onChange={setQuickFilter}
+          counts={quickFilterCounts}
+          trailing={
+            quickFilter === "all" && !debouncedSearch && !typeFilter && !vendorFilter && outOfStockCount > 0 && hasAnyInStock ? (
+              <button
+                onClick={() => setShowOutOfStock((s) => !s)}
+                aria-pressed={showOutOfStock}
+                className={`px-2.5 py-1 rounded-full text-xs border transition-colors ${
+                  showOutOfStock
+                    ? "bg-gray-700 text-white border-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:border-gray-200"
+                    : "bg-transparent text-gray-600 border-gray-300 hover:bg-gray-100 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-700"
+                }`}
+              >
+                {showOutOfStock
+                  ? t("filaments.hideOutOfStock")
+                  : t("filaments.showOutOfStock", { count: outOfStockCount })}
+              </button>
+            ) : null
+          }
+        />
         <div className="flex gap-2 shrink-0">
           {/* Import / Export dropdown */}
           <div className="relative" ref={importExportRef}>

--- a/src/components/QuickFilterChips.tsx
+++ b/src/components/QuickFilterChips.tsx
@@ -33,36 +33,42 @@ const FILTERS: { key: QuickFilter; labelKey: string }[] = [
 export default function QuickFilterChips({ active, onChange, counts, trailing }: Props) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-wrap items-center gap-1.5 mb-2" role="tablist" aria-label={t("filter.aria.quick")}>
-      {FILTERS.map((f) => {
-        const isActive = active === f.key;
-        const count = counts?.[f.key];
-        return (
-          <button
-            key={f.key}
-            type="button"
-            role="tab"
-            aria-selected={isActive}
-            onClick={() => onChange(f.key)}
-            className={`px-2.5 py-1 rounded-full text-xs border transition-colors ${
-              isActive
-                ? "bg-blue-600 text-white border-blue-600"
-                : "bg-transparent text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500"
-            }`}
-          >
-            {t(f.labelKey)}
-            {count !== undefined && count > 0 && (
-              <span
-                className={`ml-1.5 text-[10px] px-1 rounded ${
-                  isActive ? "bg-white/20" : "bg-gray-200 dark:bg-gray-700"
-                }`}
-              >
-                {count}
-              </span>
-            )}
-          </button>
-        );
-      })}
+    // Outer row carries the trailing toggle as a SIBLING of the tablist — the
+    // toggle is an aria-pressed control, not a tab, so it must not live inside
+    // the role="tablist" (which may only own role="tab" children). They share
+    // this flex row, so the toggle still matches the chips' size + baseline.
+    <div className="flex flex-wrap items-center gap-1.5 mb-2">
+      <div className="flex flex-wrap items-center gap-1.5" role="tablist" aria-label={t("filter.aria.quick")}>
+        {FILTERS.map((f) => {
+          const isActive = active === f.key;
+          const count = counts?.[f.key];
+          return (
+            <button
+              key={f.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onChange(f.key)}
+              className={`px-2.5 py-1 rounded-full text-xs border transition-colors ${
+                isActive
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "bg-transparent text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500"
+              }`}
+            >
+              {t(f.labelKey)}
+              {count !== undefined && count > 0 && (
+                <span
+                  className={`ml-1.5 text-[10px] px-1 rounded ${
+                    isActive ? "bg-white/20" : "bg-gray-200 dark:bg-gray-700"
+                  }`}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
       {trailing}
     </div>
   );

--- a/src/components/QuickFilterChips.tsx
+++ b/src/components/QuickFilterChips.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useTranslation } from "@/i18n/TranslationProvider";
 
 export type QuickFilter = "all" | "lowStock" | "hasSpools" | "noCalibration";
@@ -8,6 +9,13 @@ interface Props {
   active: QuickFilter;
   onChange: (f: QuickFilter) => void;
   counts?: Partial<Record<QuickFilter, number>>;
+  /**
+   * Extra control(s) rendered inline at the END of the chip row (e.g. the
+   * "show out of stock" toggle). Kept inside this flex row — rather than as a
+   * sibling next to the component — so the control shares the chips' size,
+   * gap, and vertical baseline instead of misaligning against the row's margin.
+   */
+  trailing?: ReactNode;
 }
 
 const FILTERS: { key: QuickFilter; labelKey: string }[] = [
@@ -22,10 +30,10 @@ const FILTERS: { key: QuickFilter; labelKey: string }[] = [
  * dedicated component so the main list file stays readable and the chips
  * can be reused on the dashboard later.
  */
-export default function QuickFilterChips({ active, onChange, counts }: Props) {
+export default function QuickFilterChips({ active, onChange, counts, trailing }: Props) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-wrap gap-1.5 mb-2" role="tablist" aria-label={t("filter.aria.quick")}>
+    <div className="flex flex-wrap items-center gap-1.5 mb-2" role="tablist" aria-label={t("filter.aria.quick")}>
       {FILTERS.map((f) => {
         const isActive = active === f.key;
         const count = counts?.[f.key];
@@ -55,6 +63,7 @@ export default function QuickFilterChips({ active, onChange, counts }: Props) {
           </button>
         );
       })}
+      {trailing}
     </div>
   );
 }


### PR DESCRIPTION
## Problem
On the filament list header, the **"Show out of stock (N)"** pill was visibly larger than the quick-filter chips (All / Low stock / Has spools / No calibration) and sat slightly off their baseline.

Two causes:
- It rendered as a **sibling** next to `<QuickFilterChips>` with bigger classes — `text-sm` / `px-3` vs the chips' `text-xs` / `px-2.5`.
- The chips row carries `mb-2`; under the wrapper's `items-center`, that bottom margin pushed the chips up relative to the sibling button, so they didn't line up.

## Fix
Render the toggle **inside** the chip row via a new `trailing?: ReactNode` prop on `QuickFilterChips`, and match the chip size classes. Now it's a true peer of the chips — same flex row, gap, height, padding, and vertical baseline. Its gray active/inactive styling is unchanged (it's a toggle, not a filter chip).

## Verification
In-browser (dev server), all five pills measure identically:

| pill | height | font-size | padding-x | top / bottom |
|------|--------|-----------|-----------|--------------|
| All / Low stock / Has spools / No calibration / **Show out of stock** | 26px | 12px | 10px | 113 / 139 |

No component-render test added — the repo has no `@testing-library/react` setup, and this is a presentational/CSS-only change (verified visually + by measured DOM metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)