### PR TITLE
Bump version to 1.61.1

### DIFF
--- a/.release-notes-1.61.1.md
+++ b/.release-notes-1.61.1.md
@@ -1,0 +1,19 @@
+## What's new
+
+Nothing user-facing — this release is a codebase-hygiene pass. Read on only if you're curious.
+
+## Under the hood
+
+An adversarial multi-agent audit walked the tree looking for dead code, unused exports, over-commented sections, and drift between docs and reality. 15 verified findings landed (#939) — **net -217 lines**.
+
+- Three component props interfaces (`FilamentPicker`, `PrintLabelDialog`) tightened from `export` to file-local — no external consumer.
+- Two unused helpers removed: `isMultiColor` and `isMdnsAdvertising`.
+- Duplicate JSDoc block on `listLabelPrinters` consolidated.
+- `deriveMaterialAbbreviation` two-branch impl collapsed to a single `slice(0, 7)`.
+- ~180 lines of over-narration trimmed from the analytics route while keeping every load-bearing WHY (Hamilton apportionment contract, malformed-date guard ordering, aggregate trade-offs, GH refs for `git blame` continuity).
+- Four doc-drift fixes in `CLAUDE.md` and `docs/mobile-app-plan.md` (renamed decoder path, script inventory typo, mobile-package layout description, mobile DTOs path).
+- Five leftover `create-next-app` scaffold SVGs deleted from `public/` — zero runtime references.
+
+Test suite is unchanged in scope (2534 tests) and passes clean. `tsc --noEmit`, `electron:typecheck`, and lint all clean.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.61.0",
+  "version": "1.61.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.61.0",
+      "version": "1.61.1",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.61.0",
+  "version": "1.61.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.61.0",
+    "version": "1.61.1",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
## Summary

Cuts v1.61.1 — the chore/cleanup release. Rolls up:

- #939 chore: cleanup pass — dead code, unused exports, over-comments, doc drift

Adds `.release-notes-1.61.1.md` and bumps versions in `package.json` / `package-lock.json` / `public/openapi.json` (info.version).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Version-only bump; no code changes beyond the notes file

After merge:
- [ ] Tag `v1.61.1`, push
- [ ] CI builds installers + publishes release
- [ ] Apply notes: `gh release edit v1.61.1 --notes-file .release-notes-1.61.1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)