### PR TITLE
fix(filaments): clear stale colorName on color sync-back (#885) + correct permanent-delete guard comment (#884)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -560,7 +560,15 @@ export async function POST(
         // because an arbitrary slicer hex won't reliably map to a named colour.
         // Gated on resolvedColor !== undefined above so the coextruded-echo
         // suppression path (which leaves color untouched) doesn't clear it.
-        if (resolvedColor !== filament.color) update.colorName = null;
+        // Codex P2 (#918): compare case-insensitively — the schema accepts
+        // mixed-case hex, so a `#ff0000` → `#FF0000` sync isn't a real colour
+        // change and must NOT drop the name.
+        if (
+          typeof filament.color !== "string" ||
+          resolvedColor.toLowerCase() !== filament.color.toLowerCase()
+        ) {
+          update.colorName = null;
+        }
       }
     }
     if (config.filament_diameter) { const v = parseFloat(config.filament_diameter); if (!isNaN(v)) update.diameter = v; }

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -550,7 +550,18 @@ export async function POST(
         ? await Filament.findById(filament.parentId, { secondaryColors: 1 }).lean<{ secondaryColors?: string[] | null } | null>()
         : null;
       const resolvedColor = resolveSyncBackColor(filament, config.filament_colour, colorParent);
-      if (resolvedColor !== undefined) update.color = resolvedColor;
+      if (resolvedColor !== undefined) {
+        update.color = resolvedColor;
+        // GH #885: colorName + color are kept paired everywhere else (the
+        // edit-form typeahead sets both together), but the slicer sends only a
+        // hex. When the synced hex actually changes the colour, clear the stale
+        // human-readable name so it can't keep describing the old colour (in the
+        // name chip + CSV/XLSX exports). Cleared rather than reverse-looked-up
+        // because an arbitrary slicer hex won't reliably map to a named colour.
+        // Gated on resolvedColor !== undefined above so the coextruded-echo
+        // suppression path (which leaves color untouched) doesn't clear it.
+        if (resolvedColor !== filament.color) update.colorName = null;
+      }
     }
     if (config.filament_diameter) { const v = parseFloat(config.filament_diameter); if (!isNaN(v)) update.diameter = v; }
     if (config.filament_density) { const v = parseFloat(config.filament_density); if (!isNaN(v)) update.density = v; }
@@ -1026,19 +1037,22 @@ export async function DELETE(
           400,
         );
       }
-      // Variant guard still applies — although a parent in trash can't
-      // have active variants (the original soft-delete refused), it could
-      // theoretically have other trashed variants pointing at it.
-      // Permanently deleting the parent would orphan them, so block. Only
-      // count variants that are themselves still in the trash and not yet
-      // purged — already-purged variant tombstones are dead weight.
+      // Variant guard still applies — permanently deleting a parent would
+      // orphan its variants. GH #884: this query counts ALL non-purged variants
+      // (active OR trashed), NOT only trashed ones — there is deliberately no
+      // `_deletedAt` clause. A parent in trash normally can't have active
+      // variants (the soft-delete path refuses, via hasVariants), but counting
+      // them anyway also blocks the should-not-happen case of an active variant
+      // under a trashed parent. The broader query is the safe choice; do NOT
+      // narrow it to trashed-only to "match intent" — that would let a purge
+      // orphan an active variant. Already-purged tombstones don't count.
       const variantCount = await Filament.countDocuments({
         parentId: id,
         _purged: { $ne: true },
       });
       if (variantCount > 0) {
         return errorResponse(
-          "Cannot permanently delete a filament that still has variants in the trash. Permanently delete those first.",
+          "Cannot permanently delete a filament that still has variants. Permanently delete (or re-parent) those first.",
           400,
         );
       }

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -866,6 +866,24 @@ describe("API route correctness", () => {
     expect((await Filament.findById(f._id)).colorName).toBe("Galaxy Black"); // no-op, name preserved
   });
 
