### PR TITLE
fix: match/resync robustness — name collision, parentId cycle, OPT quoted numerics (#954)

### DIFF
--- a/src/lib/matchFilament.ts
+++ b/src/lib/matchFilament.ts
@@ -182,14 +182,36 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
     // suggestions if they supplied those alongside.
   }
 
-  // 1. Exact name match (case-insensitive) — a confident match.
+  // 1. Name match. GH #954: the name partial-unique index is case-SENSITIVE
+  //    (src/models/Filament.ts — no collation), so two active filaments
+  //    differing only by case ("PLA Black" vs "pla black") can coexist. A bare
+  //    case-insensitive findOne returned whichever Mongo yielded first as a
+  //    CONFIDENT match — the SSE scan bus then auto-selects a possibly-wrong
+  //    PrusaSlicer preset silently. Mirror the instanceId tier above: exact case
+  //    first (deterministic in the common case, and not demoted to "ambiguous"
+  //    just because a case-variant sibling exists), then a case-insensitive
+  //    fallback that only auto-matches when it's unambiguous. Same class as the
+  //    GH #896 vendor-substring fix.
   if (name) {
-    const exact = await Filament.findOne({
-      name: { $regex: `^${escapeRegex(name)}$`, $options: "i" },
-      _deletedAt: null,
-    }).lean();
+    // 1a. Exact-case — a confident match even when a case-variant sibling exists.
+    const exact = await Filament.findOne({ name, _deletedAt: null }).lean();
     if (exact) {
       return { match: exact, candidates: [], matchedSpool: null };
+    }
+    // 1b. Case-insensitive fallback for legacy case drift. Cap at 2 to detect
+    //     "more than one" without scanning the DB. One hit → confident match;
+    //     multiple → case-only collision, surface as candidates.
+    const ciMatches = await Filament.find({
+      name: { $regex: `^${escapeRegex(name)}$`, $options: "i" },
+      _deletedAt: null,
+    })
+      .limit(2)
+      .lean();
+    if (ciMatches.length === 1) {
+      return { match: ciMatches[0], candidates: [], matchedSpool: null };
+    }
+    if (ciMatches.length > 1) {
+      return { match: null, candidates: ciMatches, matchedSpool: null };
     }
   }
 

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -243,12 +243,21 @@ export function rgbaToHex(rgba: string | undefined | null): string | null {
  * strings and non-numerics return null — NOT 0 (`Number("") === 0` would
  * silently invent a value). Same "cast at the boundary" intent as the #632 /
  * #894 fixes; the OPTMaterial interface already types every field `number | null`.
+ *
+ * Only real numbers and numeric STRINGS coerce. A malformed upstream value
+ * typed as a boolean or a sequence is left as "absent" (null) rather than
+ * fabricated — `Number(false)`/`Number([])` are 0, `Number(true)` is 1,
+ * `Number([65])` is 65, which would invent a value the downstream optResync
+ * guard otherwise skips (Codex P2 on PR #959).
  */
 export function toOptNumber(v: unknown): number | null {
-  if (v == null) return null;
-  if (typeof v === "string" && v.trim() === "") return null;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : null;
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (typeof v === "string") {
+    if (v.trim() === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
 }
 
 // ── YAML parsing ───────────────────────────────────────────────────────

--- a/src/lib/openprinttagBrowser.ts
+++ b/src/lib/openprinttagBrowser.ts
@@ -230,6 +230,27 @@ export function rgbaToHex(rgba: string | undefined | null): string | null {
   return `#${hex.slice(0, 6)}`;
 }
 
+/**
+ * GH #954: coerce a YAML-parsed scalar to a real number at the parse boundary.
+ * The `yaml` package parses a QUOTED numeric scalar (`density: "1.24"`) to the
+ * JS string "1.24" (only an unquoted `65` becomes a number), and the old
+ * `props.density as number` cast is a compile-time no-op that let the string
+ * through. That string then round-trips into the Mixed `openprinttagSnapshot`
+ * (which does no casting) while Mongoose casts the stored field to a number, so
+ * every OPT re-sync check compared `1.24` vs `"1.24"` (strict `===` → not equal)
+ * and surfaced a permanent, unapplyable conflict. Coercing here keeps types
+ * honest end-to-end (snapshot, exports, completeness scoring). Empty/whitespace
+ * strings and non-numerics return null — NOT 0 (`Number("") === 0` would
+ * silently invent a value). Same "cast at the boundary" intent as the #632 /
+ * #894 fixes; the OPTMaterial interface already types every field `number | null`.
+ */
+export function toOptNumber(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === "string" && v.trim() === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
 // ── YAML parsing ───────────────────────────────────────────────────────
 
 /**
@@ -330,17 +351,17 @@ export function parseMaterialYaml(
       abbreviation: (raw.abbreviation as string) || (raw.type as string) || "",
       color: rgbaToHex(primaryColor?.color_rgba as string | undefined),
       secondaryColors,
-      density: (props.density as number) ?? null,
-      nozzleTempMin: (props.min_print_temperature as number) ?? null,
-      nozzleTempMax: (props.max_print_temperature as number) ?? null,
-      bedTempMin: (props.min_bed_temperature as number) ?? null,
-      bedTempMax: (props.max_bed_temperature as number) ?? null,
-      chamberTemp: (props.chamber_temperature as number) ?? null,
-      preheatTemp: (props.preheat_temperature as number) ?? null,
-      dryingTemp: (props.drying_temperature as number) ?? null,
-      dryingTime: (props.drying_time as number) ?? null,
-      hardnessShoreD: (props.hardness_shore_d as number) ?? null,
-      transmissionDistance: (raw.transmission_distance as number) ?? null,
+      density: toOptNumber(props.density),
+      nozzleTempMin: toOptNumber(props.min_print_temperature),
+      nozzleTempMax: toOptNumber(props.max_print_temperature),
+      bedTempMin: toOptNumber(props.min_bed_temperature),
+      bedTempMax: toOptNumber(props.max_bed_temperature),
+      chamberTemp: toOptNumber(props.chamber_temperature),
+      preheatTemp: toOptNumber(props.preheat_temperature),
+      dryingTemp: toOptNumber(props.drying_temperature),
+      dryingTime: toOptNumber(props.drying_time),
+      hardnessShoreD: toOptNumber(props.hardness_shore_d),
+      transmissionDistance: toOptNumber(raw.transmission_distance),
       tags: Array.isArray(raw.tags) ? (raw.tags as string[]) : [],
       photoUrl:
         photos && photos.length > 0

--- a/src/lib/resolveEffectiveFilament.ts
+++ b/src/lib/resolveEffectiveFilament.ts
@@ -34,7 +34,28 @@ export interface EffectiveFilament {
 export async function resolveEffectiveFilament(
   filament: Record<string, unknown>,
 ): Promise<EffectiveFilament> {
+  return resolveEffectiveFilamentInner(filament, new Set());
+}
+
+/**
+ * GH #954: the recursion has no depth or seen guard, so a `parentId` cycle
+ * (a filament whose ancestor chain loops back — self-reference, or two variants
+ * pointing at each other in bad/corrupted data) recurses forever awaiting
+ * `Filament.findOne` and the request never returns. Thread a `seen` set of the
+ * ids resolved so far in this chain; on revisiting one, stop resolving
+ * inheritance and fall back to the raw doc (`parentEffective: null`) — the same
+ * degradation already used when the parent can't be loaded. Best-effort for
+ * broken data; a well-formed chain (no cycle) is unaffected.
+ */
+async function resolveEffectiveFilamentInner(
+  filament: Record<string, unknown>,
+  seen: Set<string>,
+): Promise<EffectiveFilament> {
   if (!filament.parentId) return { effective: filament, parentEffective: null };
+  // A DB-loaded doc always carries `_id`; String() it for the visited-set key.
+  const selfId = String(filament._id);
+  if (seen.has(selfId)) return { effective: filament, parentEffective: null };
+  seen.add(selfId);
   const parent = await Filament.findOne({
     _id: filament.parentId,
     _deletedAt: null,
@@ -46,8 +67,9 @@ export async function resolveEffectiveFilament(
   ) as unknown as Record<string, unknown>;
   // Resolve the parent too (it may itself be a variant) so the "value after
   // clearing this variant's own array" is the parent's EFFECTIVE array.
-  const { effective: parentEffective } = await resolveEffectiveFilament(
+  const { effective: parentEffective } = await resolveEffectiveFilamentInner(
     parent as unknown as Record<string, unknown>,
+    seen,
   );
   return { effective, parentEffective };
 }

--- a/tests/matchFilament.test.ts
+++ b/tests/matchFilament.test.ts
@@ -135,6 +135,28 @@ describe("matchFilament", () => {
       expect(res.matchedSpool).toBeNull();
     });
 
+    // GH #954: the name index is case-sensitive, so "PLA Black" and "pla black"
+    // can both be active. A query matching NEITHER exactly must surface both as
+    // candidates, never auto-pick one (which the SSE bus would silently select).
+    it("returns both filaments as candidates on a case-only name collision", async () => {
+      await Filament.create({ name: "PLA Black", vendor: "Test", type: "PLA" });
+      await Filament.create({ name: "pla black", vendor: "Test", type: "PLA" });
+      const res = await matchFilament({ name: "PLA BLACK" });
+      expect(res.match).toBeNull();
+      expect(res.matchedSpool).toBeNull();
+      expect(names(res.candidates)).toEqual(["PLA Black", "pla black"]);
+    });
+
+    // Exact case wins outright — a case-variant sibling must NOT demote an exact
+    // hit to ambiguous.
+    it("prefers the exact-case name when a case-variant sibling exists", async () => {
+      await Filament.create({ name: "PLA Black", vendor: "Test", type: "PLA" });
+      await Filament.create({ name: "pla black", vendor: "Test", type: "PLA" });
+      const res = await matchFilament({ name: "pla black" });
+      expect((res.match as { name: string }).name).toBe("pla black");
+      expect(res.candidates).toEqual([]);
+    });
+
     it("returns the empty result when nothing is supplied", async () => {
       const res = await matchFilament({});
       expect(res).toEqual({ match: null, candidates: [], matchedSpool: null });

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -27,6 +27,7 @@ import {
   computeCompletenessScore,
   completenessTier,
   rgbaToHex,
+  toOptNumber,
   parseBrandYaml,
   parseMaterialYaml,
   mapToFilamentPayload,
@@ -355,6 +356,48 @@ properties:
     expect(m!.tags).toEqual(["blend"]);
     expect(m!.completenessScore).toBeGreaterThanOrEqual(8);
     expect(m!.completenessTier).toBe("rich");
+  });
+
+  // GH #954: a QUOTED numeric scalar in the upstream YAML parses to a JS string;
+  // the old `as number` cast was a no-op that let it through, causing a
+  // permanent OPT re-sync conflict (number-in-DB vs string-in-snapshot). The
+  // parse boundary must coerce to a real number.
+  it("coerces quoted-numeric YAML scalars to real numbers", () => {
+    const yaml = `uuid: q1
+slug: quoted-numerics
+brand:
+  slug: prusament
+name: Quoted Numerics
+class: FFF
+type: PLA
+transmission_distance: "6.4"
+properties:
+  density: "1.24"
+  min_print_temperature: "210"
+  max_print_temperature: 230
+  drying_temperature: "55"`;
+    const m = parseMaterialYaml(yaml, brandMap);
+    expect(m).not.toBeNull();
+    // Numbers, not the strings "1.24"/"210"/"6.4".
+    expect(m!.density).toBe(1.24);
+    expect(typeof m!.density).toBe("number");
+    expect(m!.nozzleTempMin).toBe(210);
+    expect(m!.nozzleTempMax).toBe(230); // unquoted still works
+    expect(m!.dryingTemp).toBe(55);
+    expect(m!.transmissionDistance).toBe(6.4);
+  });
+
+  it("toOptNumber: coerces strings, guards blanks/garbage to null (never 0)", () => {
+    expect(toOptNumber("1.24")).toBe(1.24);
+    expect(toOptNumber(65)).toBe(65);
+    expect(toOptNumber(null)).toBeNull();
+    expect(toOptNumber(undefined)).toBeNull();
+    expect(toOptNumber("")).toBeNull(); // NOT 0 (Number("") === 0)
+    expect(toOptNumber("   ")).toBeNull();
+    expect(toOptNumber("abc")).toBeNull();
+    expect(toOptNumber(Infinity)).toBeNull();
+    expect(toOptNumber(NaN)).toBeNull();
+    expect(toOptNumber(0)).toBe(0); // a real zero survives
   });
 
   it("filters out SLA materials", () => {

--- a/tests/openprinttagBrowser.test.ts
+++ b/tests/openprinttagBrowser.test.ts
@@ -398,6 +398,14 @@ properties:
     expect(toOptNumber(Infinity)).toBeNull();
     expect(toOptNumber(NaN)).toBeNull();
     expect(toOptNumber(0)).toBe(0); // a real zero survives
+    // GH #959 (Codex P2): a malformed boolean/sequence must NOT fabricate a
+    // number — Number(false)/Number([]) are 0, Number(true) is 1, Number([65])
+    // is 65. Treat them as absent (null) so the resync guard skips bad data.
+    expect(toOptNumber(true)).toBeNull();
+    expect(toOptNumber(false)).toBeNull();
+    expect(toOptNumber([])).toBeNull();
+    expect(toOptNumber([65])).toBeNull();
+    expect(toOptNumber({})).toBeNull();
   });
 
   it("filters out SLA materials", () => {

--- a/tests/resolveEffectiveFilament.test.ts
+++ b/tests/resolveEffectiveFilament.test.ts
@@ -147,4 +147,36 @@ describe("resolveEffectiveFilament (GH #607)", () => {
     expect(parentEffective).not.toBeNull();
     expect((parentEffective as Record<string, unknown>).density).toBe(1.11);
   });
+
+  // GH #954: a parentId cycle in corrupted data (the API guards against nested
+  // inheritance, but a direct DB write / bad migration could create one) used to
+  // recurse forever awaiting Filament.findOne — the request never returned. The
+  // seen-set guard must make it terminate. If the guard regressed, these tests
+  // time out (the failure the fix prevents) rather than passing.
+  it("terminates on a two-node parentId cycle instead of hanging", async () => {
+    const a = await Filament.create({ name: "Cycle A", vendor: "Acme", type: "PLA", density: 1.2 });
+    const b = await Filament.create({ name: "Cycle B", vendor: "Acme", type: "PLA", density: 1.3 });
+    // Corrupt data: A → B → A (bypasses the API's no-nested-inheritance guard).
+    await Filament.updateOne({ _id: a._id }, { $set: { parentId: b._id } });
+    await Filament.updateOne({ _id: b._id }, { $set: { parentId: a._id } });
+    const lean = await Filament.findById(a._id).lean();
+
+    const result = await resolveEffectiveFilament(lean);
+    // The point: it RETURNS a well-formed result rather than recursing forever.
+    expect(result).toHaveProperty("effective");
+    expect(result).toHaveProperty("parentEffective");
+  });
+
+  it("terminates on a self-referential parentId", async () => {
+    const a = await Filament.create({ name: "Self Cycle", vendor: "Acme", type: "PLA", density: 1.5 });
+    await Filament.updateOne({ _id: a._id }, { $set: { parentId: a._id } });
+    const lean = await Filament.findById(a._id).lean();
+
+    const result = await resolveEffectiveFilament(lean);
+    // The point is termination (no infinite recursion). A self-reference is
+    // loadable (the doc is its own parent), so parentEffective is that doc's
+    // resolved value — the guard fires one level down. Both shapes present.
+    expect(result).toHaveProperty("effective");
+    expect(result).toHaveProperty("parentEffective");
+  });
 });


### PR DESCRIPTION
Part of the #954 triage (PR-F: match / resync robustness). Three confirmed P2 correctness gaps, each independent and low-risk.

### 1. Name-tier case-only collision auto-matches an arbitrary filament — `src/lib/matchFilament.ts`
The `name` partial-unique index is case-**sensitive** (no collation), so `PLA Black` and `pla black` can both be active. The name tier resolved with a bare case-insensitive `findOne` and returned whichever Mongo yielded first as a **confident** match — and the SSE scan bus auto-selects a PrusaSlicer preset off `match.name`, so a possibly-wrong preset was picked silently. Now mirrors the `instanceId` tier: **exact case wins**, then a CI fallback that only auto-matches on a single hit; a case-only collision surfaces both as `candidates`. (Same class as the GH #896 vendor-substring fix.)

### 2. Unbounded `parentId` recursion hangs OPT check/sync — `src/lib/resolveEffectiveFilament.ts`
The parent recursion had no seen/depth guard, so a `parentId` cycle in corrupt data (self- or mutual-reference — the API blocks nested inheritance, but a direct DB write / bad migration could create one) recursed forever awaiting `Filament.findOne` and the request never returned. Threads a visited-id set; on revisit it stops and falls back to the raw doc (same degradation as an unloadable parent).

### 3. OPT quoted-numeric YAML → permanent unapplyable resync conflict — `src/lib/openprinttagBrowser.ts`
A **quoted** upstream scalar (`density: "1.24"`) parses to a JS string; the `as number` cast is a compile-time no-op, so the string rode into the Mixed `openprinttagSnapshot` while Mongoose cast the stored field to a number. Every re-sync `check` then compared `1.24` vs `"1.24"` (strict `===`) → a **permanent conflict** that re-surfaces after every apply. Coerce to a real number at the parse boundary (new `toOptNumber`), applied uniformly to all 11 numeric fields; blank/whitespace/garbage → `null` (never `0`, since `Number("")===0`). Legacy string snapshots self-heal on the next sync — no migration. (Same "cast at the boundary" intent as #632 / #894.)

### Tests
Added for each: name case-collision + exact-case-preference (matchFilament), two- and self-node `parentId` cycles that terminate (resolveEffectiveFilament), quoted-numeric coercion + `toOptNumber` edge cases (openprinttagBrowser). Full **coverage** suite green — 99.0% stmt / 97.6% branch, all thresholds held. Typecheck + lint clean.

Part of #954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)