### PR TITLE
fix(optresync): compare hex colors case-insensitively (#894)

### DIFF
--- a/src/lib/optResync.ts
+++ b/src/lib/optResync.ts
@@ -152,6 +152,26 @@ function valuesEqual(a: OptValue, b: OptValue): boolean {
   return a === b;
 }
 
+/** The managed fields whose values are hex colors. Hex is case-insensitive
+ *  (`#AABBCC` === `#aabbcc`), so comparing them with raw `===` (GH #894) made
+ *  a casing-only difference look like a real change → a permanent spurious
+ *  `conflict` re-surfaced on every re-check. Compare these case-folded. */
+const COLOR_FIELDS: ReadonlySet<string> = new Set(["color", "secondaryColors"]);
+
+/** Lower-case a hex color value (string or array of strings) for comparison;
+ *  pass anything else through unchanged. */
+function canonicalizeColor(v: OptValue): OptValue {
+  if (typeof v === "string") return v.toLowerCase();
+  if (Array.isArray(v)) return v.map((x) => (typeof x === "string" ? x.toLowerCase() : x)) as string[];
+  return v;
+}
+
+/** `valuesEqual`, but case-insensitive for hex-color fields (GH #894). */
+function valuesEqualForField(field: string, a: OptValue, b: OptValue): boolean {
+  if (COLOR_FIELDS.has(field)) return valuesEqual(canonicalizeColor(a), canonicalizeColor(b));
+  return valuesEqual(a, b);
+}
+
 /** Does OPT actually offer a value for this field? (null / empty array = no.) */
 function hasIncoming(v: OptValue): boolean {
   if (v == null) return false;
@@ -178,7 +198,10 @@ export function buildOptSnapshot(payload: Record<string, unknown>): Record<strin
     // correctly, and the diff itself (not the snapshot) is what surfaces an
     // explicit upstream clear.
     if (!hasIncoming(v)) continue;
-    snap[optSnapshotKey(field)] = v;
+    // GH #894: store hex colors canonicalized (lower-case) so the recorded
+    // upstream offer is in a stable case; the diff also case-folds, so even a
+    // pre-existing mixed-case snapshot compares correctly without a backfill.
+    snap[optSnapshotKey(field)] = COLOR_FIELDS.has(field) ? canonicalizeColor(v) : v;
   }
   return snap;
 }
@@ -187,15 +210,18 @@ function classify(
   current: OptValue,
   snapshotVal: OptValue | undefined,
   hasSnapshotEntry: boolean,
-  isColor: boolean,
+  field: string,
 ): OptChangeKind {
-  const sentinel = isColor && current === COLOR_SENTINEL;
+  // The gray sentinel ("OPT has no real color") applies to the primary color only.
+  const sentinel = field === "color" && current === COLOR_SENTINEL;
   // A null OR empty-array local value is "the user never set this" — a
   // gap-fill, safe to adopt (covers OPT newly providing secondaries/tags).
   const empty = current == null || (Array.isArray(current) && current.length === 0);
   if (empty || sentinel) return "adopt";
   if (hasSnapshotEntry) {
-    return valuesEqual(current, snapshotVal ?? null) ? "adopt" : "conflict";
+    // GH #894: case-fold hex colors so a casing-only difference vs the stored
+    // snapshot classifies as `adopt` (unchanged), not a permanent `conflict`.
+    return valuesEqualForField(field, current, snapshotVal ?? null) ? "adopt" : "conflict";
   }
   return "conflict";
 }
@@ -250,11 +276,13 @@ export function diffOptFields(
       continue;
     }
     const current = getPath(filament, field);
-    if (valuesEqual(current, incoming)) continue;
+    // GH #894: hex colors compare case-insensitively, so `#AABBCC` already
+    // stored vs an `#aabbcc` upstream offer isn't surfaced as a spurious change.
+    if (valuesEqualForField(field, current, incoming)) continue;
     const snapKey = optSnapshotKey(field);
     const hasSnapshotEntry = !!snapshot && Object.prototype.hasOwnProperty.call(snapshot, snapKey);
     const snapshotVal = hasSnapshotEntry ? getPath(snapshot as Record<string, unknown>, snapKey) : undefined;
