### PR TITLE
fix(opentag3d): transparent-black primary maps to no color, not phantom #000000 (#895)

### DIFF
--- a/src/lib/opentag3d-decode.ts
+++ b/src/lib/opentag3d-decode.ts
@@ -75,7 +75,17 @@ export function ot3dToDecodedTag(decoded: Ot3dDecoded): DecodedOpenPrintTag {
   if (mod) aux.opentag3d_material_modifier = mod;
 
   // ── colors ──
-  const color = f.color_1 ? rgbaToHex(f.color_1 as Ot3dRgba) : undefined;
+  // GH #895: treat a transparent-black primary (r=g=b=a=0, the spec's "unused
+  // color" sentinel) as NO primary, matching the secondary-slot loop below.
+  // The decoder keeps color_1 even when transparent-black; mapping it by
+  // truthiness alone yielded a phantom "#000000" primary (rgbaToHex drops
+  // alpha) that broke the coextruded null-primary invariant in
+  // decodedTagToFilament. A real opaque-black tag has a=255, so isTransparentBlack
+  // distinguishes it and it is unaffected.
+  const color =
+    f.color_1 && !isTransparentBlack(f.color_1 as Ot3dRgba)
+      ? rgbaToHex(f.color_1 as Ot3dRgba)
+      : undefined;
   const secondaryColors: string[] = [];
   for (const id of ["color_2", "color_3", "color_4"]) {
     const c = f[id] as Ot3dRgba | undefined;

--- a/tests/opentag3d.test.ts
+++ b/tests/opentag3d.test.ts
@@ -227,6 +227,25 @@ describe("ot3dToDecodedTag mapping → DecodedOpenPrintTag", () => {
     expect(tag.secondaryColors).toEqual(["#0000FF"]);
   });
 
+  it("#895: a transparent-black primary maps to NO color, not phantom #000000", () => {
+    const coex = decodeOpenTag3DTag(
+      encodeOpenTag3D({
+        material_base: "PLA",
+        color_name: "Coextruded",
+        color_1: { r: 0, g: 0, b: 0, a: 0 }, // spec "unused color" sentinel
+        color_2: { r: 17, g: 34, b: 51, a: 255 },
+      }),
+    );
+    expect(coex.color).toBeUndefined(); // NOT "#000000"
+    expect(coex.secondaryColors).toEqual(["#112233"]);
+
+    // Regression: a real OPAQUE-black primary (a=255) still maps to #000000.
+    const black = decodeOpenTag3DTag(
+      encodeOpenTag3D({ material_base: "PLA", color_name: "Black", color_1: { r: 0, g: 0, b: 0, a: 255 } }),
+    );
+    expect(black.color).toBe("#000000");
+  });
+
   it("gives two colors of the same material DISTINCT default names (Codex P2)", () => {
     const red = decodeOpenTag3DTag(
       encodeOpenTag3D({ material_base: "PLA", color_name: "Red", color_1: { r: 255, g: 0, b: 0, a: 255 } }),


### PR DESCRIPTION
Fixes #895.

The OpenTag3D decoder keeps `color_1` even when it's the spec's transparent-black (`r=g=b=a=0`) "unused color" sentinel (the secondary slots use it as "unused"). `ot3dToDecodedTag` mapped the primary by **truthiness alone**, so `rgbaToHex` (which drops alpha) turned `{0,0,0,0}` into a phantom `#000000` primary on a coextruded / no-primary tag — and that truthy value short-circuits the null-primary fallback in `decodedTagToFilament`, breaking the coextruded null-primary invariant the rest of the app maintains.

Gate the primary on `!isTransparentBlack` (already imported), matching the secondary-slot loop two lines below. A real **opaque**-black tag has `a=255`, so `isTransparentBlack` distinguishes it — unaffected.

**Test:** transparent-black primary + populated secondary → `color === undefined` (not `#000000`); opaque-black primary still maps to `#000000`.

@codex review