### PR TITLE
fix(db): serialize cold-start migrations behind one in-flight promise (#898)

### DIFF
--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -4,6 +4,10 @@ interface MongooseCache {
   conn: typeof mongoose | null;
   promise: Promise<typeof mongoose> | null;
   uri: string | null;
+  /** GH #898 — the in-flight migration run, so two concurrent first-connects
+   *  can't both execute the migration block (the nozzle-split pass would mint
+   *  duplicate clones). Null when no run is in progress. */
+  migrationsPromise: Promise<void> | null;
   /** Per-migration completion flags. Each migration only runs until it
    * succeeds — a transient failure (network blip, MongoDB busy) won't
    * permanently mark the migration done, so the next request will retry
@@ -50,6 +54,7 @@ export default async function dbConnect() {
     conn: null,
     promise: null,
     uri: null,
+    migrationsPromise: null,
     migrations: { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false },
   };
 
@@ -64,6 +69,7 @@ export default async function dbConnect() {
     cached.conn = null;
     cached.promise = null;
     cached.uri = null;
+    cached.migrationsPromise = null;
     cached.migrations = { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false };
   }
 
@@ -103,6 +109,19 @@ export default async function dbConnect() {
     cached.conn = await cached.promise;
   }
 
+  // GH #898: serialize the migration block behind ONE in-flight promise so two
+  // concurrent first-connects can't both run it. The GH#232 nozzle-split pass
+  // reads the duplicate set and mints clones; running it twice in parallel
+  // creates duplicate "Name #N" clones. The per-migration flags below still make
+  // each step idempotent + independently retryable — this only collapses
+  // concurrent runs into one. In-process only; a multi-process deployment (two
+  // desktops / desktop + Docker on one Atlas DB) would still need a DB-level
+  // lock, which is out of scope for #898.
+  if (cached.migrationsPromise) {
+    await cached.migrationsPromise;
+    return cached.conn;
+  }
+  const runMigrations = async (): Promise<void> => {
   // GH #732 — the 5-byte hex identity is moving from the filament to the
   // spool. Backfill a per-spool `instanceId` onto every spool that lacks one
   // so existing installs converge on first connect after upgrade. The first
@@ -373,6 +392,17 @@ export default async function dbConnect() {
         err,
       );
     }
+  }
+  }; // end runMigrations
+
+  cached.migrationsPromise = runMigrations();
+  try {
+    await cached.migrationsPromise;
+  } finally {
+    // Clear the in-flight handle so a future connect can re-attempt any
+    // migration whose flag didn't flip (each step's own try/catch leaves its
+    // flag false on failure); completed steps short-circuit on the retry.
+    cached.migrationsPromise = null;
   }
 
   return cached.conn;

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -340,4 +340,36 @@ describe("dbConnect", () => {
       syncIndexesSpy.mockRestore();
     }
   });
+
+  it("#898: concurrent first-connects run the nozzle-split migration once (no duplicate clones)", async () => {
+    await dbConnect();
+    const Nozzle = mongoose.models.Nozzle || (await import("@/models/Nozzle")).default;
+    const Printer = mongoose.models.Printer || (await import("@/models/Printer")).default;
+    await Nozzle.deleteMany({});
+    await Printer.collection.deleteMany({});
+
+    // One nozzle installed on TWO printers → the #232 split should clone it
+    // EXACTLY once (keep printer 1's ref, mint one clone for printer 2).
+    const noz = await Nozzle.create({ name: "Brass", diameter: 0.4, type: "Brass" });
+    await Printer.collection.insertMany([
+      { name: "P1", installedNozzles: [noz._id], _deletedAt: null },
+      { name: "P2", installedNozzles: [noz._id], _deletedAt: null },
+    ]);
+
+    // Re-arm the split migration and clear any in-flight handle.
+    const cached = (global as Record<string, unknown>).mongoose as {
+      migrations: { nozzlePhysicalInstances: boolean };
+      migrationsPromise: Promise<void> | null;
+    };
+    cached.migrations.nozzlePhysicalInstances = false;
+    cached.migrationsPromise = null;
+
+    // Fire two connects concurrently. Pre-fix both ran the split and each
+    // minted a clone (2 clones); the #898 serialization runs it once.
+    await Promise.all([dbConnect(), dbConnect()]);
+
+    const nozzles = await Nozzle.find({ _deletedAt: null });
+    expect(nozzles).toHaveLength(2); // original + exactly ONE clone
+    expect(cached.migrations.nozzlePhysicalInstances).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #898.

## Root cause
`dbConnect()`'s migration block ran inline with no concurrency guard. Two concurrent first-connects could both pass the all-flags short-circuit and **both** execute it; the GH#232 nozzle-split pass mints clones, so a concurrent double-run created **duplicate `Name #N` nozzle clones**.

## Fix
Serialize the block behind a single `cached.migrationsPromise` — the first connect runs it, concurrent callers await the same promise. The per-migration success flags still make each step idempotent + independently retryable; the promise is cleared in a `finally` so a future connect retries any step whose flag didn't flip. **In-process only** — a multi-process deploy (two desktops / desktop + Docker on one Atlas) would still need a DB-level lock (out of scope per the issue).

## Tests
`tests/mongodb.test.ts`: two concurrent `dbConnect()` calls with a re-armed nozzle-split run it **once** (original + exactly one clone, not two). Existing 16 migration tests still pass; `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)