### PR TITLE
fix(import): use the shared parseCsv for filament CSV import (#888)

### DIFF
--- a/src/app/api/filaments/import-csv/route.ts
+++ b/src/app/api/filaments/import-csv/route.ts
@@ -1,40 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { mapHeaders, rowToImport, upsertImportRows } from "@/lib/importFilaments";
+import { parseCsv, CsvRowLimitExceededError } from "@/lib/parseCsv";
 import { assertMultipartFormData, getErrorMessage, errorResponse, checkFileSize } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 
-function parseCsvLine(line: string): string[] {
-  const fields: string[] = [];
-  let current = "";
-  let inQuotes = false;
-
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (inQuotes) {
-      if (ch === '"') {
-        if (i + 1 < line.length && line[i + 1] === '"') {
-          current += '"';
-          i++;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        current += ch;
-      }
-    } else {
-      if (ch === '"') {
-        inQuotes = true;
-      } else if (ch === ",") {
-        fields.push(current);
-        current = "";
-      } else {
-        current += ch;
-      }
-    }
-  }
-  fields.push(current);
-  return fields;
-}
+const MAX_IMPORT_ROWS = 10_000;
 
 export async function POST(request: NextRequest) {
   const guard = assertSameOriginRequest(request);
@@ -60,29 +30,44 @@ export async function POST(request: NextRequest) {
     // it becomes part of the first header cell, fails HEADER_MAP, and
     // the required-column check rejects an otherwise-valid file.
     const content = (await file.text()).replace(/^\uFEFF/, "");
-    const lines = content.split(/\r?\n/).filter((l) => l.trim() !== "");
+    // GH #888: parse with the shared CSV parser instead of a local one that
+    // split on newlines BEFORE quote-parsing — a cell with an embedded newline
+    // (a quoted multi-line notes field) was shredded across rows and
+    // mis-columned. `parseCsv` is embedded-newline-aware and enforces the row
+    // cap itself (the old local parser bypassed parseCsv's maxRows). header:false
+    // → positional string[][]; row 0 is the header. Positional mode also sidesteps
+    // the object-key __proto__ vector (keys come from `mapping`, not the file).
+    let parsedRaw: string[][];
+    try {
+      parsedRaw = parseCsv(content, { header: false, maxRows: MAX_IMPORT_ROWS + 1 }) as string[][];
+    } catch (err) {
+      if (err instanceof CsvRowLimitExceededError) {
+        return errorResponse(`Import too large: exceeds the ${MAX_IMPORT_ROWS} row limit.`, 400);
+      }
+      throw err;
+    }
+    // Non-header parseCsv returns EVERY row verbatim, including blank lines
+    // (only header mode discards them). Drop blanks so a trailing newline /
+    // separator line doesn't become a junk data row (the old parser filtered
+    // `l.trim() !== ""`).
+    const parsed = parsedRaw.filter((r) => r.some((v) => v.trim() !== ""));
 
-    if (lines.length < 2) {
+    if (parsed.length < 2) {
       return errorResponse(
         "CSV file must have a header row and at least one data row",
         400,
       );
     }
-
-    // GH #627 item 1: cap the row count — mirrors the INI importer's
-    // GH #297 cap (and parseCsv's maxRows, which this local parser
-    // bypasses). Without it a large CSV drives unbounded sequential
-    // findOneAndUpdate/create round-trips in upsertImportRows.
-    const MAX_IMPORT_ROWS = 10_000;
-    if (lines.length - 1 > MAX_IMPORT_ROWS) {
+    // We allowed maxRows+1 (header counts toward the cap in non-header mode);
+    // enforce the DATA-row cap explicitly so the message matches the INI importer.
+    if (parsed.length - 1 > MAX_IMPORT_ROWS) {
       return errorResponse(
-        `Import too large: ${lines.length - 1} rows exceeds the ${MAX_IMPORT_ROWS} limit.`,
+        `Import too large: ${parsed.length - 1} rows exceeds the ${MAX_IMPORT_ROWS} limit.`,
         400,
       );
     }
 
-    const headers = parseCsvLine(lines[0]);
-    const mapping = mapHeaders(headers);
+    const mapping = mapHeaders(parsed[0]);
 
     // Verify required columns exist
     const mappedKeys = mapping.filter(Boolean);
@@ -90,10 +75,7 @@ export async function POST(request: NextRequest) {
       return errorResponse("CSV must include Name, Vendor, and Type columns", 400);
     }
 
-    const rows = lines.slice(1).map((line) => {
-      const values = parseCsvLine(line);
-      return rowToImport(values, mapping);
-    });
+    const rows = parsed.slice(1).map((values) => rowToImport(values, mapping));
 
     const result = await upsertImportRows(rows);
 

--- a/src/app/api/filaments/import-csv/route.ts
+++ b/src/app/api/filaments/import-csv/route.ts
@@ -5,6 +5,15 @@ import { assertMultipartFormData, getErrorMessage, errorResponse, checkFileSize 
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 
 const MAX_IMPORT_ROWS = 10_000;
+// GH #888 (Codex P2): in non-header mode parseCsv counts EVERY parsed row —
+// header + blank/separator lines — toward its cap, before this route filters
+// blanks. So the parse-time cap must be a generous PHYSICAL/DoS bound, not the
+// business data-row limit; the strict MAX_IMPORT_ROWS DATA-row cap is enforced
+// below after blanks are filtered (the old parser allowed unlimited blank lines,
+// bounded only by the 10 MB file-size check that still applies). 2× leaves ample
+// headroom for the header + realistic separator blanks while parseCsv's own
+// physicalRowCap (rawRowCap + maxRows) still bounds a blank-line flood.
+const MAX_PHYSICAL_ROWS = MAX_IMPORT_ROWS * 2;
 
 export async function POST(request: NextRequest) {
   const guard = assertSameOriginRequest(request);
@@ -39,7 +48,7 @@ export async function POST(request: NextRequest) {
     // the object-key __proto__ vector (keys come from `mapping`, not the file).
     let parsedRaw: string[][];
     try {
-      parsedRaw = parseCsv(content, { header: false, maxRows: MAX_IMPORT_ROWS + 1 }) as string[][];
+      parsedRaw = parseCsv(content, { header: false, maxRows: MAX_PHYSICAL_ROWS }) as string[][];
     } catch (err) {
       if (err instanceof CsvRowLimitExceededError) {
         return errorResponse(`Import too large: exceeds the ${MAX_IMPORT_ROWS} row limit.`, 400);
@@ -58,8 +67,9 @@ export async function POST(request: NextRequest) {
         400,
       );
     }
-    // We allowed maxRows+1 (header counts toward the cap in non-header mode);
-    // enforce the DATA-row cap explicitly so the message matches the INI importer.
+    // Enforce the business DATA-row cap AFTER filtering blanks (parseCsv's
+    // parse-time cap is the generous physical/DoS bound above) so a capped
+    // export with a trailing blank line isn't falsely rejected (Codex P2 on #888).
     if (parsed.length - 1 > MAX_IMPORT_ROWS) {
       return errorResponse(
         `Import too large: ${parsed.length - 1} rows exceeds the ${MAX_IMPORT_ROWS} limit.`,

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -338,6 +338,33 @@ filamentdb_nozzle = 0.6 Brass
       expect(created).toBeTruthy();
       expect(created.color).toBe("#ff0000");
     });
+
+    it("#888: handles a quoted cell with an embedded newline without shredding the next row", async () => {
+      // The middle cell spans two physical lines; a row follows it. The old
+      // parser split on \n before quote-parsing → it shredded this into bogus
+      // rows. parseCsv keeps the quoted newline intact.
+      const csv =
+        'name,vendor,type,colorName\r\n' +
+        '"Multi PLA",MyVendor,PLA,"Galaxy\r\nBlack"\r\n' +
+        '"Second PLA",MyVendor,PETG,Red\r\n';
+      const file = new File([csv], "filaments.csv", { type: "text/csv" });
+      const res = await importCsv(
+        multipartReq("http://localhost/api/filaments/import-csv", file),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.created).toBe(2); // exactly two rows, not a shredded extra
+
+      const multi = await Filament.findOne({ name: "Multi PLA" });
+      expect(multi).toBeTruthy();
+      expect(multi.colorName).toContain("Galaxy");
+      expect(multi.colorName).toContain("Black"); // embedded newline preserved
+      const second = await Filament.findOne({ name: "Second PLA" });
+      expect(second).toBeTruthy();
+      expect(second.type).toBe("PETG"); // the row after the multi-line cell is intact
+      // No junk filament from a shredded fragment.
+      expect(await Filament.findOne({ name: 'Black"' })).toBeNull();
+    });
   });
 
   describe("GET /api/filaments/export (INI bundle)", () => {

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -365,6 +365,23 @@ filamentdb_nozzle = 0.6 Brass
       // No junk filament from a shredded fragment.
       expect(await Filament.findOne({ name: 'Black"' })).toBeNull();
     });
+
+    it("#888: a trailing blank/separator line does not count toward the data-row cap", async () => {
+      // Codex P2: the data-row cap applies AFTER blanks are filtered, so a valid
+      // file with a trailing blank line isn't falsely rejected as "too large".
+      const csv =
+        "name,vendor,type\r\n" +
+        '"Blank Tail PLA",MyVendor,PLA\r\n' +
+        "\r\n"; // trailing blank line
+      const file = new File([csv], "filaments.csv", { type: "text/csv" });
+      const res = await importCsv(
+        multipartReq("http://localhost/api/filaments/import-csv", file),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.created).toBe(1);
+      expect(await Filament.findOne({ name: "Blank Tail PLA" })).toBeTruthy();
+    });
   });
 
   describe("GET /api/filaments/export (INI bundle)", () => {


### PR DESCRIPTION
Fixes #888.

## Root cause
`src/app/api/filaments/import-csv/route.ts` split the file on `/\r?\n/` **before** quote-parsing, so a quoted cell containing an embedded newline (a multi-line value) was shredded across multiple rows and mis-columned. The local per-line parser also bypassed the shared `parseCsv`'s row cap.

## Fix
Parse with `parseCsv(content, { header: false })` (positional `string[][]`):
- embedded-newline-aware (the quoted newline stays in the cell);
- enforces `maxRows` itself — `CsvRowLimitExceededError` → 400;
- positional mode sidesteps the object-key `__proto__` vector (keys come from the header `mapping`, not the file);
- blank rows are filtered (non-header `parseCsv` returns them verbatim) to match the old `l.trim() !== ""`.

## Tests
`tests/filaments-import-export-route.test.ts`: a CSV with a quoted multi-line cell followed by another row imports **two** filaments (no shredded extra), the embedded newline is preserved, and the following row is intact. Existing import-csv + import-validation tests pass; `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)