### PR TITLE
fix(optresync): case-fold secondaryColors in variant prune (#928)

### DIFF
--- a/src/lib/optResync.ts
+++ b/src/lib/optResync.ts
@@ -436,7 +436,11 @@ export function pruneOptPayloadAgainstParent(
   for (const field of PRUNE_ARRAY_FIELDS) {
     const v = pruned[field];
     if (!Array.isArray(v) || v.length === 0) continue;
-    if (valuesEqual(v as string[], getPath(parentEffective, field))) {
+    // GH #928: use the case-folding compare for hex-color fields — a variant's
+    // secondaryColors that differ from the parent's only by case (#AABBCC vs
+    // #aabbcc) should still prune to inherit. valuesEqualForField is a no-op for
+    // the non-color array field (optTags), so this is safe for the whole set.
+    if (valuesEqualForField(field, v as OptValue, getPath(parentEffective, field))) {
       pruned[field] = [];
     }
   }

--- a/tests/optResync.test.ts
+++ b/tests/optResync.test.ts
@@ -418,6 +418,16 @@ describe("pruneOptPayloadAgainstParent (Issue #753)", () => {
     expect(pruned.optTags).toEqual([99]); // differs → kept
   });
 
+  it("#928: prunes secondaryColors that match the parent only by case", () => {
+    // OPT stores lower-case hex; the parent's effective colors are upper-case.
+    // A casing-only difference must still prune so the variant inherits.
+    const p = payload({ secondaryColors: ["#aabbcc", "#001122"] });
+    const pruned = pruneOptPayloadAgainstParent(p, {
+      secondaryColors: ["#AABBCC", "#001122"],
+    });
+    expect(pruned.secondaryColors).toEqual([]); // case-insensitively equal → inherit
+  });
+
   it("returns the payload unchanged when there is no parent", () => {
     const p = payload();
     expect(pruneOptPayloadAgainstParent(p, null)).toBe(p);


### PR DESCRIPTION
## Summary
`#894` made the OpenPrintTag re-sync **diff** compare hex colors case-insensitively, but `pruneOptPayloadAgainstParent` — the *create-variant-from-OpenPrintTag* path (#753) — still compared `secondaryColors` with raw `valuesEqual` ([optResync.ts:439](https://github.com/hyiger/filament-db/blob/main/src/lib/optResync.ts#L439)).

So when importing an OPT material **as a variant**, a `secondaryColors` array that matched the parent's effective colors only by **case** (`#aabbcc` vs `#AABBCC`) failed to prune → the variant kept redundant own-case colors instead of inheriting from the parent.

## Fix
Use the existing case-folding `valuesEqualForField` (added in #894) in the array-prune loop. It's a no-op for the only non-color array field (`optTags`), so it's safe for the whole `PRUNE_ARRAY_FIELDS` set. The scalar `color` isn't pruned there (variant-only), so this is the last case-sensitive color comparison in the OPT path.

## Test
`tests/optResync.test.ts` — new case: secondaryColors matching the parent only by case prune to `[]` (inherit).

Fixes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)