### PR TITLE
fix(api): input-validation & mass-assignment gaps on spool + snapshot writes (#953)

### DIFF
--- a/src/app/api/filaments/[id]/spools/[spoolId]/route.ts
+++ b/src/app/api/filaments/[id]/spools/[spoolId]/route.ts
@@ -4,9 +4,10 @@ import dbConnect from "@/lib/mongodb";
 import Filament, { generateInstanceId, isSpoolInstanceIdTaken } from "@/models/Filament";
 import Printer from "@/models/Printer";
 import { validateSpoolBody } from "@/lib/validateSpoolBody";
+import Location from "@/models/Location";
 import { assignSpoolToSlot } from "@/lib/spoolSlots";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
-import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught, assertActiveSpoolLocation } from "@/lib/apiErrorHandler";
 
 export async function PUT(
   request: NextRequest,
@@ -49,6 +50,12 @@ export async function PUT(
     if (!mongoose.isValidObjectId(id) || !mongoose.isValidObjectId(spoolId)) {
       return errorResponse("Invalid filament or spool id", 400);
     }
+
+    // GH #953: a moved-to location must reference an active Location, or a
+    // dangling ref persists (e.g. a queued offline move replayed after the
+    // location was deleted) and breaks every location-grouped view.
+    const locGuard = await assertActiveSpoolLocation(Location, validation.locationId);
+    if (locGuard) return locGuard;
 
     // #732 Phase 4: edit or regenerate the spool's instanceId. `regenerate`
     // wins and mints a fresh id; a user-entered id (charset/length already

--- a/src/app/api/filaments/[id]/spools/route.ts
+++ b/src/app/api/filaments/[id]/spools/route.ts
@@ -2,9 +2,10 @@ import mongoose from "mongoose";
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament, { generateInstanceId, isSpoolInstanceIdTaken } from "@/models/Filament";
+import Location from "@/models/Location";
 import { validateSpoolBody } from "@/lib/validateSpoolBody";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
-import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
+import { errorResponse, errorResponseFromCaught, assertActiveSpoolLocation } from "@/lib/apiErrorHandler";
 
 export async function POST(
   request: NextRequest,
@@ -82,6 +83,12 @@ export async function POST(
     if (!mongoose.isValidObjectId(id)) {
       return errorResponse("Invalid filament id", 400);
     }
+
+    // GH #953: a new spool's locationId must reference an active Location, so a
+    // dangling ref can't persist and produce a phantom "no location" group in
+    // every location-grouped view.
+    const locGuard = await assertActiveSpoolLocation(Location, validation.locationId);
+    if (locGuard) return locGuard;
 
     // Only push fields the validator captured. Previously the $push
     // dropped lotNumber / purchaseDate / openedDate / locationId /

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -4,9 +4,10 @@ import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
 import BedType from "@/models/BedType";
-import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError, assertActiveRefs } from "@/lib/apiErrorHandler";
+import Location from "@/models/Location";
+import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError, assertActiveRefs, assertActiveSpoolLocation } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
-import { validateSpoolPhotoDataUrl } from "@/lib/validateSpoolBody";
+import { validateSpoolPhotoDataUrl, isValidIsoDateString } from "@/lib/validateSpoolBody";
 import { decodedTagToFilamentPayload } from "@/lib/decodedTagToFilament";
 import {
   isInvertedNozzleRange,
@@ -409,18 +410,44 @@ export async function POST(request: NextRequest) {
       photoDataUrl: s?.photoDataUrl,
       retired: s?.retired,
     }));
-    // GH #626: the dedicated spool routes validate photoDataUrl through
-    // validateSpoolBody (raster-only MIME allow-list + 5MB cap — SVG is
-    // rejected because inline <script> can execute in some rendering
-    // contexts). The #431 allowlist above keeps the field but didn't
-    // validate its content, so an embedded spool on filament create was
-    // a bypass. Enforce the same rules here.
+    // The dedicated spool routes enforce a set of per-field contracts via
+    // validateSpoolBody / assertActiveSpoolLocation; the #431 allowlist above
+    // keeps the fields but historically validated only their names, so an
+    // embedded spool on filament create bypassed those checks. Enforce the same
+    // contracts here so create matches POST/PUT /spools:
+    //   - GH #626: photoDataUrl raster-only MIME allow-list + 5MB cap (SVG is
+    //     rejected — inline <script> can execute in some rendering contexts).
+    //   - GH #953 (finding 3): purchaseDate/openedDate must name a real ISO
+    //     date. Without this, Mongoose silently normalises "2025-02-29" → Mar 1
+    //     on cast (the GH #372 bug), and locale strings / epoch numbers persist
+    //     while every other spool write path 400s them.
+    //   - GH #953 (finding 2): locationId must reference an active Location, so
+    //     a dangling ref can't persist and produce a phantom "no location" group.
+    //   (label/lotNumber length is backstopped by the schema maxlength, which
+    //    Filament.create validates — a >200-char value 400s as a ValidationError.)
     for (let i = 0; i < body.spools.length; i++) {
-      const photo = validateSpoolPhotoDataUrl(body.spools[i].photoDataUrl);
+      const spool = body.spools[i];
+
+      const photo = validateSpoolPhotoDataUrl(spool.photoDataUrl);
       if (!photo.ok) {
         return errorResponse(`spools[${i}]: ${photo.error}`, 400);
       }
-      body.spools[i].photoDataUrl = photo.value;
+      spool.photoDataUrl = photo.value;
+
+      for (const field of ["purchaseDate", "openedDate"] as const) {
+        const v = spool[field];
+        if (v !== null && v !== undefined && v !== "") {
+          if (typeof v !== "string" || !isValidIsoDateString(v)) {
+            return errorResponse(
+              `spools[${i}]: ${field} must be a valid ISO date string (YYYY-MM-DD or full ISO 8601) or null`,
+              400,
+            );
+          }
+        }
+      }
+
+      const locGuard = await assertActiveSpoolLocation(Location, spool.locationId);
+      if (locGuard) return locGuard;
     }
   }
 

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -18,6 +18,24 @@ import SharedCatalog from "@/models/SharedCatalog";
 // This is acceptable for a single-instance desktop app.
 let restoreInProgress = false;
 
