### PR TITLE
fix(nozzles): enforce one-printer-per-nozzle on the nozzle PUT printerIds path (#897)

### DIFF
--- a/src/app/api/nozzles/[id]/route.ts
+++ b/src/app/api/nozzles/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import Filament from "@/models/Filament";
@@ -89,14 +90,41 @@ export async function PUT(
     }
 
     if (printerIds !== undefined) {
-      // Add this nozzle to every printer in the list (idempotent)
-      if (printerIds.length > 0) {
-        await Printer.updateMany(
-          { _id: { $in: printerIds }, _deletedAt: null },
-          { $addToSet: { installedNozzles: id } }
+      // GH #897: a single physical nozzle lives in at most ONE printer (#232).
+      // The nozzle-side assignment is AUTHORITATIVE (auto-move): the $pull below
+      // removes this nozzle from every other printer, so reassigning displaces
+      // the previous claim without a conflict prompt. But one nozzle cannot be
+      // in TWO printers at once — reject a multi-printer set rather than letting
+      // the $addToSet loop corrupt the one-printer-per-nozzle invariant (which
+      // the printer-side routes enforce via findNozzleConflicts).
+      if (printerIds.length > 1) {
+        return errorResponse(
+          "A nozzle can be installed in at most one printer at a time.",
+          400,
         );
       }
-      // Remove this nozzle from any other printer that currently has it
+      if (printerIds.length === 1) {
+        const targetId = printerIds[0];
+        if (typeof targetId !== "string" || !mongoose.isValidObjectId(targetId)) {
+          return errorResponse("printerIds must contain a valid printer id", 400);
+        }
+        // Validate the target exists + is active (mirrors the printer routes'
+        // existence check) so the assignment can't silently no-op while the
+        // $pull below still strips the nozzle from its current printer.
+        const target = await Printer.findOne(
+          { _id: targetId, _deletedAt: null },
+          { _id: 1 },
+        ).lean();
+        if (!target) {
+          return errorResponse("Target printer not found", 400);
+        }
+        await Printer.updateMany(
+          { _id: targetId, _deletedAt: null },
+          { $addToSet: { installedNozzles: id } },
+        );
+      }
+      // Auto-move: remove this nozzle from every OTHER printer that has it
+      // (one-printer-per-nozzle). An empty printerIds clears the assignment.
       await Printer.updateMany(
         { _id: { $nin: printerIds }, _deletedAt: null, installedNozzles: id },
         { $pull: { installedNozzles: id } }

--- a/src/app/api/nozzles/[id]/route.ts
+++ b/src/app/api/nozzles/[id]/route.ts
@@ -69,7 +69,7 @@ export async function PUT(
     // payload) isn't falsely rejected; it still targets ONE unique printer and
     // the $addToSet is idempotent. Mirrors the printer routes' ref-array dedup.
     const printerIds: string[] | undefined = Array.isArray(body.printerIds)
-      ? [...new Set(body.printerIds.map(String))]
+      ? [...new Set((body.printerIds as unknown[]).map((p): string => String(p)))]
       : undefined;
 
     // GH #424: replace the "delete each known leak field + spread the rest"

--- a/src/app/api/nozzles/[id]/route.ts
+++ b/src/app/api/nozzles/[id]/route.ts
@@ -64,8 +64,12 @@ export async function PUT(
     // currently has it installed gets it removed. This lets the nozzle edit
     // form manage the assignment from the nozzle side while the Printer form
     // continues to manage it from the printer side.
+    // GH #912 (Codex P3): dedupe before the one-printer check so a client that
+    // sends the same printer twice (`[id, id]` — a duplicated selection / retry
+    // payload) isn't falsely rejected; it still targets ONE unique printer and
+    // the $addToSet is idempotent. Mirrors the printer routes' ref-array dedup.
     const printerIds: string[] | undefined = Array.isArray(body.printerIds)
-      ? body.printerIds
+      ? [...new Set(body.printerIds.map(String))]
       : undefined;
 
     // GH #424: replace the "delete each known leak field + spread the rest"

--- a/src/app/api/nozzles/[id]/route.ts
+++ b/src/app/api/nozzles/[id]/route.ts
@@ -80,23 +80,14 @@ export async function PUT(
     if ("hardened" in body) update.hardened = body.hardened;
     if ("notes" in body) update.notes = body.notes;
 
-    const nozzle = await Nozzle.findOneAndUpdate(
-      { _id: id, _deletedAt: null },
-      update,
-      { returnDocument: "after", runValidators: true }
-    ).lean();
-    if (!nozzle) {
-      return errorResponse("Not found", 404);
-    }
-
+    // GH #897 / #912 (Codex P2): VALIDATE printerIds BEFORE mutating the nozzle,
+    // so a rejected assignment (multi-printer, bad/missing target) doesn't leave
+    // the nozzle partially updated (e.g. renamed but the request 400s).
+    // A single physical nozzle lives in at most ONE printer (#232); the
+    // nozzle-side assignment is AUTHORITATIVE (auto-move) — the $pull below
+    // displaces the previous claim — but it can't be in two printers at once.
+    let validatedTargetId: string | null = null;
     if (printerIds !== undefined) {
-      // GH #897: a single physical nozzle lives in at most ONE printer (#232).
-      // The nozzle-side assignment is AUTHORITATIVE (auto-move): the $pull below
-      // removes this nozzle from every other printer, so reassigning displaces
-      // the previous claim without a conflict prompt. But one nozzle cannot be
-      // in TWO printers at once — reject a multi-printer set rather than letting
-      // the $addToSet loop corrupt the one-printer-per-nozzle invariant (which
-      // the printer-side routes enforce via findNozzleConflicts).
       if (printerIds.length > 1) {
         return errorResponse(
           "A nozzle can be installed in at most one printer at a time.",
@@ -108,9 +99,9 @@ export async function PUT(
         if (typeof targetId !== "string" || !mongoose.isValidObjectId(targetId)) {
           return errorResponse("printerIds must contain a valid printer id", 400);
         }
-        // Validate the target exists + is active (mirrors the printer routes'
-        // existence check) so the assignment can't silently no-op while the
-        // $pull below still strips the nozzle from its current printer.
+        // Target must exist + be active (mirrors the printer routes' existence
+        // check) so the assignment can't silently no-op while the $pull below
+        // still strips the nozzle from its current printer.
         const target = await Printer.findOne(
           { _id: targetId, _deletedAt: null },
           { _id: 1 },
@@ -118,8 +109,23 @@ export async function PUT(
         if (!target) {
           return errorResponse("Target printer not found", 400);
         }
+        validatedTargetId = targetId;
+      }
+    }
+
+    const nozzle = await Nozzle.findOneAndUpdate(
+      { _id: id, _deletedAt: null },
+      update,
+      { returnDocument: "after", runValidators: true }
+    ).lean();
+    if (!nozzle) {
+      return errorResponse("Not found", 404);
+    }
+
+    if (printerIds !== undefined) {
+      if (validatedTargetId) {
         await Printer.updateMany(
-          { _id: targetId, _deletedAt: null },
+          { _id: validatedTargetId, _deletedAt: null },
           { $addToSet: { installedNozzles: id } },
         );
       }

--- a/tests/nozzles-route.test.ts
+++ b/tests/nozzles-route.test.ts
@@ -372,6 +372,23 @@ describe("/api/nozzles", () => {
       expect(res.status).toBe(404);
     });
 
+    it("#912: a rejected printerIds assignment does NOT partially update the nozzle", async () => {
+      const noz = await Nozzle.create({ name: "Keep Me", diameter: 0.4, type: "Brass" });
+      const a = await Printer.create({ name: "PA", manufacturer: "X", printerModel: "1" });
+      const b = await Printer.create({ name: "PB", manufacturer: "X", printerModel: "2" });
+      const res = await updateNozzle(
+        jsonReq(
+          `http://localhost/api/nozzles/${noz._id}`,
+          { name: "Renamed", printerIds: [String(a._id), String(b._id)] }, // invalid multi-printer
+          "PUT",
+        ),
+        { params: Promise.resolve({ id: String(noz._id) }) },
+      );
+      expect(res.status).toBe(400);
+      // The nozzle name must be UNCHANGED — validation runs before the write.
+      expect((await Nozzle.findById(noz._id)).name).toBe("Keep Me");
+    });
+
     it("#897: rejects assigning one nozzle to MULTIPLE printers (one-printer-per-nozzle)", async () => {
       const noz = await Nozzle.create({ name: "Shared", diameter: 0.4, type: "Brass" });
       const a = await Printer.create({ name: "A", manufacturer: "X", printerModel: "1" });

--- a/tests/nozzles-route.test.ts
+++ b/tests/nozzles-route.test.ts
@@ -371,6 +371,66 @@ describe("/api/nozzles", () => {
       );
       expect(res.status).toBe(404);
     });
+
+    it("#897: rejects assigning one nozzle to MULTIPLE printers (one-printer-per-nozzle)", async () => {
+      const noz = await Nozzle.create({ name: "Shared", diameter: 0.4, type: "Brass" });
+      const a = await Printer.create({ name: "A", manufacturer: "X", printerModel: "1" });
+      const b = await Printer.create({ name: "B", manufacturer: "X", printerModel: "2" });
+      const res = await updateNozzle(
+        jsonReq(
+          `http://localhost/api/nozzles/${noz._id}`,
+          { printerIds: [String(a._id), String(b._id)] },
+          "PUT",
+        ),
+        { params: Promise.resolve({ id: String(noz._id) }) },
+      );
+      expect(res.status).toBe(400);
+      // Neither printer got the nozzle — the invariant is preserved.
+      expect((await Printer.findById(a._id)).installedNozzles).toHaveLength(0);
+      expect((await Printer.findById(b._id)).installedNozzles).toHaveLength(0);
+    });
+
+    it("#897: assigning to a single printer auto-moves the nozzle off its previous printer", async () => {
+      const noz = await Nozzle.create({ name: "Mover", diameter: 0.4, type: "Brass" });
+      const a = await Printer.create({
+        name: "A", manufacturer: "X", printerModel: "1", installedNozzles: [noz._id],
+      });
+      const b = await Printer.create({ name: "B", manufacturer: "X", printerModel: "2" });
+      const res = await updateNozzle(
+        jsonReq(`http://localhost/api/nozzles/${noz._id}`, { printerIds: [String(b._id)] }, "PUT"),
+        { params: Promise.resolve({ id: String(noz._id) }) },
+      );
+      expect(res.status).toBe(200);
+      // Moved from A to B (no longer in two printers).
+      expect((await Printer.findById(a._id)).installedNozzles.map(String)).not.toContain(String(noz._id));
+      expect((await Printer.findById(b._id)).installedNozzles.map(String)).toContain(String(noz._id));
+    });
+
+    it("#897: rejects a printerIds entry that isn't an active printer", async () => {
+      const noz = await Nozzle.create({ name: "Ghost Target", diameter: 0.4, type: "Brass" });
+      const res = await updateNozzle(
+        jsonReq(
+          `http://localhost/api/nozzles/${noz._id}`,
+          { printerIds: [new mongoose.Types.ObjectId().toString()] },
+          "PUT",
+        ),
+        { params: Promise.resolve({ id: String(noz._id) }) },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("#897: empty printerIds clears the nozzle from all printers", async () => {
+      const noz = await Nozzle.create({ name: "Unassign", diameter: 0.4, type: "Brass" });
+      const a = await Printer.create({
+        name: "A", manufacturer: "X", printerModel: "1", installedNozzles: [noz._id],
+      });
+      const res = await updateNozzle(
+        jsonReq(`http://localhost/api/nozzles/${noz._id}`, { printerIds: [] }, "PUT"),
+        { params: Promise.resolve({ id: String(noz._id) }) },
+      );
+      expect(res.status).toBe(200);
+      expect((await Printer.findById(a._id)).installedNozzles).toHaveLength(0);
+    });
   });
 
   describe("GET /api/nozzles/{id}", () => {

--- a/tests/nozzles-route.test.ts
+++ b/tests/nozzles-route.test.ts
@@ -372,6 +372,21 @@ describe("/api/nozzles", () => {
       expect(res.status).toBe(404);
     });
 
+    it("#912: a duplicated single printer in printerIds is deduped, not rejected", async () => {
+      const noz = await Nozzle.create({ name: "Dup OK", diameter: 0.4, type: "Brass" });
+      const a = await Printer.create({ name: "PDup", manufacturer: "X", printerModel: "1" });
+      const res = await updateNozzle(
+        jsonReq(
+          `http://localhost/api/nozzles/${noz._id}`,
+          { printerIds: [String(a._id), String(a._id)] }, // same printer twice
+          "PUT",
+        ),
+        { params: Promise.resolve({ id: String(noz._id) }) },
+      );
+      expect(res.status).toBe(200); // one unique printer → not a multi-printer reject
+      expect((await Printer.findById(a._id)).installedNozzles.map(String)).toContain(String(noz._id));
+    });
+
     it("#912: a rejected printerIds assignment does NOT partially update the nozzle", async () => {
       const noz = await Nozzle.create({ name: "Keep Me", diameter: 0.4, type: "Brass" });
       const a = await Printer.create({ name: "PA", manufacturer: "X", printerModel: "1" });


### PR DESCRIPTION
Fixes #897.

## Root cause
`PUT /api/nozzles/{id}` syncs `Printer.installedNozzles` from the nozzle side via a `printerIds` body, but never enforced the #232 one-printer-per-nozzle invariant the printer routes guard with `findNozzleConflicts`. A `printerIds: [A, B]` body `$addToSet` the nozzle into **both** printers → one physical nozzle installed in multiple printers (the corruption #232 was built to prevent).

## Fix (AUTO-MOVE — per the chosen resolution)
The nozzle-side assignment is authoritative; the existing `$pull` already displaces the nozzle from its previous printer on a single-printer reassign (no conflict prompt needed — the nozzle form has no resolution modal). Added:
- reject `printerIds.length > 1` with **400** — one nozzle can't be in two printers;
- validate the single target is a valid, **active** printer (mirrors the printer routes' existence check) so the assignment can't silently no-op while the `$pull` still strips the old assignment.

**Deviation note:** the issue suggested a `findNozzleConflicts` **409**; the chosen **auto-move** keeps the reassign A→B flow working without a dead-end conflict toast.

## Tests
`tests/nozzles-route.test.ts`: multi-printer → 400 (neither printer mutated); single-printer reassign auto-moves A→B; non-existent target → 400; empty `printerIds` clears the assignment. 21 nozzle-route tests pass; `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)