### PR TITLE
fix: P3 deferred batch — 4 fixes from #955

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1006,7 +1006,7 @@
           "Filaments"
         ],
         "summary": "Get calibration for nozzle diameter",
-        "description": "Returns calibration data for a specific filament and nozzle diameter. Looks up the filament by URL-encoded name or ObjectId, resolves variant inheritance, then finds the calibration entry whose nozzle diameter matches the query param. Used by PrusaSlicer to auto-adjust filament settings when the user switches printer presets.",
+        "description": "Returns calibration data for a specific filament and nozzle diameter. Looks up the filament by URL-encoded name or ObjectId, resolves variant inheritance, then finds the calibration entry whose nozzle diameter matches the query param. Used by PrusaSlicer and OrcaSlicer to auto-adjust filament settings when the user switches printer presets. Optional high_flow, nozzle_type, and bed_type params disambiguate multiple calibrations at the same diameter (a type/bed miss falls back to a same-diameter entry rather than 404ing). With format=orcaslicer the response returns OrcaSlicer key names + array values under calibration_orca instead of the default calibration object.",
         "parameters": [
           {
             "$ref": "#/components/parameters/FilamentId"
@@ -1032,6 +1032,35 @@
               ]
             },
             "description": "Filter by high-flow nozzle flag. Disambiguates same-diameter nozzles (e.g. 0.4mm vs 0.4mm HF)."
+          },
+          {
+            "name": "nozzle_type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Disambiguate same-diameter nozzles of different TYPE (e.g. Brass vs Diamondback), case-insensitive. Symmetric with the sync-back route's filamentdb_nozzle hint so a suffixed per-nozzle preset reads back ITS nozzle's pressure_advance (#872). Soft filter: a type miss falls back to the same-diameter matches rather than 404ing.",
+            "example": "Diamondback"
+          },
+          {
+            "name": "bed_type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by bed type name OR BedType ObjectId. A bed-type-specific calibration wins; otherwise it falls back to a calibration without a bed type. When omitted, entries without a bed type are preferred.",
+            "example": "Smooth PEI"
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "orcaslicer"
+              ]
+            },
+            "description": "When set to `orcaslicer`, the 200 response returns OrcaSlicer key names with array values under `calibration_orca` instead of the default `calibration` object."
           }
         ],
         "responses": {
@@ -1065,8 +1094,22 @@
                       "nullable": true,
                       "description": "Printer name, or null if calibration is not printer-specific"
                     },
+                    "bedType": {
+                      "type": "object",
+                      "nullable": true,
+                      "description": "The bed type the matched calibration is pinned to, or null when the calibration has no bed type.",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "material": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "calibration": {
                       "type": "object",
+                      "description": "Default response shape. Omitted when format=orcaslicer (see calibration_orca instead).",
                       "properties": {
                         "pressureAdvance": {
                           "type": "number",
@@ -1133,6 +1176,11 @@
                           "description": "Bridge fan speed (0–100)"
                         }
                       }
+                    },
+                    "calibration_orca": {
+                      "type": "object",
+                      "description": "Returned INSTEAD of `calibration` when format=orcaslicer — OrcaSlicer key names (e.g. filament_flow_ratio, pressure_advance, filament_retraction_length) mapped to their array values. Additional properties are OrcaSlicer keys.",
+                      "additionalProperties": true
                     }
                   }
                 }
@@ -1171,10 +1219,18 @@
                               },
                               "name": {
                                 "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "description": "Nozzle material/type (e.g. Brass, Diamondback) — helps the caller pick a nozzle_type to retry with."
+                              },
+                              "highFlow": {
+                                "type": "boolean",
+                                "description": "Whether this calibration's nozzle is high-flow — helps the caller pick a high_flow value to retry with."
                               }
                             }
                           },
-                          "description": "List of nozzle diameters that do have calibration data"
+                          "description": "The filament's nozzles that DO have calibration data (diameter/name/type/highFlow), so the caller can retry with a matching nozzle_diameter/nozzle_type/high_flow."
                         }
                       }
                     }
@@ -4280,6 +4336,15 @@
                       "$ref": "#/components/schemas/ScanEventFilament"
                     }
                   },
+                  "matchedSpool": {
+                    "nullable": true,
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/ScanEventSpool"
+                      }
+                    ],
+                    "description": "The spool the tag's spool_uid resolved to (#732), or null/omitted for a filament-level / heuristic match. Validated against the same allow-list — requires string _id + instanceId, label bounded, else dropped to null."
+                  },
                   "decoded": {
                     "$ref": "#/components/schemas/ScanEventDecoded"
                   }
