### PR TITLE
fix(slicer): guard inverted nozzle range on Bambu import (#892) + dedup per-id Bambu route (#893)

### DIFF
--- a/src/app/api/filaments/[id]/bambustudio/route.ts
+++ b/src/app/api/filaments/[id]/bambustudio/route.ts
@@ -11,10 +11,7 @@ import {
   parseBambuStudioProfile,
   type BambuParseResult,
 } from "@/lib/bambuStudioImport";
-import {
-  buildStructuredUpdate,
-  resolveAndApplyCalibration,
-} from "@/lib/bambuStudioApply";
+import { prepareBambuUpdate } from "@/lib/bambuStudioApply";
 import {
   assertMultipartFormData,
   checkFileSize,
@@ -22,7 +19,6 @@ import {
   errorResponseFromCaught,
 } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
-import { mergeSlicerSettings } from "@/lib/slicerSettings";
 
 /**
  * GET /api/filaments/{id}/bambustudio
@@ -204,29 +200,22 @@ export async function POST(
       parent,
     };
 
-    const { set: update, unset: unsetKeys } = buildStructuredUpdate(
-      parsed.filament,
-      existingWithParent,
-    );
-
-    const settingsResult = mergeSlicerSettings(
-      (existing.settings as Record<string, unknown>) || {},
-      parsed.filament.settings,
-      new Set(Object.keys(parsed.filament.settings).filter(() => false)),
-    );
+    // GH #893: use the shared prepareBambuUpdate (structured projection +
+    // settings merge + calibration resolve) instead of re-inlining the pipeline,
+    // so this route can't drift from the bulk route / helper.
+    const { update, unsetKeys, settingsResult, calibrationOutcome, nozzleRangeInverted } =
+      await prepareBambuUpdate(parsed, existingWithParent);
     if (settingsResult.error) {
       return errorResponse(settingsResult.error, 400);
     }
-    if (settingsResult.added.length > 0) {
-      update.settings = settingsResult.settings;
+    // GH #892: reject an inverted nozzle range (min > max) the way the
+    // OrcaSlicer sync route does — the per-field 0–600 validators can't.
+    if (nozzleRangeInverted) {
+      return errorResponse(
+        "Nozzle range minimum temperature must be less than or equal to the maximum",
+        400,
+      );
     }
-
-    const calibrationOutcome = await resolveAndApplyCalibration(
-      parsed.filament,
-      parsed.calibrationHints,
-      update,
-      existing,
-    );
 
     // Never touch spool subdocs on a sync — that's strictly inventory
     // state and not in the Bambu file.

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -10,11 +10,7 @@ import {
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
-import {
-  isInvertedNozzleRange,
-  effectiveNozzleRangeForUpdate,
-  inheritNozzleRangeFromParent,
-} from "@/lib/temperatureRange";
+import { isUpdateNozzleRangeInverted } from "@/lib/temperatureRange";
 
 /**
  * Top-level body keys that map to structured Filament DB fields.
@@ -211,15 +207,16 @@ export async function POST(
     // it leaves null from its parent (resolveFilament: own ?? parent), so
     // resolve the parent's endpoints in before checking (#577).
     if (touchesNozzleRange) {
-      const own = effectiveNozzleRangeForUpdate(update, filament.temperatures);
-      let effRange = own;
+      // GH #892: shared combinator (same guard the Bambu routes use) — own
+      // effective range + parent inheritance + inversion test in one call.
+      let parentTemps = null;
       if (filament.parentId) {
         const parent = await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
           .select("temperatures.nozzleRangeMin temperatures.nozzleRangeMax")
           .lean();
-        effRange = inheritNozzleRangeFromParent(own, parent?.temperatures);
+        parentTemps = parent?.temperatures ?? null;
       }
-      if (isInvertedNozzleRange(effRange)) {
+      if (isUpdateNozzleRangeInverted(update, filament.temperatures, parentTemps)) {
         return errorResponse(
           "Nozzle range minimum temperature must be less than or equal to the maximum",
           400,

--- a/src/app/api/filaments/bambustudio/route.ts
+++ b/src/app/api/filaments/bambustudio/route.ts
@@ -5,7 +5,7 @@ import {
   parseBambuStudioProfile,
   type BambuParseResult,
 } from "@/lib/bambuStudioImport";
-import { prepareBambuUpdate } from "@/lib/bambuStudioApply";
+import { prepareBambuUpdate, type BambuUpdatePayload } from "@/lib/bambuStudioApply";
 import {
   assertMultipartFormData,
   checkFileSize,
@@ -14,6 +14,26 @@ import {
   isDuplicateKeyError,
 } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
+
+/**
+ * Per-phase validation gate for a prepared Bambu update: the settings-bag
+ * size-cap error AND the GH #892 inverted-nozzle-range guard (min > max, which
+ * the per-field 0–600 schema validators can't express — matching the OrcaSlicer
+ * sync route). Returns a 400 response, or null when the payload is clean. Used
+ * at every upsert phase so the guard can't be dropped from one of them.
+ */
+function bambuPayloadError(payload: BambuUpdatePayload): NextResponse | null {
+  if (payload.settingsResult.error) {
+    return errorResponse(payload.settingsResult.error, 400);
+  }
+  if (payload.nozzleRangeInverted) {
+    return errorResponse(
+      "Nozzle range minimum temperature must be less than or equal to the maximum",
+      400,
+    );
+  }
+  return null;
+}
 
 /**
  * POST /api/filaments/bambustudio
@@ -134,9 +154,8 @@ export async function POST(request: NextRequest) {
         parsed,
         await augmentExistingWithParent(existingActive),
       );
-      if (payload.settingsResult.error) {
-        return errorResponse(payload.settingsResult.error, 400);
-      }
+      const payloadError = bambuPayloadError(payload);
+      if (payloadError) return payloadError;
       delete (payload.update as Record<string, unknown>).spools;
       try {
         const updated = await Filament.findOneAndUpdate(
@@ -171,9 +190,8 @@ export async function POST(request: NextRequest) {
         parsed,
         await augmentExistingWithParent(existingTrashed),
       );
-      if (payload.settingsResult.error) {
-        return errorResponse(payload.settingsResult.error, 400);
-      }
+      const payloadError = bambuPayloadError(payload);
+      if (payloadError) return payloadError;
       delete (payload.update as Record<string, unknown>).spools;
       try {
         // Splice `_deletedAt: null` into the $set body so the resurrect
@@ -222,9 +240,8 @@ export async function POST(request: NextRequest) {
     }
 
     const createPayload = await prepareBambuUpdate(parsed, null);
-    if (createPayload.settingsResult.error) {
-      return errorResponse(createPayload.settingsResult.error, 400);
-    }
+    const createPayloadError = bambuPayloadError(createPayload);
+    if (createPayloadError) return createPayloadError;
     try {
       const created = await Filament.create({
         name,
@@ -250,9 +267,8 @@ export async function POST(request: NextRequest) {
         parsed,
         await augmentExistingWithParent(racing),
       );
-      if (racePayload.settingsResult.error) {
-        return errorResponse(racePayload.settingsResult.error, 400);
-      }
+      const racePayloadError = bambuPayloadError(racePayload);
+      if (racePayloadError) return racePayloadError;
       delete (racePayload.update as Record<string, unknown>).spools;
       try {
         const merged = await Filament.findOneAndUpdate(

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -25,6 +25,7 @@ import {
   type SettingsMergeResult,
 } from "@/lib/slicerSettings";
 import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
+import { isUpdateNozzleRangeInverted, type NozzleTemperatureRange } from "@/lib/temperatureRange";
 import type {
   BambuParseResult,
   CalibrationHints,
@@ -97,6 +98,12 @@ export interface BambuUpdatePayload {
    * UI can show "applied to printer X / nozzle Y" or the unresolved
    * nudge. */
   calibrationOutcome: CalibrationOutcome;
+  /** GH #892: true when the resulting EFFECTIVE nozzle range (this update's
+   * own range, with endpoints the variant leaves null inherited from its
+   * parent) is inverted (min > max). The per-field 0–600 schema validators
+   * can't express the cross-field relationship, so both Bambu routes reject
+   * with 400 when this is set — matching the OrcaSlicer sync route. */
+  nozzleRangeInverted: boolean;
 }
 
 /** Structured-projection result. `set` is the `$set` body; `unset` lists
@@ -152,7 +159,17 @@ export async function prepareBambuUpdate(
     existing,
   );
 
-  return { update, unsetKeys, settingsResult, calibrationOutcome };
+  // GH #892: reject an inverted nozzle range, mirroring the OrcaSlicer sync
+  // route. `update.temperatures` is a full replace (built from existing +
+  // parsed), so it IS the effective own range; the variant inherits any null
+  // endpoint from its already-resolved parent. The caller maps true → 400.
+  const nozzleRangeInverted = isUpdateNozzleRangeInverted(
+    update,
+    existing?.temperatures as NozzleTemperatureRange | undefined,
+    (existing?.parent?.temperatures as NozzleTemperatureRange | undefined) ?? null,
+  );
+
+  return { update, unsetKeys, settingsResult, calibrationOutcome, nozzleRangeInverted };
 }
 
 export function buildStructuredUpdate(

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -163,11 +163,23 @@ export async function prepareBambuUpdate(
   // route. `update.temperatures` is a full replace (built from existing +
   // parsed), so it IS the effective own range; the variant inherits any null
   // endpoint from its already-resolved parent. The caller maps true → 400.
-  const nozzleRangeInverted = isUpdateNozzleRangeInverted(
-    update,
-    existing?.temperatures as NozzleTemperatureRange | undefined,
-    (existing?.parent?.temperatures as NozzleTemperatureRange | undefined) ?? null,
-  );
+  //
+  // Codex P2 (#921): gate on whether THIS profile actually carried a range
+  // endpoint. buildStructuredUpdate copies the stored endpoints into
+  // update.temperatures even when the profile only set e.g. nozzle_temperature,
+  // so without this gate an unrelated sync against legacy data that already has
+  // an inverted (own or inherited) range would 400. Matches the OrcaSlicer
+  // route's `touchesNozzleRange` gate (validate only on actual range input).
+  const incoming = parsed.filament.temperatures;
+  const rangeTouched =
+    incoming?.nozzleRangeMin != null || incoming?.nozzleRangeMax != null;
+  const nozzleRangeInverted =
+    rangeTouched &&
+    isUpdateNozzleRangeInverted(
+      update,
+      existing?.temperatures as NozzleTemperatureRange | undefined,
+      (existing?.parent?.temperatures as NozzleTemperatureRange | undefined) ?? null,
+    );
 
   return { update, unsetKeys, settingsResult, calibrationOutcome, nozzleRangeInverted };
 }

--- a/src/lib/temperatureRange.ts
+++ b/src/lib/temperatureRange.ts
@@ -128,3 +128,26 @@ export function inheritNozzleRangeFromParent(
     nozzleRangeMax: o.nozzleRangeMax ?? parent?.nozzleRangeMax ?? null,
   };
 }
+
+/**
+ * GH #892: the full inverted-range guard the slicer-sync routes run, in one
+ * pure call so the three paths (OrcaSlicer sync + both Bambu import routes)
+ * can't drift. Combines the three steps:
+ *   1. compute the update's EFFECTIVE own range (`effectiveNozzleRangeForUpdate`);
+ *   2. inherit any endpoint the variant leaves null from its parent
+ *      (`inheritNozzleRangeFromParent` — pass `parentTemps = null/undefined`
+ *      for a standalone or non-variant);
+ *   3. test for inversion (`isInvertedNozzleRange`).
+ * Returns false when the update touches neither endpoint, so pre-existing bad
+ * data on an unrelated sync can't trip it. The caller loads the parent's
+ * temperatures (or passes null); this stays DB-free.
+ */
+export function isUpdateNozzleRangeInverted(
+  body: Record<string, unknown>,
+  storedTemps: NozzleTemperatureRange | null | undefined,
+  parentTemps: NozzleTemperatureRange | null | undefined,
+): boolean {
+  const own = effectiveNozzleRangeForUpdate(body, storedTemps);
+  if (own === null) return false;
+  return isInvertedNozzleRange(inheritNozzleRangeFromParent(own, parentTemps));
+}

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -558,6 +558,29 @@ describe("Bambu Studio importer routes", () => {
       expect(res.status).toBe(400);
     });
 
+    it("#921: an unrelated sync (no range fields) does NOT 400 on a filament with a pre-existing inverted range", async () => {
+      // Per-field validators allow min/max individually, so legacy data can hold
+      // an inverted range. A profile that only updates nozzle_temperature must
+      // still apply — the range guard only fires on actual range input.
+      const target = await Filament.create({
+        name: "Legacy Bad Range",
+        vendor: "QA",
+        type: "PLA",
+        diameter: 1.75,
+        temperatures: { nozzle: 200, nozzleRangeMin: 300, nozzleRangeMax: 200 },
+      });
+      const { POST } = await import("@/app/api/filaments/[id]/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          `http://localhost/api/filaments/${target._id}/bambustudio`,
+          minimalProfile({ nozzle_temperature: ["215"] }), // no range fields
+        ),
+        { params: Promise.resolve({ id: String(target._id) }) },
+      );
+      expect(res.status).toBe(200);
+      expect((await Filament.findById(target._id)).temperatures.nozzle).toBe(215);
+    });
+
     it("#892: rejects an inverted nozzle range (min > max) with 400, nothing persisted", async () => {
       const target = await Filament.create({
         name: "Range Target",

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -84,6 +84,22 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.temperatures.bed).toBe(60);
     });
 
+    it("#892: rejects an inverted nozzle range (min > max) on create with 400", async () => {
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            filament_settings_id: ["Inverted Range PLA"],
+            nozzle_temperature_range_low: ["300"],
+            nozzle_temperature_range_high: ["200"],
+          }),
+        ),
+      );
+      expect(res.status).toBe(400);
+      expect(await Filament.findOne({ name: "Inverted Range PLA" })).toBeNull(); // not created
+    });
+
     it("updates an existing filament when the name matches (raw JSON body)", async () => {
       await Filament.create({
         name: "QA Bambu PLA",
@@ -540,6 +556,30 @@ describe("Bambu Studio importer routes", () => {
         { params: Promise.resolve({ id: "not-an-id" }) },
       );
       expect(res.status).toBe(400);
+    });
+
+    it("#892: rejects an inverted nozzle range (min > max) with 400, nothing persisted", async () => {
+      const target = await Filament.create({
+        name: "Range Target",
+        vendor: "QA",
+        type: "PLA",
+        diameter: 1.75,
+        temperatures: { nozzle: 210 },
+      });
+      const { POST } = await import("@/app/api/filaments/[id]/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          `http://localhost/api/filaments/${target._id}/bambustudio`,
+          minimalProfile({
+            nozzle_temperature_range_low: ["300"],
+            nozzle_temperature_range_high: ["200"],
+          }),
+        ),
+        { params: Promise.resolve({ id: String(target._id) }) },
+      );
+      expect(res.status).toBe(400);
+      const stored = await Filament.findById(target._id);
+      expect(stored.temperatures?.nozzleRangeMin ?? null).toBeNull(); // not written
     });
 
     it("returns 404 if the filament is soft-deleted between findOne and updateOne (Codex P2 #387 r6)", async () => {

--- a/tests/temperatureRange.test.ts
+++ b/tests/temperatureRange.test.ts
@@ -3,6 +3,7 @@ import {
   isInvertedNozzleRange,
   effectiveNozzleRangeForUpdate,
   inheritNozzleRangeFromParent,
+  isUpdateNozzleRangeInverted,
 } from "@/lib/temperatureRange";
 
 describe("isInvertedNozzleRange", () => {
@@ -122,5 +123,28 @@ describe("inheritNozzleRangeFromParent (Codex P2 r3 on #577)", () => {
 
   it("returns null when neither own nor parent carries a range", () => {
     expect(inheritNozzleRangeFromParent(null, null)).toBe(null);
+  });
+});
+
+describe("isUpdateNozzleRangeInverted (#892 — shared slicer-sync guard)", () => {
+  it("flags a full temperatures replace whose own range is inverted", () => {
+    const update = { temperatures: { nozzleRangeMin: 300, nozzleRangeMax: 200 } };
+    expect(isUpdateNozzleRangeInverted(update, undefined, null)).toBe(true);
+  });
+
+  it("passes a valid own range", () => {
+    const update = { temperatures: { nozzleRangeMin: 200, nozzleRangeMax: 260 } };
+    expect(isUpdateNozzleRangeInverted(update, undefined, null)).toBe(false);
+  });
+
+  it("returns false when the update touches neither endpoint (unrelated sync)", () => {
+    const update = { temperatures: { nozzle: 210 } };
+    expect(isUpdateNozzleRangeInverted(update, { nozzleRangeMin: 300, nozzleRangeMax: 100 }, null)).toBe(false);
+  });
+
+  it("flags an inversion that only emerges after inheriting the parent's endpoint", () => {
+    // Variant sets only min=300; inherits parent max=200 → effective 300>200.
+    const update = { temperatures: { nozzleRangeMin: 300 } };
+    expect(isUpdateNozzleRangeInverted(update, undefined, { nozzleRangeMax: 200 })).toBe(true);
   });
 });


### PR DESCRIPTION
Two Bambu-import fixes, batched (same area).

### #893 — per-id route duplicated the apply pipeline
The per-id sync route hand-inlined `buildStructuredUpdate` + `mergeSlicerSettings` + `resolveAndApplyCalibration` — the exact sequence the shared `prepareBambuUpdate` centralises and the bulk route already uses — including a misleading dead `new Set(Object.keys(...).filter(() => false))`. Replaced with `prepareBambuUpdate` so the two paths can't drift. Dropped the now-unused imports.

### #892 — Bambu routes skipped the inverted-nozzle-range guard
Both Bambu routes persisted an inverted range (`min > max`) that the OrcaSlicer sync route rejects (the per-field 0–600 validators can't express the cross-field relationship). Added a shared pure combinator **`isUpdateNozzleRangeInverted(body, ownTemps, parentTemps)`** (own effective range → parent inheritance → inversion test). `prepareBambuUpdate` now returns a `nozzleRangeInverted` flag that **both** Bambu routes map to 400 (via a shared per-phase `bambuPayloadError` gate on the bulk route). **Refactored the OrcaSlicer route to call the same combinator** so all three slicer-sync paths share one implementation.

**Tests:** unit tests for the combinator (incl. inheritance-induced inversion); per-id + bulk routes reject an inverted range with 400 and persist nothing; existing orca #618 range tests still pass.

@codex review