+/** Current snapshot schema version (see the version history in GET). Bumped
+ * whenever the `collections` shape changes so restore can reject newer files
+ * (GH #953). */
+const CURRENT_SNAPSHOT_VERSION = 4;
+
+/** The collection keys a v≤4 snapshot carries. Restore requires at least one to
+ * be present so a wrong-shape / newer file 400s instead of silently wiping the
+ * DB and inserting nothing (GH #953). */
+const KNOWN_COLLECTION_KEYS = [
+  "filaments",
+  "nozzles",
+  "printers",
+  "bedTypes",
+  "locations",
+  "printHistory",
+  "sharedCatalogs",
+] as const;
+
 const OID_RE = /^[a-f0-9]{24}$/i;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 const OID_FIELDS = new Set([
@@ -144,7 +162,7 @@ export async function GET(request: NextRequest) {
   // Older snapshots still restore cleanly because POST destructures
   // missing collections to `[]`.
   const snapshot = {
-    version: 4,
+    version: CURRENT_SNAPSHOT_VERSION,
     createdAt: new Date().toISOString(),
     collections: {
       filaments,
@@ -260,10 +278,43 @@ async function restoreSnapshot(request: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON in snapshot file" }, { status: 400 });
   }
 
-  // Validate structure
-  if (!snapshot.collections) {
+  // GH #953: reject a snapshot from a NEWER app version BEFORE the destructive
+  // wipe. The restore only knows the seven v≤4 collection keys (destructured
+  // with `= []` defaults); a v5+ file that added/renamed/moved a collection
+  // would have that data silently dropped after every current collection is
+  // wiped, and the handler would still report "restored successfully" — a
+  // partial restore over a full wipe with no warning. Fail closed instead.
+  if (
+    typeof snapshot.version === "number" &&
+    snapshot.version > CURRENT_SNAPSHOT_VERSION
+  ) {
     return NextResponse.json(
-      { error: "Invalid snapshot: missing 'collections' key" },
+      {
+        error: `This snapshot is from a newer version (v${snapshot.version}). Update Filament DB to at least the version that created it before restoring.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  // Validate structure. `collections` must be a plain, non-array object that
+  // carries at least one recognized collection key. GH #953: the old bare
+  // truthiness check (`if (!snapshot.collections)`) let a wrong-shape file
+  // through — `collections: 1`, `collections: {}`, or `collections: { foo: [] }`
+  // all destructure the seven known keys to `[]`, so the wipe runs, nothing is
+  // inserted, and the handler reports success over an emptied DB.
+  const cols = snapshot.collections;
+  if (typeof cols !== "object" || cols === null || Array.isArray(cols)) {
+    return NextResponse.json(
+      { error: "Invalid snapshot: missing or malformed 'collections'" },
+      { status: 400 },
+    );
+  }
+  if (!KNOWN_COLLECTION_KEYS.some((k) => k in cols)) {
+    return NextResponse.json(
+      {
+        error:
+          "Invalid snapshot: 'collections' contains no recognized collections (filaments, nozzles, printers, bedTypes, locations, printHistory, sharedCatalogs). This file may not be a Filament DB snapshot, or is from a newer version.",
+      },
       { status: 400 },
     );
   }
@@ -276,7 +327,7 @@ async function restoreSnapshot(request: NextRequest) {
     locations = [],
     printHistory = [],
     sharedCatalogs = [],
-  } = snapshot.collections;
+  } = cols;
 
   // --- Safety: snapshot the current DB so we can roll back on failure ---
   const [

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -318,6 +318,20 @@ async function restoreSnapshot(request: NextRequest) {
       { status: 400 },
     );
   }
+  // GH #953 (Codex P1): each PRESENT known collection must be an array. The
+  // destructure below only defaults ABSENT keys to `[]` — a present non-array
+  // value (`{ filaments: {} }`, `{ locations: 1 }`) survives, its `.length` is
+  // undefined so every insert is skipped, and the handler wipes the DB then
+  // reports success with nothing restored. Reject before the backup/wipe.
+  const colsRecord = cols as Record<string, unknown>;
+  for (const key of KNOWN_COLLECTION_KEYS) {
+    if (key in colsRecord && !Array.isArray(colsRecord[key])) {
+      return NextResponse.json(
+        { error: `Invalid snapshot: 'collections.${key}' must be an array` },
+        { status: 400 },
+      );
+    }
+  }
 
   const {
     filaments = [],

--- a/src/app/api/spools/import/route.ts
+++ b/src/app/api/spools/import/route.ts
@@ -6,7 +6,7 @@ import { parseCsv } from "@/lib/parseCsv";
 import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { unsanitizeCsvCell } from "@/lib/csvWriter";
-import { isValidIsoDateString, validateSpoolInstanceId } from "@/lib/validateSpoolBody";
+import { isValidIsoDateString, validateSpoolInstanceId, MAX_SPOOL_TEXT_LENGTH } from "@/lib/validateSpoolBody";
 
 /**
  * POST /api/spools/import — bulk-create OR upsert spools from CSV.
@@ -258,6 +258,29 @@ export async function POST(request: NextRequest) {
       }
       const purchaseDate = rawPurchase ? new Date(rawPurchase) : null;
       const openedDate = rawOpened ? new Date(rawOpened) : null;
+
+      // GH #953: cap the free-form spool text fields. The schema `maxlength`
+      // backstops the save, but check here (side-effect-free, before
+      // resolveLocationId auto-creates a Location) so a too-long value fails its
+      // own row with a clean message rather than aborting the whole bucket save
+      // with a misattributed Mongoose ValidationError. Measure the UNSANITIZED
+      // value — that's what persists.
+      if (unsanitizeCsvCell(r.label || "").length > MAX_SPOOL_TEXT_LENGTH) {
+        rowResults[i] = {
+          row: i + 2,
+          ok: false,
+          error: `label must be ${MAX_SPOOL_TEXT_LENGTH} characters or fewer`,
+        };
+        continue;
+      }
+      if (r.lotNumber && unsanitizeCsvCell(r.lotNumber).length > MAX_SPOOL_TEXT_LENGTH) {
+        rowResults[i] = {
+          row: i + 2,
+          ok: false,
+          error: `lotNumber must be ${MAX_SPOOL_TEXT_LENGTH} characters or fewer`,
+        };
+        continue;
+      }
 
       // #732 Phase 5: optional `instanceId` column — the spool's own id.
       // CONTRACT: the column is honored only when CREATING a new spool; on the

--- a/src/lib/apiErrorHandler.ts
+++ b/src/lib/apiErrorHandler.ts
@@ -184,6 +184,44 @@ export async function assertActiveRefs(
   return null;
 }
 
+/** 24-hex ObjectId shape — kept local so this module stays mongoose-free and
+ * edge-safe (see the handleVersionError lazy-import note). */
+const SPOOL_OID_RE = /^[a-f0-9]{24}$/i;
+
+/**
+ * GH #953: assert a spool's `locationId` references an existing, ACTIVE
+ * (non-soft-deleted) Location. No spool write path validated this — unlike the
+ * nozzle/printer/bed-type refs on the filament routes, which flow through
+ * assertActiveRefs — so a dangling ref (e.g. a mobile offline-queue move
+ * replayed after the referenced location was deleted, or an API retry) persisted
+ * and produced a phantom "no location" group in every location-grouped view
+ * (/inventory, ?kind= filters silently drop the spool, the home-page
+ * "N spools in M locations" stat overcounts).
+ *
+ * `null`/empty = "no location" and passes. The Location model is injected (same
+ * pattern as assertActiveRefs) so this module doesn't import a model and stays
+ * edge-safe. Returns a 400 NextResponse on a bad/dangling ref, else null.
+ */
+export async function assertActiveSpoolLocation(
+  locationModel: CountableModel,
+  locationId: unknown,
+): Promise<NextResponse | null> {
+  if (locationId === null || locationId === undefined || locationId === "") {
+    return null;
+  }
+  if (typeof locationId !== "string" || !SPOOL_OID_RE.test(locationId)) {
+    return errorResponse("Invalid location id", 400);
+  }
+  const result = locationModel.countDocuments({ _id: locationId, _deletedAt: null });
+  const count = await (typeof (result as { exec?: () => Promise<number> }).exec === "function"
+    ? (result as { exec(): Promise<number> }).exec()
+    : (result as Promise<number>));
+  if (count === 0) {
+    return errorResponse("The selected location no longer exists.", 400);
+  }
+  return null;
+}
+
 /** Maximum upload file size (10 MB) */
 export const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
 

--- a/src/lib/validateSpoolBody.ts
+++ b/src/lib/validateSpoolBody.ts
@@ -147,6 +147,18 @@ export function validateSpoolPhotoDataUrl(
   return { ok: true, value: value === "" ? null : value };
 }
 
+/**
+ * GH #953: cap the free-form spool text fields (`label`, `lotNumber`). Neither
+ * had a length bound — validateSpoolBody only type-checked them, the schema
+ * fields have no `maxlength`, and the PUT positional-`$` update bypasses
+ * subdocument validation — so an unbounded string persisted and then bloated
+ * every `/api/filaments` list fetch (which projects `spools[].label`), CSV /
+ * snapshot exports, and sync payloads. Same DoS-lite class GH #350 fixed for
+ * print-history `jobLabel`; 200 matches that precedent (labels are short UI
+ * strings; lot numbers are short batch codes).
+ */
+export const MAX_SPOOL_TEXT_LENGTH = 200;
+
 export function validateSpoolBody(
   body: unknown,
   opts: ValidateOpts = {},
@@ -161,6 +173,12 @@ export function validateSpoolBody(
   if (b.label !== undefined) {
     if (typeof b.label !== "string") {
       return { ok: false, error: "label must be a string" };
+    }
+    if (b.label.length > MAX_SPOOL_TEXT_LENGTH) {
+      return {
+        ok: false,
+        error: `label must be ${MAX_SPOOL_TEXT_LENGTH} characters or fewer`,
+      };
     }
     result.label = b.label;
   } else if (!opts.partial) {
@@ -208,6 +226,12 @@ export function validateSpoolBody(
     if (b.lotNumber === null) {
       result.lotNumber = null;
     } else if (typeof b.lotNumber === "string") {
+      if (b.lotNumber.length > MAX_SPOOL_TEXT_LENGTH) {
+        return {
+          ok: false,
+          error: `lotNumber must be ${MAX_SPOOL_TEXT_LENGTH} characters or fewer`,
+        };
+      }
       result.lotNumber = b.lotNumber;
     } else {
       return { ok: false, error: "lotNumber must be a string or null" };

--- a/src/models/Filament.ts
+++ b/src/models/Filament.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import mongoose, { Schema, Document, Model, AnyBulkWriteOperation } from "mongoose";
 import { isEncodableOptTag } from "@/lib/openprinttag";
+import { MAX_SPOOL_TEXT_LENGTH } from "@/lib/validateSpoolBody";
 
 /** Generate a random 5-byte hex instance ID (10 hex chars), matching Prusament's format.
  * Exported (#732) so the spool-create routes that write via `$push` — which
@@ -387,9 +388,29 @@ const FilamentSchema = new Schema<IFilament>(
       {
         // #732: each spool gets its own 5-byte hex id (default-generated).
         instanceId: { type: String, default: generateInstanceId },
-        label: { type: String, default: "" },
+        // GH #953: bound the free-form spool text fields. The dedicated spool
+        // routes cap these via validateSpoolBody, but that runs only on the API
+        // surface; this schema `maxlength` is the backstop for every path that
+        // reaches Mongoose validation (embedded-spool create, CSV import save,
+        // snapshot restore) so an unbounded string can't persist and bloat the
+        // /api/filaments list projection, exports, and sync payloads.
+        label: {
+          type: String,
+          default: "",
+          maxlength: [
+            MAX_SPOOL_TEXT_LENGTH,
+            `label must be ${MAX_SPOOL_TEXT_LENGTH} characters or fewer`,
+          ],
+        },
         totalWeight: { type: Number, default: null, min: 0 },
-        lotNumber: { type: String, default: null },
+        lotNumber: {
+          type: String,
+          default: null,
+          maxlength: [
+            MAX_SPOOL_TEXT_LENGTH,
+            `lotNumber must be ${MAX_SPOOL_TEXT_LENGTH} characters or fewer`,
+          ],
+        },
         purchaseDate: { type: Date, default: null },
         openedDate: { type: Date, default: null },
         createdAt: { type: Date, default: Date.now },

--- a/tests/apiErrorHandler.test.ts
+++ b/tests/apiErrorHandler.test.ts
@@ -6,6 +6,7 @@ import {
   handleDuplicateKeyError,
   handleVersionError,
   assertActiveRefs,
+  assertActiveSpoolLocation,
   assertMultipartFormData,
   checkFileSize,
   isClientInputError,
@@ -294,6 +295,72 @@ describe("assertActiveRefs", () => {
     expect(res!.status).toBe(400);
     const body = await res!.json();
     expect(body.error).toBe("One or more locations no longer exist.");
+  });
+});
+
+describe("assertActiveSpoolLocation (#953)", () => {
+  const VALID_OID = "a".repeat(24);
+
+  function promiseModel(count: number) {
+    const calls: Array<Record<string, unknown>> = [];
+    return {
+      calls,
+      countDocuments(filter: Record<string, unknown>): Promise<number> {
+        calls.push(filter);
+        return Promise.resolve(count);
+      },
+    };
+  }
+
+  function queryModel(count: number) {
+    return {
+      countDocuments() {
+        return { exec: () => Promise.resolve(count) };
+      },
+    };
+  }
+
+  it("passes null/undefined/empty without a query (no location = valid)", async () => {
+    const model = promiseModel(0);
+    expect(await assertActiveSpoolLocation(model, null)).toBeNull();
+    expect(await assertActiveSpoolLocation(model, undefined)).toBeNull();
+    expect(await assertActiveSpoolLocation(model, "")).toBeNull();
+    expect(model.calls).toHaveLength(0);
+  });
+
+  it("400s a non-ObjectId locationId without a query", async () => {
+    const model = promiseModel(1);
+    const res = await assertActiveSpoolLocation(model, "not-an-objectid");
+    expect(res!.status).toBe(400);
+    expect((await res!.json()).error).toBe("Invalid location id");
+    expect(model.calls).toHaveLength(0);
+  });
+
+  it("400s a non-string locationId without a query", async () => {
+    const model = promiseModel(1);
+    const res = await assertActiveSpoolLocation(model, 12345);
+    expect(res!.status).toBe(400);
+    expect(model.calls).toHaveLength(0);
+  });
+
+  it("returns null when the location exists and is active", async () => {
+    const model = promiseModel(1);
+    const res = await assertActiveSpoolLocation(model, VALID_OID);
+    expect(res).toBeNull();
+    expect(model.calls[0]).toEqual({ _id: VALID_OID, _deletedAt: null });
+  });
+
+  it("400s a well-formed id that resolves to no active location (dangling ref)", async () => {
+    const model = promiseModel(0);
+    const res = await assertActiveSpoolLocation(model, VALID_OID);
+    expect(res!.status).toBe(400);
+    expect((await res!.json()).error).toBe("The selected location no longer exists.");
+  });
+
+  it("resolves through the .exec() query branch", async () => {
+    expect(await assertActiveSpoolLocation(queryModel(1), VALID_OID)).toBeNull();
+    const res = await assertActiveSpoolLocation(queryModel(0), VALID_OID);
+    expect(res!.status).toBe(400);
   });
 });
 

--- a/tests/embedded-spool-photo-validation.test.ts
+++ b/tests/embedded-spool-photo-validation.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/lib/mongoUriGuard", () => ({
 describe("embedded spool photoDataUrl validation (#626)", () => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   let Filament: any;
+  let Location: any;
   /* eslint-enable @typescript-eslint/no-explicit-any */
 
   const SVG_DATA_URL = `data:image/svg+xml;base64,${Buffer.from(
@@ -49,11 +50,14 @@ describe("embedded spool photoDataUrl validation (#626)", () => {
     const nozMod = await import("@/models/Nozzle");
     const printerMod = await import("@/models/Printer");
     const bedMod = await import("@/models/BedType");
+    const locMod = await import("@/models/Location");
     if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
     if (!mongoose.models.Nozzle) mongoose.model("Nozzle", nozMod.default.schema);
     if (!mongoose.models.Printer) mongoose.model("Printer", printerMod.default.schema);
     if (!mongoose.models.BedType) mongoose.model("BedType", bedMod.default.schema);
+    if (!mongoose.models.Location) mongoose.model("Location", locMod.default.schema);
     Filament = mongoose.models.Filament;
+    Location = mongoose.models.Location;
   });
 
   function postReq(url: string, body: unknown) {
@@ -120,6 +124,102 @@ describe("embedded spool photoDataUrl validation (#626)", () => {
       const fresh = await Filament.findOne({ name: "Valid Photo PLA" });
       expect(fresh.spools[0].photoDataUrl).toBe(VALID_PNG_DATA_URL);
       expect(fresh.spools[1].photoDataUrl).toBeNull();
+    });
+
+    // GH #953 finding 3: the dedicated spool routes 400 an ISO-shaped-but-
+    // impossible date (GH #372); the embedded-spool create path used to pass
+    // it through and let Mongoose silently normalise "2025-02-29" → Mar 1.
+    it("rejects an impossible ISO date on an embedded spool with 400", async () => {
+      const res = await createFilament(
+        postReq("http://localhost/api/filaments", {
+          name: "Bad Date PLA",
+          vendor: "T",
+          type: "PLA",
+          spools: [{ label: "S1", totalWeight: 1000, purchaseDate: "2025-02-29" }],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/spools\[0\]/);
+      expect(body.error).toMatch(/purchaseDate/);
+      expect(await Filament.countDocuments({ name: "Bad Date PLA" })).toBe(0);
+    });
+
+    it("rejects a non-ISO openedDate (locale string) on an embedded spool with 400", async () => {
+      const res = await createFilament(
+        postReq("http://localhost/api/filaments", {
+          name: "Locale Date PLA",
+          vendor: "T",
+          type: "PLA",
+          spools: [{ totalWeight: 1000, openedDate: "1/15/2025" }],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/openedDate/);
+      expect(await Filament.countDocuments({ name: "Locale Date PLA" })).toBe(0);
+    });
+
+    // GH #953 finding 2: a dangling locationId (references a deleted or
+    // never-existent Location) must be refused — it otherwise produces a
+    // phantom "no location" group in every location-grouped view.
+    it("rejects an embedded spool locationId that references no active Location with 400", async () => {
+      const ghostId = new mongoose.Types.ObjectId();
+      const res = await createFilament(
+        postReq("http://localhost/api/filaments", {
+          name: "Dangling Loc PLA",
+          vendor: "T",
+          type: "PLA",
+          spools: [{ totalWeight: 1000, locationId: String(ghostId) }],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/location/i);
+      expect(await Filament.countDocuments({ name: "Dangling Loc PLA" })).toBe(0);
+    });
+
+    it("rejects an embedded spool locationId that isn't an ObjectId with 400", async () => {
+      const res = await createFilament(
+        postReq("http://localhost/api/filaments", {
+          name: "Garbage Loc PLA",
+          vendor: "T",
+          type: "PLA",
+          spools: [{ totalWeight: 1000, locationId: "not-an-objectid" }],
+        }),
+      );
+      expect(res.status).toBe(400);
+      expect(await Filament.countDocuments({ name: "Garbage Loc PLA" })).toBe(0);
+    });
+
+    it("accepts an embedded spool locationId that references an active Location", async () => {
+      const loc = await Location.create({ name: "Shelf 953" });
+      const res = await createFilament(
+        postReq("http://localhost/api/filaments", {
+          name: "Good Loc PLA",
+          vendor: "T",
+          type: "PLA",
+          spools: [{ totalWeight: 1000, locationId: String(loc._id) }],
+        }),
+      );
+      expect(res.status).toBe(201);
+      const fresh = await Filament.findOne({ name: "Good Loc PLA" });
+      expect(String(fresh.spools[0].locationId)).toBe(String(loc._id));
+    });
+
+    // GH #953 finding 1: the schema `maxlength` backstops the embedded-create
+    // path (Filament.create runs subdoc validation → ValidationError → 400).
+    it("rejects an over-long embedded spool label with 400", async () => {
+      const res = await createFilament(
+        postReq("http://localhost/api/filaments", {
+          name: "Long Label PLA",
+          vendor: "T",
+          type: "PLA",
+          spools: [{ label: "x".repeat(5000), totalWeight: 1000 }],
+        }),
+      );
+      expect(res.status).toBe(400);
+      expect(await Filament.countDocuments({ name: "Long Label PLA" })).toBe(0);
     });
   });
 

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -689,6 +689,31 @@ describe("snapshot route — Location + PrintHistory round-trip", () => {
       expect(await Location.countDocuments({ _id: canary._id })).toBe(1);
     });
 
+    it("rejects a present collection whose value is not an array, and does NOT wipe (Codex P1)", async () => {
+      const canary = await Location.create({ name: "Canary Loc 5" });
+      // `locations: {}` passes the key-presence guard but isn't an array — the
+      // destructure would leave it non-array, `.length` undefined, every insert
+      // skipped after the wipe. Must 400 before the destructive path.
+      const res = await postSnapshot({
+        version: 4,
+        createdAt: new Date().toISOString(),
+        collections: { locations: {} },
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/must be an array/i);
+      expect(await Location.countDocuments({ _id: canary._id })).toBe(1);
+
+      // Also a scalar under a known key.
+      const canary2 = await Location.create({ name: "Canary Loc 6" });
+      const res2 = await postSnapshot({
+        version: 4,
+        createdAt: new Date().toISOString(),
+        collections: { filaments: 1 },
+      });
+      expect(res2.status).toBe(400);
+      expect(await Location.countDocuments({ _id: canary2._id })).toBe(1);
+    });
+
     it("still restores a snapshot with no version field (older/hand-written) when collections are recognized", async () => {
       await Location.create({ name: "Pre-existing Loc" });
       const res = await postSnapshot({

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -624,4 +624,80 @@ describe("snapshot route — Location + PrintHistory round-trip", () => {
       "snap-roll-2",
     ]);
   });
+
+  // GH #953 finding 4: restore must fail closed on a snapshot it can't fully
+  // apply, BEFORE the destructive wipe — never wipe the DB and then report
+  // success while silently dropping data.
+  describe("restore version + shape validation (#953)", () => {
+    function postSnapshot(snapshot: unknown) {
+      return POST(
+        new NextRequest("http://localhost/api/snapshot", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(snapshot),
+        }),
+      );
+    }
+
+    it("rejects a snapshot from a newer version with 400 and does NOT wipe", async () => {
+      const canary = await Location.create({ name: "Canary Loc" });
+      const res = await postSnapshot({
+        version: 5,
+        createdAt: new Date().toISOString(),
+        // A v5 file could carry a new/renamed collection the v4 restore would drop.
+        collections: { filaments: [], nozzles: [], printers: [], bedTypes: [] },
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/newer version/i);
+      // The pre-existing data survives — no wipe happened.
+      expect(await Location.countDocuments({ _id: canary._id })).toBe(1);
+    });
+
+    it("rejects an empty collections object with 400 and does NOT wipe", async () => {
+      const canary = await Location.create({ name: "Canary Loc 2" });
+      const res = await postSnapshot({
+        version: 4,
+        createdAt: new Date().toISOString(),
+        collections: {},
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/no recognized collections/i);
+      expect(await Location.countDocuments({ _id: canary._id })).toBe(1);
+    });
+
+    it("rejects a non-object collections value (collections: 1) with 400 and does NOT wipe", async () => {
+      const canary = await Location.create({ name: "Canary Loc 3" });
+      const res = await postSnapshot({
+        version: 4,
+        createdAt: new Date().toISOString(),
+        collections: 1,
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/missing or malformed/i);
+      expect(await Location.countDocuments({ _id: canary._id })).toBe(1);
+    });
+
+    it("rejects collections with only unrecognized keys with 400 and does NOT wipe", async () => {
+      const canary = await Location.create({ name: "Canary Loc 4" });
+      const res = await postSnapshot({
+        version: 4,
+        createdAt: new Date().toISOString(),
+        collections: { spoolsCollection: [{ foo: 1 }] },
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/no recognized collections/i);
+      expect(await Location.countDocuments({ _id: canary._id })).toBe(1);
+    });
+
+    it("still restores a snapshot with no version field (older/hand-written) when collections are recognized", async () => {
+      await Location.create({ name: "Pre-existing Loc" });
+      const res = await postSnapshot({
+        createdAt: new Date().toISOString(),
+        collections: { locations: [{ name: "Restored No-Version" }] },
+      });
+      expect(res.status).toBe(200);
+      const names = (await Location.find({}).lean()).map((l: { name: string }) => l.name);
+      expect(names).toEqual(["Restored No-Version"]);
+    });
+  });
 });

--- a/tests/spool-create-validation.test.ts
+++ b/tests/spool-create-validation.test.ts
@@ -104,6 +104,41 @@ describe("POST /api/filaments/[id]/spools — body validation (GH #203)", () => 
     expect(String(fresh.spools[0].locationId)).toBe(String(loc._id));
   });
 
+  // GH #953 finding 2: a locationId that doesn't reference an active Location
+  // must be refused, or a dangling ref persists and produces a phantom
+  // "no location" group in every location-grouped view.
+  it("returns 400 for a locationId that references no active Location", async () => {
+    const f = await seed();
+    const ghost = new mongoose.Types.ObjectId();
+    const res = await createSpool(postReq(String(f._id), { locationId: String(ghost) }), {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/location/i);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.spools).toHaveLength(0);
+  });
+
+  it("returns 400 for a non-ObjectId locationId", async () => {
+    const f = await seed();
+    const res = await createSpool(postReq(String(f._id), { locationId: "nope" }), {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(400);
+    const fresh = await Filament.findById(f._id);
+    expect(fresh.spools).toHaveLength(0);
+  });
+
+  // GH #953 finding 1: over-long free-form text is rejected by validateSpoolBody.
+  it("returns 400 for an over-long label", async () => {
+    const f = await seed();
+    const res = await createSpool(postReq(String(f._id), { label: "x".repeat(5000) }), {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/label must be \d+ characters or fewer/);
+  });
+
   it("persists every supplied field (no silent drop of lotNumber/dates)", async () => {
     const f = await seed();
     const res = await createSpool(

--- a/tests/spool-remaining-weight-route.test.ts
+++ b/tests/spool-remaining-weight-route.test.ts
@@ -145,4 +145,63 @@ describe("PUT /api/filaments/{id}/spools/{spoolId} — remainingWeight", () => {
     const res = await call(missingId, missingSpool, { remainingWeight: 500 });
     expect(res.status).toBe(404);
   });
+
+  // GH #953 finding 2: the PUT move-to path is the exact scenario in the
+  // finding (a mobile offline-queue move replayed after the location was
+  // deleted). A dangling locationId must be refused before the write.
+  describe("locationId validation (#953)", () => {
+    async function LocationModel() {
+      const locMod = await import("@/models/Location");
+      if (!mongoose.models.Location) mongoose.model("Location", locMod.default.schema);
+      return mongoose.models.Location;
+    }
+
+    it("rejects a move to a locationId with no active Location (400, no write)", async () => {
+      const f = await Filament.create({
+        name: "Move Host",
+        vendor: "Test",
+        type: "PLA",
+        spools: [{ label: "A", totalWeight: 1000 }],
+      });
+      const sid = String(f.spools[0]._id);
+      const ghost = new mongoose.Types.ObjectId();
+      const res = await call(String(f._id), sid, { locationId: String(ghost) });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/location/i);
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools[0].locationId ?? null).toBeNull();
+    });
+
+    it("accepts a move to an active Location (200)", async () => {
+      const Location = await LocationModel();
+      const loc = await Location.create({ name: "Shelf PUT 953" });
+      const f = await Filament.create({
+        name: "Move Host 2",
+        vendor: "Test",
+        type: "PLA",
+        spools: [{ label: "A", totalWeight: 1000 }],
+      });
+      const sid = String(f.spools[0]._id);
+      const res = await call(String(f._id), sid, { locationId: String(loc._id) });
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id);
+      expect(String(fresh.spools[0].locationId)).toBe(String(loc._id));
+    });
+
+    it("still allows clearing the location (locationId: null)", async () => {
+      const Location = await LocationModel();
+      const loc = await Location.create({ name: "Shelf PUT clear" });
+      const f = await Filament.create({
+        name: "Clear Loc Host",
+        vendor: "Test",
+        type: "PLA",
+        spools: [{ label: "A", totalWeight: 1000, locationId: loc._id }],
+      });
+      const sid = String(f.spools[0]._id);
+      const res = await call(String(f._id), sid, { locationId: null });
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.spools[0].locationId ?? null).toBeNull();
+    });
+  });
 });

--- a/tests/spools-import-route.test.ts
+++ b/tests/spools-import-route.test.ts
@@ -97,6 +97,36 @@ describe("/api/spools/import", () => {
     expect(fresh.spools[0].totalWeight).toBe(800);
   });
 
+  // GH #953 finding 1: cap the free-form spool text fields on the CSV path too.
+  // The check is side-effect-free (before resolveLocationId auto-creates a
+  // Location), so a too-long row fails alone without dirtying the catalog.
+  it("fails a row whose label exceeds the length cap without a location side effect", async () => {
+    await Filament.create({ name: "Long Label CSV", vendor: "Test", type: "PLA" });
+    const csv =
+      "filament,totalWeight,label,location\n" +
+      `Long Label CSV,500,${"x".repeat(5000)},Ghost Shelf\n`;
+    const res = await importSpools(csvRequest(csv));
+    const body = await res.json();
+    expect(body.imported).toBe(0);
+    expect(body.failed).toBe(1);
+    const failed = body.results.find((r: { ok: boolean; error?: string }) => !r.ok);
+    expect(failed.error).toMatch(/label must be \d+ characters or fewer/);
+    // side-effect-free: no orphan location auto-created for the failed row.
+    expect(await Location.countDocuments({ name: "Ghost Shelf" })).toBe(0);
+  });
+
+  it("fails a row whose lotNumber exceeds the length cap", async () => {
+    await Filament.create({ name: "Long Lot CSV", vendor: "Test", type: "PLA" });
+    const csv =
+      "filament,totalWeight,lotNumber\n" +
+      `Long Lot CSV,500,${"y".repeat(5000)}\n`;
+    const res = await importSpools(csvRequest(csv));
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    const failed = body.results.find((r: { ok: boolean; error?: string }) => !r.ok);
+    expect(failed.error).toMatch(/lotNumber must be \d+ characters or fewer/);
+  });
+
   it("auto-creates referenced locations by name", async () => {
     const f = await Filament.create({ name: "Loc Test", vendor: "Test", type: "PLA" });
     const csv =

--- a/tests/validateSpoolBody.test.ts
+++ b/tests/validateSpoolBody.test.ts
@@ -3,6 +3,7 @@ import {
   validateSpoolBody,
   isValidIsoDateString,
   validateSpoolPhotoDataUrl,
+  MAX_SPOOL_TEXT_LENGTH,
 } from "@/lib/validateSpoolBody";
 
 describe("validateSpoolBody (POST semantics)", () => {
@@ -86,6 +87,39 @@ describe("validateSpoolBody (POST semantics)", () => {
   it("rejects non-string optional fields", () => {
     expect(validateSpoolBody({ lotNumber: 12345 }).ok).toBe(false);
     expect(validateSpoolBody({ purchaseDate: { invalid: true } }).ok).toBe(false);
+  });
+
+  // GH #953: cap the free-form spool text fields so an unbounded string can't
+  // persist (and then bloat the /api/filaments list projection, exports, sync).
+  it("accepts label/lotNumber at exactly the length cap", () => {
+    const atCap = "x".repeat(MAX_SPOOL_TEXT_LENGTH);
+    const r = validateSpoolBody({ label: atCap, lotNumber: atCap });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.label).toBe(atCap);
+    expect(r.lotNumber).toBe(atCap);
+  });
+
+  it("rejects a label over the length cap", () => {
+    const r = validateSpoolBody({ label: "x".repeat(MAX_SPOOL_TEXT_LENGTH + 1) });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toMatch(/label must be \d+ characters or fewer/);
+  });
+
+  it("rejects a lotNumber over the length cap", () => {
+    const r = validateSpoolBody({ lotNumber: "x".repeat(MAX_SPOOL_TEXT_LENGTH + 1) });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toMatch(/lotNumber must be \d+ characters or fewer/);
+  });
+
+  it("caps label on PUT (partial) semantics too", () => {
+    const r = validateSpoolBody(
+      { label: "x".repeat(MAX_SPOOL_TEXT_LENGTH + 1) },
+      { partial: true },
+    );
+    expect(r.ok).toBe(false);
   });
 
   // GH #372: date strings must parse to a real date, not just be string-shaped.


### PR DESCRIPTION
Closes #953 — the four confirmed P2 findings from the automated adversarial review: mutating routes that accepted unbounded/unvalidated input, or bypassed validation a parallel dedicated route already enforced.

## Findings fixed

### 1. Unbounded spool `label` / `lotNumber`
`validateSpoolBody` only type-checked them, the schema had no `maxlength`, and the positional-`$` PUT bypasses subdoc validation — so a multi-MB string persisted and bloated every `/api/filaments` list fetch (which projects `spools[].label`), CSV/snapshot exports, and sync payloads (same DoS-lite class as #350).
- `MAX_SPOOL_TEXT_LENGTH = 200` enforced in `validateSpoolBody` (POST/PUT `/spools`).
- Schema `maxlength` **backstop** on `spools[].label`/`lotNumber` → covers every path that reaches Mongoose validation (embedded-create, CSV save, snapshot restore) with a clean 400 `ValidationError`.
- CSV importer adds a side-effect-free per-row check (before `resolveLocationId` auto-creates a Location) for a precise per-row error.

### 2. Dangling spool `locationId`
No spool write path checked that `locationId` referenced an **active** Location (unlike nozzle/printer/bed-type refs via `assertActiveRefs`), so a dangling ref persisted and produced a phantom "no location" group in every location-grouped view (`/inventory`, `?kind=` filters, the #616 home stat). Realistic trigger: a mobile offline-queue move replayed after the location was deleted.
- New `assertActiveSpoolLocation` (mongoose-free; Location model injected like `assertActiveRefs`) gates **PUT** + **POST** `/spools` and the embedded-spools loop in **POST `/api/filaments`**. CSV auto-creates locations, so it's inherently safe.

### 3. Embedded spools bypassed ISO-date validation
`POST /api/filaments` embedded spools passed `purchaseDate`/`openedDate` through raw, so Mongoose silently normalised `2025-02-29` → Mar 1 (the #372 bug) while every dedicated route 400s it. Now validated with `isValidIsoDateString`.

### 4. Snapshot restore didn't validate `version` / shape before the destructive wipe
`POST /api/snapshot` only did a truthiness check on `collections`, so a newer-version file (dropping added/renamed collections) or a wrong shape (`collections: {}`, `collections: 1`, unknown-keys-only) wiped the DB, inserted nothing, and reported **success**. Now rejects `version > CURRENT_SNAPSHOT_VERSION` and requires `collections` to be a plain object with ≥1 recognized key — **before** the wipe. Canary tests confirm no wipe on rejection.

## Out of scope (by design)
`import-atlas` (sanitize-not-reject posture for the user's own remote Atlas data) and `prusament/import` (no user locations; already date-validated) are not named in the finding and keep their existing postures.

## Tests
Regression coverage added for every finding — unit (`validateSpoolBody`, `assertActiveSpoolLocation`) + route (embedded create, POST/PUT `/spools`, CSV import, snapshot restore). Full suite green: **2921 passed**. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)