@@ -6154,6 +6219,28 @@
           }
         }
       },
+      "ScanEventSpool": {
+        "type": "object",
+        "required": [
+          "_id",
+          "instanceId"
+        ],
+        "description": "The specific spool a scan resolved to (#732), when the tag's spool_uid matched a spools[].instanceId. Null on the event for a filament-level / heuristic match.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "Spool subdocument ObjectId"
+          },
+          "instanceId": {
+            "type": "string",
+            "description": "The spool's 5-byte hex instanceId that matched"
+          },
+          "label": {
+            "type": "string",
+            "description": "The spool's label (empty string when unset)"
+          }
+        }
+      },
       "ScanEvent": {
         "type": "object",
         "required": [
@@ -6183,6 +6270,15 @@
               "$ref": "#/components/schemas/ScanEventFilament"
             },
             "description": "Plausible alternatives (vendor+type, then vendor-only) when there is no exact match"
+          },
+          "matchedSpool": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScanEventSpool"
+              }
+            ],
+            "description": "The spool the tag's spool_uid resolved to (#732), or null for a filament-level / heuristic match."
           },
           "decoded": {
             "$ref": "#/components/schemas/ScanEventDecoded"

--- a/src/lib/matchFilament.ts
+++ b/src/lib/matchFilament.ts
@@ -57,6 +57,25 @@ export function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * #955.12: matchFilament runs on the hot scan path (desktop SSE bus + the
+ * mobile scanner) and returns lean filament docs verbatim. A spool's
+ * `photoDataUrl` can be a ~5 MB data URL, and `usageHistory` / `dryCycles` grow
+ * unbounded — none of which any match consumer reads. The desktop scan handler,
+ * the scan-bus publish route, and the mobile app all read only identity fields
+ * (`_id`/`name`/`vendor`/`type`/`color`) off `match`/`candidates` plus the
+ * matched spool's `_id`/`instanceId`/`label`; the mobile app fetches full spool
+ * detail from the SEPARATE `/api/filaments/{id}` endpoint. So every match query
+ * prunes these three heavy subfields to keep a scan from pulling megabytes per
+ * read.
+ *
+ * PURE exclusion on purpose: it keeps every other field (top-level `instanceId`
+ * for the decode route's `matchedBy` check, and `spools[].instanceId`/`label`
+ * for `toMatchedSpool`) — a mixed include/exclude projection would drop them.
+ */
+const MATCH_PROJECTION =
+  "-spools.photoDataUrl -spools.usageHistory -spools.dryCycles";
+
 /** Minimal lean shapes for reading spool subdocs off a `.lean()` filament. */
 interface LeanSpool {
   _id: unknown;
@@ -96,6 +115,7 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
       "spools.instanceId": instanceId,
       _deletedAt: null,
     })
+      .select(MATCH_PROJECTION)
       .limit(2)
       .lean()) as LeanFilamentWithSpools[];
     const exactPairs = spoolExact.flatMap((f) => {
@@ -117,6 +137,7 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
       "spools.instanceId": { $regex: `^${escapeRegex(instanceId)}$`, $options: "i" },
       _deletedAt: null,
     })
+      .select(MATCH_PROJECTION)
       .limit(2)
       .lean()) as LeanFilamentWithSpools[];
     const lowerId = instanceId.toLowerCase();
@@ -154,7 +175,9 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
     const exact = await Filament.findOne({
       instanceId,
       _deletedAt: null,
-    }).lean();
+    })
+      .select(MATCH_PROJECTION)
+      .lean();
     if (exact) {
       return { match: exact, candidates: [], matchedSpool: null };
     }
@@ -168,6 +191,7 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
       instanceId: { $regex: `^${escapeRegex(instanceId)}$`, $options: "i" },
       _deletedAt: null,
     })
+      .select(MATCH_PROJECTION)
       .limit(2)
       .lean();
     if (ciMatches.length === 1) {
@@ -194,7 +218,9 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
   //    GH #896 vendor-substring fix.
   if (name) {
     // 1a. Exact-case — a confident match even when a case-variant sibling exists.
-    const exact = await Filament.findOne({ name, _deletedAt: null }).lean();
+    const exact = await Filament.findOne({ name, _deletedAt: null })
+      .select(MATCH_PROJECTION)
+      .lean();
     if (exact) {
       return { match: exact, candidates: [], matchedSpool: null };
     }
@@ -205,6 +231,7 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
       name: { $regex: `^${escapeRegex(name)}$`, $options: "i" },
       _deletedAt: null,
     })
