### PR TITLE
fix(filaments): preserve variant inheritance on import/sync round-trips (#951)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -9,6 +9,7 @@ import { errorResponse, errorResponseFromCaught, handleDuplicateKeyError, isDupl
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
 import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
+import { splitInheritedImportSet } from "@/lib/importFilaments";
 import { escapeRegex } from "@/lib/matchFilament";
 import { assignSpoolToSlot } from "@/lib/spoolSlots";
 import {
@@ -917,6 +918,32 @@ export async function POST(
       }
     }
 
+    // GH #951: a variant's PrusaSlicer export flattens its inherited values
+    // through resolveFilament, so the fork echoes the parent's
+    // density/cost/temps/spoolWeight/diameter/… back on every sync. Blindly
+    // $set-ing them onto the variant pins each as a local override and severs
+    // GH #106 live inheritance — a later parent edit stops propagating. Before
+    // this, only `color` had echo suppression (resolveSyncBackColor). Reuse the
+    // CSV importer's battle-tested split (GH #628 / #649): drop each inheritable
+    // field whose incoming value equals the parent's (keep inheriting), and
+    // $unset a stale diverging local override so inheritance resumes. Variant-
+    // only + non-inheritable keys (color, colorName, name, settings, soluble,
+    // …) pass through untouched. `calParent` is the already-fetched parent doc;
+    // when it's null (standalone/parent, or a soft-deleted/missing parent —
+    // nothing to inherit) the update is written verbatim.
+    const mongoUpdate: Record<string, unknown> = { $set: update };
+    if (filament.parentId && calParent) {
+      const split = splitInheritedImportSet(
+        update,
+        filament.toObject(),
+        calParent.toObject(),
+      );
+      mongoUpdate.$set = split.set;
+      if (split.unset.length > 0) {
+        mongoUpdate.$unset = Object.fromEntries(split.unset.map((k) => [k, ""]));
+      }
+    }
+
     // GH #618: `runValidators` so the numeric range validators (#337)
     // actually fire on a PrusaSlicer sync — without it a config like
     // `filament_cost = -3` parses clean and persists a negative cost the
@@ -926,7 +953,7 @@ export async function POST(
     try {
       await Filament.findByIdAndUpdate(
         filament._id,
-        { $set: update },
+        mongoUpdate,
         { runValidators: true, context: "query" },
       );
     } catch (validationErr) {

--- a/src/app/api/filaments/import/route.ts
+++ b/src/app/api/filaments/import/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
-import Filament from "@/models/Filament";
 import { parseIniFilaments } from "@/lib/parseIni";
 import { collapsePerNozzleImportSections } from "@/lib/prusaSlicerBundle";
-import { assertMultipartFormData, checkFileSize, isDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { upsertIniFilament } from "@/lib/iniImportApply";
+import { assertMultipartFormData, checkFileSize } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 
 export async function POST(request: NextRequest) {
@@ -60,56 +60,16 @@ export async function POST(request: NextRequest) {
 
     for (const filament of filaments) {
       try {
-        const { name, ...rest } = filament;
-
-        // GH #327 (Codex): each branch is a single atomic operation so
-        // there is no findOne→write window for a concurrent soft-delete
-        // or insert to slip through. `runValidators` keeps the update
-        // path enforcing the same schema constraints as a create (#308).
-
-        // 1) Update an existing ACTIVE filament with this name.
-        const activeUpdated = await Filament.findOneAndUpdate(
-          { name, _deletedAt: null },
-          { $set: rest },
-          { runValidators: true, context: "query", returnDocument: "after" },
-        );
-        if (activeUpdated) {
-          updated++;
-          continue;
-        }
-
-        // 2) GH #297: if a TRASHED (non-purged) filament owns this name,
-        // resurrect-and-update it rather than creating a second active
-        // row — a duplicate would strand the trashed one (its restore
-        // would 409 on the name conflict forever).
-        const trashedResurrected = await Filament.findOneAndUpdate(
-          { name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
-          { $set: { ...rest, _deletedAt: null } },
-          { runValidators: true, context: "query", returnDocument: "after" },
-        );
-        if (trashedResurrected) {
-          updated++;
-          continue;
-        }
-
-        // 3) No active or trashed row — create. A concurrent import of
-        // the same new name can still race two requests into create();
-        // the partial-unique index throws E11000 for the loser. Treat
-        // that as "another request just created it" and resolve it as
-        // an update, so identical parallel imports stay idempotent.
-        try {
-          await Filament.create({ name, ...rest });
-          created++;
-        } catch (createErr) {
-          if (!isDuplicateKeyError(createErr)) throw createErr;
-          const raced = await Filament.findOneAndUpdate(
-            { name, _deletedAt: null },
-            { $set: rest },
-            { runValidators: true, context: "query", returnDocument: "after" },
-          );
-          if (!raced) throw createErr;
-          updated++;
-        }
+        // GH #951: the three-phase atomic upsert (active → resurrect-trashed →
+        // create/race) lives in `upsertIniFilament`, shared with
+        // POST /api/filaments/prusaslicer, and preserves variant→parent
+        // inheritance — the export flattens a variant's inherited values
+        // through resolveFilament, so re-importing must NOT pin them as local
+        // overrides (that would sever GH #106 live inheritance). See
+        // src/lib/iniImportApply.ts.
+        const outcome = await upsertIniFilament(filament);
+        if (outcome === "created") created++;
+        else updated++;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         errors.push(`${filament.name}: ${msg}`);

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -7,7 +7,8 @@ import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
 import { generatePrusaSlicerBundle, collapsePerNozzleImportSections } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
-import { isDuplicateKeyError, checkContentLength, errorResponse, MAX_UPLOAD_SIZE } from "@/lib/apiErrorHandler";
+import { upsertIniFilament } from "@/lib/iniImportApply";
+import { checkContentLength, errorResponse, MAX_UPLOAD_SIZE } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 
 /** 24-hex ObjectId, for validating user-supplied `?ids=` before a `$in`. */
@@ -185,60 +186,15 @@ export async function POST(request: NextRequest) {
       // section collapsed without its required vendor/type fails create validation.
       // Mirrors the /api/filaments/import route's per-row resilience.
       try {
-        // #872: CollapsedFilamentData maps 1:1 to Filament fields. Spreading means a
-        // key a collapsed per-nozzle section OMITS — temps / max-vol (baked per nozzle)
-        // and any shared scalar the suffixed section didn't supply — is simply not
-        // $set, so a round-trip re-import preserves the base filament's value instead
-        // of clobbering it with one nozzle's baked value or a parse default (Codex P3).
-        // Matches the /api/filaments/import update path's `$set: rest`.
-        const doc = { ...f };
-
-        // GH #327 (Codex): each branch is a single atomic operation so
-        // there is no findOne→write window for a concurrent soft-delete
-        // or insert to slip through.
-
-        // 1) Update an existing ACTIVE filament with this name.
-        const activeUpdated = await Filament.findOneAndUpdate(
-          { name: f.name, _deletedAt: null },
-          { $set: doc },
-          { runValidators: true, context: "query", returnDocument: "after" },
-        );
-        if (activeUpdated) {
-          updated++;
-        } else {
-          // 2) GH #297: a trashed (non-purged) filament owning this name
-          // is resurrected-and-updated rather than shadowed by a duplicate
-          // active row — a duplicate would strand the trashed one (its
-          // restore would 409 forever on the name conflict).
-          const trashedResurrected = await Filament.findOneAndUpdate(
-            { name: f.name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
-            { $set: { ...doc, _deletedAt: null } },
-            { runValidators: true, context: "query", returnDocument: "after" },
-          );
-          if (trashedResurrected) {
-            updated++;
-          } else {
-            // 3) Create; retry-on-duplicate. Two concurrent imports of the
-            // same new name can both pass the lookups above and race into
-            // create(); the partial-unique index throws E11000 for the
-            // loser. Resolve that as an update so parallel identical
-            // imports stay idempotent instead of 500-ing.
-            try {
-              await Filament.create(doc);
-              created++;
-            } catch (createErr) {
-              if (!isDuplicateKeyError(createErr)) throw createErr;
-              const raced = await Filament.findOneAndUpdate(
-                { name: f.name, _deletedAt: null },
-                { $set: doc },
-                { runValidators: true, context: "query", returnDocument: "after" },
-              );
-              if (!raced) throw createErr;
-              updated++;
-            }
-          }
-        }
-
+        // GH #951: the three-phase atomic upsert (active → resurrect-trashed →
+        // create/race) lives in `upsertIniFilament`, shared with
+        // POST /api/filaments/import, and preserves variant→parent inheritance
+        // — the export flattens a variant's inherited values through
+        // resolveFilament, so re-importing must NOT pin them as local overrides
+        // (that would sever GH #106 live inheritance). See src/lib/iniImportApply.ts.
+        const outcome = await upsertIniFilament(f);
+        if (outcome === "created") created++;
+        else updated++;
         names.push(f.name);
       } catch (rowErr) {
         const msg = rowErr instanceof Error ? rowErr.message : String(rowErr);

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -283,6 +283,12 @@ const IMPORT_INHERITABLE_SCALARS = new Set<string>([
   "maxPrintSpeed",
   "spoolType",
   "tdsUrl",
+  // GH #951 (Codex): `inherits` (PrusaSlicer preset-inheritance key) is
+  // inheritable per resolveFilament and carried top-level by parseIniFilaments,
+  // so an INI round-trip would otherwise pin the parent's echoed value onto a
+  // variant. The CSV/XLSX importer maps no `inherits` column, so listing it
+  // here is a no-op for that path (it never appears in the CSV setBody).
+  "inherits",
 ]);
 
 /** Required by the Filament schema — never `$unset` on a variant (the
@@ -321,6 +327,10 @@ type LeanFilament = Record<string, any>;
  *     an empty array as "inherit"), so it's skipped only when the incoming
  *     array matches the parent's array exactly (order-sensitive — order is
  *     meaningful for multi-color rendering).
+ *   - `settings` inherits by SHALLOW PER-KEY merge, so it's rebuilt to hold
+ *     only keys that differ from the parent's `settings` (parent-equal keys
+ *     keep inheriting). This runs only when the caller supplies the parent's
+ *     settings; without them it writes through (GH #951, Codex).
  *   - The variant-local empty-string rule mirrors resolveFilament:67-72 —
  *     a variant value of `""` counts as "missing" (already inheriting), so
  *     it never triggers an $unset.
@@ -366,6 +376,34 @@ export function splitInheritedImportSet(
         continue;
       }
       set[key] = incoming;
+      continue;
+    }
+
+    if (key === "settings" && incoming && typeof incoming === "object" && !Array.isArray(incoming)) {
+      // GH #951 (Codex): `settings` is inherited by SHALLOW PER-KEY merge
+      // (resolveFilament: `{ ...parent.settings, ...variant.settings }`), so a
+      // variant that inherits a setting has the parent's value echoed back into
+      // the incoming bag on a round-trip. Treating `settings` as pass-through
+      // (variant-only) would copy those echoed keys onto the variant and sever
+      // inheritance. Store only keys that DIFFER from the parent — parent-equal
+      // keys keep inheriting, and because we rebuild the whole bag a stale
+      // variant key that now matches the parent self-heals (same equal-==-inherit
+      // rule as the scalar path). When the caller doesn't supply the parent's
+      // settings (e.g. the INI import's projection omits them, keeping its raw
+      // settings-bag behaviour unchanged), fall back to writing through.
+      const parentSettings =
+        parent.settings && typeof parent.settings === "object"
+          ? (parent.settings as Record<string, unknown>)
+          : null;
+      if (!parentSettings) {
+        set[key] = incoming;
+        continue;
+      }
+      const filtered: Record<string, unknown> = {};
+      for (const [sk, sv] of Object.entries(incoming as Record<string, unknown>)) {
+        if (parentSettings[sk] !== sv) filtered[sk] = sv;
+      }
+      set[key] = filtered;
       continue;
     }
 
@@ -512,7 +550,7 @@ export async function upsertImportRows(
     "maxVolumetricSpeed spoolWeight netFilamentWeight dryingTemperature " +
     "dryingTime transmissionDistance glassTempTransition heatDeflectionTemp " +
     "shoreHardnessA shoreHardnessD shrinkageXY shrinkageZ minPrintSpeed " +
-    "maxPrintSpeed spoolType tdsUrl temperatures secondaryColors";
+    "maxPrintSpeed spoolType tdsUrl inherits temperatures secondaryColors";
 
   const allExisting = await Filament.find({ name: { $in: [...namesToLoad] } })
     .select(INHERITANCE_PROJECTION)

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -250,11 +250,16 @@ export interface ImportResult {
 }
 
 /**
- * GH #628: scalar fields the CSV/XLSX import can write that participate in
- * variant→parent inheritance (the intersection of `INHERITABLE_FIELDS` in
- * `src/lib/resolveFilament.ts` with the columns the importer maps).
- * `temperatures.*` dot-keys and the `secondaryColors` array are handled
- * separately in `splitInheritedImportSet` below.
+ * GH #628: scalar fields that participate in variant→parent inheritance —
+ * the subset of `INHERITABLE_FIELDS` in `src/lib/resolveFilament.ts` that is
+ * a plain scalar (`temperatures.*` dot-keys and the `secondaryColors` array
+ * are handled separately in `splitInheritedImportSet` / `pruneInheritedCreateDoc`
+ * below). Deliberately covers the FULL set of inheritable scalars, not just the
+ * columns the CSV/XLSX importer maps, because GH #951 shares
+ * `splitInheritedImportSet` with the PrusaSlicer per-id sync route (which also
+ * writes `shrinkageXY`/`shrinkageZ`). Keys the CSV importer never emits are
+ * simply absent from its `setBody`, so listing them here is a no-op for that
+ * path while making the shared helper correct for the sync path too.
  */
 const IMPORT_INHERITABLE_SCALARS = new Set<string>([
   "vendor",
@@ -272,6 +277,8 @@ const IMPORT_INHERITABLE_SCALARS = new Set<string>([
   "heatDeflectionTemp",
   "shoreHardnessA",
   "shoreHardnessD",
+  "shrinkageXY",
+  "shrinkageZ",
   "minPrintSpeed",
   "maxPrintSpeed",
   "spoolType",
@@ -394,6 +401,82 @@ export function splitInheritedImportSet(
   return { set, unset };
 }
 
+/**
+ * GH #951: the create/resurrect counterpart to `splitInheritedImportSet`.
+ *
+ * The CSV/XLSX export flattens a variant's inherited values through
+ * `resolveFilament` (correct for export — every row stands alone). Re-importing
+ * that flattened row on the UPDATE path already skips pinning parent-equal
+ * values (splitInheritedImportSet, GH #628), but the CREATE path
+ * (`Filament.create`) and the RESURRECT path (`updateOne` on a trashed row)
+ * wrote the whole flattened doc verbatim — so a fresh-DB migration or a
+ * trashed-variant restore pinned every inherited field as a local override,
+ * severing GH #106 live inheritance exactly the way #628 fixed for updates.
+ *
+ * Returns a copy of the create doc with each inheritable field whose incoming
+ * value equals the parent's value reset to its "inherit" sentinel:
+ *   - scalars + `temperatures.*` subfields → `null`
+ *   - `secondaryColors` → `[]` (resolveFilament treats an empty array as
+ *     "inherit"; comparison is order-sensitive, matching splitInheritedImportSet)
+ *
+ * There is no `$unset` step (unlike the update path): a create/resurrect writes
+ * the whole document, so a value that equals the parent just becomes the
+ * inherit sentinel — there is no pre-existing divergent override to clear.
+ *
+ * Never touched: `vendor`/`type` (schema-required — a variant always carries
+ * its own value and resolveFilament never inherits them) and the
+ * always-variant-specific `name`/`color`. `vendor`/`type` are excluded via
+ * `IMPORT_REQUIRED_FIELDS`; `name`/`color` are simply not in any inheritable
+ * set here.
+ *
+ * Pure + exported for unit tests.
+ */
+export function pruneInheritedCreateDoc(
+  doc: Record<string, unknown>,
+  parent: LeanFilament,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...doc };
+
+  for (const key of IMPORT_INHERITABLE_SCALARS) {
+    if (IMPORT_REQUIRED_FIELDS.has(key)) continue;
+    const incoming = out[key];
+    if (incoming != null && incoming !== "" && incoming === parent[key]) {
+      out[key] = null;
+    }
+  }
+
+  // Temperatures ride the create doc as a NESTED object; compare each subfield
+  // against the parent's same subfield (resolveFilament inherits each temp
+  // independently via `??`).
+  const temps = out.temperatures;
+  if (temps && typeof temps === "object" && !Array.isArray(temps)) {
+    const parentTemps = (parent.temperatures ?? {}) as Record<string, unknown>;
+    const nextTemps: Record<string, unknown> = { ...(temps as Record<string, unknown>) };
+    for (const sub of Object.keys(nextTemps)) {
+      const val = nextTemps[sub];
+      if (val != null && val === parentTemps[sub]) nextTemps[sub] = null;
+    }
+    out.temperatures = nextTemps;
+  }
+
+  // secondaryColors inherits as a WHOLE array (empty === inherit); drop it to
+  // [] only when it matches the parent's array exactly (order-sensitive).
+  if (Array.isArray(out.secondaryColors) && out.secondaryColors.length > 0) {
+    const parentArr: unknown[] = Array.isArray(parent.secondaryColors)
+      ? parent.secondaryColors
+      : [];
+    const incoming = out.secondaryColors as unknown[];
+    if (
+      parentArr.length === incoming.length &&
+      incoming.every((v, i) => v === parentArr[i])
+    ) {
+      out.secondaryColors = [];
+    }
+  }
+
+  return out;
+}
+
 export async function upsertImportRows(
   rows: ImportRow[],
 ): Promise<ImportResult> {
@@ -428,8 +511,8 @@ export async function upsertImportRows(
     "_id name parentId _deletedAt vendor type cost density diameter " +
     "maxVolumetricSpeed spoolWeight netFilamentWeight dryingTemperature " +
     "dryingTime transmissionDistance glassTempTransition heatDeflectionTemp " +
-    "shoreHardnessA shoreHardnessD minPrintSpeed maxPrintSpeed spoolType " +
-    "tdsUrl temperatures secondaryColors";
+    "shoreHardnessA shoreHardnessD shrinkageXY shrinkageZ minPrintSpeed " +
+    "maxPrintSpeed spoolType tdsUrl temperatures secondaryColors";
 
   const allExisting = await Filament.find({ name: { $in: [...namesToLoad] } })
     .select(INHERITANCE_PROJECTION)
@@ -713,6 +796,35 @@ export async function upsertImportRows(
         };
       }
       if (resolvedParentId) doc.parentId = resolvedParentId;
+
+      // GH #951: create/resurrect inheritance parity with the UPDATE path.
+      // The export flattened this variant's inherited values through
+      // resolveFilament; writing them verbatim would pin every inherited field
+      // as a local override and sever GH #106 live inheritance (a fresh-DB
+      // migration or trashed-variant restore). Null/empty each field whose
+      // incoming value equals the parent's so the new/resurrected variant keeps
+      // tracking parent edits. The effective parent after a resurrect is
+      // `resolvedParentId ?? softDeleted.parentId` (see the resurrect note
+      // below — parentId only rides `doc` when a Parent column was supplied).
+      let writeDoc = doc;
+      const createParentId = softDeleted
+        ? resolvedParentId ?? softDeleted.parentId
+        : resolvedParentId;
+      if (createParentId) {
+        // `parentById` (loaded after pass 1) indexes the parents of EXISTING
+        // active variants, so it won't hold a parent freshly created earlier in
+        // THIS batch — fall back to a direct fetch. Guard a missing/soft-deleted
+        // parent (nothing to inherit → write the doc as-is).
+        let parentDoc = parentById.get(String(createParentId));
+        if (!parentDoc) {
+          parentDoc =
+            (await Filament.findOne({ _id: createParentId, _deletedAt: null })
+              .select(INHERITANCE_PROJECTION)
+              .lean()) ?? undefined;
+        }
+        if (parentDoc) writeDoc = pruneInheritedCreateDoc(doc, parentDoc);
+      }
+
       if (softDeleted) {
         // GH #228: the resurrect path was the only Filament write in the
         // codebase running `updateOne` without `runValidators`. The pre-
@@ -724,7 +836,7 @@ export async function upsertImportRows(
         // invalid numeric fields.
         await Filament.updateOne(
           { _id: softDeleted._id },
-          { ...doc, _deletedAt: null },
+          { ...writeDoc, _deletedAt: null },
           { runValidators: true, context: "query" },
         );
         // GH #379: re-promote into activeByName so a later pass-2 row
@@ -740,7 +852,7 @@ export async function upsertImportRows(
         deletedByName.delete(row.name);
         updated++;
       } else {
-        const newDoc = await Filament.create(doc);
+        const newDoc = await Filament.create(writeDoc);
         // GH #379: seed activeByName with the freshly-created row so a
         // later pass-2 row referencing it as Parent can resolve in-batch
         // (the round-trip case: parent and variant rows in the same CSV).

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -768,9 +768,13 @@ export async function upsertImportRows(
     if (row.maxPrintSpeed !== undefined) doc.maxPrintSpeed = row.maxPrintSpeed ?? null;
     if (row.colorName !== undefined) doc.colorName = row.colorName ?? null;
     if (row.spoolType !== undefined) doc.spoolType = row.spoolType ?? null;
-    if (row.nozzleRangeMin !== undefined) doc["temperatures.nozzleRangeMin"] = row.nozzleRangeMin ?? null;
-    if (row.nozzleRangeMax !== undefined) doc["temperatures.nozzleRangeMax"] = row.nozzleRangeMax ?? null;
-    if (row.standbyTemp !== undefined) doc["temperatures.standby"] = row.standbyTemp ?? null;
+    // GH #951: nozzleRangeMin/Max/standby ride the nested `temperatures` object
+    // (create/resurrect) and the temps loop's dotted `$set` (update) below —
+    // they must NOT also be added as dotted keys on `doc`. On create the dotted
+    // key overrode the nested null that `pruneInheritedCreateDoc` writes,
+    // re-pinning an inherited range temp on a variant; on resurrect the dotted
+    // key + nested object collided in one `updateOne` (MongoDB code 40
+    // "would create a conflict at 'temperatures'"), failing the whole row.
     if (row.tdsUrl !== undefined) doc.tdsUrl = row.tdsUrl ?? null;
     if (row.instanceId) doc.instanceId = row.instanceId;
 

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -34,12 +34,16 @@ import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
 /**
  * Fields a collapsed INI section can carry that participate in
  * variant→parent inheritance (`parseIniFilaments` only produces this subset:
- * vendor/type/cost/density/diameter/maxVolumetricSpeed + the four temp
+ * vendor/type/cost/density/diameter/maxVolumetricSpeed/inherits + the four temp
  * subfields). Projected on the variant AND its parent so `splitInheritedImportSet`
  * can compare incoming vs parent and detect a stale variant override to clear.
+ * `settings` is deliberately NOT projected: the INI settings bag is a raw
+ * key-dump (it includes the structured keys), so per-key parent filtering isn't
+ * meaningful here — `splitInheritedImportSet` falls back to writing it through
+ * unchanged when the parent's settings are absent (GH #951, Codex).
  */
 const INI_INHERITANCE_PROJECTION =
-  "_id parentId vendor type cost density diameter maxVolumetricSpeed temperatures";
+  "_id parentId vendor type cost density diameter maxVolumetricSpeed inherits temperatures";
 
 /** Loosely-typed lean filament — same posture as resolveFilament / importFilaments. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -34,17 +34,19 @@ import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
 
 /**
  * Fields a collapsed INI section can carry that participate in
- * variant→parent inheritance (`parseIniFilaments` only produces this subset:
- * vendor/type/cost/density/diameter/maxVolumetricSpeed/inherits + the four temp
- * subfields). Projected on the variant AND its parent so `splitInheritedImportSet`
- * can compare incoming vs parent and detect a stale variant override to clear.
- * `settings` is deliberately NOT projected: the INI settings bag is a raw
- * key-dump (it includes the structured keys), so per-key parent filtering isn't
- * meaningful here — `splitInheritedImportSet` falls back to writing it through
- * unchanged when the parent's settings are absent (GH #951, Codex).
+ * variant→parent inheritance (the top-level fields `parseIniFilaments` lifts:
+ * vendor/type/cost/density/diameter/maxVolumetricSpeed/inherits/spoolWeight/
+ * shrinkageXY/shrinkageZ + the four temp subfields). Projected on the variant
+ * AND its parent so `splitInheritedImportSet` can compare incoming vs parent and
+ * detect a stale variant override to clear. `settings` is deliberately NOT
+ * projected: after `stripStructuredSettings` removes the top-level shadows the
+ * bag holds only genuine passthrough keys, so `splitInheritedImportSet` writes it
+ * through unchanged (its settings branch no-ops when the parent's settings are
+ * absent). GH #951 (Codex).
  */
 const INI_INHERITANCE_PROJECTION =
-  "_id parentId vendor type cost density diameter maxVolumetricSpeed inherits temperatures";
+  "_id parentId vendor type cost density diameter maxVolumetricSpeed inherits " +
+  "spoolWeight shrinkageXY shrinkageZ temperatures";
 
 /** Loosely-typed lean filament — same posture as resolveFilament / importFilaments. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -1,0 +1,174 @@
+/**
+ * Applier-side helper for the two PrusaSlicer INI bulk importers:
+ *   - `POST /api/filaments/import`      (multipart file upload — UI flow)
+ *   - `POST /api/filaments/prusaslicer` (text/plain body — script flow)
+ *
+ * Both parse the bundle the same way (`collapsePerNozzleImportSections(
+ * parseIniFilaments(...))`) and then upsert each collapsed section by NAME.
+ * This module owns the write half so the two routes can't drift — and so the
+ * GH #951 variant-inheritance fix lands in one place.
+ *
+ * GH #951: the bundle EXPORT resolves a variant through `resolveFilament`, so
+ * each variant's flat `[filament:Name]` section carries the parent's
+ * cost/density/temperatures/… as materialised values. The old importers
+ * `$set` that whole doc onto the name-matched variant, pinning every inherited
+ * field as a local override and severing GH #106 live inheritance on an
+ * otherwise-idempotent round-trip. We reuse the CSV importer's battle-tested
+ * `splitInheritedImportSet` (GH #628 / #649): for a variant target, drop each
+ * inheritable field whose incoming value equals the parent's (keep inheriting)
+ * and `$unset` a stale diverging override so inheritance resumes.
+ *
+ * The three-phase atomic upsert (active → resurrect-trashed → create/race)
+ * mirrors `src/app/api/filaments/bambustudio/route.ts`: read the target, then
+ * write by `_id` with the soft-delete state re-checked in the filter so a
+ * concurrent delete/purge/restore in the read→write window falls through to
+ * the next phase instead of silently mis-writing (the same safety the old
+ * single-op `findOneAndUpdate({name})` had, kept intact).
+ */
+
+import Filament from "@/models/Filament";
+import { splitInheritedImportSet } from "@/lib/importFilaments";
+import { isDuplicateKeyError } from "@/lib/apiErrorHandler";
+import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
+
+/**
+ * Fields a collapsed INI section can carry that participate in
+ * variant→parent inheritance (`parseIniFilaments` only produces this subset:
+ * vendor/type/cost/density/diameter/maxVolumetricSpeed + the four temp
+ * subfields). Projected on the variant AND its parent so `splitInheritedImportSet`
+ * can compare incoming vs parent and detect a stale variant override to clear.
+ */
+const INI_INHERITANCE_PROJECTION =
+  "_id parentId vendor type cost density diameter maxVolumetricSpeed temperatures";
+
+/** Loosely-typed lean filament — same posture as resolveFilament / importFilaments. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LeanFilament = Record<string, any>;
+
+/**
+ * Flatten the collapsed section into an update `$set` body: nested
+ * `temperatures` → `temperatures.<sub>` DOT-keys. Dot-keys (a) let
+ * `splitInheritedImportSet` compare each temp subfield independently against
+ * the parent, and (b) merge into the stored subdoc instead of replacing it —
+ * so a whole-object `$set` no longer wipes untouched sibling temps
+ * (`nozzleRangeMin`/`nozzleRangeMax`/`standby`) the INI bundle never carries.
+ * A collapsed per-nozzle section omits `temperatures` entirely (#872), so no
+ * temp key is emitted and the base filament's shared temps are left alone.
+ */
+function toUpdateSet(collapsed: CollapsedFilamentData): Record<string, unknown> {
+  const { temperatures, ...rest } = collapsed;
+  const flat: Record<string, unknown> = { ...rest };
+  if (temperatures) {
+    for (const [sub, val] of Object.entries(temperatures)) {
+      flat[`temperatures.${sub}`] = val;
+    }
+  }
+  return flat;
+}
+
+/**
+ * Build the atomic Mongo update body ({ $set } + optional { $unset }) for a
+ * name-matched INI import target. For a variant it applies the inheritance
+ * split; for a root (or a variant whose parent is missing/trashed — nothing to
+ * inherit) it writes the flattened doc verbatim.
+ */
+async function buildIniUpdate(
+  collapsed: CollapsedFilamentData,
+  existing: LeanFilament,
+): Promise<Record<string, unknown>> {
+  const flat = toUpdateSet(collapsed);
+  if (!existing.parentId) return { $set: flat };
+
+  const parent = await Filament.findOne({ _id: existing.parentId, _deletedAt: null })
+    .select(INI_INHERITANCE_PROJECTION)
+    .lean();
+  if (!parent) return { $set: flat };
+
+  const split = splitInheritedImportSet(flat, existing, parent as LeanFilament);
+  const out: Record<string, unknown> = { $set: split.set };
+  if (split.unset.length > 0) {
+    out.$unset = Object.fromEntries(split.unset.map((k) => [k, ""]));
+  }
+  return out;
+}
+
+export type IniUpsertOutcome = "created" | "updated";
+
+/**
+ * Upsert a single collapsed INI section, preserving variant inheritance
+ * (GH #951). Three atomic phases (active → resurrect-trashed → create/race).
+ * Returns whether the row was created or updated. Throws on a genuine create
+ * failure (validation, non-duplicate driver error); callers wrap per-row for
+ * error isolation, exactly as the routes did before.
+ */
+export async function upsertIniFilament(
+  collapsed: CollapsedFilamentData,
+): Promise<IniUpsertOutcome> {
+  const name = collapsed.name;
+
+  // Phase 1 — update an existing ACTIVE row.
+  const existingActive = await Filament.findOne({ name, _deletedAt: null })
+    .select(INI_INHERITANCE_PROJECTION)
+    .lean();
+  if (existingActive) {
+    const updated = await Filament.findOneAndUpdate(
+      { _id: existingActive._id, _deletedAt: null },
+      await buildIniUpdate(collapsed, existingActive),
+      { runValidators: true, context: "query", returnDocument: "after" },
+    );
+    if (updated) return "updated";
+    // Soft-deleted between read and write → fall through to phase 2/3.
+  }
+
+  // Phase 2 — resurrect a TRASHED (non-purged) row of the same name rather
+  // than creating a duplicate that would strand the trashed record (its
+  // restore would 409 forever on the name conflict). GH #297.
+  const existingTrashed = await Filament.findOne({
+    name,
+    _deletedAt: { $ne: null },
+    _purged: { $ne: true },
+  })
+    .select(INI_INHERITANCE_PROJECTION)
+    .lean();
+  if (existingTrashed) {
+    const update = await buildIniUpdate(collapsed, existingTrashed);
+    // Splice the tombstone clear into the $set so the resurrect is one atomic
+    // write; any $unset for stale variant overrides composes alongside.
+    update.$set = {
+      ...(update.$set as Record<string, unknown>),
+      _deletedAt: null,
+    };
+    const resurrected = await Filament.findOneAndUpdate(
+      { _id: existingTrashed._id, _deletedAt: { $ne: null }, _purged: { $ne: true } },
+      update,
+      { runValidators: true, context: "query", returnDocument: "after" },
+    );
+    if (resurrected) return "updated";
+    // Purged/restored between read and write → fall through to phase 3.
+  }
+
+  // Phase 3 — create. INI sections never carry a parentId, so a freshly
+  // created filament is always a root: no inheritance to preserve here, and
+  // the nested `temperatures` object rides straight into the create.
+  try {
+    await Filament.create({ ...collapsed });
+    return "created";
+  } catch (createErr) {
+    if (!isDuplicateKeyError(createErr)) throw createErr;
+    // A concurrent import created this name between our phase-1 read and the
+    // create. Recompute the update against THAT row (it may be a variant) and
+    // apply it as if we'd taken phase 1, so parallel identical imports stay
+    // idempotent instead of throwing.
+    const racing = await Filament.findOne({ name, _deletedAt: null })
+      .select(INI_INHERITANCE_PROJECTION)
+      .lean();
+    if (!racing) throw createErr;
+    const merged = await Filament.findOneAndUpdate(
+      { _id: racing._id, _deletedAt: null },
+      await buildIniUpdate(collapsed, racing),
+      { runValidators: true, context: "query", returnDocument: "after" },
+    );
+    if (!merged) throw createErr;
+    return "updated";
+  }
+}

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -29,6 +29,7 @@
 import Filament from "@/models/Filament";
 import { splitInheritedImportSet } from "@/lib/importFilaments";
 import { isDuplicateKeyError } from "@/lib/apiErrorHandler";
+import { INI_TOP_LEVEL_SETTING_KEYS } from "@/lib/parseIni";
 import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
 
 /**
@@ -99,15 +100,48 @@ async function buildIniUpdate(
 export type IniUpsertOutcome = "created" | "updated";
 
 /**
+ * GH #951 (Codex): drop the structured keys that also live in a top-level
+ * `FilamentData` field from the raw INI `settings` bag. `parseIniFilaments`
+ * dumps every `key=value` line into `settings`, so the bag shadows the
+ * top-level fields. On a VARIANT re-import the top-level scalars are correctly
+ * left inheriting (null), but the settings-bag shadow would survive verbatim
+ * and leak back into exports (`filamentToSlicerKeys` seeds `keys` from the
+ * settings bag, then only overwrites when the resolved top-level value is
+ * truthy — a null resolved value with a non-null shadow is a no-op). Stripping
+ * keeps the settings bag to genuine passthrough keys, matching the per-id sync
+ * route (which already excludes STRUCTURED_KEYS). Returns a shallow clone so
+ * the caller's parsed object isn't mutated; every stripped key round-trips via
+ * its top-level field, so nothing is lost.
+ */
+function stripStructuredSettings(collapsed: CollapsedFilamentData): CollapsedFilamentData {
+  if (!collapsed.settings) return collapsed;
+  const settings = { ...collapsed.settings };
+  for (const k of INI_TOP_LEVEL_SETTING_KEYS) delete settings[k];
+  return { ...collapsed, settings };
+}
+
+/**
  * Upsert a single collapsed INI section, preserving variant inheritance
  * (GH #951). Three atomic phases (active → resurrect-trashed → create/race).
  * Returns whether the row was created or updated. Throws on a genuine create
  * failure (validation, non-duplicate driver error); callers wrap per-row for
  * error isolation, exactly as the routes did before.
+ *
+ * Each phase reads the target by name then writes by `_id` — the `name` is
+ * ALSO kept in the write filter so a concurrent rename in the read→write
+ * window makes the write miss and fall through (create a fresh row) instead of
+ * reverting the rename / pinning this section onto the renamed filament. This
+ * restores the old single-op `findOneAndUpdate({ name })` semantics (the Bambu
+ * bulk route stays safe differently — it never puts `name` in its `$set`).
  */
 export async function upsertIniFilament(
-  collapsed: CollapsedFilamentData,
+  section: CollapsedFilamentData,
 ): Promise<IniUpsertOutcome> {
+  // Strip the settings-bag shadows of top-level fields up front so every write
+  // path (update / resurrect / create / race) and both roots and variants see
+  // a clean settings bag — in particular the phase-3 `Filament.create` below
+  // spreads `collapsed` directly rather than going through `buildIniUpdate`.
+  const collapsed = stripStructuredSettings(section);
   const name = collapsed.name;
 
   // Phase 1 — update an existing ACTIVE row.
@@ -116,12 +150,15 @@ export async function upsertIniFilament(
     .lean();
   if (existingActive) {
     const updated = await Filament.findOneAndUpdate(
-      { _id: existingActive._id, _deletedAt: null },
+      // `name` re-checked so a concurrent rename in the read→write window
+      // misses here and falls through (rather than the by-id write reverting
+      // the rename via the `name` in `$set`). GH #951 (Codex).
+      { _id: existingActive._id, name, _deletedAt: null },
       await buildIniUpdate(collapsed, existingActive),
       { runValidators: true, context: "query", returnDocument: "after" },
     );
     if (updated) return "updated";
-    // Soft-deleted between read and write → fall through to phase 2/3.
+    // Soft-deleted or renamed between read and write → fall through to phase 2/3.
   }
 
   // Phase 2 — resurrect a TRASHED (non-purged) row of the same name rather
@@ -143,12 +180,13 @@ export async function upsertIniFilament(
       _deletedAt: null,
     };
     const resurrected = await Filament.findOneAndUpdate(
-      { _id: existingTrashed._id, _deletedAt: { $ne: null }, _purged: { $ne: true } },
+      // `name` re-checked for the same rename-race reason as phase 1.
+      { _id: existingTrashed._id, name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
       update,
       { runValidators: true, context: "query", returnDocument: "after" },
     );
     if (resurrected) return "updated";
-    // Purged/restored between read and write → fall through to phase 3.
+    // Purged/restored/renamed between read and write → fall through to phase 3.
   }
 
   // Phase 3 — create. INI sections never carry a parentId, so a freshly
@@ -168,7 +206,8 @@ export async function upsertIniFilament(
       .lean();
     if (!racing) throw createErr;
     const merged = await Filament.findOneAndUpdate(
-      { _id: racing._id, _deletedAt: null },
+      // `name` re-checked for the same rename-race reason as phase 1.
+      { _id: racing._id, name, _deletedAt: null },
       await buildIniUpdate(collapsed, racing),
       { runValidators: true, context: "query", returnDocument: "after" },
     );

--- a/src/lib/parseIni.ts
+++ b/src/lib/parseIni.ts
@@ -19,6 +19,32 @@ export interface FilamentData {
   settings: Record<string, string | null>;
 }
 
+/**
+ * GH #951 (Codex): the INI keys that `flushFilament` below lifts into a
+ * TOP-LEVEL `FilamentData` field (rather than leaving only in the `settings`
+ * passthrough bag). The bulk INI importers strip these from the stored
+ * `settings` bag so a variant that inherits one of them doesn't keep a stale
+ * shadow copy that leaks back into exports (`filamentToSlicerKeys` seeds `keys`
+ * from `settings`, so a shadow survives when the resolved top-level value is
+ * null). Every key here round-trips via its top-level field, so stripping loses
+ * nothing. Keep this in lockstep with the `currentSettings.*` reads in
+ * `flushFilament` — `tests/parseIni.test.ts` pins that invariant.
+ */
+export const INI_TOP_LEVEL_SETTING_KEYS = [
+  "filament_vendor",
+  "filament_type",
+  "filament_colour",
+  "filament_cost",
+  "filament_density",
+  "filament_diameter",
+  "filament_max_volumetric_speed",
+  "temperature",
+  "first_layer_temperature",
+  "bed_temperature",
+  "first_layer_bed_temperature",
+  "inherits",
+] as const;
+
 export function parseIniFilaments(content: string): FilamentData[] {
   const filaments: FilamentData[] = [];
   const lines = content.split("\n");

--- a/src/lib/parseIni.ts
+++ b/src/lib/parseIni.ts
@@ -16,6 +16,14 @@ export interface FilamentData {
   };
   maxVolumetricSpeed: number | null;
   inherits: string | null;
+  // GH #951 (Codex): spool weight + shrinkage are lifted to top-level (like
+  // cost/density) so their settings-bag shadow can be stripped without data
+  // loss. OPTIONAL and set ONLY when the source INI key is present — an omitted
+  // key must not become `$set: null` and clobber an existing value on a root
+  // (the "carry only when supplied" idiom the per-nozzle collapse also uses).
+  spoolWeight?: number | null;
+  shrinkageXY?: number | null;
+  shrinkageZ?: number | null;
   settings: Record<string, string | null>;
 }
 
@@ -43,6 +51,9 @@ export const INI_TOP_LEVEL_SETTING_KEYS = [
   "bed_temperature",
   "first_layer_bed_temperature",
   "inherits",
+  "filament_spool_weight",
+  "filament_shrinkage_compensation_xy",
+  "filament_shrinkage_compensation_z",
 ] as const;
 
 export function parseIniFilaments(content: string): FilamentData[] {
@@ -66,7 +77,7 @@ export function parseIniFilaments(content: string): FilamentData[] {
         return val;
       };
 
-      filaments.push({
+      const fd: FilamentData = {
         name: currentName!,
         vendor: currentSettings.filament_vendor || "Unknown",
         type: currentSettings.filament_type || "Unknown",
@@ -83,7 +94,21 @@ export function parseIniFilaments(content: string): FilamentData[] {
         maxVolumetricSpeed: parseNum(currentSettings.filament_max_volumetric_speed),
         inherits: nilOrVal(currentSettings.inherits),
         settings: { ...currentSettings },
-      });
+      };
+      // GH #951 (Codex): lift spool weight + shrinkage to top-level ONLY when the
+      // source key is present, so an INI that omits them leaves the field
+      // `undefined` (→ omitted from the importer's `$set`) rather than nulling a
+      // value already on the row. See the FilamentData comment above.
+      if ("filament_spool_weight" in currentSettings) {
+        fd.spoolWeight = parseNum(currentSettings.filament_spool_weight);
+      }
+      if ("filament_shrinkage_compensation_xy" in currentSettings) {
+        fd.shrinkageXY = parseNum(currentSettings.filament_shrinkage_compensation_xy);
+      }
+      if ("filament_shrinkage_compensation_z" in currentSettings) {
+        fd.shrinkageZ = parseNum(currentSettings.filament_shrinkage_compensation_z);
+      }
+      filaments.push(fd);
     }
   }
 

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1023,6 +1023,56 @@ describe("API route correctness", () => {
     expect(fresh.cost == null).toBe(true); // $unset → inheritance resumes
   });
 
+  it("#951 (Codex F1) — a variant sync does not pin parent-inherited slicer settings", async () => {
+    const parent = await Filament.create({
+      name: "Settings PLA",
+      vendor: "Acme",
+      type: "PLA",
+      settings: { some_passthrough_key: "parentval", shared_key: "same" },
+    });
+    const variant = await Filament.create({
+      name: "Settings PLA — Green",
+      vendor: "Acme",
+      type: "PLA",
+      color: "#00FF00",
+      parentId: parent._id,
+      // inherits settings from the parent
+    });
+
+    // The fork echoes the resolved settings (parent ∪ variant); shared_key ==
+    // parent, some_passthrough_key == parent, and one genuine variant override.
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}`, {
+        config: {
+          filamentdb_id: String(variant._id),
+          some_passthrough_key: "parentval", // == parent → must not pin
+          shared_key: "same", // == parent → must not pin
+          variant_only_key: "mine", // ≠ parent → genuine override
+        },
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const fresh = await Filament.findById(variant._id).lean();
+    const vs = (fresh.settings ?? {}) as Record<string, unknown>;
+    // Parent-equal keys are NOT stored on the variant → they keep inheriting.
+    expect(vs.some_passthrough_key).toBeUndefined();
+    expect(vs.shared_key).toBeUndefined();
+    // The genuine override is stored.
+    expect(vs.variant_only_key).toBe("mine");
+
+    // A later parent settings edit still propagates to the variant.
+    await Filament.updateOne(
+      { _id: parent._id },
+      { $set: { "settings.some_passthrough_key": "changed" } },
+    );
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    const resolved = resolveFilament(fresh, freshParent);
+    expect(resolved.settings.some_passthrough_key).toBe("changed");
+  });
+
   it("#872 — a per-nozzle sync with an out-of-range baked calibration value is rejected with 400 (nothing persisted)", async () => {
     const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
     const f = await Filament.create({

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -905,6 +905,124 @@ describe("API route correctness", () => {
     expect(fresh.colorName).toBe("Rainbow"); // so name is NOT cleared
   });
 
+  // ── #951: a variant sync must not pin parent-inherited values ──────
+  // The bundle export flattens a variant through resolveFilament, so the fork
+  // echoes the parent's density/cost/temps back on every sync. Blindly $set-ing
+  // them onto the variant would sever GH #106 live inheritance.
+
+  it("#951 — syncing a variant does NOT pin parent-equal inherited values (inheritance survives)", async () => {
+    const parent = await Filament.create({
+      name: "Sync PLA",
+      vendor: "Acme",
+      type: "PLA",
+      cost: 25,
+      density: 1.24,
+      spoolWeight: 250,
+      temperatures: { nozzle: 215, bed: 60 },
+    });
+    const variant = await Filament.create({
+      name: "Sync PLA — Red",
+      vendor: "Acme",
+      type: "PLA",
+      color: "#FF0000",
+      parentId: parent._id,
+      // fully inheriting
+    });
+
+    // The fork echoes the full (resolved) config — every value equals the parent.
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}`, {
+        config: {
+          filamentdb_id: String(variant._id),
+          filament_type: "PLA",
+          filament_vendor: "Acme",
+          filament_density: "1.24",
+          filament_cost: "25",
+          filament_spool_weight: "250",
+          temperature: "215",
+          bed_temperature: "60",
+        },
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const fresh = await Filament.findById(variant._id).lean();
+    // None of the parent-equal inherited fields were pinned as local overrides.
+    expect(fresh.cost).toBeNull();
+    expect(fresh.density).toBeNull();
+    expect(fresh.spoolWeight ?? null).toBeNull();
+    expect(fresh.temperatures?.nozzle ?? null).toBeNull();
+    expect(fresh.temperatures?.bed ?? null).toBeNull();
+
+    // A later parent edit still propagates to the variant (GH #106 intact).
+    await Filament.updateOne({ _id: parent._id }, { $set: { cost: 30 } });
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    expect(resolveFilament(fresh, freshParent).cost).toBe(30);
+  });
+
+  it("#951 — a variant sync value that DIFFERS from the parent is written as a genuine override", async () => {
+    const parent = await Filament.create({
+      name: "Sync PETG",
+      vendor: "Acme",
+      type: "PETG",
+      cost: 20,
+      temperatures: { nozzle: 240 },
+    });
+    const variant = await Filament.create({
+      name: "Sync PETG — Black",
+      vendor: "Acme",
+      type: "PETG",
+      color: "#000000",
+      parentId: parent._id,
+    });
+
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}`, {
+        config: {
+          filamentdb_id: String(variant._id),
+          filament_cost: "20", // == parent → not pinned
+          temperature: "250", // ≠ parent 240 → genuine override
+        },
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const fresh = await Filament.findById(variant._id).lean();
+    expect(fresh.cost).toBeNull(); // inherited
+    expect(fresh.temperatures.nozzle).toBe(250); // override written
+  });
+
+  it("#951 — a variant sync clears a stale local override once it matches the parent again ($unset)", async () => {
+    const parent = await Filament.create({
+      name: "Sync ASA",
+      vendor: "Acme",
+      type: "ASA",
+      cost: 35,
+    });
+    const variant = await Filament.create({
+      name: "Sync ASA — White",
+      vendor: "Acme",
+      type: "ASA",
+      color: "#FFFFFF",
+      parentId: parent._id,
+      cost: 40, // stale divergence
+    });
+
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}`, {
+        config: { filamentdb_id: String(variant._id), filament_cost: "35" }, // == parent
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const fresh = await Filament.findById(variant._id).lean();
+    expect(fresh.cost == null).toBe(true); // $unset → inheritance resumes
+  });
+
   it("#872 — a per-nozzle sync with an out-of-range baked calibration value is rejected with 400 (nothing persisted)", async () => {
     const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
     const f = await Filament.create({

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -188,6 +188,55 @@ filament_max_volumetric_speed = 20
       expect(fresh.settings?.filamentdb_nozzle).toBeUndefined();
       expect(fresh.settings?.extrusion_multiplier).toBeUndefined();
     });
+
+    it("#951: re-importing a variant's flattened section does NOT pin parent-inherited values", async () => {
+      // The bundle export resolves a variant through resolveFilament, so its
+      // flat [filament:…] section carries the parent's cost/density/temps.
+      // Re-importing must skip pinning them so GH #106 live inheritance survives.
+      const parent = await Filament.create({
+        name: "PLA Base",
+        vendor: "Acme",
+        type: "PLA",
+        cost: 25,
+        density: 1.24,
+        temperatures: { nozzle: 215, bed: 60 },
+      });
+      const variant = await Filament.create({
+        name: "PLA Base — Red",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#FF0000",
+        parentId: parent._id,
+        // fully inheriting
+      });
+
+      const ini = `[filament:PLA Base — Red]
+filament_type = PLA
+filament_vendor = Acme
+filament_cost = 25
+filament_density = 1.24
+temperature = 215
+bed_temperature = 60
+`;
+      const file = new File([ini], "variant.ini", { type: "text/plain" });
+      const res = await importFilaments(
+        multipartReq("http://localhost/api/filaments/import", file),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).updated).toBe(1);
+
+      const fresh = await Filament.findById(variant._id).lean();
+      expect(fresh.cost).toBeNull();
+      expect(fresh.density).toBeNull();
+      expect(fresh.temperatures?.nozzle ?? null).toBeNull();
+      expect(fresh.temperatures?.bed ?? null).toBeNull();
+
+      // parent edit still propagates.
+      await Filament.updateOne({ _id: parent._id }, { $set: { cost: 30 } });
+      const { resolveFilament } = await import("@/lib/resolveFilament");
+      const freshParent = await Filament.findById(parent._id).lean();
+      expect(resolveFilament(fresh, freshParent).cost).toBe(30);
+    });
   });
 
   describe("POST /api/filaments/prusaslicer (bundle import)", () => {
@@ -284,6 +333,157 @@ filamentdb_nozzle = 0.4 Brass
       expect(body.errors[0]).toMatch(/Ghost/);
       expect(await Filament.findOne({ name: "Good PLA" })).toBeTruthy();
       expect(await Filament.findOne({ name: "Ghost" })).toBeNull();
+    });
+
+    it("#951: re-importing a variant's flattened section keeps inheritance (text-body route)", async () => {
+      const parent = await Filament.create({
+        name: "PETG Base",
+        vendor: "Acme",
+        type: "PETG",
+        cost: 20,
+        temperatures: { nozzle: 240, bed: 70 },
+      });
+      const variant = await Filament.create({
+        name: "PETG Base — Blue",
+        vendor: "Acme",
+        type: "PETG",
+        color: "#0000FF",
+        parentId: parent._id,
+      });
+
+      // Section carries parent-equal cost/temps, plus one genuine override (bed 80).
+      const ini = `[filament:PETG Base — Blue]
+filament_type = PETG
+filament_vendor = Acme
+filament_cost = 20
+temperature = 240
+bed_temperature = 80
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).updated).toBe(1);
+
+      const fresh = await Filament.findById(variant._id).lean();
+      expect(fresh.cost).toBeNull(); // == parent → not pinned
+      expect(fresh.temperatures?.nozzle ?? null).toBeNull(); // == parent → not pinned
+      expect(fresh.temperatures.bed).toBe(80); // ≠ parent 70 → genuine override written
+    });
+
+    it("#951: temps flatten to dot-keys — an update no longer wipes untouched range/standby subfields", async () => {
+      // A root import that carries only nozzle/bed must NOT reset the stored
+      // nozzleRangeMin/Max/standby (the old whole-object $set replaced the
+      // entire subdoc). Dot-key merge leaves untouched siblings intact.
+      const root = await Filament.create({
+        name: "ASA Base",
+        vendor: "Acme",
+        type: "ASA",
+        temperatures: {
+          nozzle: 200,
+          bed: 90,
+          nozzleRangeMin: 190,
+          nozzleRangeMax: 250,
+          standby: 170,
+        },
+      });
+      const ini = `[filament:ASA Base]
+filament_type = ASA
+filament_vendor = Acme
+temperature = 250
+bed_temperature = 100
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findById(root._id).lean();
+      expect(fresh.temperatures.nozzle).toBe(250); // updated
+      expect(fresh.temperatures.bed).toBe(100); // updated
+      expect(fresh.temperatures.nozzleRangeMin).toBe(190); // preserved (was wiped pre-fix)
+      expect(fresh.temperatures.nozzleRangeMax).toBe(250); // preserved
+      expect(fresh.temperatures.standby).toBe(170); // preserved
+    });
+
+    it("#951: a variant whose parent is trashed writes values verbatim (nothing to inherit)", async () => {
+      // Guard branch: with no active parent, there is no inheritance to
+      // preserve, so the flattened values are written as the variant's own.
+      const parent = await Filament.create({
+        name: "TPU Base",
+        vendor: "Acme",
+        type: "TPU",
+        cost: 40,
+      });
+      const variant = await Filament.create({
+        name: "TPU Base — Red",
+        vendor: "Acme",
+        type: "TPU",
+        color: "#FF0000",
+        parentId: parent._id,
+      });
+      await Filament.updateOne({ _id: parent._id }, { $set: { _deletedAt: new Date() } });
+
+      const ini = `[filament:TPU Base — Red]
+filament_type = TPU
+filament_vendor = Acme
+filament_cost = 99
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).updated).toBe(1);
+
+      const fresh = await Filament.findById(variant._id).lean();
+      expect(fresh.cost).toBe(99); // written as the variant's own value
+    });
+
+    it("#951: re-importing a section matching the parent clears a variant's stale override ($unset)", async () => {
+      const parent = await Filament.create({
+        name: "PC Base",
+        vendor: "Acme",
+        type: "PC",
+        cost: 45,
+      });
+      const variant = await Filament.create({
+        name: "PC Base — Clear",
+        vendor: "Acme",
+        type: "PC",
+        color: "#EEEEEE",
+        parentId: parent._id,
+        cost: 50, // stale local divergence
+      });
+
+      const ini = `[filament:PC Base — Clear]
+filament_type = PC
+filament_vendor = Acme
+filament_cost = 45
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).updated).toBe(1);
+
+      const fresh = await Filament.findById(variant._id).lean();
+      expect(fresh.cost == null).toBe(true); // $unset → inheritance resumes
     });
   });
 

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -485,6 +485,48 @@ filament_cost = 45
       const fresh = await Filament.findById(variant._id).lean();
       expect(fresh.cost == null).toBe(true); // $unset → inheritance resumes
     });
+
+    it("#951 (Codex F2): re-importing a variant does NOT pin the inherited `inherits` preset key", async () => {
+      const parent = await Filament.create({
+        name: "PLA Inh",
+        vendor: "Acme",
+        type: "PLA",
+        inherits: "*PLA*",
+      });
+      const variant = await Filament.create({
+        name: "PLA Inh — Red",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#FF0000",
+        parentId: parent._id,
+        // inheriting `inherits` from the parent
+      });
+
+      const ini = `[filament:PLA Inh — Red]
+filament_type = PLA
+filament_vendor = Acme
+inherits = *PLA*
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).updated).toBe(1);
+
+      const fresh = await Filament.findById(variant._id).lean();
+      // Top-level `inherits` matches the parent → NOT pinned (keeps inheriting).
+      expect(fresh.inherits == null).toBe(true);
+
+      // parent edit still propagates.
+      await Filament.updateOne({ _id: parent._id }, { $set: { inherits: "*PLA-HF*" } });
+      const { resolveFilament } = await import("@/lib/resolveFilament");
+      const freshParent = await Filament.findById(parent._id).lean();
+      expect(resolveFilament(fresh, freshParent).inherits).toBe("*PLA-HF*");
+    });
   });
 
   describe("POST /api/filaments/parse-ini (#872 prefill)", () => {

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -42,6 +42,21 @@ describe("/api/filaments/import + export", () => {
     return new NextRequest(url, { method: "POST", body: fd });
   }
 
+  /** Return the body lines of a `[filament:<name>]` section from a bundle. */
+  function extractSection(bundle: string, name: string): string {
+    const lines = bundle.split("\n");
+    const start = lines.findIndex((l) => l.trim() === `[filament:${name}]`);
+    if (start === -1) return "";
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+      if (lines[i].trim().startsWith("[")) {
+        end = i;
+        break;
+      }
+    }
+    return lines.slice(start + 1, end).join("\n");
+  }
+
   describe("POST /api/filaments/import (INI)", () => {
     it("returns 400 when no file is attached", async () => {
       const req = new NextRequest("http://localhost/api/filaments/import", {
@@ -526,6 +541,132 @@ inherits = *PLA*
       const { resolveFilament } = await import("@/lib/resolveFilament");
       const freshParent = await Filament.findById(parent._id).lean();
       expect(resolveFilament(fresh, freshParent).inherits).toBe("*PLA-HF*");
+    });
+
+    it("#951 (Codex R2-B): re-importing a variant leaves NO structured shadow in its settings bag, so a later parent-clear doesn't leak stale values on re-export", async () => {
+      const { INI_TOP_LEVEL_SETTING_KEYS } = await import("@/lib/parseIni");
+      const parent = await Filament.create({
+        name: "RT Base",
+        vendor: "Acme",
+        type: "PLA",
+        cost: 25,
+        density: 1.24,
+        temperatures: { nozzle: 210, bed: 60 },
+        inherits: "*PLA*",
+      });
+      const variant = await Filament.create({
+        name: "RT Base — Red",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#FF0000",
+        parentId: parent._id,
+        // fully inheriting
+      });
+
+      // The flattened variant section the export produced (parent values baked in).
+      const ini = `[filament:RT Base — Red]
+filament_type = PLA
+filament_vendor = Acme
+filament_colour = #FF0000
+filament_cost = 25
+filament_density = 1.24
+temperature = 210
+bed_temperature = 60
+inherits = *PLA*
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findById(variant._id).lean();
+      // No structured shadow survives in the settings bag.
+      const vs = (fresh.settings ?? {}) as Record<string, unknown>;
+      for (const k of INI_TOP_LEVEL_SETTING_KEYS) {
+        expect(vs[k]).toBeUndefined();
+      }
+      // Top-level inheritance intact.
+      expect(fresh.cost).toBeNull();
+      expect(fresh.temperatures?.nozzle ?? null).toBeNull();
+      expect(fresh.inherits == null).toBe(true);
+
+      // Now the parent CLEARS those fields. A stale shadow would keep leaking
+      // them into the export; with the shadow stripped the variant emits nothing.
+      await Filament.updateOne(
+        { _id: parent._id },
+        { $set: { cost: null, inherits: null }, $unset: { "temperatures.nozzle": "" } },
+      );
+      const exportRes = await exportFilaments();
+      const bundle = await exportRes.text();
+      const section = extractSection(bundle, "RT Base — Red");
+      expect(section).not.toMatch(/^\s*inherits\s*=\s*\*PLA\*/m);
+      expect(section).not.toMatch(/^\s*filament_cost\s*=\s*25/m);
+      expect(section).not.toMatch(/^\s*temperature\s*=\s*210/m);
+    });
+
+    it("#951 (Codex R2-B): a fresh ROOT create drops structured shadows from settings but keeps the top-level fields", async () => {
+      const { INI_TOP_LEVEL_SETTING_KEYS } = await import("@/lib/parseIni");
+      const ini = `[filament:Fresh ABS]
+filament_type = ABS
+filament_vendor = Acme
+filament_cost = 30
+filament_density = 1.04
+temperature = 245
+inherits = *ABS*
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).created).toBe(1);
+
+      const fresh = await Filament.findOne({ name: "Fresh ABS" }).lean();
+      const vs = (fresh.settings ?? {}) as Record<string, unknown>;
+      for (const k of INI_TOP_LEVEL_SETTING_KEYS) {
+        expect(vs[k]).toBeUndefined();
+      }
+      // Values persisted via their canonical top-level fields.
+      expect(fresh.cost).toBe(30);
+      expect(fresh.density).toBe(1.04);
+      expect(fresh.temperatures.nozzle).toBe(245);
+      expect(fresh.inherits).toBe("*ABS*");
+    });
+
+    it("#951 (Codex R2-B): settings-only keys (no top-level home) SURVIVE the strip", async () => {
+      const ini = `[filament:Passthrough PLA]
+filament_type = PLA
+filament_vendor = Acme
+filament_spool_weight = 250
+filament_soluble = 1
+filament_notes = keep me
+filament_settings_id = MyPreset
+filament_shrinkage_compensation_xy = 0.3%
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findOne({ name: "Passthrough PLA" }).lean();
+      const vs = (fresh.settings ?? {}) as Record<string, unknown>;
+      // These have no top-level home in the INI mapping, so they must remain.
+      expect(vs.filament_spool_weight).toBe("250");
+      expect(vs.filament_soluble).toBe("1");
+      expect(vs.filament_notes).toBe("keep me");
+      expect(vs.filament_settings_id).toBe("MyPreset");
+      expect(vs.filament_shrinkage_compensation_xy).toBe("0.3%");
     });
   });
 

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -640,7 +640,7 @@ inherits = *ABS*
       expect(fresh.inherits).toBe("*ABS*");
     });
 
-    it("#951 (Codex R2-B): settings-only keys (no top-level home) SURVIVE the strip", async () => {
+    it("#951 (Codex R2-B/R3): settings-only keys survive; top-level-mapped keys are stripped + extracted", async () => {
       const ini = `[filament:Passthrough PLA]
 filament_type = PLA
 filament_vendor = Acme
@@ -661,12 +661,99 @@ filament_shrinkage_compensation_xy = 0.3%
 
       const fresh = await Filament.findOne({ name: "Passthrough PLA" }).lean();
       const vs = (fresh.settings ?? {}) as Record<string, unknown>;
-      // These have no top-level home in the INI mapping, so they must remain.
-      expect(vs.filament_spool_weight).toBe("250");
+      // No top-level home in the INI mapping → must remain in the settings bag.
       expect(vs.filament_soluble).toBe("1");
       expect(vs.filament_notes).toBe("keep me");
       expect(vs.filament_settings_id).toBe("MyPreset");
-      expect(vs.filament_shrinkage_compensation_xy).toBe("0.3%");
+      // GH #951 (R3): spool weight + shrinkage now HAVE a top-level home, so they
+      // are stripped from the settings bag and stored as structured fields.
+      expect(vs.filament_spool_weight).toBeUndefined();
+      expect(vs.filament_shrinkage_compensation_xy).toBeUndefined();
+      expect(fresh.spoolWeight).toBe(250);
+      expect(fresh.shrinkageXY).toBe(0.3);
+    });
+
+    it("#951 (Codex R3): a variant inheriting spool weight + shrinkage doesn't leak the shadow on re-export after a FORM-created parent clears them", async () => {
+      // The parent sets spoolWeight/shrinkage as TOP-LEVEL fields only (as the
+      // form does) — the case option (b) would have missed.
+      const parent = await Filament.create({
+        name: "SW Base",
+        vendor: "Acme",
+        type: "PLA",
+        spoolWeight: 250,
+        shrinkageXY: 0.3,
+      });
+      const variant = await Filament.create({
+        name: "SW Base — Red",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#FF0000",
+        parentId: parent._id,
+        // inheriting spoolWeight + shrinkageXY
+      });
+
+      // The flattened export bakes the parent's resolved values into the section.
+      const ini = `[filament:SW Base — Red]
+filament_type = PLA
+filament_vendor = Acme
+filament_spool_weight = 250
+filament_shrinkage_compensation_xy = 0.3
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findById(variant._id).lean();
+      // No shadow in settings, and top-level stays inheriting (null).
+      const vs = (fresh.settings ?? {}) as Record<string, unknown>;
+      expect(vs.filament_spool_weight).toBeUndefined();
+      expect(vs.filament_shrinkage_compensation_xy).toBeUndefined();
+      expect(fresh.spoolWeight ?? null).toBeNull();
+      expect(fresh.shrinkageXY ?? null).toBeNull();
+
+      // Parent CLEARS the fields; a stale shadow would re-emit them on export.
+      await Filament.updateOne(
+        { _id: parent._id },
+        { $set: { spoolWeight: null, shrinkageXY: null } },
+      );
+      const exportRes = await exportFilaments();
+      const section = extractSection(await exportRes.text(), "SW Base — Red");
+      expect(section).not.toMatch(/^\s*filament_spool_weight\s*=/m);
+      expect(section).not.toMatch(/^\s*filament_shrinkage_compensation_xy\s*=/m);
+    });
+
+    it("#951 (Codex R3): a partial INI that omits spool weight does NOT clobber an existing top-level value (no-clobber guard)", async () => {
+      const root = await Filament.create({
+        name: "Clobber Guard PLA",
+        vendor: "Acme",
+        type: "PLA",
+        spoolWeight: 200,
+        shrinkageXY: 0.4,
+      });
+      // Re-import a section for the same name WITHOUT filament_spool_weight/shrinkage.
+      const ini = `[filament:Clobber Guard PLA]
+filament_type = PLA
+filament_vendor = Acme
+filament_cost = 25
+`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      const fresh = await Filament.findById(root._id).lean();
+      expect(fresh.spoolWeight).toBe(200); // NOT nulled by the omitted key
+      expect(fresh.shrinkageXY).toBe(0.4);
+      expect(fresh.cost).toBe(25); // the supplied field did update
     });
   });
 

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -1515,6 +1515,102 @@ describe("upsertImportRows — create/resurrect preserve inheritance (GH #951)",
     expect(variant.temperatures?.bed ?? null).toBeNull(); // == parent → inherited
   });
 
+  it("CREATE does not pin inherited RANGE temps (nozzleRangeMin/Max/standby) on a variant", async () => {
+    // Regression for GH #951 Codex finding 3: the dotted `temperatures.*` keys
+    // added alongside the nested `temperatures` object overrode the null that
+    // `pruneInheritedCreateDoc` writes, re-pinning inherited range temps.
+    const RANGE_COLS = [
+      "Name",
+      "Vendor",
+      "Type",
+      "Color",
+      "Nozzle Range Min (°C)",
+      "Nozzle Range Max (°C)",
+      "Standby Temp (°C)",
+      "Parent",
+    ];
+    const mapping = mapHeaders(RANGE_COLS);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rangeRows = (rows: any[][]) => rows.map((r) => rowToImport(r, mapping));
+
+    const result = await upsertImportRows(
+      rangeRows([
+        ["Range Parent", "Acme", "PLA", "#808080", 190, 230, 150, ""],
+        // variant row carries the parent-resolved range temps (flattened export)
+        ["Range Parent — Red", "Acme", "PLA", "#FF0000", 190, 230, 150, "Range Parent"],
+      ]),
+    );
+    expect(result.created).toBe(2);
+    expect(result.skipped).toBe(0);
+
+    const variant = await Filament.findOne({ name: "Range Parent — Red" }).lean();
+    // Inherited range temps must NOT be pinned — they read as null on the variant.
+    expect(variant.temperatures?.nozzleRangeMin ?? null).toBeNull();
+    expect(variant.temperatures?.nozzleRangeMax ?? null).toBeNull();
+    expect(variant.temperatures?.standby ?? null).toBeNull();
+
+    // …and a later parent edit still propagates through resolveFilament.
+    const parent = await Filament.findOne({ name: "Range Parent" }).lean();
+    await Filament.updateOne(
+      { _id: parent._id },
+      { $set: { "temperatures.nozzleRangeMin": 200 } },
+    );
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    const resolved = resolveFilament(variant, freshParent);
+    expect(resolved.temperatures.nozzleRangeMin).toBe(200);
+    expect(resolved.temperatures.standby).toBe(150);
+  });
+
+  it("RESURRECT of a trashed variant with RANGE temps succeeds (no dotted/nested conflict)", async () => {
+    // Regression for GH #951 Codex finding 3: on resurrect the dotted
+    // `temperatures.nozzleRangeMin` key + the nested `temperatures` object
+    // collided in a single updateOne (MongoServerError code 40), so the row
+    // was caught and SKIPPED — the trashed variant never came back.
+    const parent = await Filament.create({
+      name: "Range Resurrect Parent",
+      vendor: "Acme",
+      type: "PLA",
+      temperatures: { nozzleRangeMin: 190, nozzleRangeMax: 230, standby: 150 },
+    });
+    const variant = await Filament.create({
+      name: "Range Resurrect Variant",
+      vendor: "Acme",
+      type: "PLA",
+      color: "#00FF00",
+      parentId: parent._id,
+      _deletedAt: new Date(), // trashed
+    });
+
+    const RANGE_COLS = [
+      "Name",
+      "Vendor",
+      "Type",
+      "Color",
+      "Nozzle Range Min (°C)",
+      "Nozzle Range Max (°C)",
+      "Standby Temp (°C)",
+      "Parent",
+    ];
+    const mapping = mapHeaders(RANGE_COLS);
+    const result = await upsertImportRows([
+      rowToImport(
+        ["Range Resurrect Variant", "Acme", "PLA", "#00FF00", 190, 230, 150, "Range Resurrect Parent"],
+        mapping,
+      ),
+    ]);
+
+    expect(result.skipped).toBe(0);
+    expect(result.updated).toBe(1);
+
+    const resurrected = await Filament.findById(variant._id).lean();
+    expect(resurrected._deletedAt).toBeNull(); // actually revived
+    // inherited range temps not pinned
+    expect(resurrected.temperatures?.nozzleRangeMin ?? null).toBeNull();
+    expect(resurrected.temperatures?.nozzleRangeMax ?? null).toBeNull();
+    expect(resurrected.temperatures?.standby ?? null).toBeNull();
+  });
+
   it("RESURRECT of a trashed variant does not pin parent-inherited values", async () => {
     const parent = await Filament.create({
       name: "Universal ABS",

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mapHeaders, rowToImport, splitInheritedImportSet, upsertImportRows } from "@/lib/importFilaments";
+import { mapHeaders, pruneInheritedCreateDoc, rowToImport, splitInheritedImportSet, upsertImportRows } from "@/lib/importFilaments";
 
 describe("mapHeaders", () => {
   it("maps standard export headers", () => {
@@ -1150,6 +1150,106 @@ describe("splitInheritedImportSet (GH #628)", () => {
 });
 
 /**
+ * GH #951 — pure-helper coverage for the create/resurrect inheritance prune.
+ * Counterpart to splitInheritedImportSet: instead of {set, unset} for an
+ * UPDATE, it returns a create doc with each parent-equal inheritable field
+ * reset to its inherit sentinel (null for scalars/temps, [] for
+ * secondaryColors). Never touches vendor/type (required) or name/color.
+ */
+describe("pruneInheritedCreateDoc (GH #951)", () => {
+  const parent = {
+    vendor: "Acme",
+    type: "PLA",
+    cost: 25,
+    density: 1.24,
+    diameter: 1.75,
+    spoolType: "cardboard",
+    temperatures: { nozzle: 215, bed: 60 },
+    secondaryColors: ["#FF0000", "#00FF00"],
+  };
+
+  it("nulls a scalar whose incoming value equals the parent (keep inheriting)", () => {
+    const out = pruneInheritedCreateDoc(
+      { name: "V", cost: 25, density: 1.24 },
+      parent,
+    );
+    expect(out.cost).toBeNull();
+    expect(out.density).toBeNull();
+    expect(out.name).toBe("V");
+  });
+
+  it("keeps a scalar that differs from the parent (genuine override)", () => {
+    const out = pruneInheritedCreateDoc({ name: "V", cost: 30 }, parent);
+    expect(out.cost).toBe(30);
+  });
+
+  it("nulls diameter when it equals the parent (inheritable, not excluded)", () => {
+    const out = pruneInheritedCreateDoc({ name: "V", diameter: 1.75 }, parent);
+    expect(out.diameter).toBeNull();
+  });
+
+  it("never nulls the schema-required fields vendor/type even when they match the parent", () => {
+    const out = pruneInheritedCreateDoc(
+      { name: "V", vendor: "Acme", type: "PLA" },
+      parent,
+    );
+    expect(out.vendor).toBe("Acme");
+    expect(out.type).toBe("PLA");
+  });
+
+  it("never touches name/color (variant-only)", () => {
+    const out = pruneInheritedCreateDoc(
+      { name: "V", color: "#123456", colorName: "Custom" },
+      { ...parent, color: "#123456" },
+    );
+    expect(out.color).toBe("#123456");
+    // colorName is not an inheritable scalar → passes through untouched.
+    expect(out.colorName).toBe("Custom");
+  });
+
+  it("nulls temperature subfields equal to the parent, keeps differing ones", () => {
+    const out = pruneInheritedCreateDoc(
+      { name: "V", temperatures: { nozzle: 215, bed: 55, nozzleFirstLayer: null } },
+      parent,
+    );
+    const temps = out.temperatures as Record<string, unknown>;
+    expect(temps.nozzle).toBeNull(); // == parent 215 → inherit
+    expect(temps.bed).toBe(55); // differs from parent 60 → override kept
+    expect(temps.nozzleFirstLayer).toBeNull();
+  });
+
+  it("empties secondaryColors when the incoming array equals the parent's (whole-array inheritance)", () => {
+    const out = pruneInheritedCreateDoc(
+      { name: "V", secondaryColors: ["#FF0000", "#00FF00"] },
+      parent,
+    );
+    expect(out.secondaryColors).toEqual([]);
+  });
+
+  it("keeps secondaryColors that differ from the parent's", () => {
+    const out = pruneInheritedCreateDoc(
+      { name: "V", secondaryColors: ["#0000FF"] },
+      parent,
+    );
+    expect(out.secondaryColors).toEqual(["#0000FF"]);
+  });
+
+  it("leaves fields the row didn't supply (undefined) untouched — schema defaults still apply", () => {
+    const out = pruneInheritedCreateDoc({ name: "V", vendor: "Acme", type: "PLA" }, parent);
+    expect("cost" in out).toBe(false);
+    expect("diameter" in out).toBe(false);
+  });
+
+  it("does not mutate the input doc", () => {
+    const doc = { name: "V", cost: 25, temperatures: { nozzle: 215 } };
+    const out = pruneInheritedCreateDoc(doc, parent);
+    expect(doc.cost).toBe(25); // original untouched
+    expect((doc.temperatures as Record<string, unknown>).nozzle).toBe(215);
+    expect(out).not.toBe(doc);
+  });
+});
+
+/**
  * GH #627 item 2: a row whose write throws (the realistic trigger: the
  * create path carries an exported Instance ID that collides with the
  * partial-unique instanceId index after the user renamed the filament)
@@ -1308,5 +1408,121 @@ describe("upsertImportRows — variant round-trip preserves inheritance (GH #628
     const updated = await Filament.findById(variant._id).lean();
     // $unset → the field is gone/null and inheritance resumes.
     expect(updated.cost == null).toBe(true);
+  });
+});
+
+/**
+ * GH #951 — the create + resurrect paths must preserve inheritance the same
+ * way the update path (GH #628) does. The export flattens a variant through
+ * resolveFilament; importing that row into a FRESH DB (migration) or onto a
+ * TRASHED variant (restore) used to pin every inherited value as a local
+ * override, severing GH #106 live inheritance on create/resurrect.
+ */
+describe("upsertImportRows — create/resurrect preserve inheritance (GH #951)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+  });
+
+  const COLS = ["Name", "Vendor", "Type", "Color", "Cost", "Density", "Nozzle Temp", "Bed Temp", "Parent"];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const toRows = (rows: any[][]) => {
+    const mapping = mapHeaders(COLS);
+    return rows.map((r) => rowToImport(r, mapping));
+  };
+
+  it("CREATE into a fresh DB does not pin parent-inherited values (parent + variant in one file)", async () => {
+    // The export wrote the parent-resolved values into the variant row
+    // (cost 25 / density 1.24 / nozzle 215 / bed 60 — all == parent).
+    const result = await upsertImportRows(
+      toRows([
+        ["Universal PLA", "Acme", "PLA", "#808080", 25, 1.24, 215, 60, ""],
+        ["Universal PLA — Red", "Acme", "PLA", "#FF0000", 25, 1.24, 215, 60, "Universal PLA"],
+      ]),
+    );
+    expect(result.created).toBe(2);
+    expect(result.skipped).toBe(0);
+
+    const parent = await Filament.findOne({ name: "Universal PLA" }).lean();
+    const variant = await Filament.findOne({ name: "Universal PLA — Red" }).lean();
+    expect(variant.parentId?.toString()).toBe(parent._id.toString());
+
+    // Inherited fields were NOT pinned — they read as null on the variant.
+    expect(variant.cost).toBeNull();
+    expect(variant.density).toBeNull();
+    expect(variant.temperatures?.nozzle ?? null).toBeNull();
+    expect(variant.temperatures?.bed ?? null).toBeNull();
+    // Variant-specific values survive.
+    expect(variant.color).toBe("#FF0000");
+
+    // …and a later parent edit still propagates (GH #106 live link intact).
+    await Filament.updateOne({ _id: parent._id }, { $set: { cost: 30, density: 1.3 } });
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    const resolved = resolveFilament(variant, freshParent);
+    expect(resolved.cost).toBe(30);
+    expect(resolved.density).toBe(1.3);
+    expect(resolved.temperatures.nozzle).toBe(215);
+  });
+
+  it("CREATE keeps a genuine variant override that differs from the parent", async () => {
+    const result = await upsertImportRows(
+      toRows([
+        ["Universal PETG", "Acme", "PETG", "#808080", 20, 1.27, 240, 70, ""],
+        // variant overrides nozzle temp (250 ≠ 240) and cost (22 ≠ 20)
+        ["Universal PETG — Blue", "Acme", "PETG", "#0000FF", 22, 1.27, 250, 70, "Universal PETG"],
+      ]),
+    );
+    expect(result.created).toBe(2);
+
+    const variant = await Filament.findOne({ name: "Universal PETG — Blue" }).lean();
+    expect(variant.cost).toBe(22); // genuine override kept
+    expect(variant.temperatures.nozzle).toBe(250); // genuine override kept
+    expect(variant.density).toBeNull(); // == parent → inherited
+    expect(variant.temperatures?.bed ?? null).toBeNull(); // == parent → inherited
+  });
+
+  it("RESURRECT of a trashed variant does not pin parent-inherited values", async () => {
+    const parent = await Filament.create({
+      name: "Universal ABS",
+      vendor: "Acme",
+      type: "ABS",
+      cost: 28,
+      density: 1.04,
+      temperatures: { nozzle: 245, bed: 100 },
+    });
+    const variant = await Filament.create({
+      name: "Universal ABS — Grey",
+      vendor: "Acme",
+      type: "ABS",
+      color: "#888888",
+      parentId: parent._id,
+      // fully inheriting
+      _deletedAt: new Date(), // trashed
+    });
+
+    // Re-import the flattened export row for the trashed variant (values == parent).
+    const result = await upsertImportRows(
+      toRows([
+        ["Universal ABS — Grey", "Acme", "ABS", "#888888", 28, 1.04, 245, 100, "Universal ABS"],
+      ]),
+    );
+    expect(result.updated).toBe(1);
+    expect(result.created).toBe(0);
+
+    const resurrected = await Filament.findById(variant._id).lean();
+    expect(resurrected._deletedAt).toBeNull(); // revived
+    expect(resurrected.cost).toBeNull(); // inherited, not pinned
+    expect(resurrected.density).toBeNull();
+    expect(resurrected.temperatures?.nozzle ?? null).toBeNull();
+    expect(resurrected.temperatures?.bed ?? null).toBeNull();
+
+    // parent edit propagates.
+    await Filament.updateOne({ _id: parent._id }, { $set: { cost: 33 } });
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    expect(resolveFilament(resurrected, freshParent).cost).toBe(33);
   });
 });

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -1147,6 +1147,37 @@ describe("splitInheritedImportSet (GH #628)", () => {
     expect(set).toEqual({ name: "V" });
     expect(unset).toEqual([]);
   });
+
+  // GH #951 (Codex F2): `inherits` is now an inheritable scalar.
+  it("skips $set for `inherits` when it matches the parent, keeps a genuine override", () => {
+    const p = { ...parent, inherits: "*PLA*" };
+    const skip = splitInheritedImportSet({ name: "V", inherits: "*PLA*" }, { inherits: null }, p);
+    expect(skip.set).toEqual({ name: "V" });
+    const keep = splitInheritedImportSet({ name: "V", inherits: "*PLA-CF*" }, { inherits: null }, p);
+    expect(keep.set).toEqual({ name: "V", inherits: "*PLA-CF*" });
+  });
+
+  // GH #951 (Codex F1): `settings` inherits by shallow per-key merge.
+  it("filters `settings` per-key against the parent (parent-equal keys keep inheriting)", () => {
+    const p = { ...parent, settings: { fan_speed: "60", z_hop: "0.2", nozzle: "hot" } };
+    const { set } = splitInheritedImportSet(
+      // fan_speed matches parent → drop; z_hop differs → keep; brim is variant-only → keep
+      { name: "V", settings: { fan_speed: "60", z_hop: "0.4", brim: "5" } },
+      { settings: {} },
+      p,
+    );
+    expect(set).toEqual({ name: "V", settings: { z_hop: "0.4", brim: "5" } });
+  });
+
+  it("writes `settings` through unchanged when the parent has no settings to inherit", () => {
+    const p = { ...parent }; // no settings key
+    const { set } = splitInheritedImportSet(
+      { name: "V", settings: { fan_speed: "60" } },
+      { settings: {} },
+      p,
+    );
+    expect(set).toEqual({ name: "V", settings: { fan_speed: "60" } });
+  });
 });
 
 /**

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { upsertIniFilament } from "@/lib/iniImportApply";
+import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
+
+/**
+ * GH #951 — the create/race branch of the shared INI upsert (lines the two
+ * routes' happy-path tests can't reach deterministically). Phase 3's E11000
+ * recovery only fires when a concurrent writer creates the same name between
+ * our phase-1 read and our create — so it's exercised here by mocking
+ * `Filament.create` to simulate that race.
+ */
+describe("upsertIniFilament — create-race recovery (GH #951)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    // Use the module's singleton default export — the SAME object
+    // `iniImportApply.ts` imports — so vi.spyOn(Filament, "create") actually
+    // intercepts the helper's call. (setup.ts wipes mongoose.models between
+    // tests, but the original model class still runs plain CRUD against the DB;
+    // re-registering would create a second class the helper doesn't use.)
+    Filament = (await import("@/models/Filament")).default;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const section = (name: string): CollapsedFilamentData => ({
+    name,
+    vendor: "Acme",
+    type: "PLA",
+    color: "#808080",
+    cost: 25,
+    density: 1.24,
+    diameter: 1.75,
+    temperatures: { nozzle: 210, nozzleFirstLayer: null, bed: 60, bedFirstLayer: null },
+    maxVolumetricSpeed: null,
+    inherits: null,
+    settings: {},
+  });
+
+  it("recovers from a concurrent create (E11000) by updating the racing row", async () => {
+    // Simulate the race: phases 1 & 2 find nothing, then a concurrent writer
+    // wins the create. The mock persists the row (via the real create) and
+    // then throws E11000, exactly as a losing racer would observe.
+    const origCreate = Filament.create.bind(Filament);
+    vi.spyOn(Filament, "create").mockImplementation(async (doc: unknown) => {
+      await origCreate(doc);
+      const err = Object.assign(new Error("E11000 duplicate key"), { code: 11000 });
+      throw err;
+    });
+
+    const outcome = await upsertIniFilament(section("Race PLA"));
+    expect(outcome).toBe("updated");
+
+    // Exactly one row exists — the racing recovery updated it in place.
+    const rows = await Filament.find({ name: "Race PLA" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].vendor).toBe("Acme");
+  });
+
+  it("rethrows a non-duplicate create error unchanged", async () => {
+    vi.spyOn(Filament, "create").mockRejectedValue(new Error("disk on fire"));
+    await expect(upsertIniFilament(section("Boom PLA"))).rejects.toThrow(/disk on fire/);
+  });
+
+  it("rethrows the E11000 when no racing row is found (the winner was deleted)", async () => {
+    // create throws E11000 but nothing was actually persisted, so the racing
+    // lookup finds no row → the original duplicate error propagates.
+    vi.spyOn(Filament, "create").mockImplementation(async () => {
+      throw Object.assign(new Error("E11000 duplicate key"), { code: 11000 });
+    });
+    await expect(upsertIniFilament(section("Ghost PLA"))).rejects.toMatchObject({
+      code: 11000,
+    });
+    expect(await Filament.findOne({ name: "Ghost PLA" })).toBeNull();
+  });
+});

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -76,4 +76,79 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
     });
     expect(await Filament.findOne({ name: "Ghost PLA" })).toBeNull();
   });
+
+  // ── GH #951 (Codex R2-C): a concurrent rename in the read→write window must
+  //    not be reverted / mis-targeted; the `name` in each by-_id filter makes
+  //    the write miss and fall through to create a fresh row. ────────────────
+
+  /** Wrap findOne so the Nth call renames the row it's about to return. */
+  function renameOnCall(nth: number, newName: string) {
+    const orig = Filament.findOne.bind(Filament);
+    let calls = 0;
+    vi.spyOn(Filament, "findOne").mockImplementation((...args: unknown[]) => {
+      calls += 1;
+      const query = orig(...args);
+      if (calls !== nth) return query;
+      // Fake the .select().lean() chain: read the real snapshot, then simulate a
+      // concurrent rename before the caller's by-_id write runs.
+      return {
+        select: () => ({
+          lean: async () => {
+            const snap = await query.lean();
+            if (snap) await Filament.updateOne({ _id: snap._id }, { $set: { name: newName } });
+            return snap;
+          },
+        }),
+      };
+    });
+  }
+
+  it("does NOT revert a rename that races the phase-1 update — falls through to create", async () => {
+    const original = await Filament.create({ name: "Race X", vendor: "Acme", type: "PLA" });
+    renameOnCall(1, "Race Y"); // phase-1 active lookup renames X→Y mid-flight
+
+    const outcome = await upsertIniFilament(section("Race X"));
+    expect(outcome).toBe("created");
+
+    // The renamed row is untouched (rename NOT reverted, fields NOT overwritten).
+    const renamed = await Filament.findById(original._id).lean();
+    expect(renamed.name).toBe("Race Y");
+    expect(renamed.cost ?? null).toBeNull(); // section's cost=25 did NOT land here
+    // A fresh active "Race X" was created instead.
+    const freshX = await Filament.findOne({ name: "Race X", _deletedAt: null }).lean();
+    expect(freshX).not.toBeNull();
+    expect(String(freshX._id)).not.toBe(String(original._id));
+    expect(freshX.cost).toBe(25);
+  });
+
+  it("does NOT revert a rename that races the resurrect (phase-2) update", async () => {
+    const trashed = await Filament.create({
+      name: "Res X",
+      vendor: "Acme",
+      type: "PLA",
+      _deletedAt: new Date(),
+    });
+    // Call 1 = phase-1 active lookup (no active row → null); call 2 = phase-2
+    // trashed lookup → rename it mid-flight.
+    renameOnCall(2, "Res Y");
+
+    const outcome = await upsertIniFilament(section("Res X"));
+    expect(outcome).toBe("created");
+
+    const renamed = await Filament.findById(trashed._id).lean();
+    expect(renamed.name).toBe("Res Y");
+    expect(renamed._deletedAt).not.toBeNull(); // NOT resurrected
+    const freshX = await Filament.findOne({ name: "Res X", _deletedAt: null }).lean();
+    expect(freshX).not.toBeNull();
+  });
+
+  it("still updates the matching row normally when no rename races (guards against an over-tight filter)", async () => {
+    const existing = await Filament.create({ name: "Plain PLA", vendor: "Old", type: "PLA" });
+    const outcome = await upsertIniFilament({ ...section("Plain PLA"), vendor: "New" });
+    expect(outcome).toBe("updated");
+    const fresh = await Filament.findById(existing._id).lean();
+    expect(fresh.vendor).toBe("New");
+    // no duplicate created
+    expect(await Filament.countDocuments({ name: "Plain PLA" })).toBe(1);
+  });
 });

--- a/tests/parseIni.test.ts
+++ b/tests/parseIni.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseIniFilaments } from "@/lib/parseIni";
+import { parseIniFilaments, INI_TOP_LEVEL_SETTING_KEYS } from "@/lib/parseIni";
 
 describe("parseIniFilaments", () => {
   it("returns empty array for empty content", () => {
@@ -325,5 +325,56 @@ temperature = 200
 `;
     const result = parseIniFilaments(content);
     expect(result).toHaveLength(0);
+  });
+
+  // GH #951 (Codex R2-B): INI_TOP_LEVEL_SETTING_KEYS is the source of truth the
+  // bulk importers use to strip settings-bag shadows of top-level fields. It
+  // MUST list exactly the keys flushFilament lifts into a top-level FilamentData
+  // field — otherwise a listed-but-not-extracted key would be lost on import, or
+  // an extracted-but-unlisted key would keep leaking a stale shadow.
+  it("INI_TOP_LEVEL_SETTING_KEYS matches the keys parseIni lifts to top-level fields", () => {
+    const ini = `[filament:Lockstep]
+filament_vendor = Acme
+filament_type = PLA
+filament_colour = #123456
+filament_cost = 25
+filament_density = 1.24
+filament_diameter = 1.6
+filament_max_volumetric_speed = 15
+temperature = 210
+first_layer_temperature = 215
+bed_temperature = 60
+first_layer_bed_temperature = 65
+inherits = *PLA*
+`;
+    const [f] = parseIniFilaments(ini);
+    // Every listed key resolves to a populated (non-default) top-level field.
+    expect(f.vendor).toBe("Acme");
+    expect(f.type).toBe("PLA");
+    expect(f.color).toBe("#123456");
+    expect(f.cost).toBe(25);
+    expect(f.density).toBe(1.24);
+    expect(f.diameter).toBe(1.6);
+    expect(f.maxVolumetricSpeed).toBe(15);
+    expect(f.temperatures.nozzle).toBe(210);
+    expect(f.temperatures.nozzleFirstLayer).toBe(215);
+    expect(f.temperatures.bed).toBe(60);
+    expect(f.temperatures.bedFirstLayer).toBe(65);
+    expect(f.inherits).toBe("*PLA*");
+    // The exact set (guards drift in either direction).
+    expect([...INI_TOP_LEVEL_SETTING_KEYS].sort()).toEqual([
+      "bed_temperature",
+      "filament_colour",
+      "filament_cost",
+      "filament_density",
+      "filament_diameter",
+      "filament_max_volumetric_speed",
+      "filament_type",
+      "filament_vendor",
+      "first_layer_bed_temperature",
+      "first_layer_temperature",
+      "inherits",
+      "temperature",
+    ]);
   });
 });

--- a/tests/parseIni.test.ts
+++ b/tests/parseIni.test.ts
@@ -369,6 +369,9 @@ inherits = *PLA*
       "filament_density",
       "filament_diameter",
       "filament_max_volumetric_speed",
+      "filament_shrinkage_compensation_xy",
+      "filament_shrinkage_compensation_z",
+      "filament_spool_weight",
       "filament_type",
       "filament_vendor",
       "first_layer_bed_temperature",
@@ -376,5 +379,35 @@ inherits = *PLA*
       "inherits",
       "temperature",
     ]);
+  });
+
+  // GH #951 (Codex R3): spool weight + shrinkage are lifted to top-level so
+  // their settings-bag shadow can be stripped without data loss.
+  it("lifts filament_spool_weight and filament_shrinkage_* to top-level fields", () => {
+    const ini = `[filament:Lift]
+filament_type = PLA
+filament_vendor = Acme
+filament_spool_weight = 250
+filament_shrinkage_compensation_xy = 0.3%
+filament_shrinkage_compensation_z = 0.5%
+`;
+    const [f] = parseIniFilaments(ini);
+    expect(f.spoolWeight).toBe(250);
+    // parseNum strips the trailing '%', matching the form + per-id sync handling.
+    expect(f.shrinkageXY).toBe(0.3);
+    expect(f.shrinkageZ).toBe(0.5);
+  });
+
+  it("leaves spool weight + shrinkage UNDEFINED (not null) when the INI omits them — no-clobber guard", () => {
+    const ini = `[filament:NoLift]
+filament_type = PLA
+filament_vendor = Acme
+`;
+    const [f] = parseIniFilaments(ini);
+    // undefined (key absent) — NOT null — so the importer's $set omits them and
+    // can't clobber an existing top-level value on a root/resurrected filament.
+    expect("spoolWeight" in f).toBe(false);
+    expect("shrinkageXY" in f).toBe(false);
+    expect("shrinkageZ" in f).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #951 — one bug class across three (really four) import/sync paths that
wrote parent-resolved **flattened** values as **local overrides** onto
variants, severing GH #106 / #628 live inheritance so a later parent edit
silently stopped propagating.

The exports resolve variants through `resolveFilament`, so a variant's preset /
CSV row / INI section carries the parent's density/cost/temps/… When those come
back on a round-trip, only fields that genuinely **differ** from the parent
should be pinned; parent-equal fields must keep inheriting.

## Fixes

**951.2 — PrusaSlicer per-id sync** (`POST /api/filaments/[id]`)
Routed the built `update` through the CSV importer's battle-tested
`splitInheritedImportSet` (GH #628/#649) before the write — for a variant it
drops each inheritable scalar/temp equal to the parent and `$unset`s a stale
diverging override. Reuses the already-fetched `calParent`; variant-only /
non-inheritable keys (color, colorName, name, settings, …) pass through.

**951.1 — CSV/XLSX importer create/resurrect** (`upsertImportRows`)
`splitInheritedImportSet` only ran on the UPDATE branch; CREATE + RESURRECT
wrote the flattened doc verbatim (export → import into a fresh DB / trashed-
variant restore pinned everything). New pure `pruneInheritedCreateDoc` nulls
scalars/temps and empties `secondaryColors` when they equal the parent, fetching
the parent by id on demand (a freshly-created parent isn't in `loadParentDocs`)
and guarding a null parent. Never prunes `vendor`/`type`/`name`/`color`.

**951.3 — PrusaSlicer bulk INI import** (`POST /api/filaments/prusaslicer`)
Extracted a shared `upsertIniFilament` (`src/lib/iniImportApply.ts`): a
three-phase atomic upsert (active → resurrect-trashed → create/race) that reads
the target then writes by `_id` (mirroring the Bambu bulk route's read-then-
write-by-id, with the soft-delete state re-checked in the filter so a concurrent
delete/purge/restore falls through instead of mis-writing). It flattens the
nested INI `temperatures` object to `temperatures.<sub>` dot-keys before calling
`splitInheritedImportSet` — which additionally stops an update from wiping
untouched `nozzleRange*`/`standby` siblings (the old whole-object `$set`
replaced the subdoc).

**Also fixed: the twin `POST /api/filaments/import`** (multipart UI upload)
The issue named the text-body `prusaslicer` route, but `/api/filaments/import`
is the same INI importer (shares `collapsePerNozzleImportSections(parseIniFilaments())`)
with the identical pinning bug. Both routes now call the one shared
`upsertIniFilament`, so the bug class is fully closed and can't drift.

## Open question — resolved (parity)

create/resurrect adopt the same *equal-to-parent === inherit* rule as the update
path, so a deliberate override that happens to match the parent today becomes
dynamically tracked. This matches the accepted #628/#649 trade-off. (Per the
recommendation in the task.)

## Tests

- `tests/importFilaments.test.ts` — pure `pruneInheritedCreateDoc` cases +
  create-into-fresh-DB / genuine-override / resurrect integration.
- `tests/api-route-correctness.test.ts` — variant sync doesn't pin parent-equal
  values (inheritance survives a later parent edit), genuine override written,
  stale override `$unset`.
- `tests/filaments-import-export-route.test.ts` — variant round-trip preserved
  on both INI routes, dot-key temps preserve range/standby, trashed-parent
  guard, stale-override `$unset`.
- `tests/iniImportApply.test.ts` — the shared upsert's create/E11000-race
  recovery branches.

Full suite green: **2982 tests pass**; coverage clears thresholds
(lines 99.51%, branches 97.44%, statements 99.04%, functions 97.34%);
lint + `tsc` + `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
