### PR TITLE
fix(match): anchor the vendor regex in the confident vendor+type auto-match (#896)

### DIFF
--- a/src/lib/matchFilament.ts
+++ b/src/lib/matchFilament.ts
@@ -194,10 +194,16 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
   }
 
   // 2. Vendor + type match. A confident auto-match requires BOTH to agree.
+  // GH #896: anchor the vendor regex to a full-string match (`^…$`), matching
+  // the name + type tiers. Unanchored, a scanned vendor was a SUBSTRING match
+  // ("Sun" → "Sunlu"), so a substring collision yielding a single vendor+type
+  // hit silently auto-resolved to a DIFFERENT vendor's filament with no chooser.
+  // (The vendor-ONLY suggestions tier below stays unanchored — it only ever
+  // returns `candidates`, so substring there is harmless.)
   const vendorTypeMatches =
     vendor && type
       ? await Filament.find({
-          vendor: { $regex: escapeRegex(vendor), $options: "i" },
+          vendor: { $regex: `^${escapeRegex(vendor)}$`, $options: "i" },
           type: { $regex: `^${escapeRegex(type)}$`, $options: "i" },
           _deletedAt: null,
         })

--- a/tests/filaments-match-route.test.ts
+++ b/tests/filaments-match-route.test.ts
@@ -51,6 +51,22 @@ describe("/api/filaments/match", () => {
     expect(body.candidates).toEqual([]);
   });
 
+  it("#896: does NOT confidently match when the scanned vendor is only a SUBSTRING of the stored vendor", async () => {
+    // "Sun" must not auto-resolve to "Sunlu" — the vendor regex is anchored, so
+    // a substring brand can't silently select a different vendor's filament.
+    await Filament.create({ name: "Sunlu PLA Meta", vendor: "Sunlu", type: "PLA" });
+    const res = await matchFilaments(
+      matchReq({ name: "Some Tag", vendor: "Sun", type: "PLA" }),
+    );
+    const body = await res.json();
+    expect(body.match).toBeNull(); // no confident substring match
+    // exact vendor still resolves confidently
+    const exact = await matchFilaments(
+      matchReq({ name: "Some Tag", vendor: "Sunlu", type: "PLA" }),
+    );
+    expect((await exact.json()).match?.name).toBe("Sunlu PLA Meta");
+  });
+
   it("returns multiple vendor+type hits as candidates, with no auto-match", async () => {
     await Filament.create({ name: "Bambu PC Black", vendor: "Bambu Lab", type: "PC" });
     await Filament.create({ name: "Bambu PC Clear", vendor: "Bambu Lab", type: "PC" });


### PR DESCRIPTION
Fixes #896.

In `matchFilament` the confident vendor+type tier matched `vendor` with an **unanchored** case-insensitive regex, while the sibling `name` and `type` checks are anchored full-string matches. So a scanned vendor was a **substring** match — `"Sun"` matches stored `"Sunlu"`, `"Pro"` matches `"Prusament"`, etc. When that collision (with the anchored type filter) yielded exactly one row, it was returned as a *confident* match — the scan path silently selects a filament from a **different vendor** with no chooser.

Anchored the vendor regex to `^…$` (case-insensitive), matching the name/type tiers. The vendor-**only** suggestions tier stays unanchored — substring there is harmless because it only ever returns `candidates`.

**Test:** `{vendor: "Sun", type: "PLA"}` no longer confidently matches stored `"Sunlu"`; exact `"Sunlu"` still does.

@codex review