### PR TITLE
fix(tds): replace retired gemini-2.0-flash model (#916)

### DIFF
--- a/docs/de/usage.md
+++ b/docs/de/usage.md
@@ -346,7 +346,7 @@ Die TDS-URL wird zusätzlich im `tdsUrl`-Feld des Filaments für spätere Refere
 
 | Anbieter | Modell | Kostenlose Stufe | PDF-Unterstützung |
 |----------|--------|------------------|-------------------|
-| Google Gemini | gemini-2.0-flash | 15 Anfragen/Min | Nativ |
+| Google Gemini | gemini-2.5-flash | 15 Anfragen/Min | Nativ |
 | Anthropic Claude | claude-sonnet-4-20250514 | Pay-per-use | Nativ |
 | OpenAI ChatGPT | gpt-4o-mini | Pay-per-use | Textextraktion |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -346,7 +346,7 @@ The TDS URL is also saved to the filament's `tdsUrl` field for future reference.
 
 | Provider | Model | Free Tier | PDF Support |
 |----------|-------|-----------|-------------|
-| Google Gemini | gemini-2.0-flash | 15 requests/minute | Native |
+| Google Gemini | gemini-2.5-flash | 15 requests/minute | Native |
 | Anthropic Claude | claude-sonnet-4-20250514 | Pay-per-use | Native |
 | OpenAI ChatGPT | gpt-4o-mini | Pay-per-use | Text extraction |
 

--- a/src/lib/tdsExtractor.ts
+++ b/src/lib/tdsExtractor.ts
@@ -236,6 +236,18 @@ const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 5_000; // 5 seconds initial wait
 
 /**
+ * Gemini model used for TDS extraction (GH #916). The previous hard-coded
+ * `gemini-2.0-flash` was permanently retired by Google on 2026-06-01, so every
+ * extraction failed with a 429 that surfaced as a misleading "rate limit
+ * exceeded". `gemini-2.5-flash` is the conservative, broadly-available
+ * replacement. Google's guidance is to migrate to a 3.x model
+ * (`gemini-3.1-flash` / `gemini-3.1-flash-lite`); this single constant makes
+ * that a one-line bump once the target model is confirmed on the deployment's
+ * API tier. Keep the docs model table (docs/usage.md) in sync when changing it.
+ */
+const GEMINI_MODEL = "gemini-2.5-flash";
+
+/**
  * Retry a provider call with exponential backoff on rate-limit errors.
  */
 async function withRetry(
@@ -285,7 +297,7 @@ async function callGemini(
   }
 
   const res = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${apiKey}`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/tests/tds-route-status.test.ts
+++ b/tests/tds-route-status.test.ts
@@ -92,4 +92,31 @@ describe("POST /api/tds — SSRF / scheme rejections return 400, real upstream f
     const res = await POST(jsonReq({ url: "https://example.com/tds.pdf", apiKey: "fake-key", provider: "gemini" }));
     expect(res.status).toBe(502);
   });
+
+  it("#916: targets a current (non-retired) Gemini model", async () => {
+    // gemini-2.0-flash was permanently retired 2026-06-01; pin the request URL
+    // to a current model so a future EOL regression is caught at test time.
+    let geminiUrl = "";
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (url.includes("generativelanguage.googleapis.com")) {
+        geminiUrl = url;
+        return Promise.resolve({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ candidates: [{ content: { parts: [{ text: "{}" }] } }] }),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        status: 200,
+        ok: true,
+        url: "https://example.com/tds.pdf",
+        headers: new Headers({ "content-type": "application/pdf" }),
+        arrayBuffer: () => Promise.resolve(new Uint8Array([0x25, 0x50, 0x44, 0x46]).buffer),
+      } as unknown as Response);
+    }));
+    const { POST } = await import("@/app/api/tds/route");
+    await POST(jsonReq({ url: "https://example.com/tds.pdf", apiKey: "fake-key", provider: "gemini" }));
+    expect(geminiUrl).not.toContain("gemini-2.0-flash");
+    expect(geminiUrl).toMatch(/models\/gemini-[0-9.]+-flash/);
+  });
 });


### PR DESCRIPTION
Fixes #916.

`gemini-2.0-flash` was permanently retired by Google on 2026-06-01, so every Gemini TDS extraction now fails — the upstream 429 surfaces as a misleading "rate limit exceeded" (reported by @dcode on a fresh API key).

**Change:** extract a single `GEMINI_MODEL` constant and point the generateContent URL at it. Set to **`gemini-2.5-flash`** — the conservative, broadly-available replacement the reporter confirms works.

**On 3.x:** the reporter notes Google's guidance is to migrate to a 3.x model (`gemini-3.1-flash` / `gemini-3.1-flash-lite`), and that 2.5-flash itself retires 2026-10-16. I went with 2.5-flash because I can't verify 3.1 availability across API tiers from here, and a wrong model id means "still broken" for everyone. The single constant makes bumping to 3.1 a one-line change once you've confirmed it on your tier — happy to switch if you'd prefer to ship 3.1 directly.

- Docs model table updated (en + de).
- Test pins the request URL to a non-retired `gemini-*-flash` model so a future EOL regression trips CI.

@codex review