### PR TITLE
fix(import): round-trip calibration chamber temp on Bambu/Orca import (#891)

### DIFF
--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -312,6 +312,7 @@ export async function resolveAndApplyCalibration(
   if (hints.fanMinSpeed != null) row.fanMinSpeed = hints.fanMinSpeed;
   if (hints.fanMaxSpeed != null) row.fanMaxSpeed = hints.fanMaxSpeed;
   if (hints.fanBridgeSpeed != null) row.fanBridgeSpeed = hints.fanBridgeSpeed;
+  if (hints.chamberTemp != null) row.chamberTemp = hints.chamberTemp; // GH #891
   if (parsed.temperatures.nozzle != null) row.nozzleTemp = parsed.temperatures.nozzle;
   if (parsed.temperatures.nozzleFirstLayer != null) row.nozzleTempFirstLayer = parsed.temperatures.nozzleFirstLayer;
   if (parsed.temperatures.bed != null) row.bedTemp = parsed.temperatures.bed;

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -148,6 +148,14 @@ const CALIBRATION_KEYS = new Set<string>([
   "fan_min_speed",
   "fan_max_speed",
   "bridge_fan_speed",
+  // GH #891: the exporter emits chamber temp under these keys; pull them out of
+  // the settings bag so the round-trip lands chamberTemp on the calibration row.
+  "chamber_temperature",
+  // `activate_chamber_temp_control` is the ONE documented exception to the
+  // "every member maps to a hint" invariant above: it's a derived enable flag
+  // (no independent datum) that the exporter re-emits from chamberTemp, so it's
+  // dropped from settings on import and regenerated on the next export.
+  "activate_chamber_temp_control",
 ]);
 
 /**
@@ -230,6 +238,8 @@ export interface CalibrationHints {
   fanMinSpeed?: number;
   fanMaxSpeed?: number;
   fanBridgeSpeed?: number;
+  /** Chamber temp (chamber_temperature) → calibrations[].chamberTemp (#891). */
+  chamberTemp?: number;
   /** True when at least one calibration-relevant value was present. The
    * route uses this to decide whether to upsert a calibrations[] row vs
    * leave the filament's calibration data alone. */
@@ -337,6 +347,9 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
     fanMaxSpeed:
       num(json.additional_cooling_fan_speed) ?? num(json.fan_max_speed),
     fanBridgeSpeed: num(json.bridge_fan_speed),
+    // GH #891: round-trips the exporter's chamber_temperature back onto the
+    // calibration row instead of dropping it into the settings bag.
+    chamberTemp: num(json.chamber_temperature),
     hasAnyHint: false,
   };
   // Codex P3 on PR #387 round 6: `maxVolumetricSpeed` is the ONE
@@ -356,7 +369,8 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
     calibrationHints.retractLift != null ||
     calibrationHints.fanMinSpeed != null ||
     calibrationHints.fanMaxSpeed != null ||
-    calibrationHints.fanBridgeSpeed != null;
+    calibrationHints.fanBridgeSpeed != null ||
+    calibrationHints.chamberTemp != null;
 
   // ── Settings bag passthrough ────────────────────────────────────────
   // Anything we didn't pluck into a structured field OR a calibration

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -243,11 +243,15 @@ describe("parseBambuStudioProfile", () => {
       // though the importer side declared it in CALIBRATION_KEYS, so
       // every export → calibrate → re-import cycle silently dropped it.
       fanBridgeSpeed: 70,
+      // GH #891: chamber temp must round-trip too — pre-fix the exported
+      // chamber_temperature fell into the settings bag instead of the
+      // calibration row.
+      chamberTemp: 45,
     };
     const exported = calibrationToOrcaSlicerKeys(original);
     // Stamp a minimum identifier so the parser accepts the payload.
     const profile = { name: ["X"], ...exported };
-    const { calibrationHints } = parseBambuStudioProfile(profile);
+    const { calibrationHints, filament } = parseBambuStudioProfile(profile);
     expect(calibrationHints.extrusionMultiplier).toBe(original.extrusionMultiplier);
     expect(calibrationHints.maxVolumetricSpeed).toBe(original.maxVolumetricSpeed);
     expect(calibrationHints.pressureAdvance).toBe(original.pressureAdvance);
@@ -257,6 +261,11 @@ describe("parseBambuStudioProfile", () => {
     expect(calibrationHints.fanMinSpeed).toBe(original.fanMinSpeed);
     expect(calibrationHints.fanMaxSpeed).toBe(original.fanMaxSpeed);
     expect(calibrationHints.fanBridgeSpeed).toBe(original.fanBridgeSpeed);
+    expect(calibrationHints.chamberTemp).toBe(original.chamberTemp);
+    // #891: chamber keys must NOT leak into the settings passthrough bag
+    // (that would double-write on the next export).
+    expect(filament.settings.chamber_temperature).toBeUndefined();
+    expect(filament.settings.activate_chamber_temp_control).toBeUndefined();
   });
 
   it("stashes unknown keys in the settings passthrough bag", () => {


### PR DESCRIPTION
Fixes #891.

## Root cause
The exporter (`calibrationToOrcaSlicerKeys`, `src/lib/orcaSlicerBundle.ts:160-164`) emits chamber temp as `chamber_temperature` + the derived `activate_chamber_temp_control` flag, but `src/lib/bambuStudioImport.ts`'s `CALIBRATION_KEYS` and `CalibrationHints` had neither. So on import the chamber temp fell into the settings passthrough bag instead of `calibrations[].chamberTemp` — an export → calibrate → re-import cycle silently dropped it (same class as the #508 fan round-trip break).

## Fix
- Add `chamber_temperature` + `activate_chamber_temp_control` to `CALIBRATION_KEYS`. The latter is the single documented exception to the "every member maps to a hint" invariant — a derived enable flag re-emitted from `chamberTemp` on export.
- Add `chamberTemp` to `CalibrationHints`, extract it from `chamber_temperature`, include it in `hasAnyHint`, and write it to the calibrations[] row in `prepareBambuUpdate`.

## Tests
Extended the `calibrationToOrcaSlicerKeys` round-trip test: `chamberTemp` survives export → re-import as a hint and the chamber keys do **not** leak into the settings bag. bambu import + route suites (40) pass; `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)