-    const kind = classify(current, snapshotVal, hasSnapshotEntry, !!isColor);
+    const kind = classify(current, snapshotVal, hasSnapshotEntry, field);
     changes.push({ field, labelKey, current, incoming, kind });
   }
   return changes;

--- a/tests/optResync.test.ts
+++ b/tests/optResync.test.ts
@@ -130,6 +130,48 @@ describe("diffOptFields", () => {
     expect(c!.kind).toBe("adopt");
   });
 
+  it("#894: a casing-only color difference is NOT a change (case-insensitive hex)", () => {
+    // Stored color is the same hue as OPT but upper-cased; must not surface.
+    const stored = {
+      color: "#3D3E3D",
+      secondaryColors: [],
+      density: 1.24,
+      temperatures: { nozzle: 225, nozzleRangeMin: 205, nozzleRangeMax: 225, bed: 60, standby: 170 },
+      shoreHardnessD: 81,
+      transmissionDistance: 0.2,
+    };
+    const changes = diffOptFields(stored, payload(), null);
+    expect(changes.find((c) => c.field === "color")).toBeUndefined();
+  });
+
+  it("#894: a casing-only secondaryColors difference is NOT a change", () => {
+    const stored = {
+      color: null,
+      secondaryColors: ["#000000", "#98282F"],
+      density: 1.24,
+      temperatures: { nozzle: 225, nozzleRangeMin: 205, nozzleRangeMax: 225, bed: 60, standby: 170 },
+      shoreHardnessD: 81,
+      transmissionDistance: 0.2,
+    };
+    const p = payload({ color: null, secondaryColors: ["#000000", "#98282f"] });
+    const changes = diffOptFields(stored, p, null);
+    expect(changes.find((c) => c.field === "secondaryColors")).toBeUndefined();
+  });
+
+  it("#894: an upper-cased local color equal to a lower-cased snapshot classifies as adopt, not conflict", () => {
+    // Provenance snapshot recorded the OPT offer; the user's stored value is the
+    // same hue in different case. Pre-fix this was a permanent spurious conflict.
+    const stored = { color: "#3D3E3D", density: 1.24, temperatures: { nozzle: 225, nozzleRangeMin: 205, nozzleRangeMax: 225, bed: 60, standby: 170 }, shoreHardnessD: 81, transmissionDistance: 0.2 };
+    const snapshot = buildOptSnapshot(payload({ color: "#3d3e3d" }));
+    // OPT now offers a different color, so `color` IS surfaced — but as the
+    // user-unedited (snapshot-matched) case it must be adopt, never conflict.
+    const p = payload({ color: "#aabbcc" });
+    const changes = diffOptFields(stored, p, snapshot);
+    const c = changes.find((x) => x.field === "color");
+    expect(c).toBeDefined();
+    expect(c!.kind).toBe("adopt");
+  });
+
   it("classifies an edited field with no snapshot as conflict", () => {
     // User set nozzle 215; OPT says 225; no provenance to prove safe.
     const stored = { color: "#3d3e3d", density: 1.24, temperatures: { nozzle: 215, nozzleRangeMin: 205, nozzleRangeMax: 225, bed: 60, standby: 170 }, shoreHardnessD: 81, transmissionDistance: 0.2 };


### PR DESCRIPTION
Fixes #894.

## Root cause
`diffOptFields` / `classify` in `src/lib/optResync.ts` compared `color` and `secondaryColors` with strict `===` (via `valuesEqual`). Hex is case-insensitive, so a casing-only difference between the stored value and the OPT offer (or the provenance snapshot) read as a real change → a permanent `conflict` that re-surfaced on every "Check for updates".

## Fix
- Added `COLOR_FIELDS` + `canonicalizeColor` + `valuesEqualForField`, and used the color-aware comparison in both the diff (`current` vs `incoming`) and `classify` (`current` vs the snapshot).
- `buildOptSnapshot` now stores hex colors lower-cased, so the recorded offer is in a stable case. The diff also case-folds, so **pre-existing mixed-case snapshots compare correctly with no data backfill** (deferred per the triage).
- Non-color fields are unchanged (still strict structural equality).

## Tests
3 new cases in `tests/optResync.test.ts`: casing-only `color` and `secondaryColors` differences are not surfaced; an upper-cased local color equal to a lower-cased snapshot classifies as `adopt`, not `conflict`. Full `optResync` (38) + `opt-resync-route` (34) suites pass; `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)