### PR TITLE
fix(slicer): don't clobber a coextruded filament's null primary on sync-back (#883)

### DIFF
--- a/src/app/api/filaments/[id]/bambustudio/route.ts
+++ b/src/app/api/filaments/[id]/bambustudio/route.ts
@@ -186,6 +186,10 @@ export async function POST(
       // the unset branch unreachable in this route.
       type: existing.type ?? null,
       vendor: existing.vendor ?? null,
+      // GH #883: color + secondaryColors let resolveSyncBackColor detect the
+      // coextruded shape and suppress the exported-secondary echo on sync-back.
+      color: existing.color ?? null,
+      secondaryColors: existing.secondaryColors ?? null,
       diameter: existing.diameter ?? null,
       density: existing.density ?? null,
       cost: existing.cost ?? null,

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import { generateOrcaSlicerProfiles } from "@/lib/orcaSlicerBundle";
+import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
 import {
   resolveFilamentForExport,
   exportFilenameStem,
@@ -155,7 +156,12 @@ export async function POST(
 
     if (body.type != null) update.type = body.type;
     if (body.vendor != null) update.vendor = body.vendor;
-    if (body.color != null) update.color = body.color;
+    // GH #883: don't write a coextruded filament's exported secondary back onto
+    // its null primary (see resolveSyncBackColor). undefined = leave color alone.
+    if (typeof body.color === "string") {
+      const resolvedColor = resolveSyncBackColor(filament, body.color);
+      if (resolvedColor !== undefined) update.color = resolvedColor;
+    }
 
     // GH #618: numeric fields must coerce to finite numbers (numeric
     // strings are accepted, matching the cast Mongoose applies on save).

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -158,8 +158,13 @@ export async function POST(
     if (body.vendor != null) update.vendor = body.vendor;
     // GH #883: don't write a coextruded filament's exported secondary back onto
     // its null primary (see resolveSyncBackColor). undefined = leave color alone.
+    // GH #913: pass the parent's secondaryColors so an inherited-coextruded
+    // variant is detected too.
     if (typeof body.color === "string") {
-      const resolvedColor = resolveSyncBackColor(filament, body.color);
+      const colorParent = filament.parentId
+        ? await Filament.findById(filament.parentId, { secondaryColors: 1 }).lean<{ secondaryColors?: string[] | null } | null>()
+        : null;
+      const resolvedColor = resolveSyncBackColor(filament, body.color, colorParent);
       if (resolvedColor !== undefined) update.color = resolvedColor;
     }
 

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -542,9 +542,14 @@ export async function POST(
     if (config.filament_vendor) update.vendor = config.filament_vendor;
     // GH #883: a coextruded filament exports secondaryColors[0] as its single
     // colour key; suppress writing that echo back onto the null primary so the
-    // round-trip doesn't corrupt the spec-pure coextruded shape.
+    // round-trip doesn't corrupt the spec-pure coextruded shape. GH #913: for a
+    // variant that inherits its parent's coextruded colors, resolve the parent's
+    // secondaryColors so the inherited-coextruded case is detected too.
     if (config.filament_colour) {
-      const resolvedColor = resolveSyncBackColor(filament, config.filament_colour);
+      const colorParent = filament.parentId
+        ? await Filament.findById(filament.parentId, { secondaryColors: 1 }).lean<{ secondaryColors?: string[] | null } | null>()
+        : null;
+      const resolvedColor = resolveSyncBackColor(filament, config.filament_colour, colorParent);
       if (resolvedColor !== undefined) update.color = resolvedColor;
     }
     if (config.filament_diameter) { const v = parseFloat(config.filament_diameter); if (!isNaN(v)) update.diameter = v; }

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -8,6 +8,7 @@ import { resolveFilament, hasVariants } from "@/lib/resolveFilament";
 import { errorResponse, errorResponseFromCaught, handleDuplicateKeyError, isDuplicateKeyError, assertActiveRefs } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
+import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
 import { escapeRegex } from "@/lib/matchFilament";
 import { assignSpoolToSlot } from "@/lib/spoolSlots";
 import {
@@ -539,7 +540,13 @@ export async function POST(
     // Core fields
     if (config.filament_type) update.type = config.filament_type;
     if (config.filament_vendor) update.vendor = config.filament_vendor;
-    if (config.filament_colour) update.color = config.filament_colour;
+    // GH #883: a coextruded filament exports secondaryColors[0] as its single
+    // colour key; suppress writing that echo back onto the null primary so the
+    // round-trip doesn't corrupt the spec-pure coextruded shape.
+    if (config.filament_colour) {
+      const resolvedColor = resolveSyncBackColor(filament, config.filament_colour);
+      if (resolvedColor !== undefined) update.color = resolvedColor;
+    }
     if (config.filament_diameter) { const v = parseFloat(config.filament_diameter); if (!isNaN(v)) update.diameter = v; }
     if (config.filament_density) { const v = parseFloat(config.filament_density); if (!isNaN(v)) update.density = v; }
     if (config.filament_cost) { const v = parseFloat(config.filament_cost); if (!isNaN(v)) update.cost = v; }

--- a/src/app/api/filaments/bambustudio/route.ts
+++ b/src/app/api/filaments/bambustudio/route.ts
@@ -302,6 +302,10 @@ async function augmentExistingWithParent(existing: {
     // shape.
     type: existing.type ?? null,
     vendor: existing.vendor ?? null,
+    // GH #883: ride color + secondaryColors along so resolveSyncBackColor can
+    // detect the coextruded shape and suppress the exported-secondary echo.
+    color: existing.color ?? null,
+    secondaryColors: existing.secondaryColors ?? null,
     diameter: existing.diameter ?? null,
     density: existing.density ?? null,
     cost: existing.cost ?? null,

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -231,7 +231,12 @@ export function buildStructuredUpdate(
   // secondaries) the export echoes secondaryColors[0] as the single color, so
   // suppress writing that echo back onto the null primary; undefined = leave it.
   if (parsed.color != null) {
-    const resolvedColor = resolveSyncBackColor(existing, parsed.color);
+    // GH #913: pass the parent so an inherited-coextruded variant is detected.
+    const resolvedColor = resolveSyncBackColor(
+      existing,
+      parsed.color,
+      parent as { secondaryColors?: string[] | null } | null,
+    );
     if (resolvedColor !== undefined) u.color = resolvedColor;
   }
   setIfNotInherited("diameter", parsed.diameter);

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -24,6 +24,7 @@ import {
   mergeSlicerSettings,
   type SettingsMergeResult,
 } from "@/lib/slicerSettings";
+import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
 import type {
   BambuParseResult,
   CalibrationHints,
@@ -51,6 +52,11 @@ import type {
 export interface ExistingFilamentForApply {
   type?: string | null;
   vendor?: string | null;
+  /** GH #883: read by resolveSyncBackColor to detect the spec-pure coextruded
+   *  shape (null primary + populated secondaries) and suppress writing the
+   *  exported secondary echo back onto the null primary. */
+  color?: string | null;
+  secondaryColors?: string[] | null;
   diameter?: number | null;
   density?: number | null;
   cost?: number | null;
@@ -221,7 +227,13 @@ export function buildStructuredUpdate(
 
   setIfNotInherited("type", parsed.type);
   setIfNotInherited("vendor", parsed.vendor);
-  if (parsed.color != null) u.color = parsed.color; // not inheritable
+  // not inheritable. GH #883: for a coextruded filament (null primary +
+  // secondaries) the export echoes secondaryColors[0] as the single color, so
+  // suppress writing that echo back onto the null primary; undefined = leave it.
+  if (parsed.color != null) {
+    const resolvedColor = resolveSyncBackColor(existing, parsed.color);
+    if (resolvedColor !== undefined) u.color = resolvedColor;
+  }
   setIfNotInherited("diameter", parsed.diameter);
   setIfNotInherited("density", parsed.density);
   setIfNotInherited("cost", parsed.cost);

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -41,6 +41,51 @@ function slicerExportColor(filament: FilamentDoc): string | null {
 }
 
 /**
+ * GH #883: the inverse guard for `slicerExportColor` on a slicer SYNC-BACK.
+ *
+ * A coextruded / multi-color filament is stored spec-pure as `color: null` +
+ * a populated `secondaryColors[]`. The export above gives the slicer ONE
+ * representative color — `secondaryColors[0]` — under the single colour key.
+ * On sync-back the slicer echoes that hex back, and a naïve mapping would write
+ * it onto the null primary, leaving a hybrid (real primary + secondaries) that
+ * no longer matches the user's coextruded shape.
+ *
+ * Decide what (if anything) to write to `color` from an incoming slicer hex:
+ *   - no incoming hex                                   → undefined (don't write)
+ *   - stored is coextruded AND incoming == secondaries[0] (case-insensitive)
+ *       → undefined: it's the exported echo, preserve the null primary
+ *   - otherwise                                         → the incoming hex
+ *       (a genuine user edit, OR a normal single-color filament — write it)
+ *
+ * Returns `undefined` to mean "leave `color` unchanged".
+ *
+ * Known limitation (tracked as a follow-up): a VARIANT that INHERITS its
+ * parent's coextruded colors has its OWN `color` null and OWN `secondaryColors`
+ * empty, so it isn't detected as coextruded here and an echoed hex would be
+ * written onto the variant. Resolving effective (parent-merged) values first
+ * would close that; out of scope for this fix.
+ */
+export function resolveSyncBackColor(
+  stored: { color?: string | null; secondaryColors?: string[] | null } | null | undefined,
+  incomingHex: string | null | undefined,
+): string | undefined {
+  if (incomingHex == null || incomingHex === "") return undefined;
+  const primary = stored?.color;
+  const secondaries = stored?.secondaryColors;
+  const isCoextruded =
+    (primary == null || primary === "") &&
+    Array.isArray(secondaries) &&
+    secondaries.length > 0;
+  if (isCoextruded) {
+    const echo = secondaries![0];
+    if (typeof echo === "string" && echo.toLowerCase() === incomingHex.toLowerCase()) {
+      return undefined; // the exported representative color — keep null primary
+    }
+  }
+  return incomingHex;
+}
+
+/**
  * Map a resolved Filament DB document to PrusaSlicer INI key-value pairs.
  * Structured DB fields are mapped to their PrusaSlicer equivalents.
  * The `settings` bag is merged underneath (DB fields win on conflict).

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -59,19 +59,26 @@ function slicerExportColor(filament: FilamentDoc): string | null {
  *
  * Returns `undefined` to mean "leave `color` unchanged".
  *
- * Known limitation (tracked as a follow-up): a VARIANT that INHERITS its
- * parent's coextruded colors has its OWN `color` null and OWN `secondaryColors`
- * empty, so it isn't detected as coextruded here and an echoed hex would be
- * written onto the variant. Resolving effective (parent-merged) values first
- * would close that; out of scope for this fix.
+ * GH #913 (Codex P2): a VARIANT that INHERITS its parent's coextruded colors has
+ * its OWN `secondaryColors` empty (array-fallback inheritance, #477/#106) — the
+ * export resolves the parent first, so the slicer gets the PARENT's
+ * `secondaryColors[0]`. Pass the resolved `parent` so the guard compares against
+ * the EFFECTIVE secondaries and recognizes the inherited-coextruded case too.
  */
 export function resolveSyncBackColor(
   stored: { color?: string | null; secondaryColors?: string[] | null } | null | undefined,
   incomingHex: string | null | undefined,
+  parent?: { secondaryColors?: string[] | null } | null,
 ): string | undefined {
   if (incomingHex == null || incomingHex === "") return undefined;
   const primary = stored?.color;
-  const secondaries = stored?.secondaryColors;
+  // secondaryColors is array-fallback inheritable: a variant with an empty own
+  // array inherits the parent's. Resolve the EFFECTIVE secondaries so an
+  // inherited-coextruded variant is detected (Codex P2 #913).
+  let secondaries = stored?.secondaryColors;
+  if ((!Array.isArray(secondaries) || secondaries.length === 0) && parent) {
+    secondaries = parent.secondaryColors;
+  }
   const isCoextruded =
     (primary == null || primary === "") &&
     Array.isArray(secondaries) &&

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -788,6 +788,46 @@ describe("API route correctness", () => {
     expect(fresh.settings?.filament_retract_length).toBeUndefined();
   });
 
+  it("#883 — PrusaSlicer sync-back doesn't clobber a coextruded filament's null primary with the echoed secondary", async () => {
+    const f = await Filament.create({
+      name: "Coex PLA",
+      vendor: "X",
+      type: "PLA",
+      color: null,
+      secondaryColors: ["#112233", "#445566"],
+    });
+    // The export gives the slicer secondaryColors[0] as the single colour; the
+    // slicer echoes it back (upper-cased). It must NOT become the primary.
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}`, {
+        config: { filamentdb_id: String(f._id), filament_colour: "#112233".toUpperCase() },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.color).toBeNull(); // null primary preserved
+    expect(fresh.secondaryColors).toEqual(["#112233", "#445566"]); // untouched
+  });
+
+  it("#883 — a genuinely new color from the slicer IS written to a coextruded filament", async () => {
+    const f = await Filament.create({
+      name: "Coex PETG",
+      vendor: "X",
+      type: "PETG",
+      color: null,
+      secondaryColors: ["#112233"],
+    });
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}`, {
+        config: { filamentdb_id: String(f._id), filament_colour: "#ff0000" },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await Filament.findById(f._id)).color).toBe("#ff0000"); // real edit applied
+  });
+
   it("#872 — a per-nozzle sync with an out-of-range baked calibration value is rejected with 400 (nothing persisted)", async () => {
     const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
     const f = await Filament.create({

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -3,6 +3,7 @@ import {
   filamentToSlicerKeys,
   generatePrusaSlicerBundle,
   collapsePerNozzleImportSections,
+  resolveSyncBackColor,
 } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
 
@@ -876,5 +877,34 @@ describe("collapsePerNozzleImportSections (#872)", () => {
     expect(base.cost).toBe(25);
     expect(base.density).toBe(1.24);
     expect(base.diameter).toBe(1.75);
+  });
+});
+
+describe("resolveSyncBackColor (#883)", () => {
+  it("suppresses the echoed secondary on a coextruded filament (keeps null primary)", () => {
+    const stored = { color: null, secondaryColors: ["#112233", "#445566"] };
+    // The slicer echoes secondaryColors[0]; must NOT be written onto the primary.
+    expect(resolveSyncBackColor(stored, "#112233")).toBeUndefined();
+    // Case-insensitive — the slicer may upper-case it.
+    expect(resolveSyncBackColor(stored, "#112233".toUpperCase())).toBeUndefined();
+  });
+
+  it("writes a genuinely different incoming color on a coextruded filament", () => {
+    const stored = { color: null, secondaryColors: ["#112233"] };
+    expect(resolveSyncBackColor(stored, "#ff0000")).toBe("#ff0000");
+  });
+
+  it("writes the incoming color for a normal single-color filament", () => {
+    expect(resolveSyncBackColor({ color: "#000000", secondaryColors: [] }, "#ff0000")).toBe("#ff0000");
+    expect(resolveSyncBackColor({ color: "#000000" }, "#abcdef")).toBe("#abcdef");
+  });
+
+  it("writes the incoming color when there is no stored doc (create branch)", () => {
+    expect(resolveSyncBackColor(null, "#123456")).toBe("#123456");
+  });
+
+  it("returns undefined for an absent incoming color", () => {
+    expect(resolveSyncBackColor({ color: null, secondaryColors: ["#112233"] }, null)).toBeUndefined();
+    expect(resolveSyncBackColor({ color: "#000000" }, "")).toBeUndefined();
   });
 });

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -903,6 +903,20 @@ describe("resolveSyncBackColor (#883)", () => {
     expect(resolveSyncBackColor(null, "#123456")).toBe("#123456");
   });
 
+  it("#913: suppresses the echo for a variant that INHERITS the parent's coextruded secondaries", () => {
+    // Variant's own color null + own secondaryColors empty → inherits parent's.
+    const variant = { color: null, secondaryColors: [] };
+    const parent = { secondaryColors: ["#112233", "#445566"] };
+    // The export gave the slicer the PARENT's secondaryColors[0]; the echo must
+    // not be written onto the variant's primary.
+    expect(resolveSyncBackColor(variant, "#112233", parent)).toBeUndefined();
+    expect(resolveSyncBackColor(variant, "#112233".toUpperCase(), parent)).toBeUndefined();
+    // A genuinely different incoming color is still written.
+    expect(resolveSyncBackColor(variant, "#ff0000", parent)).toBe("#ff0000");
+    // A variant that OWNS its secondaries uses those, not the parent's.
+    expect(resolveSyncBackColor({ color: null, secondaryColors: ["#abcabc"] }, "#abcabc", parent)).toBeUndefined();
+  });
+
   it("returns undefined for an absent incoming color", () => {
     expect(resolveSyncBackColor({ color: null, secondaryColors: ["#112233"] }, null)).toBeUndefined();
     expect(resolveSyncBackColor({ color: "#000000" }, "")).toBeUndefined();


### PR DESCRIPTION
Fixes #883.

## Root cause
A coextruded filament is stored spec-pure as `color: null` + populated `secondaryColors[]`. `slicerExportColor` gives the slicer ONE representative color (`secondaryColors[0]`) under the single colour key. On sync-back the slicer echoes that hex and the naïve mapping wrote it onto the null primary → a hybrid (real primary + secondaries) that breaks the spec-pure shape. All three sync-back paths were affected: PrusaSlicer (`route.ts`), OrcaSlicer single-preset (`orcaslicer/route.ts`), and Bambu apply (`bambuStudioApply.ts`). The export already guards against inventing gray (#485) — the import lacked the symmetric guard.

## Fix
New pure helper `resolveSyncBackColor(stored, incomingHex)` (in `prusaSlicerBundle.ts`): returns `undefined` (don't write) when stored is coextruded **and** incoming == `secondaryColors[0]` (case-insensitive — the exported echo); otherwise returns the incoming hex (a genuine user edit, or a normal single-color filament). Wired into all three sync-back color writes; the Bambu routes' `existing` shape now carries `color` + `secondaryColors`.

**Known limitation** (documented, follow-up): a *variant* inheriting its parent's coextruded colors has its own `color` null + own `secondaryColors` empty, so it isn't detected as coextruded; resolving effective (parent-merged) values would close that — out of scope here.

## Tests
- `tests/prusaSlicerBundle.test.ts`: helper unit cases (echo suppressed incl. case-insensitive; real edit written; single-color written; null stored = create branch; absent incoming).
- `tests/api-route-correctness.test.ts`: PrusaSlicer sync-back of a coextruded filament preserves the null primary + secondaries; a genuinely different color IS applied.
- 120 tests across the affected suites pass; `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)