+  it("#885/#918 — a case-only hex difference is NOT a change; colorName preserved", async () => {
+    const f = await Filament.create({
+      name: "Case PLA",
+      vendor: "X",
+      type: "PLA",
+      color: "#ff0000",
+      colorName: "Red",
+    });
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}`, {
+        config: { filamentdb_id: String(f._id), filament_colour: "#FF0000" },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await Filament.findById(f._id)).colorName).toBe("Red"); // no-op, name kept
+  });
+
   it("#885 — coextruded echo suppression leaves colorName untouched", async () => {
     const f = await Filament.create({
       name: "Coex named",

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -828,6 +828,65 @@ describe("API route correctness", () => {
     expect((await Filament.findById(f._id)).color).toBe("#ff0000"); // real edit applied
   });
 
+  it("#885 — sync-back of a changed color clears the stale colorName", async () => {
+    const f = await Filament.create({
+      name: "Galaxy PLA",
+      vendor: "X",
+      type: "PLA",
+      color: "#101010",
+      colorName: "Galaxy Black",
+    });
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}`, {
+        config: { filamentdb_id: String(f._id), filament_colour: "#ff0000" },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.color).toBe("#ff0000");
+    expect(fresh.colorName ?? null).toBeNull(); // stale name cleared, not left as "Galaxy Black"
+  });
+
+  it("#885 — sync-back of the SAME color keeps the colorName", async () => {
+    const f = await Filament.create({
+      name: "Galaxy PLA 2",
+      vendor: "X",
+      type: "PLA",
+      color: "#101010",
+      colorName: "Galaxy Black",
+    });
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}`, {
+        config: { filamentdb_id: String(f._id), filament_colour: "#101010" },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await Filament.findById(f._id)).colorName).toBe("Galaxy Black"); // no-op, name preserved
+  });
+
+  it("#885 — coextruded echo suppression leaves colorName untouched", async () => {
+    const f = await Filament.create({
+      name: "Coex named",
+      vendor: "X",
+      type: "PLA",
+      color: null,
+      colorName: "Rainbow",
+      secondaryColors: ["#112233", "#445566"],
+    });
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}`, {
+        config: { filamentdb_id: String(f._id), filament_colour: "#112233" },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.color).toBeNull(); // echo suppressed (resolvedColor undefined)
+    expect(fresh.colorName).toBe("Rainbow"); // so name is NOT cleared
+  });
+
   it("#872 — a per-nozzle sync with an out-of-range baked calibration value is rejected with 400 (nothing persisted)", async () => {
     const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
     const f = await Filament.create({

--- a/tests/trash-route.test.ts
+++ b/tests/trash-route.test.ts
@@ -252,7 +252,9 @@ describe("Filament trash workflow", () => {
     const res = await permanentDelete(String(parent._id));
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toMatch(/variants in the trash/i);
+    // GH #884: error reworded to "still has variants" (the guard counts ALL
+    // non-purged variants — active or trashed — not just trashed ones).
+    expect(body.error).toMatch(/still has variants/i);
 
     // Permanently delete the variant first → parent purge then succeeds.
     // After variant purge the variant is a `_purged` tombstone, which the


### PR DESCRIPTION
Two filament `[id]` route fixes, batched (same file).

### #885 — sync-back leaves stale `colorName`
The sync-back handler wrote the primary hex but never touched the paired `colorName`, so after a slicer color change the stored name kept describing the old hex (name chip + CSV/XLSX exports). Now clears `colorName` when the synced hex actually changes the color. **Gated on `resolvedColor !== undefined`** so the #883/#913 coextruded-echo suppression path (which intentionally leaves `color` unwritten) doesn't clear the name. Cleared rather than reverse-looked-up — an arbitrary slicer hex won't reliably map to a named color.

### #884 — permanent-delete variant guard comment vs query
The `?permanent=true` guard's comment claimed it counts only *trashed* variants, but the query has no `_deletedAt` clause and counts **all** non-purged variants (active or trashed). No functional bug — the guard is stricter than the comment — but a maintainer "fixing" the query to match could let a purge orphan an active variant. Reworded the comment to match the (safe, broader) query + warn against narrowing it; reworded the error string to drop the inaccurate "in the trash". No query change.

**Tests:** #885 — changed-color clears name, same-color keeps it, coextruded-echo leaves it untouched (3 cases). #884 — updated the existing orphan-refusal assertion to the new error text.

@codex review