### PR TITLE
Bump version to 1.61.0

### DIFF
--- a/.release-notes-1.61.0.md
+++ b/.release-notes-1.61.0.md
@@ -1,6 +1,6 @@
 ## What's new
 
-### Stacked "Usage by day" chart on Analytics
+### Stacked "Usage by day" chart on Analytics (#936)
 
 The Analytics page's **Usage by day** chart gets an opt-in **Detailed** toggle that stacks each bar by filament, with every segment painted in the filament's actual hex color.
 
@@ -8,12 +8,27 @@ The Analytics page's **Usage by day** chart gets an opt-in **Detailed** toggle t
 - **Per-user preference.** The toggle's state persists per browser (via `localStorage`) so the same view comes back on the next visit. Off by default — nothing changes for users who haven't opted in.
 - **Correct colors on inheriting variants.** A variant with no own color inherits ONLY its parent's `secondaryColors[0]` — never the parent's primary color — matching the rest of the app (list, detail, exports). Coextruded filaments (null primary) also resolve to `secondaryColors[0]` so they render in their real color instead of the gray fallback.
 
+### Faster refresh on the OpenPrintTag browser (#937)
+
+The **Refresh** button on `/openprinttag` used to re-download the ~3 MB GitHub tarball and re-parse ~11k YAML files every time, even when nothing upstream had changed. It now asks GitHub for just the latest commit SHA on `main` — a ~40-byte round-trip — and slides the cache TTL forward when the SHA is unchanged. The full tarball fetch only runs when upstream actually moved.
+
+- **Same SHA** → slides TTL, serves cached, no tarball download. Refresh is instant.
+- **Different SHA** → falls through to the existing tarball download + extract path (unchanged).
+- **Cold cache or probe failure** → straight to the tarball (fail-open — the probe never wedges a refresh that was already willing to download the whole tarball anyway).
+- The OpenPrintTag page now surfaces `Last refreshed from commit abc1234 · checked 3m ago` under the title so you can see when the cache was last validated.
+
 ## Notes
 
+### Analytics (#936)
 - **Chart totals reconcile with the headline by construction.** Each day's bar total equals `Math.round(rawDaySum)`, and the per-filament segments within a day sum to that total EXACTLY via Hamilton's largest-remainder apportionment. Sub-0.5g contributions that round to zero individually still count toward the day (and toward `totals.grams`) — no more silent chart-vs-headline drift on days with a bunch of tiny entries.
 - **Future-dated entries excluded from every aggregate.** A row with a `startedAt` past `now` (bad slicer clock, mis-imported snapshot) is no longer counted in `totals` while missing from the chart — every aggregate now agrees on the day-of-window boundary. Fractional `?days=` inputs are floored so today's bucket always exists.
 - **`totals.jobs` no longer over-reports.** It now counts only PrintHistory rows that passed the JS-side guards (malformed / future-dated skipped), so the headline agrees with every other aggregate.
 - **Locale-aware date tooltips.** The stacked-mode segment tooltip formats the date via `Intl.DateTimeFormat` in UTC so it doesn't shift by one day west of UTC, and honours the app's active locale.
 - **OpenAPI schema for `/api/analytics`** is now fully documented — every response field (totals, `usageByDay[].byFilament[]`, `byFilament`, `byVendor`, `byPrinter`) has a description covering the invariants above.
+
+### OpenPrintTag refresh (#937)
+- **Single-flight guard covers the probe** so mashing Refresh across tabs shares ONE commits-API call instead of burning through GitHub's unauthenticated 60-req/hr quota.
+- **Response is hardened.** Uses the docs-supported `application/vnd.github.sha` media type so the probe response is fixed at ~40 bytes regardless of what the upstream commit touched. Body reads through a 4 KB `readBodyCapped` — a hostile / misconfigured proxy can't OOM the embedded server. 5-second timeout so a dead connection fails fast instead of eroding the retry budget.
+- **Shorter-than-7-char SHAs are refused** — matches the tarball regex's floor, so a broken proxy can't lock the cache on a low-entropy prefix (7-char SHA is 1/268M random-collision rate; 4-char was 1/65k).
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.60.1",
+  "version": "1.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.60.1",
+      "version": "1.61.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.60.1",
+  "version": "1.61.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.60.1",
+    "version": "1.61.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
## Summary

Cuts v1.61.0. Rolls up the two feature PRs that landed on `main` since v1.60.1:

- #936 feat(analytics): stack Usage-by-day chart by filament
- #937 feat(openprinttag): SHA-aware cache refresh — skip tarball when upstream unchanged

Renames `.release-notes-1.60.1.md` → `.release-notes-1.61.0.md`. The prior file was authored on PR #936 assuming that PR would ship as v1.60.1, but v1.60.1 was already tagged before #936 landed — those notes never went into the v1.60.1 release body. This release body now covers both #936 and #937.

Bumps versions in:
- `package.json` (top-level `version`)
- `package-lock.json` (top-level `version` + `packages[""].version`)
- `public/openapi.json` (`info.version`)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Version bump only — no code changes

After merge:
- [ ] Pull main, tag `v1.61.0`, push tag
- [ ] Release CI builds installers + uploads to draft release + auto-publishes
- [ ] Apply notes: `gh release edit v1.61.0 --notes-file .release-notes-1.61.0.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)