### PR TITLE
fix(print-history): validate only modified paths on spool-debit save() (#905)

### DIFF
--- a/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/usage/route.ts
@@ -91,7 +91,9 @@ export async function POST(
     if (spool.usageHistory.length > MAX_SPOOL_HISTORY) {
       spool.usageHistory = spool.usageHistory.slice(-MAX_SPOOL_HISTORY);
     }
-    await filament.save();
+    // GH #905: usage logging only mutates this spool — validate modified paths
+    // only so a legacy out-of-range field elsewhere can't block the log/debit.
+    await filament.save({ validateModifiedOnly: true });
     return NextResponse.json(filament.toObject(), { status: 201 });
   } catch (err) {
     // GH #504: surface optimistic-concurrency conflicts as 409 with a

--- a/src/app/api/print-history/[id]/route.ts
+++ b/src/app/api/print-history/[id]/route.ts
@@ -311,7 +311,9 @@ export async function DELETE(
           spool.totalWeight = refunded;
         }
       }
-      await filament.save();
+      // GH #905: a refund only mutates spool weight — validate modified paths
+      // only so a legacy out-of-range field elsewhere can't block the refund.
+      await filament.save({ validateModifiedOnly: true });
     }
 
     // Soft-delete by setting _deletedAt. Hard `deleteOne` would let a peer

--- a/src/app/api/print-history/route.ts
+++ b/src/app/api/print-history/route.ts
@@ -285,7 +285,14 @@ export async function POST(request: NextRequest) {
       try {
         await session.withTransaction(async () => {
           for (const f of filaments) {
-            await f.save({ session });
+            // GH #905: this job only mutates spool weight + usageHistory. Validate
+            // ONLY modified paths so a legacy out-of-range field elsewhere on the
+            // filament (e.g. a temperature stored before the numeric validators
+            // existed) can't throw a ValidationError and block the spool debit.
+            // Safe here because `f` was loaded from the DB with all required
+            // fields present (unlike a create, where omitted required fields must
+            // still be caught — which is why this is per-save, not schema-wide).
+            await f.save({ session, validateModifiedOnly: true });
           }
           const created = await PrintHistory.create(
             [{
@@ -333,7 +340,7 @@ export async function POST(request: NextRequest) {
       const savedFilaments: typeof filaments = [];
       try {
         for (const f of filaments) {
-          await f.save();
+          await f.save({ validateModifiedOnly: true }); // GH #905 (see above)
           savedFilaments.push(f);
         }
         history = await PrintHistory.create({
@@ -370,7 +377,7 @@ export async function POST(request: NextRequest) {
                 );
               }
             }
-            await fresh.save();
+            await fresh.save({ validateModifiedOnly: true }); // GH #905 (rollback debit)
           } catch {
             // Best-effort rollback — if a save errors here, log via
             // the wrapper and continue. Manual reconciliation is

--- a/tests/Filament.test.ts
+++ b/tests/Filament.test.ts
@@ -1312,4 +1312,33 @@ describe("Filament Model — v1.11 spool fields", () => {
       expect(f.secondaryColors).toEqual([]);
     });
   });
+
+  describe("#905 — spool-mutation save() validates modified paths only", () => {
+    it("a spool debit via save({validateModifiedOnly:true}) succeeds despite a legacy out-of-range field", async () => {
+      const f = await Filament.create({
+        name: "Legacy PLA",
+        vendor: "Test",
+        type: "PLA",
+        spools: [{ totalWeight: 1000 }],
+      });
+      // Inject a value that predates the numeric validators, bypassing Mongoose.
+      await Filament.collection.updateOne(
+        { _id: f._id },
+        { $set: { "temperatures.nozzle": 999 } }, // schema max is 600
+      );
+      const reloaded = await Filament.findById(f._id);
+      reloaded.spools[0].totalWeight = 800; // the print-history debit shape
+      // Without the option this throws on the legacy 999; with it, only the
+      // modified spool path is validated (the route-scoped #905 fix).
+      await expect(reloaded.save({ validateModifiedOnly: true })).resolves.toBeTruthy();
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools[0].totalWeight).toBe(800);
+    });
+
+    it("still rejects a MODIFIED out-of-range field even with validateModifiedOnly", async () => {
+      const f = await Filament.create({ name: "Edit Me", vendor: "Test", type: "PLA" });
+      f.temperatures.nozzle = 999; // this path IS modified → must still throw
+      await expect(f.save({ validateModifiedOnly: true })).rejects.toThrow();
+    });
+  });
 });

--- a/tests/print-history.test.ts
+++ b/tests/print-history.test.ts
@@ -78,6 +78,35 @@ describe("print-history POST", () => {
     expect(updated.spools[0].totalWeight).toBe(1175);
   });
 
+  it("#905: debits a spool even when the filament carries a legacy out-of-range field", async () => {
+    const f = await Filament.create({
+      name: "Legacy Field PLA",
+      vendor: "Test",
+      type: "PLA",
+      spools: [{ label: "", totalWeight: 1000 }],
+    });
+    // Inject a value that predates the numeric validators (bypasses Mongoose),
+    // e.g. a temperature stored before the max-600 validator existed.
+    await Filament.collection.updateOne(
+      { _id: f._id },
+      { $set: { "temperatures.nozzle": 999 } },
+    );
+
+    const res = await postPrintHistory(
+      makeReq({
+        jobLabel: "legacy.gcode",
+        source: "manual",
+        usage: [{ filamentId: String(f._id), grams: 50 }],
+      }),
+    );
+    // Pre-fix: full-document save() validation threw on the legacy 999 and the
+    // debit failed (5xx). Now the debit validates only modified paths.
+    expect(res.status).toBe(201);
+    const updated = await Filament.findById(f._id);
+    expect(updated.spools[0].totalWeight).toBe(950);
+    expect(updated.spools[0].usageHistory).toHaveLength(1);
+  });
+
   it("aborts with 404 on missing filament without mutating earlier filaments", async () => {
     const a = await Filament.create({
       name: "Atomic A",


### PR DESCRIPTION
Fixes #905.

## Root cause
A print-history job debits a spool via `filament.save()` (`src/app/api/print-history/route.ts:288/336/373`), which re-validates the **whole** document. A legacy out-of-range field elsewhere on the filament (e.g. a `temperatures.nozzle` stored before the max-600 validator existed) throws a `ValidationError` and blocks the unrelated spool-weight debit. The refund (`print-history/[id]` DELETE) and per-spool usage log have the identical exposure.

## Fix
Pass `{ validateModifiedOnly: true }` to the spool-mutation `save()` calls (POST debit + sequential-fallback + rollback, DELETE refund, usage log). They operate on docs **loaded from the DB** (all required fields present), so validating only the changed paths is safe and lets the debit proceed.

### Deviation from the triage's suggested option (worth a look)
The triage recommended a **schema-level** `validateModifiedOnly`. I implemented it, but it **broke required-field enforcement on create** — an omitted `name`/`vendor`/`type` is "unmodified" so its `required` validator is skipped (the existing "fails without required name/vendor/type" model tests caught this). So I reverted to the **route-scoped** form: creates still validate in full; only the loaded-doc debit saves relax re-validation of untouched fields.

## Tests
- `tests/print-history.test.ts`: a job debits a spool successfully even when the filament carries a legacy out-of-range field (was 5xx pre-fix).
- `tests/Filament.test.ts`: `save({validateModifiedOnly:true})` skips an unmodified legacy field but still rejects a *modified* out-of-range field.
- Full Filament-model (incl. the required-field tests) + print-history suites pass; `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)