### PR TITLE
fix(inventory): compute last-dried as MAX cycle date, not last array element (#887)

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -179,8 +179,18 @@ export async function GET() {
       for (const s of f.spools || []) {
         if (s.retired) continue;
         const cycles = s.dryCycles || [];
-        const lastCycle = cycles.length > 0 ? cycles[cycles.length - 1].date : null;
-        const lastCycleMs = lastCycle ? new Date(lastCycle).getTime() : 0;
+        // GH #887: take the MAX date, not the last element — the dry-cycle POST
+        // honors an arbitrary client `date` and appends with no sort, so a
+        // backdated cycle would otherwise be read as the most-recent dry.
+        let lastCycleMs = 0;
+        let lastCycle: typeof cycles[number]["date"] | null = null;
+        for (const c of cycles) {
+          const t = c.date ? new Date(c.date).getTime() : 0;
+          if (t > lastCycleMs) {
+            lastCycleMs = t;
+            lastCycle = c.date;
+          }
+        }
         if (now - lastCycleMs > dryThresholdMs) {
           dryDue.push({
             filamentId: String(f._id),

--- a/src/app/api/spools/by-location/route.ts
+++ b/src/app/api/spools/by-location/route.ts
@@ -309,20 +309,12 @@ export async function GET(request: NextRequest) {
               // AggregatedSpool field comment above. The /inventory page
               // lazy-loads photos when expanding a row.
               dryCycleCount: { $size: { $ifNull: ["$spools.dryCycles", []] } },
-              lastDryAt: {
-                // Latest dryCycles[].date if any. Subdocs are appended
-                // chronologically; the last element is the newest.
-                $let: {
-                  vars: { cycles: { $ifNull: ["$spools.dryCycles", []] } },
-                  in: {
-                    $cond: [
-                      { $gt: [{ $size: "$$cycles" }, 0] },
-                      { $arrayElemAt: ["$$cycles.date", -1] },
-                      null,
-                    ],
-                  },
-                },
-              },
+              // GH #887: the MAX date over dryCycles, NOT the last element.
+              // The POST honors an arbitrary client `date` and $pushes with no
+              // $sort, so a backdated cycle lands last — taking the last element
+              // would report that older date as "last dried". $max over an
+              // empty/missing array yields null.
+              lastDryAt: { $max: "$spools.dryCycles.date" },
               filamentId: "$_id",
               filamentName: "$name",
               // Use the same EFFECTIVE values the filter stages used so

--- a/src/app/api/spools/by-location/route.ts
+++ b/src/app/api/spools/by-location/route.ts
@@ -312,9 +312,18 @@ export async function GET(request: NextRequest) {
               // GH #887: the MAX date over dryCycles, NOT the last element.
               // The POST honors an arbitrary client `date` and $pushes with no
               // $sort, so a backdated cycle lands last — taking the last element
-              // would report that older date as "last dried". $max over an
-              // empty/missing array yields null.
-              lastDryAt: { $max: "$spools.dryCycles.date" },
+              // would report that older date as "last dried". A $reduce makes
+              // the per-document array traversal unambiguous (this is an
+              // EXPRESSION nested in $push, not a $group accumulator): $max with
+              // two scalar args ignores the null seed, so an empty/missing array
+              // yields null.
+              lastDryAt: {
+                $reduce: {
+                  input: { $ifNull: ["$spools.dryCycles", []] },
+                  initialValue: null,
+                  in: { $max: ["$$value", "$$this.date"] },
+                },
+              },
               filamentId: "$_id",
               filamentName: "$name",
               // Use the same EFFECTIVE values the filter stages used so

--- a/tests/dashboard-route.test.ts
+++ b/tests/dashboard-route.test.ts
@@ -118,6 +118,33 @@ describe("/api/dashboard — dry-cycle inheritance", () => {
       .map((d) => d.filamentId);
     expect(ids).not.toContain(String(variant._id));
   });
+
+  it("#887: uses the MAX dryCycles date, so a recent dry stored before a backdated one is not 'due'", async () => {
+    const f = await Filament.create({
+      name: "Backdated dry PA",
+      vendor: "Test",
+      type: "PA",
+      dryingTemperature: 80,
+      dryingTime: 480,
+      spools: [
+        {
+          label: "Out of order",
+          totalWeight: 1000,
+          // Recent dry stored FIRST, an older backdated cycle appended LAST.
+          // Taking the last element (the old date) would wrongly mark this due.
+          dryCycles: [
+            { date: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), tempC: 80, durationMin: 480, notes: "" },
+            { date: new Date(Date.now() - 200 * 24 * 60 * 60 * 1000), tempC: 80, durationMin: 480, notes: "" },
+          ],
+        },
+      ],
+    });
+
+    const res = await getDashboard();
+    const body = await res.json();
+    const ids = (body.dryDue as { filamentId: string }[]).map((d) => d.filamentId);
+    expect(ids).not.toContain(String(f._id)); // newest dry is 3 days ago → not due
+  });
 });
 
 /**

--- a/tests/spools-by-location-route.test.ts
+++ b/tests/spools-by-location-route.test.ts
@@ -95,6 +95,36 @@ describe("GET /api/spools/by-location", () => {
     expect(shelfGroup.spools[0].instanceId).toMatch(/^[0-9a-f]{10}$/);
   });
 
+  it("#887: lastDryAt is the MAX dryCycles date, not the last-appended (backdated cycle)", async () => {
+    const shelf = await Location.create({ name: "Shelf", kind: "shelf" });
+    await Filament.create({
+      name: "Dried PLA",
+      vendor: "QA",
+      type: "PLA",
+      diameter: 1.75,
+      spools: [
+        {
+          label: "S1",
+          totalWeight: 1000,
+          locationId: shelf._id,
+          // Stored OUT of chronological order: the newest cycle is first, an
+          // older backdated cycle is appended last (what the no-$sort $push
+          // produces when a user backfills a past dry).
+          dryCycles: [
+            { date: new Date("2026-06-01T00:00:00Z"), temperature: 55, durationHours: 6 },
+            { date: new Date("2026-01-15T00:00:00Z"), temperature: 55, durationHours: 6 },
+          ],
+        },
+      ],
+    });
+
+    const { GET } = await import("@/app/api/spools/by-location/route");
+    const body = await (await GET(req())).json();
+    const spool = body.groups.flatMap((g: { spools: { label: string; lastDryAt: string }[] }) => g.spools)
+      .find((s: { label: string }) => s.label === "S1");
+    expect(new Date(spool.lastDryAt).toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+
   it("totalGrams subtracts INHERITED parent tare for variant spools (Codex P2 #391)", async () => {
     // Regression test for the over-report: when a variant has no
     // spoolWeight of its own but its parent does, the aggregation


### PR DESCRIPTION
Fixes #887.

The dry-cycle POST honors an arbitrary client `date` and `$push`es with no `$sort`, so a **backdated** dry cycle lands last in the array. Two readers took the last element as 'newest', so a backfilled past cycle was reported as the most-recent dry:

- **/inventory** (`spools/by-location`): `$arrayElemAt[-1]` → replaced with `$max` over `dryCycles.date` (`$max` yields null on empty/missing).
- **dashboard** 'needs drying' tile: `cycles[length-1].date` → replaced with a max-by-time loop (so a recent dry stored before a backdated one no longer flags the spool as due).

**Tests:** both routes seed out-of-order `dryCycles` (recent first, older appended last) and assert the newest date wins.

@codex review