+      .select(MATCH_PROJECTION)
       .limit(2)
       .lean();
     if (ciMatches.length === 1) {
@@ -229,6 +256,7 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
           type: { $regex: `^${escapeRegex(type)}$`, $options: "i" },
           _deletedAt: null,
         })
+          .select(MATCH_PROJECTION)
           .sort({ name: 1 })
           .limit(5)
           .lean()
@@ -251,6 +279,7 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
       vendor: { $regex: escapeRegex(vendor), $options: "i" },
       _deletedAt: null,
     })
+      .select(MATCH_PROJECTION)
       .sort({ name: 1 })
       .limit(5)
       .lean();

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -235,7 +235,24 @@ export default async function dbConnect() {
   // E11000. syncIndexes() drops mismatched indexes and recreates them —
   // idempotent on fresh DBs, corrective on upgraded ones. Same
   // retry-tracked pattern as the SharedCatalog block above.
-  if (!cached.migrations.coreModelIndexes) {
+  //
+  // GATED ON BOTH instanceId backfills (#955.14, Codex re-review): this MUST NOT
+  // run until every active filament has an `instanceId`. Building the
+  // partial-unique `instanceId` index over legacy rows the backfill hasn't
+  // filled yet E11000s on the SHARED null value — but that's exactly what the
+  // backfill repairs, so it's transient, NOT terminal. If the backfills throw
+  // transiently (leaving their flags false) and this ran anyway, the terminal
+  // E11000 handling below would mark the flag done and PERMANENTLY skip the
+  // rebuild even after the backfill later succeeds — until a process restart.
+  // Gating means that once we DO run, a remaining E11000 can only be genuine
+  // duplicate ACTIVE rows (dup name or dup real instanceId), which is terminal.
+  // In the common single-pass connect both backfills succeed just above, so the
+  // gate is already satisfied and this runs in the same pass.
+  if (
+    cached.migrations.spoolInstanceIds &&
+    cached.migrations.instanceIds &&
+    !cached.migrations.coreModelIndexes
+  ) {
     try {
       const models = await Promise.all([
         import("@/models/Filament"),
@@ -245,9 +262,10 @@ export default async function dbConnect() {
         import("@/models/Printer"),
       ]);
       // #955.14: sync each model INDEPENDENTLY, and treat a duplicate-key
-      // (E11000) failure as TERMINAL rather than retryable. syncIndexes() throws
-      // E11000 when a DB already holds duplicate active rows on a unique field
-      // (`name` / `instanceId`) — a DATA problem no retry can fix. Before this,
+      // (E11000) failure as TERMINAL rather than retryable. Because this block is
+      // gated on the instanceId backfills above, a syncIndexes() E11000 here can
+      // only be genuine duplicate active rows on a unique field (`name` / a real
+      // `instanceId`) — a DATA problem no retry can fix. Before this,
       // that error escaped the shared try, left `coreModelIndexes` false, and
       // the whole block re-ran on EVERY subsequent request — re-throwing and
       // re-logging forever, and doing wasted index work per request. Now a

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -41,6 +41,21 @@ declare global {
   var mongoose: MongooseCache | undefined;
 }
 
+/**
+ * True for a MongoDB duplicate-key error (E11000). `syncIndexes()` throws this
+ * when it tries to build a UNIQUE index on a collection that already holds
+ * duplicate values on that key — stale DATA a retry can never fix. Matched by
+ * the driver's numeric `code` first, with a message fallback for wrappers that
+ * don't surface `.code`. Used by the `coreModelIndexes` migration to treat a
+ * dup-key index build as terminal instead of retrying it forever (#955.14).
+ */
+export function isDuplicateKeyError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  if ((err as { code?: unknown }).code === 11000) return true;
+  const message = (err as { message?: unknown }).message;
+  return typeof message === "string" && /E11000|duplicate key/i.test(message);
+}
+
 export default async function dbConnect() {
   const MONGODB_URI = process.env.MONGODB_URI;
 
@@ -229,15 +244,44 @@ export default async function dbConnect() {
         import("@/models/Nozzle"),
         import("@/models/Printer"),
       ]);
+      // #955.14: sync each model INDEPENDENTLY, and treat a duplicate-key
+      // (E11000) failure as TERMINAL rather than retryable. syncIndexes() throws
+      // E11000 when a DB already holds duplicate active rows on a unique field
+      // (`name` / `instanceId`) — a DATA problem no retry can fix. Before this,
+      // that error escaped the shared try, left `coreModelIndexes` false, and
+      // the whole block re-ran on EVERY subsequent request — re-throwing and
+      // re-logging forever, and doing wasted index work per request. Now a
+      // dup-key error is caught per model, logged ONCE with actionable
+      // guidance, and the loop moves on so the flag still converges to true
+      // (the block never re-enters ⇒ the log fires once). A TRANSIENT
+      // (non-E11000) failure is re-thrown to the outer catch, which leaves the
+      // flag unset so the next connect genuinely retries.
       for (const mod of models) {
         const model = mod.default;
-        const dropped = await model.syncIndexes();
-        if (dropped.length > 0) {
-          console.log(
-            `[migration] Rebuilt ${model.modelName} indexes (dropped: ${dropped.join(", ")})`,
-          );
+        try {
+          const dropped = await model.syncIndexes();
+          if (dropped.length > 0) {
+            console.log(
+              `[migration] Rebuilt ${model.modelName} indexes (dropped: ${dropped.join(", ")})`,
+            );
+          }
+        } catch (err) {
+          if (isDuplicateKeyError(err)) {
+            console.error(
+              `[migration] ${model.modelName}: cannot build a unique index — the collection has duplicate ACTIVE rows on a unique field (name/instanceId). A retry can't fix stale data, so this index is being SKIPPED (other migrations continue). Resolve the duplicates (rename or trash one of each colliding pair) and restart to build it.`,
+              err,
+            );
+            // Terminal — fall through to the next model. Do NOT re-throw:
+            // re-throwing would leave the flag false and loop forever.
+          } else {
+            // Transient (network blip, DB busy) — a retry may succeed, so bubble
+            // to the outer catch which leaves the flag unset.
+            throw err;
+          }
         }
       }
+      // Reached only when every model either succeeded or hit a terminal E11000
+      // — never after a transient throw. Converge so the block stops running.
       cached.migrations.coreModelIndexes = true;
     } catch (err) {
       console.error("[migration] Failed to sync core model indexes (will retry on next connect):", err);

--- a/src/lib/parseCsv.ts
+++ b/src/lib/parseCsv.ts
@@ -7,7 +7,9 @@
  *   - quoted fields with embedded commas and newlines
  *   - doubled quotes ("") as an escaped quote inside a quoted field
  *   - LF, CR, and CRLF line endings
- *   - leading/trailing whitespace around unquoted values (trimmed)
+ *   - leading/trailing whitespace around unquoted values (trimmed); a QUOTED
+ *     field keeps its whitespace verbatim so round-tripped values survive
+ *     (#955.1)
  *
  * Does NOT handle:
  *   - BOMs (caller should strip if needed)
@@ -48,6 +50,12 @@ export function parseCsv(
   // turning `maxRows: N` into an `N-1` data-row ceiling in header mode.
   const rawRowCap = opts.header ? maxRows + 1 : maxRows;
   const rows: string[][] = [];
+  // #955.1: track per-field quoted-ness in lockstep with `rows` so the final
+  // trim pass can leave quoted fields untouched (as the docblock claims). A
+  // field is "quoted" if the parser entered a quoted section anywhere while
+  // accumulating it — csvCell only ever emits fully-quoted values, so this is
+  // exact for round-trips; a hand-authored mixed field errs toward preserving.
+  const rowsQuoted: boolean[][] = [];
   // A blank row from a spreadsheet export can carry delimiters — `,\n`
   // parses to `["", ""]`, not `[""]` — so "blank" means every field is
   // empty after trimming (matches the header-mode output skip below).
@@ -84,18 +92,25 @@ export function parseCsv(
   // while an abusive flood trips it.
   const physicalRowCap = rawRowCap + maxRows;
   let physicalRowCount = 0;
-  const commitRow = (r: string[]): void => {
+  // `q` is the parallel quoted-ness for the fields of `r` — pushed/discarded in
+  // lockstep so `rowsQuoted[i]` always lines up with `rows[i]`.
+  const commitRow = (r: string[], q: boolean[]): void => {
     physicalRowCount++;
     if (physicalRowCount > physicalRowCap) {
       throw new CsvRowLimitExceededError(maxRows);
     }
     if (opts.header && isBlankRow(r)) return; // discard — never buffered
     rows.push(r);
+    rowsQuoted.push(q);
     if (rows.length > rawRowCap) throw new CsvRowLimitExceededError(maxRows);
   };
 
   let row: string[] = [];
+  let rowQuoted: boolean[] = [];
   let field = "";
+  // Set true when a quoted section opens while accumulating the current field;
+  // reset when the field is pushed. Preserves whitespace in quoted fields.
+  let fieldQuoted = false;
   let i = 0;
   let inQuotes = false;
 
@@ -122,31 +137,40 @@ export function parseCsv(
     // Not in quotes
     if (ch === '"') {
       inQuotes = true;
+      fieldQuoted = true;
       i++;
       continue;
     }
     if (ch === ",") {
       row.push(field);
+      rowQuoted.push(fieldQuoted);
       field = "";
+      fieldQuoted = false;
       i++;
       continue;
     }
     if (ch === "\r") {
       // Handle CRLF by skipping the LF; bare CR also treated as a line end.
       row.push(field);
+      rowQuoted.push(fieldQuoted);
       field = "";
+      fieldQuoted = false;
       i++;
       if (input[i] === "\n") i++;
-      commitRow(row);
+      commitRow(row, rowQuoted);
       row = [];
+      rowQuoted = [];
       continue;
     }
     if (ch === "\n") {
       row.push(field);
+      rowQuoted.push(fieldQuoted);
       field = "";
+      fieldQuoted = false;
       i++;
-      commitRow(row);
+      commitRow(row, rowQuoted);
       row = [];
+      rowQuoted = [];
       continue;
     }
     field += ch;
@@ -156,13 +180,17 @@ export function parseCsv(
   // Flush any trailing field/row that didn't end with a newline
   if (field.length > 0 || row.length > 0) {
     row.push(field);
-    commitRow(row);
+    rowQuoted.push(fieldQuoted);
+    commitRow(row, rowQuoted);
   }
 
-  // Strip outer whitespace from unquoted strings — we keep quoted values
-  // untouched for callers that need literal content.
-  // (This is a compromise; full CSV semantics would preserve all whitespace.)
-  const trimmed = rows.map((r) => r.map((v) => v.trim()));
+  // Strip outer whitespace from UNQUOTED fields only — a quoted value is kept
+  // verbatim so a round-tripped value with intentional leading/trailing
+  // whitespace (csvCell quoted it) survives re-import (#955.1). Unquoted
+  // trimming stays a deliberate compromise for spreadsheet-paste ergonomics.
+  const trimmed = rows.map((r, ri) =>
+    r.map((v, ci) => (rowsQuoted[ri][ci] ? v : v.trim())),
+  );
 
   if (!opts.header) return trimmed;
 

--- a/tests/matchFilament.test.ts
+++ b/tests/matchFilament.test.ts
@@ -162,4 +162,79 @@ describe("matchFilament", () => {
       expect(res).toEqual({ match: null, candidates: [], matchedSpool: null });
     });
   });
+
+  // #955.12: every match query prunes the heavy spool subfields (a photoDataUrl
+  // data URL can be ~5 MB; usageHistory / dryCycles grow unbounded) that no scan
+  // consumer reads, while keeping the identity fields the matcher — and the
+  // matchedSpool builder — depend on. Pure-exclusion projection: everything
+  // else, including spools[].instanceId / label, survives.
+  describe("heavy-field projection (#955.12)", () => {
+    const heavySpool = (label: string, instanceId: string) => ({
+      label,
+      totalWeight: 1000,
+      instanceId,
+      photoDataUrl: "data:image/png;base64,AAAAAAAA",
+      usageHistory: [{ grams: 12, date: new Date() }],
+      dryCycles: [{ date: new Date(), tempC: 50, durationMin: 120 }],
+    });
+
+    const assertPruned = (spool: Record<string, unknown>) => {
+      expect(spool.photoDataUrl).toBeUndefined();
+      expect(spool.usageHistory).toBeUndefined();
+      expect(spool.dryCycles).toBeUndefined();
+    };
+
+    it("omits photoDataUrl / usageHistory / dryCycles from a name-tier match, keeping spool identity", async () => {
+      await Filament.create({
+        name: "Projected PLA",
+        vendor: "Acme",
+        type: "PLA",
+        spools: [heavySpool("Bin 1", "proj0000a1")],
+      });
+      const res = await matchFilament({ name: "Projected PLA" });
+      const spool = (res.match as { spools: Record<string, unknown>[] }).spools[0];
+      assertPruned(spool);
+      // Identity fields the consumers rely on survive the pure-exclusion projection.
+      expect(spool.instanceId).toBe("proj0000a1");
+      expect(spool.label).toBe("Bin 1");
+      expect(spool.totalWeight).toBe(1000);
+    });
+
+    it("prunes candidates in the vendor+type tier too", async () => {
+      await Filament.create({
+        name: "Cand A",
+        vendor: "Acme",
+        type: "PETG",
+        spools: [heavySpool("A", "cand0000a1")],
+      });
+      await Filament.create({
+        name: "Cand B",
+        vendor: "Acme",
+        type: "PETG",
+        spools: [heavySpool("B", "cand0000b1")],
+      });
+      const res = await matchFilament({ vendor: "Acme", type: "PETG" });
+      expect(res.match).toBeNull();
+      expect(res.candidates.length).toBe(2);
+      for (const c of res.candidates as { spools: Record<string, unknown>[] }[]) {
+        assertPruned(c.spools[0]);
+      }
+    });
+
+    it("still resolves matchedSpool from the pruned spool tier", async () => {
+      const f = await Filament.create({
+        name: "Spool Tier",
+        vendor: "Acme",
+        type: "PLA",
+        spools: [heavySpool("Drybox", "spool00001")],
+      });
+      const res = await matchFilament({ instanceId: "spool00001" });
+      expect(res.matchedSpool).toMatchObject({
+        instanceId: "spool00001",
+        label: "Drybox",
+        _id: String(f.spools[0]._id),
+      });
+      assertPruned((res.match as { spools: Record<string, unknown>[] }).spools[0]);
+    });
+  });
 });

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -623,6 +623,62 @@ describe("dbConnect", () => {
     }
   });
 
+  // #955.14 (Codex re-review): the terminal-E11000 handling must NOT fire while
+  // the instanceId backfills are still pending. If the spool backfill throws
+  // transiently, the filament backfill is gated off and legacy rows stay without
+  // an instanceId — building the partial-unique index would E11000 on the shared
+  // null. Treating THAT as terminal would permanently skip the index rebuild even
+  // after the backfill later succeeds. The coreModelIndexes block is gated on
+  // both backfills, so it doesn't run (and doesn't converge) until they finish.
+  it("keeps the index sync retryable until the instanceId backfills finish", async () => {
+    (global as Record<string, unknown>).mongoose = undefined;
+    await dbConnect(); // establish; all flags true
+    const Filament = (await import("@/models/Filament")).default;
+
+    const cached = (global as Record<string, unknown>).mongoose as {
+      migrations: {
+        spoolInstanceIds: boolean;
+        instanceIds: boolean;
+        coreModelIndexes: boolean;
+      };
+      migrationsPromise: Promise<void> | null;
+    };
+    // Re-arm: pretend NOTHING has migrated yet this process.
+    cached.migrations.spoolInstanceIds = false;
+    cached.migrations.instanceIds = false;
+    cached.migrations.coreModelIndexes = false;
+    cached.migrationsPromise = null;
+
+    const filamentMod = await import("@/models/Filament");
+    const backfillSpy = vi
+      .spyOn(filamentMod, "backfillSpoolInstanceIds")
+      .mockRejectedValueOnce(new Error("transient backfill failure"));
+    const syncSpy = vi.spyOn(Filament, "syncIndexes");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Cycle 1: spool backfill throws → filament backfill gated off → the
+      // coreModelIndexes gate (both backfills) is UNMET → syncIndexes not called,
+      // flag stays false (retryable), NOT terminally converged.
+      await dbConnect();
+      expect(cached.migrations.spoolInstanceIds).toBe(false);
+      expect(cached.migrations.instanceIds).toBe(false);
+      expect(cached.migrations.coreModelIndexes).toBe(false);
+      expect(syncSpy).not.toHaveBeenCalled();
+
+      // Cycle 2: backfills succeed (mock consumed) → gate met → the index sync
+      // runs and converges. The rebuild wasn't permanently skipped.
+      await dbConnect();
+      expect(cached.migrations.spoolInstanceIds).toBe(true);
+      expect(cached.migrations.instanceIds).toBe(true);
+      expect(cached.migrations.coreModelIndexes).toBe(true);
+      expect(syncSpy).toHaveBeenCalled();
+    } finally {
+      backfillSpy.mockRestore();
+      syncSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
   // src/lib/mongodb.ts:285 (`p.installedNozzles || []`) + :301 (`if (!source)
   // continue`). A nozzle referenced by two printers but soft-deleted between
   // the ref walk and the hydrate is skipped, minting no clone; a

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import mongoose from "mongoose";
-import dbConnect from "@/lib/mongodb";
+import dbConnect, { isDuplicateKeyError } from "@/lib/mongodb";
 
 describe("dbConnect", () => {
   beforeEach(() => {
@@ -541,6 +541,85 @@ describe("dbConnect", () => {
     } finally {
       spy.mockRestore();
       errSpy.mockRestore();
+    }
+  });
+
+  // #955.14: the duplicate-key classifier. Covers every branch deterministically
+  // so the integration test below doesn't have to reproduce each error shape.
+  describe("isDuplicateKeyError (#955.14)", () => {
+    it("is true for a driver E11000 (numeric code)", () => {
+      expect(isDuplicateKeyError({ code: 11000, message: "whatever" })).toBe(true);
+    });
+    it("is true when only the message carries E11000 / 'duplicate key'", () => {
+      expect(isDuplicateKeyError({ message: "E11000 duplicate key error" })).toBe(true);
+      expect(isDuplicateKeyError({ message: "duplicate key on index" })).toBe(true);
+    });
+    it("is false for an unrelated error, a wrong code, and non-objects", () => {
+      expect(isDuplicateKeyError(new Error("transient blip"))).toBe(false);
+      expect(isDuplicateKeyError({ code: 26, message: "ns not found" })).toBe(false);
+      expect(isDuplicateKeyError(null)).toBe(false);
+      expect(isDuplicateKeyError("E11000")).toBe(false);
+    });
+  });
+
+  // #955.14: a DB with duplicate ACTIVE rows on a unique field made the
+  // coreModelIndexes migration loop forever — syncIndexes() E11000'd, the shared
+  // catch left the flag false, and the block re-ran on every request. Now the
+  // dup-key error is terminal: it logs once, the flag converges, and the block
+  // stops re-entering. Seed the collision with a raw insertMany (bypassing the
+  // model's validators + the unique index, which is dropped first) to reproduce
+  // a pre-migration upgraded DB.
+  it("treats a duplicate-active-rows E11000 as terminal so the index migration converges", async () => {
+    (global as Record<string, unknown>).mongoose = undefined;
+    await dbConnect(); // establish + build the Filament indexes once
+    const Filament = (await import("@/models/Filament")).default;
+
+    // Drop every non-_id index so the colliding pair can be inserted, then seed
+    // two ACTIVE filaments sharing a name (distinct instanceIds isolate the
+    // E11000 to the name partial-unique index).
+    await Filament.collection.dropIndexes().catch(() => {});
+    await Filament.collection.insertMany([
+      { name: "DupName", vendor: "V", type: "PLA", color: "#808080", diameter: 1.75, instanceId: "dupinst001", _deletedAt: null },
+      { name: "DupName", vendor: "V", type: "PLA", color: "#808080", diameter: 1.75, instanceId: "dupinst002", _deletedAt: null },
+    ]);
+
+    const cached = (global as Record<string, unknown>).mongoose as {
+      migrations: { coreModelIndexes: boolean };
+      migrationsPromise: Promise<void> | null;
+    };
+    cached.migrations.coreModelIndexes = false;
+    cached.migrationsPromise = null;
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Spy WITHOUT a mock impl so the real syncIndexes runs (and throws E11000);
+    // we only need the call count to prove the block stops re-entering.
+    const syncSpy = vi.spyOn(Filament, "syncIndexes");
+    try {
+      // Cycle 1: Filament.syncIndexes throws E11000 → terminal → logged once →
+      // flag converges to true despite the unbuildable index.
+      await dbConnect();
+      expect(cached.migrations.coreModelIndexes).toBe(true);
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining("cannot build a unique index"),
+        expect.anything(),
+      );
+      // It must NOT have logged the retryable "will retry" message — E11000 is
+      // terminal, not transient.
+      expect(errSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Failed to sync core model indexes"),
+        expect.anything(),
+      );
+      const callsAfterCycle1 = syncSpy.mock.calls.length;
+      expect(callsAfterCycle1).toBeGreaterThan(0);
+
+      // Cycle 2: the flag is now true, so the migration block never re-enters —
+      // syncIndexes isn't called again. This is the anti-infinite-loop proof.
+      await dbConnect();
+      expect(syncSpy.mock.calls.length).toBe(callsAfterCycle1);
+    } finally {
+      errSpy.mockRestore();
+      syncSpy.mockRestore();
+      await Filament.deleteMany({ name: "DupName" });
     }
   });
 

--- a/tests/parseCsv.test.ts
+++ b/tests/parseCsv.test.ts
@@ -103,6 +103,53 @@ describe("parseCsv", () => {
     expect(rows[0]).toEqual({ a: "1", b: "2" });
   });
 
+  // #955.1: a QUOTED field keeps its leading/trailing whitespace (the docblock
+  // promises "quoted values untouched"). Before the fix the trim pass ran after
+  // quoted-ness was lost, so csvCell-quoted round-trip values silently lost
+  // their whitespace and missed the importer's exact-name match → duplicates.
+  describe("quoted-field whitespace preservation (#955.1)", () => {
+    it("preserves leading/trailing whitespace inside a quoted field", () => {
+      const csv = 'a,b\n"  hello  ",world\n';
+      const rows = parseCsv(csv) as Array<Record<string, string>>;
+      expect(rows[0]).toEqual({ a: "  hello  ", b: "world" });
+    });
+
+    it("trims an unquoted field but keeps a quoted one in the SAME row", () => {
+      const csv = 'a,b\n  x  ,"  y  "\n';
+      const rows = parseCsv(csv) as Array<Record<string, string>>;
+      expect(rows[0]).toEqual({ a: "x", b: "  y  " });
+    });
+
+    it("round-trips a value whose quoting was triggered by a comma, keeping the trailing space", () => {
+      // The finding's exact case: 'Red, matte ' — csvCell quotes it (embedded
+      // comma), and re-import must return the identical string, space and all.
+      const csv = 'name\n"Red, matte "\n';
+      const rows = parseCsv(csv) as Array<Record<string, string>>;
+      expect(rows[0].name).toBe("Red, matte ");
+    });
+
+    it("preserves quoted whitespace in header:false mode too", () => {
+      const csv = '"  a  ",b\n';
+      const rows = parseCsv(csv, { header: false }) as string[][];
+      expect(rows).toEqual([["  a  ", "b"]]);
+    });
+
+    it("keeps an empty quoted field empty (trim vs no-trim agree)", () => {
+      const csv = 'a,b\n"",z\n';
+      const rows = parseCsv(csv) as Array<Record<string, string>>;
+      expect(rows[0]).toEqual({ a: "", b: "z" });
+    });
+
+    it("still discards a header-mode row whose only field is quoted whitespace (blank-row rule unchanged)", () => {
+      // isBlankRow trims the raw buffer, so a quoted "   " row is still blank
+      // and discarded in header mode — the fix preserves whitespace on KEPT
+      // fields without resurrecting whitespace-only separator rows.
+      const csv = 'h\nd1\n"   "\nd2\n';
+      const rows = parseCsv(csv) as Array<Record<string, string>>;
+      expect(rows.map((r) => r.h)).toEqual(["d1", "d2"]);
+    });
+  });
+
   // GH #294: pin the exact row-limit boundary so an off-by-one or a
   // 2x-too-large cap on the CSV DoS guard would fail a test. Per the
   // CsvParseOptions contract, `maxRows` caps emitted DATA rows — the


### PR DESCRIPTION
The four #955 P3 findings deferred from the hygiene sweep PR #962 — each needed more than a one-liner. No file overlap with #962, so this branches cleanly off `main`.

| # | Fix | File(s) |
|---|-----|---------|
| 955.1 | parseCsv preserves whitespace in **quoted** fields — tracks per-field quoted-ness in a parallel `rowsQuoted[][]` through `commitRow`, trims only unquoted fields (DoS caps + blank-row discard untouched). Fixes a silent duplicate-filament on re-import of a comma-quoted value like `Red, matte `. | `src/lib/parseCsv.ts` |
| 955.12 | `matchFilament` prunes heavy spool subfields (`photoDataUrl` up to ~5MB, `usageHistory`, `dryCycles`) from all 8 scan-path queries via a shared pure-exclusion `.select()`. Verified no consumer reads them — the desktop scan handler, `/api/scan/publish`, and the mobile app read only identity + `matchedSpool` (`_id`/`instanceId`/`label`); full spool detail comes from the separate `/api/filaments/{id}`. | `src/lib/matchFilament.ts` |
| 955.13 | OpenAPI drift: documents the calibration endpoint's `nozzle_type`/`bed_type`/`format=orcaslicer` params + the `bedType`/`calibration_orca` 200-response fields + the 404 `available[]` `type`/`highFlow`; adds a `ScanEventSpool` component + nullable `matchedSpool` to the `ScanEvent` schema and the `/api/scan/publish` requestBody. Doc-only, 3.0.3 `nullable:true`, jq-validated. | `public/openapi.json` |
| 955.14 | `coreModelIndexes` migration converges on a DB with duplicate active rows: each model's `syncIndexes` gets its own try/catch; an **E11000** is terminal (logged once, flag still set) so the block stops re-running every request; a transient error still leaves the flag unset to retry. | `src/lib/mongodb.ts` |

Tests added for each code fix (955.1/955.12/955.14); 955.14 includes a real-data integration test that seeds a colliding active pair via raw `insertMany` and proves the migration converges.

### Verification
- `npm test` — **2935 passed** (146 files)
- `npm run test:coverage` — **99.04% stmt / 97.61% branch / 97.52% func / 99.5% lines**, all thresholds held
- `eslint`, root `tsc --noEmit`, `electron:typecheck` — clean

Part of #955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)