### PR TITLE
fix(snapshot): cap raw body before buffering (#889) + field-gate array ObjectId coercion (#890)

### DIFF
--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
+import { checkContentLength } from "@/lib/apiErrorHandler";
 import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
@@ -30,6 +31,15 @@ const OID_FIELDS = new Set([
   "filamentId",
   "spoolId",
 ]);
+/**
+ * GH #890: the ObjectId-array fields. The array branch of restoreTypes must
+ * coerce a 24-hex string element to an ObjectId ONLY for these keys — mirroring
+ * the field-gated scalar path (OID_FIELDS). Without this gate it coerced EVERY
+ * 24-hex array element regardless of field name, so a future string-array field
+ * whose values happened to be 24 hex chars would have its type silently changed
+ * on restore. The only ObjectId arrays in the schema are the two nozzle arrays.
+ */
+const OID_ARRAY_FIELDS = new Set(["compatibleNozzles", "installedNozzles"]);
 const DATE_FIELDS = new Set([
   "createdAt",
   "updatedAt",
@@ -43,8 +53,11 @@ const DATE_FIELDS = new Set([
 
 /**
  * Recursively restore ObjectId and Date fields that were serialized as strings.
- * Handles _id, parentId, array elements in compatibleNozzles/installedNozzles,
- * nested refs in calibrations/spools, and timestamp fields.
+ * Handles _id, parentId, ObjectId-array elements (only the keys in
+ * OID_ARRAY_FIELDS — compatibleNozzles/installedNozzles), nested refs in
+ * calibrations/spools, and timestamp fields. Array-element ObjectId coercion is
+ * field-gated (GH #890) so a non-ObjectId 24-hex string in any other array
+ * round-trips as a string.
  */
 function restoreTypes(doc: Record<string, unknown>): Record<string, unknown> {
   for (const [key, val] of Object.entries(doc)) {
@@ -58,7 +71,9 @@ function restoreTypes(doc: Record<string, unknown>): Record<string, unknown> {
       }
     } else if (Array.isArray(val)) {
       doc[key] = val.map((item) => {
-        if (typeof item === "string" && OID_RE.test(item)) {
+        // GH #890: gate on the key, mirroring the scalar path — only coerce
+        // 24-hex elements of the known ObjectId arrays, never any 24-hex string.
+        if (typeof item === "string" && OID_RE.test(item) && OID_ARRAY_FIELDS.has(key)) {
           return new mongoose.Types.ObjectId(item);
         }
         if (typeof item === "object" && item !== null && !Array.isArray(item)) {
@@ -222,6 +237,11 @@ async function restoreSnapshot(request: NextRequest) {
       const text = await file.text();
       snapshot = JSON.parse(text);
     } else {
+      // GH #889: cap the raw body via Content-Length BEFORE buffering it, so a
+      // multi-GB body can't force full allocation before the post-buffer guard
+      // fires (the sibling raw-body routes — prusaslicer, nfc/decode — do this).
+      const lenError = checkContentLength(request, MAX_SNAPSHOT_SIZE);
+      if (lenError) return lenError;
       const text = await request.text();
       if (text.length > MAX_SNAPSHOT_SIZE) {
         return NextResponse.json(

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -243,7 +243,12 @@ async function restoreSnapshot(request: NextRequest) {
       const lenError = checkContentLength(request, MAX_SNAPSHOT_SIZE);
       if (lenError) return lenError;
       const text = await request.text();
-      if (text.length > MAX_SNAPSHOT_SIZE) {
+      // Codex P2 (#890→#920): measure BYTES, not UTF-16 code units. When the
+      // Content-Length header is missing/wrong the preflight above doesn't fire,
+      // so this belt-and-suspenders check is the only byte cap — and multi-byte
+      // text would slip past a `text.length` (code-unit) comparison. Matches the
+      // sibling raw-body routes' `Buffer.byteLength(body, "utf8")`.
+      if (Buffer.byteLength(text, "utf8") > MAX_SNAPSHOT_SIZE) {
         return NextResponse.json(
           { error: `Snapshot too large (max ${MAX_SNAPSHOT_SIZE / 1024 / 1024}MB)` },
           { status: 413 },

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -125,6 +125,64 @@ describe("snapshot route — bedTypes round-trip", () => {
     expect(bedTypes).toHaveLength(0);
   });
 
+  it("#889: rejects a raw body whose declared Content-Length exceeds the cap (413, no buffering)", async () => {
+    const req = new NextRequest("http://localhost/api/snapshot", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(51 * 1024 * 1024), // > 50 MB cap
+      },
+      body: JSON.stringify({ version: 2, createdAt: new Date().toISOString(), collections: {} }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+  });
+
+  it("#890: restore coerces ObjectId-array fields but leaves other 24-hex string arrays as strings", async () => {
+    const nozzleHex = "aaaaaaaaaaaaaaaaaaaaaaaa"; // valid 24-hex → real nozzle ref
+    const notARef = "bbbbbbbbbbbbbbbbbbbbbbbb"; // 24-hex but NOT an ObjectId field
+    const snapshot = {
+      version: 2,
+      createdAt: new Date().toISOString(),
+      collections: {
+        filaments: [
+          {
+            name: "Coerce guard",
+            vendor: "QA",
+            type: "PLA",
+            // A 24-hex string riding in the Mixed settings bag inside an array.
+            // The array branch must NOT coerce it (key isn't an OID array field).
+            settings: { customRefs: [notARef] },
+          },
+        ],
+        nozzles: [],
+        printers: [
+          {
+            name: "P1",
+            manufacturer: "X",
+            printerModel: "1",
+            installedNozzles: [nozzleHex], // genuine ObjectId array → must coerce
+          },
+        ],
+      },
+    };
+    const req = new NextRequest("http://localhost/api/snapshot", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(snapshot),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const printer = await Printer.findOne({ name: "P1" }).lean();
+    expect(printer.installedNozzles[0]).toBeInstanceOf(mongoose.Types.ObjectId);
+    expect(String(printer.installedNozzles[0])).toBe(nozzleHex);
+
+    const fil = await Filament.findOne({ name: "Coerce guard" }).lean();
+    expect(typeof fil.settings.customRefs[0]).toBe("string"); // NOT coerced to ObjectId
+    expect(fil.settings.customRefs[0]).toBe(notARef);
+  });
+
   /**
    * GH #158 regression guard.
    *


### PR DESCRIPTION
Two snapshot-restore hardening fixes, batched (same file).

### #889 — raw body buffered before size check
The non-multipart restore branch buffered the entire body via `request.text()` *before* the 50 MB `text.length` check — a same-origin / non-browser client (curl, the desktop renderer) could force full allocation of a multi-GB body. Added `checkContentLength` (the GH #676 helper the sibling `prusaslicer` / `nfc-decode` raw-body routes already use) to short-circuit on `Content-Length` before buffering; the post-buffer check stays as belt-and-suspenders.

### #890 — array ObjectId coercion ignored the field name
`restoreTypes` coerced **every** 24-hex array element to an `ObjectId` regardless of key — asymmetric to the field-gated scalar path. A future (or `settings`-bag) string array whose elements happened to be 24 hex chars would have its type silently changed on restore. Added `OID_ARRAY_FIELDS = {compatibleNozzles, installedNozzles}` and gated the array coercion on it. Object-element recursion stays unconditional; docstring corrected.

**Tests:** #889 — oversized `Content-Length` → 413. #890 — `installedNozzles` 24-hex still coerces to ObjectId; a 24-hex string in a `settings` array round-trips as a string.

@codex review