### PR TITLE
fix(nfc): serialize transport ops to avoid auto-read racing a user op (#903)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -643,13 +643,25 @@ const MAX_NFC_PAYLOAD_BYTES = 4096;
  * operations should report progress through their own status channel
  * instead.
  */
-function withIpcTimeout<T>(fn: () => Promise<T>, label: string, timeoutMs: number = IPC_TIMEOUT_MS): Promise<T> {
-  return Promise.race([
-    fn(),
-    new Promise<T>((_, reject) =>
-      setTimeout(() => reject(new Error(`IPC timeout: ${label} took longer than ${timeoutMs}ms`)), timeoutMs)
-    ),
-  ]);
+function withIpcTimeout<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  label: string,
+  timeoutMs: number = IPC_TIMEOUT_MS,
+): Promise<T> {
+  // GH #915: abort on timeout so an operation that's still QUEUED behind a stuck
+  // op (e.g. an NFC write waiting on a stalled auto-read) can be dropped before
+  // it runs — without this the renderer promise rejects but the queued work
+  // still executes later, possibly against a different tag. Callers that don't
+  // need cancellation simply ignore the signal arg.
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`IPC timeout: ${label} took longer than ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([fn(controller.signal), timeout]).finally(() => clearTimeout(timer));
 }
 
 /**
@@ -1158,7 +1170,7 @@ ipcMain.handle("nfc-get-status", (event) => {
 ipcMain.handle("nfc-read-tag", async (event) => {
   assertTrustedSender(event, "nfc-read-tag");
   if (!nfcService) throw new Error("NFC not initialized");
-  return withIpcTimeout(() => nfcService!.readTag(), "nfc-read-tag");
+  return withIpcTimeout((signal) => nfcService!.readTag(signal), "nfc-read-tag");
 });
 
 ipcMain.handle("nfc-write-tag", async (event, payload: number[], productUrl?: string) => {
@@ -1186,7 +1198,7 @@ ipcMain.handle("nfc-write-tag", async (event, payload: number[], productUrl?: st
     throw new Error("nfc-write-tag: productUrl must be an http(s) URL");
   }
 
-  await withIpcTimeout(() => nfcService!.writeTag(new Uint8Array(payload), productUrl), "nfc-write-tag");
+  await withIpcTimeout((signal) => nfcService!.writeTag(new Uint8Array(payload), productUrl, signal), "nfc-write-tag");
 
   // After a successful write, schedule a delayed read-back so the UI shows
   // the updated tag data. We delay to let the disconnect settle — reading
@@ -1206,7 +1218,7 @@ ipcMain.handle("nfc-write-tag", async (event, payload: number[], productUrl?: st
 ipcMain.handle("nfc-format-tag", async (event) => {
   assertTrustedSender(event, "nfc-format-tag");
   if (!nfcService) throw new Error("NFC not initialized");
-  await withIpcTimeout(() => nfcService!.formatTag(), "nfc-format-tag");
+  await withIpcTimeout((signal) => nfcService!.formatTag(signal), "nfc-format-tag");
   return { success: true };
 });
 
@@ -1218,7 +1230,7 @@ ipcMain.handle("nfc-set-readonly", async (event, readOnly: unknown) => {
   if (typeof readOnly !== "boolean") {
     throw new Error("nfc-set-readonly: readOnly must be a boolean");
   }
-  await withIpcTimeout(() => nfcService!.setReadOnly(readOnly), "nfc-set-readonly");
+  await withIpcTimeout((signal) => nfcService!.setReadOnly(readOnly, signal), "nfc-set-readonly");
   return { success: true };
 });
 

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -130,8 +130,26 @@ export class NfcService extends EventEmitter {
    */
   private txChain: Promise<unknown> = Promise.resolve();
 
-  private runExclusive<T>(op: () => Promise<T>): Promise<T> {
-    const run = this.txChain.then(op, op);
+  /**
+   * Run `op` after all prior transport ops settle. When a `signal` is passed
+   * (from the IPC-timeout AbortController in main.ts), it is checked at DEQUEUE
+   * — the moment this op reaches the front of the queue — so a mutation whose
+   * 15s IPC timeout already fired WHILE QUEUED is dropped before it touches the
+   * tag (GH #915: otherwise a queued write/format runs later against whatever
+   * tag is now present, after the user saw failure and may have swapped tags).
+   * An op already in progress when the timeout fires is left to finish (the
+   * hazard is the still-queued one, not the in-flight one).
+   */
+  private runExclusive<T>(op: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    const guarded = () => {
+      if (signal?.aborted) {
+        throw new Error(
+          "NFC operation aborted — the reader was busy too long; remove the tag and try again.",
+        );
+      }
+      return op();
+    };
+    const run = this.txChain.then(guarded, guarded);
     this.txChain = run.then(
       () => undefined,
       () => undefined,
@@ -782,8 +800,8 @@ export class NfcService extends EventEmitter {
    *      blank/unrecognized content so its friendly message surfaces.
    *   3. ISO 15693 / NFC-V (SLIX2) — OpenPrintTag, or OpenTag3D on SLIX2.
    */
-  async readTag(): Promise<DecodedOpenPrintTag> {
-    return this.runExclusive(() => this.readTagImpl()); // GH #903: serialize
+  async readTag(signal?: AbortSignal): Promise<DecodedOpenPrintTag> {
+    return this.runExclusive(() => this.readTagImpl(), signal); // GH #903/#915
   }
 
   private async readTagImpl(): Promise<DecodedOpenPrintTag> {
@@ -811,8 +829,8 @@ export class NfcService extends EventEmitter {
     });
   }
 
-  async writeTag(cborPayload: Uint8Array, productUrl?: string): Promise<void> {
-    return this.runExclusive(() => this.writeTagImpl(cborPayload, productUrl)); // GH #903
+  async writeTag(cborPayload: Uint8Array, productUrl?: string, signal?: AbortSignal): Promise<void> {
+    return this.runExclusive(() => this.writeTagImpl(cborPayload, productUrl), signal); // GH #903/#915
   }
 
   private async writeTagImpl(cborPayload: Uint8Array, productUrl?: string): Promise<void> {
@@ -890,8 +908,8 @@ export class NfcService extends EventEmitter {
     });
   }
 
-  async formatTag(): Promise<void> {
-    return this.runExclusive(() => this.formatTagImpl()); // GH #903: serialize
+  async formatTag(signal?: AbortSignal): Promise<void> {
+    return this.runExclusive(() => this.formatTagImpl(), signal); // GH #903/#915
   }
 
   private async formatTagImpl(): Promise<void> {
@@ -976,8 +994,8 @@ export class NfcService extends EventEmitter {
    * a blank/foreign tag has no CC to lock, so both are refused with a typed
    * message the renderer maps to friendly copy.
    */
-  async setReadOnly(readOnly: boolean): Promise<void> {
-    return this.runExclusive(() => this.setReadOnlyImpl(readOnly)); // GH #903
+  async setReadOnly(readOnly: boolean, signal?: AbortSignal): Promise<void> {
+    return this.runExclusive(() => this.setReadOnlyImpl(readOnly), signal); // GH #903/#915
   }
 
   private async setReadOnlyImpl(readOnly: boolean): Promise<void> {

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -120,6 +120,25 @@ export class NfcService extends EventEmitter {
     lastError: null,
   };
 
+  /**
+   * GH #903: a single PC/SC connection is shared across all transport ops, so
+   * the present-edge auto-read in `electron/main.ts` (one-shot verification on
+   * tag arrival) could run a `readTag()` while a user-triggered write/read/erase
+   * is mid-flight — interleaving APDUs on the same reader. Serialize every
+   * public transport op through this chain: QUEUE-AND-WAIT, so a second op runs
+   * only after the first finishes. A failed op doesn't reject the next caller.
+   */
+  private txChain: Promise<unknown> = Promise.resolve();
+
+  private runExclusive<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.txChain.then(op, op);
+    this.txChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
   constructor() {
     super();
     this.pcsc = pcsclite();
@@ -764,6 +783,10 @@ export class NfcService extends EventEmitter {
    *   3. ISO 15693 / NFC-V (SLIX2) — OpenPrintTag, or OpenTag3D on SLIX2.
    */
   async readTag(): Promise<DecodedOpenPrintTag> {
+    return this.runExclusive(() => this.readTagImpl()); // GH #903: serialize
+  }
+
+  private async readTagImpl(): Promise<DecodedOpenPrintTag> {
     // 1. Try Bambu (MIFARE Classic) first
     try {
       return await this.withConnection(async (protocol) => {
@@ -789,6 +812,10 @@ export class NfcService extends EventEmitter {
   }
 
   async writeTag(cborPayload: Uint8Array, productUrl?: string): Promise<void> {
+    return this.runExclusive(() => this.writeTagImpl(cborPayload, productUrl)); // GH #903
+  }
+
+  private async writeTagImpl(cborPayload: Uint8Array, productUrl?: string): Promise<void> {
     return this.withConnection(async (protocol) => {
       const block0 = await this.readBlock(protocol, 0);
       // GH #437: refuse to overwrite a tag that doesn't carry an NFC-
@@ -864,6 +891,10 @@ export class NfcService extends EventEmitter {
   }
 
   async formatTag(): Promise<void> {
+    return this.runExclusive(() => this.formatTagImpl()); // GH #903: serialize
+  }
+
+  private async formatTagImpl(): Promise<void> {
     // GH #583: a Bambu Lab tag is MIFARE Classic (ISO 14443) and read-only
     // (RSA-signed). The ISO 15693 `readBlock(0)` below would fail on it with
     // a raw "Read block 0 failed: SW=6a81" — opaque to the user. Detect it
@@ -946,6 +977,10 @@ export class NfcService extends EventEmitter {
    * message the renderer maps to friendly copy.
    */
   async setReadOnly(readOnly: boolean): Promise<void> {
+    return this.runExclusive(() => this.setReadOnlyImpl(readOnly)); // GH #903
+  }
+
+  private async setReadOnlyImpl(readOnly: boolean): Promise<void> {
     // Bambu tags are MIFARE Classic, RSA-signed and inherently read-only —
     // there's no NFC-Forum CC to toggle. Detect first (own connection, like
     // formatTag) so we give a clear message instead of a raw ISO 15693 error.


### PR DESCRIPTION
Fixes #903.

## Root cause
`NfcService` shares one PC/SC connection across all transport operations. The present-edge auto-read in `electron/main.ts` (one-shot silent verification fired on tag arrival) could run `readTag()` while a user-triggered `writeTag`/`formatTag`/`setReadOnly` was mid-flight — interleaving APDUs on the same reader.

## Fix (QUEUE-AND-WAIT, per the chosen resolution)
Serialize every public transport op through a single promise chain (`runExclusive`): a second op runs only after the first finishes; a failed op doesn't reject the next caller. Each public method now delegates to a private `*Impl` — no internal call goes through a public (serialized) entry point, so there's no re-entrant deadlock.

## Verification
- `electron:typecheck` passes.
- **No CI test**: `NfcService` instantiates `pcsclite()` (native module) and isn't in the vitest harness. **On-device confirmation is owed** (ACR1552U: an auto-read overlapping a user write no longer interleaves/errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)