### PR TITLE
fix(openprinttag): fix OPT browse timeout on Win

### DIFF
--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -416,14 +416,15 @@ export default function OpenPrintTagBrowser() {
       // #743: a backstop against a truly-stuck request (the real "whole app
       // hangs" cause — a synchronous parse blocking the event loop — is fixed
       // server-side). This MUST exceed the server's worst-case window so it
-      // never pre-empts the legitimate slow paths: the server retries the
-      // GitHub fetch up to 3×60s + backoff (~183s) and then serves a stale
-      // cached DB (GH #225) — a cached user on a flaky network must still get
-      // that stale data, not a premature timeout (Codex P2). 240s clears the
-      // ~183s server window with margin; the single-flight means a retry after
-      // a timeout joins the in-progress load rather than duplicating it.
+      // never pre-empts the legitimate slow paths: the server retries only the
+      // GitHub download (3×45s + ~3.2s backoff ≈ 138s), then extracts/parses
+      // ONCE (≤120s), then serves a stale cached DB (GH #225) — a cached user
+      // on a flaky network must still get that stale data, not a premature
+      // timeout (PR #933 review). 300s (5 min) clears the ~258s server window
+      // with margin; the single-flight means a retry after a timeout joins the
+      // in-progress load rather than duplicating it.
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 240_000);
+      const timeout = setTimeout(() => controller.abort(), 300_000);
       try {
         // GH #427: refresh moved from `GET ?refresh=true` to POST so
         // the cache-mutation isn't a GET-with-side-effect.

--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -417,12 +417,15 @@ export default function OpenPrintTagBrowser() {
       // hangs" cause — a synchronous parse blocking the event loop — is fixed
       // server-side). This MUST exceed the server's worst-case window so it
       // never pre-empts the legitimate slow paths: the server retries only the
-      // GitHub download (3×45s + ~3.2s backoff ≈ 138s), then extracts/parses
-      // ONCE (≤120s), then serves a stale cached DB (GH #225) — a cached user
-      // on a flaky network must still get that stale data, not a premature
-      // timeout (PR #933 review). 300s (5 min) clears the ~258s server window
-      // with margin; the single-flight means a retry after a timeout joins the
-      // in-progress load rather than duplicating it.
+      // GitHub download (3×45s + ~3.2s backoff ≈ 138s), then extracts ONCE
+      // under a 120s pipeline deadline (the YAML parse loop that follows is
+      // unbounded — CPU-bound, yields every 256 files, runs once per cold
+      // load), then serves a stale cached DB (GH #225) — a cached user on a
+      // flaky network must still get that stale data, not a premature timeout
+      // (PR #933 review). 300s (5 min) clears the ~258s server window with
+      // ~42s of margin for the unbounded parse; the single-flight means a
+      // retry after a timeout joins the in-progress load rather than
+      // duplicating it.
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 300_000);
       try {

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -583,6 +583,15 @@ async function runFetchWithRetries(): Promise<OPTDatabase> {
 // only once. Worst case: MAX_ATTEMPTS × DOWNLOAD_TIMEOUT_MS + backoff(3.2s) +
 // EXTRACT_TIMEOUT_MS = 3×45 + 3.2 + 120 ≈ 258s, comfortably under the client's
 // 300s (5 min) abort.
+//
+// Strictly: EXTRACT_TIMEOUT_MS bounds the gunzip→counter→tar.x PIPELINE only.
+// `clearTimeout(extractTimer)` fires right after the pipeline resolves, so the
+// YAML parse loop that follows has NO deadline. That's fine in practice —
+// parse is CPU-bound, yields to the event loop every 256 files, and runs once
+// per cold load — but a pathologically slow parse can still eat into the ~42s
+// margin between the 258s server window and the 300s client abort. If parse
+// ever takes long enough to matter, give it its own per-file or whole-loop
+// budget rather than widening EXTRACT_TIMEOUT_MS, which only governs unpack.
 const MAX_ATTEMPTS = 3;
 const DOWNLOAD_TIMEOUT_MS = 45_000;
 const EXTRACT_TIMEOUT_MS = 120_000;
@@ -591,6 +600,12 @@ const EXTRACT_TIMEOUT_MS = 120_000;
 // tarball is ~3 MB; 128 MB is generous headroom. (The decompressed-size /
 // file-count tar-bomb guard still runs during extraction below.)
 const MAX_DOWNLOAD_BYTES = 128 * 1024 * 1024;
+// Cap the DECOMPRESSED stream during extract. A counting Transform between
+// gunzip and tar.x trips this against bytes actually streamed (not the lyable
+// header `size`). Injectable into extractAndParse so the trip can be unit-
+// tested without allocating 256 MB; production uses the default.
+const MAX_TARBALL_EXTRACT_BYTES = 256 * 1024 * 1024;
+const MAX_TARBALL_FILES = 50_000;
 
 /**
  * Retry the network download (exponential backoff) and return the compressed
@@ -730,9 +745,10 @@ async function extractParseOnce(tarballBuffer: Buffer): Promise<OPTDatabase> {
   }
 }
 
-async function extractAndParse(
+export async function extractAndParse(
   tarballBuffer: Buffer,
   tmpDir: string,
+  opts?: { maxExtractBytes?: number },
 ): Promise<OPTDatabase> {
   try {
     // GH #258: bound the extraction so a hostile/compromised tarball (tar
@@ -748,9 +764,11 @@ async function extractAndParse(
     // EXTRACT_TIMEOUT_MS budget. Aborting the pipeline rejects with an
     // AbortError, which relabelTimeoutError recognises so the surfaced message
     // names the extract phase honestly.
+    //
+    // `maxExtractBytes` is injectable so the decompressed-size trip can be
+    // unit-tested with a tiny cap — production uses MAX_TARBALL_EXTRACT_BYTES.
+    const maxExtractBytes = opts?.maxExtractBytes ?? MAX_TARBALL_EXTRACT_BYTES;
     const extractStart = Date.now();
-    const MAX_TARBALL_EXTRACT_BYTES = 256 * 1024 * 1024;
-    const MAX_TARBALL_FILES = 50_000;
     let decompressedBytes = 0;
     let fileCount = 0;
     const extractController = new AbortController();
@@ -761,7 +779,7 @@ async function extractAndParse(
     const byteCounter = new Transform({
       transform(chunk: Buffer, _enc, cb) {
         decompressedBytes += chunk.length;
-        if (decompressedBytes > MAX_TARBALL_EXTRACT_BYTES) {
+        if (decompressedBytes > maxExtractBytes) {
           cb(
             new Error(
               "OpenPrintTag tarball exceeds extraction limits (possible tar bomb).",

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -13,9 +13,9 @@
  */
 
 import { parse as parseYaml } from "yaml";
-import { mkdtempSync, rmSync } from "fs";
-import { readFile, readdir } from "fs/promises";
-import { join } from "path";
+import { mkdtempSync } from "fs";
+import { readFile, readdir, rm, stat } from "fs/promises";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -424,6 +424,81 @@ async function walkDir(dir: string): Promise<string[]> {
   return results;
 }
 
+// Prefix on every diagnostic line so the OPT fetch flow is greppable in the
+// packaged app's main.log (electron/main.ts mirrors the embedded server's
+// stdout/stderr to %APPDATA%/Filament DB/logs/main.log).
+const LOG = "[openprinttag]";
+
+// All temp dirs this module creates share this prefix; the stale-dir sweep
+// keys off it to reclaim partial copies left by an earlier interrupted run.
+const TMP_PREFIX = "openprinttag-";
+
+/**
+ * Remove a temp dir robustly. Uses async `rm` (yields the event loop instead
+ * of blocking it on a ~11k-file recursive delete — the reported "hang") with
+ * Node's built-in retry, which backs off on the Windows file-lock errors
+ * (EBUSY/EPERM/ENOTEMPTY) that antivirus / lingering handles trigger and that
+ * a plain `force: true` does NOT retry — the cause of the partial leftovers.
+ * Best-effort: logs the failure rather than throwing (cleanup must not mask
+ * the real result), but does NOT swallow it silently.
+ */
+async function cleanupTempDir(dir: string): Promise<void> {
+  try {
+    await rm(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
+  } catch (err) {
+    console.warn(
+      `${LOG} cleanup failed for ${dir} — may leave a partial copy:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Best-effort sweep of stale `openprinttag-*` temp dirs from earlier runs that
+ * failed to clean up (e.g. an interrupted extract on Windows). Only removes
+ * dirs older than STALE_AGE_MS so it can't race a concurrent in-progress fetch
+ * (another tab/instance sharing %TEMP%). Never throws.
+ */
+async function sweepStaleTempDirs(): Promise<void> {
+  const STALE_AGE_MS = 60 * 60 * 1000; // 1 hour
+  const root = tmpdir();
+  let reclaimed = 0;
+  try {
+    for (const name of await readdir(root)) {
+      if (!name.startsWith(TMP_PREFIX)) continue;
+      const full = join(root, name);
+      try {
+        const info = await stat(full);
+        if (!info.isDirectory()) continue;
+        if (Date.now() - info.mtimeMs < STALE_AGE_MS) continue;
+        await rm(full, {
+          recursive: true,
+          force: true,
+          maxRetries: 5,
+          retryDelay: 100,
+        });
+        reclaimed += 1;
+      } catch {
+        // per-entry best-effort — a locked dir is reclaimed on a later sweep
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `${LOG} stale temp-dir sweep failed:`,
+      err instanceof Error ? err.message : err,
+    );
+    return;
+  }
+  if (reclaimed > 0) {
+    console.log(`${LOG} swept ${reclaimed} stale temp dir(s) from ${root}`);
+  }
+}
+
 /**
  * Fetch the OpenPrintTag database from GitHub, parse all YAML files,
  * and return the structured result.
@@ -465,21 +540,31 @@ async function runFetchWithRetries(): Promise<OPTDatabase> {
   const MAX_ATTEMPTS = 3;
   let lastError: unknown = null;
 
+  // Reclaim any partial copies an earlier interrupted run left behind before
+  // we start adding more.
+  await sweepStaleTempDirs();
+
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const tmpDir = mkdtempSync(join(tmpdir(), "openprinttag-"));
+    const tmpDir = mkdtempSync(join(tmpdir(), TMP_PREFIX));
+    console.log(
+      `${LOG} attempt ${attempt}/${MAX_ATTEMPTS} starting (tmpDir=${basename(tmpDir)})`,
+    );
 
     try {
       const result = await fetchAndParse(tmpDir);
+      console.log(
+        `${LOG} attempt ${attempt} succeeded — ${result.totalFFF} FFF / ${result.totalSLA} SLA materials`,
+      );
       return result;
     } catch (err) {
       lastError = err;
+      console.error(
+        `${LOG} attempt ${attempt}/${MAX_ATTEMPTS} failed:`,
+        err instanceof Error ? err.message : err,
+      );
       // Clean up the tmp dir from the failed attempt before retrying so
       // disk usage doesn't grow on a flaky network.
-      try {
-        rmSync(tmpDir, { recursive: true, force: true });
-      } catch {
-        // best-effort
-      }
+      await cleanupTempDir(tmpDir);
       if (attempt < MAX_ATTEMPTS) {
         // Exponential backoff: 800ms, 2400ms. Total worst-case wait
         // ~3.2s extra over the base 60s per attempt — still well under
@@ -504,11 +589,31 @@ async function runFetchWithRetries(): Promise<OPTDatabase> {
     : new Error("OpenPrintTag fetch failed: " + String(lastError));
 }
 
+// Download is network-bound and fast (the compressed tarball is ~3 MB and
+// completes in well under a second on a healthy connection). The extract,
+// by contrast, writes ~11k tiny YAML files to disk — and on Windows hosts
+// real-time antivirus (Defender) scans every one of those writes, which can
+// push a cold extract past a minute even when the download itself took 600ms.
+// So the two phases get SEPARATE, independently-armed deadlines: a tight one
+// for the network, a generous one for the disk-bound unpack.
+const DOWNLOAD_TIMEOUT_MS = 60_000;
+const EXTRACT_TIMEOUT_MS = 180_000;
+// Cap the compressed download we buffer into memory before extracting, so a
+// hostile/huge response can't OOM the embedded server. The real OpenPrintTag
+// tarball is ~3 MB; 128 MB is generous headroom. (The decompressed-size /
+// file-count tar-bomb guard still runs per-entry during extraction below.)
+const MAX_DOWNLOAD_BYTES = 128 * 1024 * 1024;
+
 /**
  * Single-attempt fetch + tarball extract + parse. Factored out so the
  * retry loop above can call it multiple times against fresh temp dirs.
  */
 async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
+  // Track which phase is running so a timeout/abort (the 60s AbortSignal is
+  // armed on the whole body stream, so it can fire during extract, not just
+  // download) is reported HONESTLY instead of always reading "connection
+  // timed out" — the misleading message users saw when extract/parse stalled.
+  let phase: "download" | "extract" | "parse" = "download";
   try {
     // Download and extract the tarball via the GitHub tarball API. Earlier
     // versions shelled out to `curl ... | tar xz`, but the production
@@ -523,15 +628,18 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     // undici-flavoured option not present on the standard RequestInit type,
     // hence the cast — it's a documented Node fetch extension.
     const dispatcher = getProxyDispatcher();
+    const downloadStart = Date.now();
+    console.log(`${LOG} download starting: ${tarballUrl}`);
     const response = await fetch(tarballUrl, {
       headers: {
         Accept: "application/vnd.github+json",
         // GitHub returns 403 on unauthenticated requests with no UA.
         "User-Agent": "filament-db",
       },
-      // 60s matches the previous execSync timeout. AbortSignal.timeout
-      // produces a TypeError-shaped abort if exceeded.
-      signal: AbortSignal.timeout(60_000),
+      // The download gets its OWN deadline (the extract that follows gets a
+      // separate, more generous one). AbortSignal.timeout produces a
+      // TimeoutError-shaped abort if exceeded.
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
       ...(dispatcher ? { dispatcher } : {}),
     } as RequestInit & { dispatcher?: Dispatcher });
     if (!response.ok) {
@@ -543,6 +651,34 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
       throw new Error("GitHub tarball response had no body");
     }
 
+    // Buffer the full compressed tarball into memory FIRST, bounded by the
+    // download AbortSignal above. This decouples the extract phase from the
+    // network: previously the response body was streamed straight into tar.x,
+    // so the 60s download signal stayed armed across the whole disk-bound
+    // unpack and a slow Windows extract (antivirus scanning each of ~11k file
+    // writes) aborted the still-open fetch even though the bytes were already
+    // down. With the bytes fully in hand, extraction runs under its own,
+    // independent deadline (EXTRACT_TIMEOUT_MS) and the network timeout can no
+    // longer misfire mid-unpack.
+    let downloadedBytes = 0;
+    const chunks: Buffer[] = [];
+    for await (const chunk of Readable.fromWeb(
+      response.body as Parameters<typeof Readable.fromWeb>[0],
+    )) {
+      const buf = chunk as Buffer;
+      downloadedBytes += buf.length;
+      if (downloadedBytes > MAX_DOWNLOAD_BYTES) {
+        throw new Error(
+          "OpenPrintTag download exceeds size limit (possible malicious response).",
+        );
+      }
+      chunks.push(buf);
+    }
+    const tarballBuffer = Buffer.concat(chunks);
+    console.log(
+      `${LOG} download response ${response.status}, ${downloadedBytes} bytes in ${Date.now() - downloadStart}ms — extracting`,
+    );
+
     // tar.x is a Writable transform that auto-detects gzip; pipeline()
     // resolves once the entire tarball has been extracted to disk.
     //
@@ -552,37 +688,59 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     // — or a flood of small entries — trips the limit before the data
     // is written. It also rejects absolute paths and `..` traversal as
     // defence-in-depth over tar's own path sanitisation.
+    //
+    // The extract gets its OWN AbortController/timeout, independent of the
+    // network deadline — a slow disk (Windows + antivirus) gets the full
+    // EXTRACT_TIMEOUT_MS budget. Aborting the pipeline rejects with an
+    // AbortError, which `isTimeoutAbort` recognises so the surfaced message
+    // names the extract phase honestly.
+    phase = "extract";
+    const extractStart = Date.now();
     const MAX_TARBALL_EXTRACT_BYTES = 256 * 1024 * 1024;
     const MAX_TARBALL_FILES = 50_000;
     let extractedBytes = 0;
     let fileCount = 0;
-    await pipeline(
-      // Cast: response.body is a Web ReadableStream, Readable.fromWeb wants
-      // the same shape but the type lib for streams/web is a bit loose
-      // across Node versions. Functionally identical.
-      Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
-      tar.x({
-        cwd: tmpDir,
-        filter: (entryPath: string, entry: { size?: number }) => {
-          if (
-            entryPath.startsWith("/") ||
-            entryPath.split(/[\\/]/).includes("..")
-          ) {
-            throw new Error(`Unsafe tarball entry path: ${entryPath}`);
-          }
-          fileCount += 1;
-          extractedBytes += entry.size ?? 0;
-          if (
-            fileCount > MAX_TARBALL_FILES ||
-            extractedBytes > MAX_TARBALL_EXTRACT_BYTES
-          ) {
-            throw new Error(
-              "OpenPrintTag tarball exceeds extraction limits (possible tar bomb).",
-            );
-          }
-          return true;
-        },
-      }),
+    const extractController = new AbortController();
+    const extractTimer = setTimeout(
+      () => extractController.abort(),
+      EXTRACT_TIMEOUT_MS,
+    );
+    try {
+      await pipeline(
+        // Wrap in an array so the whole buffer is emitted as ONE chunk —
+        // `Readable.from(buffer)` is special-cased today but the array form is
+        // unambiguous across Node versions (CI runs 20 + 22).
+        Readable.from([tarballBuffer]),
+        tar.x({
+          cwd: tmpDir,
+          filter: (entryPath: string, entry: { size?: number }) => {
+            if (
+              entryPath.startsWith("/") ||
+              entryPath.split(/[\\/]/).includes("..")
+            ) {
+              throw new Error(`Unsafe tarball entry path: ${entryPath}`);
+            }
+            fileCount += 1;
+            extractedBytes += entry.size ?? 0;
+            if (
+              fileCount > MAX_TARBALL_FILES ||
+              extractedBytes > MAX_TARBALL_EXTRACT_BYTES
+            ) {
+              throw new Error(
+                "OpenPrintTag tarball exceeds extraction limits (possible tar bomb).",
+              );
+            }
+            return true;
+          },
+        }),
+        { signal: extractController.signal },
+      );
+    } finally {
+      clearTimeout(extractTimer);
+    }
+
+    console.log(
+      `${LOG} extract done: ${fileCount} files / ${extractedBytes} bytes in ${Date.now() - extractStart}ms`,
     );
 
     // The tarball extracts to a subdirectory like OpenPrintTag-openprinttag-database-<sha>/
@@ -591,6 +749,8 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     const repoRoot = join(tmpDir, extracted[0]);
 
     // Parse brands
+    phase = "parse";
+    const parseStart = Date.now();
     const brandMap = new Map<string, { name: string; country?: string }>();
     const brandsDir = join(repoRoot, "data", "brands");
     try {
@@ -613,6 +773,7 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     let totalSLA = 0;
     const materialsDir = join(repoRoot, "data", "materials");
     const allFiles = await walkDir(materialsDir);
+    console.log(`${LOG} parsing ${allFiles.length} files under data/materials`);
 
     const YIELD_EVERY = 256;
     let seen = 0;
@@ -620,6 +781,7 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
       if (!filePath.endsWith(".yaml")) continue;
       if (++seen % YIELD_EVERY === 0) {
         await new Promise<void>((resolve) => setImmediate(resolve));
+        console.log(`${LOG} parse progress: ${seen}/${allFiles.length} files`);
       }
       try {
         const content = await readFile(filePath, "utf-8");
@@ -637,6 +799,10 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
         // Skip unparseable files
       }
     }
+
+    console.log(
+      `${LOG} parse done: ${materials.length} FFF / ${totalSLA} SLA in ${Date.now() - parseStart}ms`,
+    );
 
     // Build brand list with counts
     const brandCounts = new Map<string, number>();
@@ -669,14 +835,38 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     cacheTimestamp = Date.now();
 
     return result;
-  } finally {
-    // Clean up temp directory
-    try {
-      rmSync(tmpDir, { recursive: true, force: true });
-    } catch {
-      // Best-effort cleanup
+  } catch (err) {
+    // Re-label a timeout/abort with the phase it actually struck so the
+    // surfaced error (route returns err.message as `detail`) tells the truth
+    // instead of implying a download/connection failure for an extract/parse
+    // stall. Non-timeout errors keep their own message.
+    if (isTimeoutAbort(err)) {
+      const limitSec = Math.round(
+        (phase === "download" ? DOWNLOAD_TIMEOUT_MS : EXTRACT_TIMEOUT_MS) / 1000,
+      );
+      throw new Error(
+        phase === "download"
+          ? `OpenPrintTag download timed out (${limitSec}s limit)`
+          : `OpenPrintTag ${phase} timed out (${limitSec}s limit) — the download completed but the ${phase} phase exceeded the deadline`,
+      );
     }
+    throw err;
+  } finally {
+    // Clean up the temp directory. Async + retrying so it neither blocks the
+    // event loop nor leaves a partial copy on a Windows file lock.
+    await cleanupTempDir(tmpDir);
   }
+}
+
+/**
+ * True for the DOMException/TypeError shapes Node's fetch + AbortSignal.timeout
+ * produce when the 60s deadline fires (name is "TimeoutError" or "AbortError").
+ */
+function isTimeoutAbort(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === "TimeoutError" || err.name === "AbortError")
+  );
 }
 
 // ── Module-level cache ─────────────────────────────────────────────────

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -17,8 +17,9 @@ import { mkdtempSync } from "fs";
 import { readFile, readdir, rm, stat } from "fs/promises";
 import { basename, join } from "path";
 import { tmpdir } from "os";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
 import * as tar from "tar";
 import { EnvHttpProxyAgent, type Dispatcher } from "undici";
 import { OPT_TAG } from "@/lib/openprinttag";
@@ -504,15 +505,19 @@ async function sweepStaleTempDirs(): Promise<void> {
  * and return the structured result.
  *
  * GH #225 — cold-fetch resilience:
- * - The fetch+extract pipeline is wrapped in a retry loop (3 attempts,
- *   exponential backoff) so a transient TimeoutError or network blip on
- *   the first request after Electron startup doesn't surface to the user
- *   as a 500. Most "OpenPrintTag fetch error: TimeoutError" reports trace
- *   to a cold connection that resolves on retry.
- * - If every retry fails BUT we have a previously-cached payload (even an
- *   expired one), serve the stale payload instead of throwing. The
- *   freshness window is wide enough that users prefer a one-hour-old
- *   brand list to "Failed to load."
+ * - Only the DOWNLOAD is retried (3 attempts, exponential backoff): a
+ *   transient TimeoutError or network blip on the first request after
+ *   Electron startup is the thing that actually resolves on retry. Most
+ *   "OpenPrintTag fetch error: TimeoutError" reports trace to a cold
+ *   connection. The extract/parse is deterministic — a retry won't fix a
+ *   slow disk — so once the bytes are in hand it runs ONCE under its own
+ *   generous deadline (PR #933 review: retrying the extract multiplied the
+ *   worst-case wait past the client's timeout, so a cached user never
+ *   reached the stale-cache fallback below).
+ * - If the download (after retries) or the single extract/parse fails BUT
+ *   we have a previously-cached payload (even an expired one), serve the
+ *   stale payload instead of throwing. The freshness window is wide enough
+ *   that users prefer a one-hour-old brand list to "Failed to load."
  */
 export async function fetchOpenPrintTagDatabase(): Promise<OPTDatabase> {
   // Check cache
@@ -537,99 +542,122 @@ export async function fetchOpenPrintTagDatabase(): Promise<OPTDatabase> {
 }
 
 async function runFetchWithRetries(): Promise<OPTDatabase> {
-  const MAX_ATTEMPTS = 3;
-  let lastError: unknown = null;
-
   // Reclaim any partial copies an earlier interrupted run left behind before
   // we start adding more.
   await sweepStaleTempDirs();
 
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const tmpDir = mkdtempSync(join(tmpdir(), TMP_PREFIX));
-    console.log(
-      `${LOG} attempt ${attempt}/${MAX_ATTEMPTS} starting (tmpDir=${basename(tmpDir)})`,
-    );
-
-    try {
-      const result = await fetchAndParse(tmpDir);
-      console.log(
-        `${LOG} attempt ${attempt} succeeded — ${result.totalFFF} FFF / ${result.totalSLA} SLA materials`,
+  try {
+    // Retry ONLY the network download — that's the transient part (cold
+    // connection / blip). Once the bytes are in hand, extract + parse runs
+    // ONCE: it's deterministic, so a retry wouldn't fix a slow disk, and
+    // retrying it would multiply the worst-case wait past the client's
+    // timeout (PR #933 review) — at which point a cached user never reaches
+    // the stale-cache fallback this path exists to serve.
+    const tarballBuffer = await downloadWithRetries();
+    return await extractParseOnce(tarballBuffer);
+  } catch (err) {
+    // The download (after retries) or the single extract/parse failed. If we
+    // have a previously-cached payload (even past the TTL), serve it — better
+    // than failing the UI.
+    if (cachedDatabase) {
+      console.warn(
+        `${LOG} fetch failed — serving stale cache from`,
+        new Date(cacheTimestamp).toISOString(),
+        err instanceof Error ? err.message : err,
       );
-      return result;
+      return cachedDatabase;
+    }
+    throw err instanceof Error
+      ? err
+      : new Error("OpenPrintTag fetch failed: " + String(err));
+  }
+}
+
+// Budget math (kept in lockstep with the client abort in
+// src/app/openprinttag/page.tsx). The download is network-bound and fast (the
+// compressed tarball is ~3 MB), so it gets a tight deadline and is retried for
+// transient blips. The extract writes ~11k tiny YAML files to disk — and on
+// Windows hosts real-time antivirus (Defender) scans every one of those
+// writes, which can push a cold extract past a minute even when the download
+// itself took 600ms — so it gets a separate, more generous deadline but runs
+// only once. Worst case: MAX_ATTEMPTS × DOWNLOAD_TIMEOUT_MS + backoff(3.2s) +
+// EXTRACT_TIMEOUT_MS = 3×45 + 3.2 + 120 ≈ 258s, comfortably under the client's
+// 300s (5 min) abort.
+const MAX_ATTEMPTS = 3;
+const DOWNLOAD_TIMEOUT_MS = 45_000;
+const EXTRACT_TIMEOUT_MS = 120_000;
+// Cap the compressed download we buffer into memory before extracting, so a
+// hostile/huge response can't OOM the embedded server. The real OpenPrintTag
+// tarball is ~3 MB; 128 MB is generous headroom. (The decompressed-size /
+// file-count tar-bomb guard still runs during extraction below.)
+const MAX_DOWNLOAD_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Retry the network download (exponential backoff) and return the compressed
+ * tarball as an in-memory Buffer. Only the download is retried — see
+ * runFetchWithRetries.
+ */
+async function downloadWithRetries(): Promise<Buffer> {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    console.log(`${LOG} download attempt ${attempt}/${MAX_ATTEMPTS} starting`);
+    try {
+      return await downloadTarballToBuffer();
     } catch (err) {
       lastError = err;
       console.error(
-        `${LOG} attempt ${attempt}/${MAX_ATTEMPTS} failed:`,
+        `${LOG} download attempt ${attempt}/${MAX_ATTEMPTS} failed:`,
         err instanceof Error ? err.message : err,
       );
-      // Clean up the tmp dir from the failed attempt before retrying so
-      // disk usage doesn't grow on a flaky network.
-      await cleanupTempDir(tmpDir);
       if (attempt < MAX_ATTEMPTS) {
-        // Exponential backoff: 800ms, 2400ms. Total worst-case wait
-        // ~3.2s extra over the base 60s per attempt — still well under
-        // the user's tolerance for a one-time DB browser cold-load.
+        // Exponential backoff: 800ms, 2400ms (~3.2s total).
         await new Promise((r) => setTimeout(r, 800 * Math.pow(3, attempt - 1)));
       }
     }
   }
-
-  // All retries failed. If we have a previously-cached payload (even
-  // if it's past the TTL), serve it — better than failing the UI.
-  if (cachedDatabase) {
-    console.warn(
-      "OpenPrintTag fetch failed after retries — serving stale cache from",
-      new Date(cacheTimestamp).toISOString(),
-    );
-    return cachedDatabase;
-  }
-
   throw lastError instanceof Error
     ? lastError
-    : new Error("OpenPrintTag fetch failed: " + String(lastError));
+    : new Error("OpenPrintTag download failed: " + String(lastError));
 }
 
-// Download is network-bound and fast (the compressed tarball is ~3 MB and
-// completes in well under a second on a healthy connection). The extract,
-// by contrast, writes ~11k tiny YAML files to disk — and on Windows hosts
-// real-time antivirus (Defender) scans every one of those writes, which can
-// push a cold extract past a minute even when the download itself took 600ms.
-// So the two phases get SEPARATE, independently-armed deadlines: a tight one
-// for the network, a generous one for the disk-bound unpack.
-const DOWNLOAD_TIMEOUT_MS = 60_000;
-const EXTRACT_TIMEOUT_MS = 180_000;
-// Cap the compressed download we buffer into memory before extracting, so a
-// hostile/huge response can't OOM the embedded server. The real OpenPrintTag
-// tarball is ~3 MB; 128 MB is generous headroom. (The decompressed-size /
-// file-count tar-bomb guard still runs per-entry during extraction below.)
-const MAX_DOWNLOAD_BYTES = 128 * 1024 * 1024;
-
 /**
- * Single-attempt fetch + tarball extract + parse. Factored out so the
- * retry loop above can call it multiple times against fresh temp dirs.
+ * Fetch the GitHub tarball and buffer the full compressed body into memory.
+ *
+ * Buffering first decouples the extract phase from the network: previously the
+ * response body streamed straight into tar.x, so the download signal stayed
+ * armed across the whole disk-bound unpack and a slow Windows extract
+ * (antivirus scanning each of ~11k file writes) aborted the still-open fetch
+ * even though the bytes were already down. With the bytes fully in hand,
+ * extraction runs under its own independent deadline and the network timeout
+ * can no longer misfire mid-unpack.
+ *
+ * `maxBytes` / `timeoutMs` are injectable so the size cap and the
+ * download-phase timeout relabel can be unit-tested without a 128 MB
+ * allocation or a real 45s wait. Production uses the module defaults.
  */
-async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
-  // Track which phase is running so a timeout/abort (the 60s AbortSignal is
-  // armed on the whole body stream, so it can fire during extract, not just
-  // download) is reported HONESTLY instead of always reading "connection
-  // timed out" — the misleading message users saw when extract/parse stalled.
-  let phase: "download" | "extract" | "parse" = "download";
-  try {
-    // Download and extract the tarball via the GitHub tarball API. Earlier
-    // versions shelled out to `curl ... | tar xz`, but the production
-    // Docker image (node:22-alpine) doesn't ship curl, so users got
-    // "/bin/sh: curl: not found" the moment they tried to browse the OPT
-    // database (GH #136). Doing it in pure Node removes the dep on host
-    // tools and works the same in dev, Electron, and Docker.
-    const tarballUrl =
-      "https://api.github.com/repos/OpenPrintTag/openprinttag-database/tarball/main";
+export async function downloadTarballToBuffer(opts?: {
+  maxBytes?: number;
+  timeoutMs?: number;
+}): Promise<Buffer> {
+  const maxBytes = opts?.maxBytes ?? MAX_DOWNLOAD_BYTES;
+  const timeoutMs = opts?.timeoutMs ?? DOWNLOAD_TIMEOUT_MS;
 
-    // Pass the proxy dispatcher when one is configured. `dispatcher` is an
-    // undici-flavoured option not present on the standard RequestInit type,
-    // hence the cast — it's a documented Node fetch extension.
-    const dispatcher = getProxyDispatcher();
-    const downloadStart = Date.now();
-    console.log(`${LOG} download starting: ${tarballUrl}`);
+  // Download the tarball via the GitHub tarball API. Earlier versions shelled
+  // out to `curl ... | tar xz`, but the production Docker image
+  // (node:22-alpine) doesn't ship curl, so users got "/bin/sh: curl: not
+  // found" the moment they tried to browse the OPT database (GH #136). Doing
+  // it in pure Node removes the dep on host tools and works the same in dev,
+  // Electron, and Docker.
+  const tarballUrl =
+    "https://api.github.com/repos/OpenPrintTag/openprinttag-database/tarball/main";
+
+  // Pass the proxy dispatcher when one is configured. `dispatcher` is an
+  // undici-flavoured option not present on the standard RequestInit type,
+  // hence the cast — it's a documented Node fetch extension.
+  const dispatcher = getProxyDispatcher();
+  const downloadStart = Date.now();
+  console.log(`${LOG} download starting: ${tarballUrl}`);
+  try {
     const response = await fetch(tarballUrl, {
       headers: {
         Accept: "application/vnd.github+json",
@@ -639,7 +667,7 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
       // The download gets its OWN deadline (the extract that follows gets a
       // separate, more generous one). AbortSignal.timeout produces a
       // TimeoutError-shaped abort if exceeded.
-      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
       ...(dispatcher ? { dispatcher } : {}),
     } as RequestInit & { dispatcher?: Dispatcher });
     if (!response.ok) {
@@ -651,69 +679,113 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
       throw new Error("GitHub tarball response had no body");
     }
 
-    // Buffer the full compressed tarball into memory FIRST, bounded by the
-    // download AbortSignal above. This decouples the extract phase from the
-    // network: previously the response body was streamed straight into tar.x,
-    // so the 60s download signal stayed armed across the whole disk-bound
-    // unpack and a slow Windows extract (antivirus scanning each of ~11k file
-    // writes) aborted the still-open fetch even though the bytes were already
-    // down. With the bytes fully in hand, extraction runs under its own,
-    // independent deadline (EXTRACT_TIMEOUT_MS) and the network timeout can no
-    // longer misfire mid-unpack.
     let downloadedBytes = 0;
-    const chunks: Buffer[] = [];
+    // Readable.fromWeb can yield Uint8Array (the chunk type isn't always a
+    // Node Buffer); Buffer.concat + .length accept it, so type honestly.
+    const chunks: Uint8Array[] = [];
     for await (const chunk of Readable.fromWeb(
       response.body as Parameters<typeof Readable.fromWeb>[0],
     )) {
-      const buf = chunk as Buffer;
-      downloadedBytes += buf.length;
-      if (downloadedBytes > MAX_DOWNLOAD_BYTES) {
+      downloadedBytes += chunk.length;
+      // Check BEFORE push so the over-limit chunk is never retained.
+      if (downloadedBytes > maxBytes) {
         throw new Error(
           "OpenPrintTag download exceeds size limit (possible malicious response).",
         );
       }
-      chunks.push(buf);
+      chunks.push(chunk);
     }
-    const tarballBuffer = Buffer.concat(chunks);
+    // Concat to a known total, then drop the per-chunk copies right away so the
+    // ~3 MB (cap: maxBytes) of chunks isn't held GC-rooted through the entire
+    // extract + ~11k-file parse — otherwise peak memory was ~2× the buffer.
+    const tarballBuffer = Buffer.concat(chunks, downloadedBytes);
+    chunks.length = 0;
     console.log(
-      `${LOG} download response ${response.status}, ${downloadedBytes} bytes in ${Date.now() - downloadStart}ms — extracting`,
+      `${LOG} download response ${response.status}, ${downloadedBytes} bytes in ${Date.now() - downloadStart}ms`,
     );
+    return tarballBuffer;
+  } catch (err) {
+    const relabeled = relabelTimeoutError(err, "download", { downloadTimeoutMs: timeoutMs });
+    throw relabeled ?? err;
+  }
+}
 
-    // tar.x is a Writable transform that auto-detects gzip; pipeline()
-    // resolves once the entire tarball has been extracted to disk.
-    //
-    // GH #258: bound the extraction so a hostile/compromised tarball
-    // (tar bomb) can't fill the disk. The `filter` runs per entry with
-    // the header-declared size, so a single entry claiming a huge size
-    // — or a flood of small entries — trips the limit before the data
-    // is written. It also rejects absolute paths and `..` traversal as
-    // defence-in-depth over tar's own path sanitisation.
+/**
+ * Extract the buffered tarball into `tmpDir`, parse all YAML, and clean up.
+ * Runs once (no retry) — see runFetchWithRetries. Caches the result.
+ */
+async function extractParseOnce(tarballBuffer: Buffer): Promise<OPTDatabase> {
+  const tmpDir = mkdtempSync(join(tmpdir(), TMP_PREFIX));
+  console.log(`${LOG} extract starting (tmpDir=${basename(tmpDir)})`);
+  try {
+    const result = await extractAndParse(tarballBuffer, tmpDir);
+    console.log(
+      `${LOG} succeeded — ${result.totalFFF} FFF / ${result.totalSLA} SLA materials`,
+    );
+    return result;
+  } finally {
+    // Clean up the temp directory. Async + retrying so it neither blocks the
+    // event loop nor leaves a partial copy on a Windows file lock.
+    await cleanupTempDir(tmpDir);
+  }
+}
+
+async function extractAndParse(
+  tarballBuffer: Buffer,
+  tmpDir: string,
+): Promise<OPTDatabase> {
+  try {
+    // GH #258: bound the extraction so a hostile/compromised tarball (tar
+    // bomb) can't fill the disk. The `filter` rejects absolute paths / `..`
+    // traversal (defence-in-depth over tar's own sanitisation) and caps the
+    // file COUNT. A counting Transform between gunzip and the tar parser caps
+    // the total DECOMPRESSED bytes against bytes actually streamed to disk —
+    // not the attacker-declared header `size`, which a lying header could
+    // under-report (PR #933 follow-up).
     //
     // The extract gets its OWN AbortController/timeout, independent of the
     // network deadline — a slow disk (Windows + antivirus) gets the full
     // EXTRACT_TIMEOUT_MS budget. Aborting the pipeline rejects with an
-    // AbortError, which `isTimeoutAbort` recognises so the surfaced message
+    // AbortError, which relabelTimeoutError recognises so the surfaced message
     // names the extract phase honestly.
-    phase = "extract";
     const extractStart = Date.now();
     const MAX_TARBALL_EXTRACT_BYTES = 256 * 1024 * 1024;
     const MAX_TARBALL_FILES = 50_000;
-    let extractedBytes = 0;
+    let decompressedBytes = 0;
     let fileCount = 0;
     const extractController = new AbortController();
     const extractTimer = setTimeout(
       () => extractController.abort(),
       EXTRACT_TIMEOUT_MS,
     );
+    const byteCounter = new Transform({
+      transform(chunk: Buffer, _enc, cb) {
+        decompressedBytes += chunk.length;
+        if (decompressedBytes > MAX_TARBALL_EXTRACT_BYTES) {
+          cb(
+            new Error(
+              "OpenPrintTag tarball exceeds extraction limits (possible tar bomb).",
+            ),
+          );
+          return;
+        }
+        cb(null, chunk);
+      },
+    });
     try {
       await pipeline(
         // Wrap in an array so the whole buffer is emitted as ONE chunk —
         // `Readable.from(buffer)` is special-cased today but the array form is
         // unambiguous across Node versions (CI runs 20 + 22).
         Readable.from([tarballBuffer]),
+        // Gunzip ourselves so the counter sees DECOMPRESSED bytes; tar.x then
+        // parses raw (gzip:false) instead of detecting+decompressing again.
+        createGunzip(),
+        byteCounter,
         tar.x({
           cwd: tmpDir,
-          filter: (entryPath: string, entry: { size?: number }) => {
+          gzip: false,
+          filter: (entryPath: string) => {
             if (
               entryPath.startsWith("/") ||
               entryPath.split(/[\\/]/).includes("..")
@@ -721,11 +793,7 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
               throw new Error(`Unsafe tarball entry path: ${entryPath}`);
             }
             fileCount += 1;
-            extractedBytes += entry.size ?? 0;
-            if (
-              fileCount > MAX_TARBALL_FILES ||
-              extractedBytes > MAX_TARBALL_EXTRACT_BYTES
-            ) {
+            if (fileCount > MAX_TARBALL_FILES) {
               throw new Error(
                 "OpenPrintTag tarball exceeds extraction limits (possible tar bomb).",
               );
@@ -740,7 +808,7 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     }
 
     console.log(
-      `${LOG} extract done: ${fileCount} files / ${extractedBytes} bytes in ${Date.now() - extractStart}ms`,
+      `${LOG} extract done: ${fileCount} files / ${decompressedBytes} bytes in ${Date.now() - extractStart}ms`,
     );
 
     // The tarball extracts to a subdirectory like OpenPrintTag-openprinttag-database-<sha>/
@@ -749,7 +817,6 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
     const repoRoot = join(tmpDir, extracted[0]);
 
     // Parse brands
-    phase = "parse";
     const parseStart = Date.now();
     const brandMap = new Map<string, { name: string; country?: string }>();
     const brandsDir = join(repoRoot, "data", "brands");
@@ -836,36 +903,51 @@ async function fetchAndParse(tmpDir: string): Promise<OPTDatabase> {
 
     return result;
   } catch (err) {
-    // Re-label a timeout/abort with the phase it actually struck so the
-    // surfaced error (route returns err.message as `detail`) tells the truth
-    // instead of implying a download/connection failure for an extract/parse
-    // stall. Non-timeout errors keep their own message.
-    if (isTimeoutAbort(err)) {
-      const limitSec = Math.round(
-        (phase === "download" ? DOWNLOAD_TIMEOUT_MS : EXTRACT_TIMEOUT_MS) / 1000,
-      );
-      throw new Error(
-        phase === "download"
-          ? `OpenPrintTag download timed out (${limitSec}s limit)`
-          : `OpenPrintTag ${phase} timed out (${limitSec}s limit) — the download completed but the ${phase} phase exceeded the deadline`,
-      );
-    }
-    throw err;
-  } finally {
-    // Clean up the temp directory. Async + retrying so it neither blocks the
-    // event loop nor leaves a partial copy on a Windows file lock.
-    await cleanupTempDir(tmpDir);
+    // Re-label an extract timeout/abort so the surfaced error (route returns
+    // err.message as `detail`) tells the truth — the download completed but
+    // the unpack stalled — instead of the old "connection timed out"
+    // misattribution. Non-timeout errors (tar bomb, unsafe path) keep theirs.
+    const relabeled = relabelTimeoutError(err, "extract");
+    throw relabeled ?? err;
   }
 }
 
 /**
- * True for the DOMException/TypeError shapes Node's fetch + AbortSignal.timeout
- * produce when the 60s deadline fires (name is "TimeoutError" or "AbortError").
+ * True for the AbortError / TimeoutError shapes Node's fetch +
+ * AbortSignal.timeout (download deadline) and the extract AbortController
+ * produce when a deadline fires. Exported for unit coverage.
  */
-function isTimeoutAbort(err: unknown): boolean {
+export function isTimeoutAbort(err: unknown): boolean {
   return (
     err instanceof Error &&
     (err.name === "TimeoutError" || err.name === "AbortError")
+  );
+}
+
+/**
+ * If `err` is a timeout/abort, return a fresh Error naming the phase it struck
+ * (so an extract stall reads as an extract timeout, not a download failure);
+ * otherwise return null and let the caller rethrow the original. Pure +
+ * exported so both the phase wording and the per-phase deadline math are
+ * unit-testable without driving a real timeout. The two phases carry separate
+ * deadlines (download 45s / extract 120s); there is no "parse" phase here — the
+ * parse loop has no abort signal, so it can never produce a timeout to relabel.
+ */
+export function relabelTimeoutError(
+  err: unknown,
+  phase: "download" | "extract",
+  opts?: { downloadTimeoutMs?: number; extractTimeoutMs?: number },
+): Error | null {
+  if (!isTimeoutAbort(err)) return null;
+  const limitMs =
+    phase === "download"
+      ? opts?.downloadTimeoutMs ?? DOWNLOAD_TIMEOUT_MS
+      : opts?.extractTimeoutMs ?? EXTRACT_TIMEOUT_MS;
+  const limitSec = Math.round(limitMs / 1000);
+  return new Error(
+    phase === "download"
+      ? `OpenPrintTag download timed out (${limitSec}s limit)`
+      : `OpenPrintTag extract timed out (${limitSec}s limit) — the download completed but the extract phase exceeded the deadline`,
   );
 }
 

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, createReadStream } from "fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  createReadStream,
+  readdirSync,
+  utimesSync,
+  existsSync,
+} from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
 import * as tar from "tar";
@@ -920,5 +929,104 @@ type: Resin
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1); // joined, not duplicated
     expect(a).toBe(b);
+  });
+
+  // Helper: count `openprinttag-*` temp dirs currently in tmpdir().
+  function countTempDirs(): number {
+    return readdirSync(tmpdir()).filter((n) => n.startsWith("openprinttag-")).length;
+  }
+
+  it("cleans up its own temp dir after a successful fetch", async () => {
+    const before = countTempDirs();
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-clean/data/brands/.gitkeep": "",
+      "OpenPrintTag-clean/data/materials/m.yaml":
+        "uuid: m\nslug: m\nbrand:\n  slug: x\nname: M\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    await fetchOpenPrintTagDatabase();
+
+    // The per-attempt mkdtemp dir must be removed in the finally — no net
+    // growth in `openprinttag-*` dirs (the cause of the %TEMP% buildup).
+    expect(countTempDirs()).toBe(before);
+  });
+
+  it("sweeps stale openprinttag-* temp dirs (>1h old) on fetch", async () => {
+    // Simulate a partial copy left by an earlier interrupted run: an
+    // openprinttag-* dir with an mtime well over an hour ago.
+    const stale = mkdtempSync(join(tmpdir(), "openprinttag-"));
+    writeFileSync(join(stale, "leftover.txt"), "partial");
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    utimesSync(stale, twoHoursAgo, twoHoursAgo);
+    expect(existsSync(stale)).toBe(true);
+
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-sweep/data/brands/.gitkeep": "",
+      "OpenPrintTag-sweep/data/materials/m.yaml":
+        "uuid: m\nslug: m\nbrand:\n  slug: x\nname: M\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    await fetchOpenPrintTagDatabase();
+
+    // The stale dir is reclaimed by the start-of-run sweep.
+    expect(existsSync(stale)).toBe(false);
+  });
+
+  it("does NOT sweep a fresh openprinttag-* dir (mtime within the window)", async () => {
+    // A concurrent instance's in-progress dir (recent mtime) must survive the
+    // sweep — only >1h-old dirs are reclaimed.
+    const fresh = mkdtempSync(join(tmpdir(), "openprinttag-"));
+    writeFileSync(join(fresh, "inprogress.txt"), "x");
+
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-fresh/data/brands/.gitkeep": "",
+      "OpenPrintTag-fresh/data/materials/m.yaml":
+        "uuid: m\nslug: m\nbrand:\n  slug: x\nname: M\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    try {
+      await fetchOpenPrintTagDatabase();
+      expect(existsSync(fresh)).toBe(true);
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("re-labels a download-phase timeout honestly (not a generic failure)", async () => {
+    // The download AbortSignal fires as a TimeoutError. A timeout in the
+    // download phase should surface a download-specific message.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      const e = new Error("The operation was aborted due to timeout");
+      e.name = "TimeoutError";
+      throw e;
+    });
+
+    await expect(fetchOpenPrintTagDatabase()).rejects.toThrow(
+      /OpenPrintTag download timed out/,
+    );
+  });
+
+  it("buffers the full body before extracting (download/extract deadlines decoupled)", async () => {
+    // Regression for the Windows extract-timeout report: the response body is
+    // drained into memory FIRST and extraction runs from that buffer, so the
+    // network AbortSignal can't abort a slow disk-bound unpack. We assert the
+    // body is fully consumed before any file is read back out by completing a
+    // multi-file extract end-to-end from a chunked stream.
+    const tarballPath = mockFetchTarball({
+      "OpenPrintTag-buf/data/brands/amolen.yaml":
+        "slug: amolen\nname: Amolen\n",
+      "OpenPrintTag-buf/data/materials/amolen/a.yaml":
+        "uuid: a\nslug: a\nbrand:\n  slug: amolen\nname: A\nclass: FFF\ntype: PLA\n",
+      "OpenPrintTag-buf/data/materials/amolen/b.yaml":
+        "uuid: b\nslug: b\nbrand:\n  slug: amolen\nname: B\nclass: FFF\ntype: PETG\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+
+    const db = await fetchOpenPrintTagDatabase();
+    expect(db.totalFFF).toBe(2);
+    expect(db.brands[0].name).toBe("Amolen");
   });
 });

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
 import {
   mkdirSync,
   mkdtempSync,
@@ -23,6 +32,9 @@ import {
   fetchOpenPrintTagDatabase,
   getProxyDispatcher,
   clearCache,
+  downloadTarballToBuffer,
+  isTimeoutAbort,
+  relabelTimeoutError,
 } from "@/lib/openprinttagBrowser";
 import { EnvHttpProxyAgent } from "undici";
 
@@ -724,6 +736,35 @@ describe("getProxyDispatcher", () => {
 describe("fetchOpenPrintTagDatabase", () => {
   let tarballsToCleanup: string[] = [];
 
+  // Isolate the temp root from the shared real os.tmpdir(): the suite's
+  // countTempDirs()/sweep assertions key off the literal `openprinttag-`
+  // prefix, but production sweepStaleTempDirs() runs against that same dir on
+  // every fetch — a >1h-old leftover from a crashed earlier CI run would make
+  // a count assertion fail for unrelated reasons. os.tmpdir() reads
+  // TMPDIR/TMP/TEMP at call time, so pointing them at a private dir redirects
+  // both the module's mkdtemp/sweep AND this file's helpers there.
+  const savedTmpEnv: Record<string, string | undefined> = {};
+  let isolatedTmpRoot = "";
+  beforeAll(() => {
+    for (const k of ["TMPDIR", "TMP", "TEMP"]) savedTmpEnv[k] = process.env[k];
+    // Create the private root under the ORIGINAL temp dir before we repoint.
+    isolatedTmpRoot = mkdtempSync(join(tmpdir(), "opt-test-root-"));
+    process.env.TMPDIR = isolatedTmpRoot;
+    process.env.TMP = isolatedTmpRoot;
+    process.env.TEMP = isolatedTmpRoot;
+  });
+  afterAll(() => {
+    for (const k of ["TMPDIR", "TMP", "TEMP"]) {
+      if (savedTmpEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedTmpEnv[k];
+    }
+    try {
+      rmSync(isolatedTmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
   beforeEach(() => {
     clearCache();
     tarballsToCleanup = [];
@@ -1028,5 +1069,106 @@ type: Resin
     const db = await fetchOpenPrintTagDatabase();
     expect(db.totalFFF).toBe(2);
     expect(db.brands[0].name).toBe("Amolen");
+  });
+
+  it("rejects a download that exceeds the size cap (OOM/DoS guard)", async () => {
+    // Stream more bytes than the (injected, tiny) cap and assert the guard
+    // trips. The check runs BEFORE the chunk is retained, so this never holds
+    // more than one over-limit chunk in memory.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // 3 × 100-byte chunks = 300 bytes, over the 150-byte cap below.
+          for (let i = 0; i < 3; i++) controller.enqueue(new Uint8Array(100));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, statusText: "OK" });
+    });
+
+    await expect(
+      downloadTarballToBuffer({ maxBytes: 150 }),
+    ).rejects.toThrow(/exceeds size limit/);
+  });
+
+  it("returns the buffered body when under the size cap", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.enqueue(new Uint8Array([4, 5]));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, statusText: "OK" });
+    });
+
+    const buf = await downloadTarballToBuffer({ maxBytes: 1024 });
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(Array.from(buf)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("relabels a download-phase fetch timeout as a download timeout", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      const e = new Error("The operation was aborted due to timeout");
+      e.name = "TimeoutError";
+      throw e;
+    });
+
+    await expect(
+      downloadTarballToBuffer({ timeoutMs: 45_000 }),
+    ).rejects.toThrow(/OpenPrintTag download timed out \(45s limit\)/);
+  });
+});
+
+describe("isTimeoutAbort", () => {
+  it("is true for TimeoutError and AbortError", () => {
+    const t = new Error("timeout");
+    t.name = "TimeoutError";
+    const a = new Error("aborted");
+    a.name = "AbortError";
+    expect(isTimeoutAbort(t)).toBe(true);
+    expect(isTimeoutAbort(a)).toBe(true);
+  });
+
+  it("is false for other errors and non-errors", () => {
+    expect(isTimeoutAbort(new Error("nope"))).toBe(false);
+    expect(isTimeoutAbort("AbortError")).toBe(false);
+    expect(isTimeoutAbort(null)).toBe(false);
+  });
+});
+
+describe("relabelTimeoutError", () => {
+  it("labels an extract-phase AbortError honestly (download completed)", () => {
+    // The core of PR #933: an extract stall must NOT read as a download
+    // failure. An AbortError from the extract AbortController feeds this.
+    const abort = new Error("The operation was aborted");
+    abort.name = "AbortError";
+    const out = relabelTimeoutError(abort, "extract");
+    expect(out).toBeInstanceOf(Error);
+    expect(out!.message).toMatch(/extract timed out \(120s limit\)/);
+    expect(out!.message).toMatch(/the download completed but the extract phase/);
+  });
+
+  it("labels a download-phase TimeoutError as a download timeout", () => {
+    const to = new Error("timeout");
+    to.name = "TimeoutError";
+    const out = relabelTimeoutError(to, "download");
+    expect(out!.message).toMatch(/OpenPrintTag download timed out \(45s limit\)/);
+  });
+
+  it("honours injected deadlines in the surfaced message", () => {
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    expect(
+      relabelTimeoutError(abort, "extract", { extractTimeoutMs: 90_000 })!.message,
+    ).toMatch(/90s limit/);
+    expect(
+      relabelTimeoutError(abort, "download", { downloadTimeoutMs: 30_000 })!.message,
+    ).toMatch(/30s limit/);
+  });
+
+  it("returns null for a non-timeout error (caller rethrows the original)", () => {
+    expect(relabelTimeoutError(new Error("tar bomb"), "extract")).toBeNull();
   });
 });

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -13,6 +13,7 @@ import {
   mkdtempSync,
   rmSync,
   writeFileSync,
+  readFileSync,
   createReadStream,
   readdirSync,
   utimesSync,
@@ -35,6 +36,7 @@ import {
   downloadTarballToBuffer,
   isTimeoutAbort,
   relabelTimeoutError,
+  extractAndParse,
 } from "@/lib/openprinttagBrowser";
 import { EnvHttpProxyAgent } from "undici";
 
@@ -1170,5 +1172,62 @@ describe("relabelTimeoutError", () => {
 
   it("returns null for a non-timeout error (caller rethrows the original)", () => {
     expect(relabelTimeoutError(new Error("tar bomb"), "extract")).toBeNull();
+  });
+});
+
+describe("extractAndParse maxExtractBytes cap", () => {
+  // Parity test for PR #933 review follow-up: downloadTarballToBuffer({maxBytes})
+  // is exported + tested for the compressed download cap. The symmetric guard
+  // on the DECOMPRESSED stream (the counting Transform between gunzip and
+  // tar.x) needs the same coverage so a future refactor can't silently drop
+  // the bound. The cap is injectable so we can trip it without allocating
+  // 256 MB of zeros.
+  let tarballsToCleanup: string[] = [];
+  let extractTmpDir = "";
+
+  beforeEach(() => {
+    clearCache();
+    tarballsToCleanup = [];
+    extractTmpDir = mkdtempSync(join(tmpdir(), "opt-test-extract-"));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const p of tarballsToCleanup) {
+      try { rmSync(p, { force: true }); } catch { /* swallow */ }
+    }
+    try { rmSync(extractTmpDir, { recursive: true, force: true }); } catch { /* swallow */ }
+  });
+
+  it("rejects a tarball whose decompressed bytes exceed the injected cap (tar-bomb guard)", async () => {
+    // A normal-looking tarball with a few hundred bytes of decompressed
+    // content. Setting maxExtractBytes well below that total trips the
+    // counting Transform mid-stream; the pipeline tears down and the error
+    // surfaces with the tar-bomb wording.
+    const tarballPath = buildTarball({
+      "OpenPrintTag-bomb/data/brands/.gitkeep": "",
+      // ~500 bytes of payload — comfortably over the 100-byte cap below.
+      "OpenPrintTag-bomb/data/materials/big.yaml":
+        "x".repeat(500),
+    });
+    tarballsToCleanup.push(tarballPath);
+    const buf = readFileSync(tarballPath);
+
+    await expect(
+      extractAndParse(buf, extractTmpDir, { maxExtractBytes: 100 }),
+    ).rejects.toThrow(/exceeds extraction limits/);
+  });
+
+  it("accepts a tarball whose decompressed bytes stay under the injected cap", async () => {
+    const tarballPath = buildTarball({
+      "OpenPrintTag-ok/data/brands/.gitkeep": "",
+      "OpenPrintTag-ok/data/materials/m.yaml":
+        "uuid: m\nslug: m\nbrand:\n  slug: x\nname: M\nclass: FFF\ntype: PLA\n",
+    });
+    tarballsToCleanup.push(tarballPath);
+    const buf = readFileSync(tarballPath);
+
+    // Generous cap — the tiny test tarball decompresses to well under 10 KB.
+    const db = await extractAndParse(buf, extractTmpDir, { maxExtractBytes: 10 * 1024 });
+    expect(db.totalFFF).toBe(1);
   });
 });


### PR DESCRIPTION
The OpenPrintTag DB browse could hang after download with partial repo copies accumulating in %TEMP% and a misleading "connection timed out". On Windows, unpacking the ~11k tiny YAML files is slow (AV real-time-scans each write + NTFS overhead), so a cold extract blew past 60s and aborted the still-open fetch even though the ~3 MB download had finished in ~600ms. This would cause repeated "extract timed out (60s limit)" failures and an empty OpenPrintTag browser.

Root causes, all in src/lib/openprinttagBrowser.ts:

- Cleanup used synchronous rmSync(recursive) on the ~11k-file extracted repo, blocking the embedded server's event loop, and force:true does not retry on Windows EBUSY/EPERM/ENOTEMPTY, so a locked delete threw and was silently swallowed -> partial dir left behind.
- Each of 3 retry attempts minted a new temp dir with no sweep of leftovers -> several partial copies.
- The 60s AbortSignal is armed on the whole body stream, so an extract/parse stall surfaced as a download-shaped timeout.

Changes:
- Add [openprinttag]-prefixed phase logging (download/extract/parse/ cleanup, with elapsed + counts). In the packaged app these flow to %APPDATA%/Filament DB/logs/main.log via the existing stdout mirror, so there is finally something to see when diagnosing a stall.
- Replace rmSync with an awaited async rm helper (maxRetries/retryDelay) at both call sites; log failures instead of swallowing.
- Remove stale openprinttag-* temp dirs (>1h old) at the start of a run.
- Re-label timeout/abort errors with the phase they struck so the surfaced message is honest.
- Buffer the tarball into memory first (bounded by existing download timeout + a 128 MB size cap), then extract from the memory buffer under a more generous timeout (180s).

Tests:
- Cleanup leaves no net temp dirs
- Stale cleanup removes >1h dirs but spares fresh ones
- Download-phase timeout surfaces a download-specific message.
- Download goes into buffer and then successfully extracts.

Fixes: #932 