### PR TITLE
fix(share): remap source ids on shared-catalog import (#956)

### DIFF
--- a/src/app/share/[slug]/page.tsx
+++ b/src/app/share/[slug]/page.tsx
@@ -7,6 +7,12 @@ import { useToast } from "@/components/Toast";
 import FilamentPicker from "@/components/FilamentPicker";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { formatDate } from "@/lib/dateFormat";
+import {
+  partitionByParent,
+  buildFilamentImportBody,
+  buildPrinterImportBody,
+  type ShareImportPrinter,
+} from "@/lib/shareImport";
 
 interface SharedFilament {
   _id: string;
@@ -141,6 +147,11 @@ export default function SharedCatalogPage() {
         endpoint: string,
         records: SharedRef[],
         idSet: Set<string>,
+        // GH #956: printers carry source-DB installedNozzles/installedBedTypes/
+        // amsSlots refs that must be remapped/stripped before POST (they'd 400
+        // otherwise). An optional per-endpoint transform builds the POST body;
+        // the default just strips the source `_id`.
+        transform?: (r: SharedRef) => Record<string, unknown>,
       ): Promise<Map<string, string>> {
         const map = new Map<string, string>();
         for (const r of records) {
@@ -148,7 +159,7 @@ export default function SharedCatalogPage() {
           const res = await fetch(endpoint, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ ...r, _id: undefined }),
+            body: JSON.stringify(transform ? transform(r) : { ...r, _id: undefined }),
             signal: ac.signal,
           });
           if (res.ok) {
@@ -176,52 +187,84 @@ export default function SharedCatalogPage() {
         return map;
       }
 
-      const [nozzleMap, printerMap, bedTypeMap] = await Promise.all([
+      // GH #956: import nozzles + bed types FIRST, then printers — a printer's
+      // installedNozzles/installedBedTypes must be remapped through those maps,
+      // and `buildPrinterImportBody` also strips amsSlots (source spool ids are
+      // meaningless on the destination). Without this the printer POST 400s, the
+      // printerMap stays empty, and every printer-scoped calibration silently
+      // degrades to `printer: null`.
+      const [nozzleMap, bedTypeMap] = await Promise.all([
         rehydrate("/api/nozzles", data.payload.nozzles ?? [], neededNozzleIds),
-        rehydrate("/api/printers", data.payload.printers ?? [], neededPrinterIds),
         rehydrate("/api/bed-types", data.payload.bedTypes ?? [], neededBedTypeIds),
       ]);
+      const printerMap = await rehydrate(
+        "/api/printers",
+        data.payload.printers ?? [],
+        neededPrinterIds,
+        (p) => buildPrinterImportBody(p as ShareImportPrinter, nozzleMap, bedTypeMap),
+      );
 
-      // Remap every id reference on each filament so the destination
-      // calibrations/compatibleNozzles point at real local records.
-      // Unresolved ids are dropped — better a missing reference than a
-      // pointer to a random document on the destination.
-      const remapped = filtered.map((f) => {
-        const compatibleNozzles = (f.compatibleNozzles || [])
-          .map((nid) => nozzleMap.get(String(nid)))
-          .filter((x): x is string => Boolean(x));
-        const calibrations = (f.calibrations || [])
-          .map((cal) => ({
-            ...cal,
-            nozzle: cal.nozzle ? nozzleMap.get(String(cal.nozzle)) ?? null : null,
-            printer: cal.printer ? printerMap.get(String(cal.printer)) ?? null : null,
-            bedType: cal.bedType ? bedTypeMap.get(String(cal.bedType)) ?? null : null,
-          }))
-          // Calibrations require a nozzle; drop any that we couldn't map.
-          .filter((cal) => cal.nozzle);
-        return {
-          ...f,
-          _id: undefined,
-          compatibleNozzles,
-          calibrations,
-        };
-      });
-
+      // GH #956: two-phase filament import. ROOTS first (to build the
+      // source→local id map), then VARIANTS with `parentId` remapped through
+      // it. `buildFilamentImportBody` also remaps compatibleNozzles +
+      // calibration refs (dropping unresolved) so the destination points at
+      // real local records. A variant whose parent wasn't imported (not
+      // selected, or its create failed and it doesn't exist locally) is SKIPPED
+      // and surfaced — importing it standalone would drop every inherited value.
+      const { roots, variants } = partitionByParent(filtered);
+      const filamentIdMap = new Map<string, string>();
       let created = 0;
       const conflicts: string[] = [];
-      for (const f of remapped) {
+
+      // POST one filament; on success record source→local id so variants can
+      // resolve their parent. On a 409 (name already exists on the destination)
+      // resolve the existing local filament by name into the map, so a variant
+      // still attaches to a parent the recipient already owns — mirrors the
+      // reference rehydrate's 409-reuse path.
+      const postFilament = async (
+        sourceId: string,
+        body: Record<string, unknown>,
+      ): Promise<boolean> => {
         const res = await fetch("/api/filaments", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(f),
+          body: JSON.stringify(body),
           signal: ac.signal,
         });
         if (res.ok) {
-          created++;
-        } else {
-          const body = await res.json().catch(() => null);
-          conflicts.push(body?.error || f.name);
+          const c = await res.json();
+          filamentIdMap.set(sourceId, String(c._id));
+          return true;
         }
+        if (res.status === 409) {
+          const listRes = await fetch("/api/filaments", { signal: ac.signal });
+          if (listRes.ok) {
+            const list = await listRes.json();
+            const match = Array.isArray(list)
+              ? list.find((x: { name?: string }) => x.name === body.name)
+              : null;
+            if (match?._id) filamentIdMap.set(sourceId, String(match._id));
+          }
+        }
+        const errBody = await res.json().catch(() => null);
+        conflicts.push(errBody?.error || String(body.name));
+        return false;
+      };
+
+      for (const f of roots) {
+        if (ac.signal.aborted) return;
+        const body = buildFilamentImportBody(f, nozzleMap, printerMap, bedTypeMap, undefined);
+        if (await postFilament(String(f._id), body)) created++;
+      }
+      for (const v of variants) {
+        if (ac.signal.aborted) return;
+        const localParent = filamentIdMap.get(String(v.parentId));
+        if (!localParent) {
+          conflicts.push(t("share.public.orphanVariant", { name: v.name }));
+          continue;
+        }
+        const body = buildFilamentImportBody(v, nozzleMap, printerMap, bedTypeMap, localParent);
+        if (await postFilament(String(v._id), body)) created++;
       }
       if (ac.signal.aborted) return;
       toast(t("share.public.imported", { count: created }));

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -347,6 +347,7 @@
   "share.public.importing": "Importiere...",
   "share.public.imported": "{count} Filament(e) importiert",
   "share.public.conflicts": "{count} Konflikt(e):",
+  "share.public.orphanVariant": "Variante \"{name}\" übersprungen — das übergeordnete Filament wurde nicht importiert",
   "share.public.importError": "Import fehlgeschlagen. Bitte erneut versuchen.",
   "analytics.title": "Analyse",
   "analytics.subtitle": "Filamentverbrauch über kürzliche Drucke.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -347,6 +347,7 @@
   "share.public.importing": "Importing...",
   "share.public.imported": "Imported {count} filament(s)",
   "share.public.conflicts": "{count} conflict(s):",
+  "share.public.orphanVariant": "Variant \"{name}\" skipped — its parent wasn't imported",
   "share.public.importError": "Import failed. Please try again.",
   "analytics.title": "Analytics",
   "analytics.subtitle": "Filament usage across recent prints.",

--- a/src/lib/shareImport.ts
+++ b/src/lib/shareImport.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure transforms for the client-side shared-catalog import
+ * (`src/app/share/[slug]/page.tsx`). Extracted here so the id-remap + strip
+ * logic is unit-testable independent of the `"use client"` component.
+ *
+ * GH #956: a published catalog serialises its docs as raw lean documents that
+ * still carry SOURCE-DB ObjectIds — filament `parentId`, printer
+ * `installedNozzles` / `installedBedTypes` / `amsSlots`. Those ids don't exist
+ * on the destination, so POSTing them verbatim 400s (parent-not-found /
+ * ref-existence checks) and the import silently drops variants and degrades
+ * printer-scoped calibrations to `printer: null`. Every reference must be
+ * remapped to the freshly-created local record (or stripped) before POST.
+ */
+
+type IdMap = Map<string, string>;
+
+export interface ShareImportFilament {
+  _id: string;
+  name: string;
+  parentId?: unknown;
+  compatibleNozzles?: unknown[];
+  calibrations?: Array<{
+    nozzle?: unknown;
+    printer?: unknown;
+    bedType?: unknown;
+    [k: string]: unknown;
+  }>;
+  [k: string]: unknown;
+}
+
+export interface ShareImportPrinter {
+  _id: string;
+  name: string;
+  installedNozzles?: unknown[];
+  installedBedTypes?: unknown[];
+  amsSlots?: unknown[];
+  [k: string]: unknown;
+}
+
+const mapId = (v: unknown, m: IdMap): string | undefined =>
+  v == null ? undefined : m.get(String(v));
+
+/**
+ * Split filaments into roots (imported FIRST, to build the source→local id map)
+ * and variants (imported SECOND, with `parentId` remapped through that map).
+ * A variant is any filament carrying a truthy `parentId`.
+ */
+export function partitionByParent<T extends ShareImportFilament>(
+  items: T[],
+): { roots: T[]; variants: T[] } {
+  const roots: T[] = [];
+  const variants: T[] = [];
+  for (const item of items) {
+    if (item.parentId) variants.push(item);
+    else roots.push(item);
+  }
+  return { roots, variants };
+}
+
+/**
+ * Build the POST body for a filament import: strip the source `_id`, remap
+ * `compatibleNozzles` + each calibration's nozzle/printer/bedType through the
+ * id maps (dropping unresolved refs, and dropping a calibration that loses its
+ * required nozzle), and set `parentId` explicitly:
+ *   - `undefined` (a root)  → the key is removed (create a root filament),
+ *   - a string  (a variant) → the remapped LOCAL parent id.
+ * There is deliberately no "keep the source parentId" path — a raw source id
+ * would 400 on the destination.
+ */
+export function buildFilamentImportBody(
+  f: ShareImportFilament,
+  nozzleMap: IdMap,
+  printerMap: IdMap,
+  bedTypeMap: IdMap,
+  parentId: string | undefined,
+): Record<string, unknown> {
+  const compatibleNozzles = (f.compatibleNozzles || [])
+    .map((n) => mapId(n, nozzleMap))
+    .filter((x): x is string => Boolean(x));
+  const calibrations = (f.calibrations || [])
+    .map((cal) => ({
+      ...cal,
+      nozzle: mapId(cal.nozzle, nozzleMap) ?? null,
+      printer: mapId(cal.printer, printerMap) ?? null,
+      bedType: mapId(cal.bedType, bedTypeMap) ?? null,
+    }))
+    // Calibrations require a nozzle; drop any whose nozzle didn't resolve.
+    .filter((cal) => cal.nozzle);
+  const body: Record<string, unknown> = {
+    ...f,
+    _id: undefined,
+    compatibleNozzles,
+    calibrations,
+  };
+  if (parentId === undefined) delete body.parentId;
+  else body.parentId = parentId;
+  return body;
+}
+
+/**
+ * Build the POST body for a printer import: strip the source `_id`, remap
+ * `installedNozzles` / `installedBedTypes` through the id maps (dropping
+ * unresolved entries), and strip `amsSlots` entirely — its spool/filament ids
+ * are source-DB-specific and meaningless on the destination (the publish route
+ * already strips spools for the same reason). Requires the nozzle/bed-type
+ * maps, so the caller must import nozzles + bed types BEFORE printers.
+ */
+export function buildPrinterImportBody(
+  p: ShareImportPrinter,
+  nozzleMap: IdMap,
+  bedTypeMap: IdMap,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { ...p, _id: undefined };
+  if (Array.isArray(p.installedNozzles)) {
+    body.installedNozzles = p.installedNozzles
+      .map((n) => mapId(n, nozzleMap))
+      .filter((x): x is string => Boolean(x));
+  }
+  if (Array.isArray(p.installedBedTypes)) {
+    body.installedBedTypes = p.installedBedTypes
+      .map((b) => mapId(b, bedTypeMap))
+      .filter((x): x is string => Boolean(x));
+  }
+  delete body.amsSlots;
+  return body;
+}

--- a/tests/shareImport.test.ts
+++ b/tests/shareImport.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  partitionByParent,
+  buildFilamentImportBody,
+  buildPrinterImportBody,
+  type ShareImportFilament,
+  type ShareImportPrinter,
+} from "@/lib/shareImport";
+
+const fil = (over: Partial<ShareImportFilament>): ShareImportFilament => ({
+  _id: "src1",
+  name: "F",
+  vendor: "V",
+  type: "PLA",
+  ...over,
+});
+
+describe("partitionByParent (GH #956)", () => {
+  it("splits roots (no parentId) from variants (truthy parentId)", () => {
+    const { roots, variants } = partitionByParent([
+      fil({ _id: "a", parentId: undefined }),
+      fil({ _id: "b", parentId: null }),
+      fil({ _id: "c", parentId: "p1" }),
+      fil({ _id: "d" }),
+    ]);
+    expect(roots.map((r) => r._id)).toEqual(["a", "b", "d"]);
+    expect(variants.map((v) => v._id)).toEqual(["c"]);
+  });
+});
+
+describe("buildFilamentImportBody (GH #956)", () => {
+  const nozzleMap = new Map([["n_src", "n_local"]]);
+  const printerMap = new Map([["p_src", "p_local"]]);
+  const bedTypeMap = new Map([["b_src", "b_local"]]);
+
+  it("strips _id and removes parentId for a root", () => {
+    const body = buildFilamentImportBody(fil({ _id: "x" }), nozzleMap, printerMap, bedTypeMap, undefined);
+    expect(body._id).toBeUndefined();
+    expect("parentId" in body).toBe(false);
+  });
+
+  it("sets the remapped parentId for a variant", () => {
+    const body = buildFilamentImportBody(fil({ parentId: "p_src" }), nozzleMap, printerMap, bedTypeMap, "p_local");
+    expect(body.parentId).toBe("p_local");
+  });
+
+  it("remaps compatibleNozzles and drops unresolved ones", () => {
+    const body = buildFilamentImportBody(
+      fil({ compatibleNozzles: ["n_src", "unknown_src"] }),
+      nozzleMap,
+      printerMap,
+      bedTypeMap,
+      undefined,
+    );
+    expect(body.compatibleNozzles).toEqual(["n_local"]);
+  });
+
+  it("remaps calibration refs; keeps a mapped nozzle, nulls unresolved printer/bedType", () => {
+    const body = buildFilamentImportBody(
+      fil({ calibrations: [{ nozzle: "n_src", printer: "unknown", bedType: "b_src", extra: 1 }] }),
+      nozzleMap,
+      printerMap,
+      bedTypeMap,
+      undefined,
+    );
+    const cals = body.calibrations as Array<Record<string, unknown>>;
+    expect(cals).toHaveLength(1);
+    expect(cals[0]).toMatchObject({ nozzle: "n_local", printer: null, bedType: "b_local", extra: 1 });
+  });
+
+  it("drops a calibration whose nozzle can't be resolved (nozzle is required)", () => {
+    const body = buildFilamentImportBody(
+      fil({ calibrations: [{ nozzle: "unknown", printer: "p_src" }] }),
+      nozzleMap,
+      printerMap,
+      bedTypeMap,
+      undefined,
+    );
+    expect(body.calibrations).toEqual([]);
+  });
+});
+
+describe("buildPrinterImportBody (GH #956)", () => {
+  const nozzleMap = new Map([["n_src", "n_local"]]);
+  const bedTypeMap = new Map([["b_src", "b_local"]]);
+  const printer = (over: Partial<ShareImportPrinter>): ShareImportPrinter => ({
+    _id: "pr1",
+    name: "Core One",
+    ...over,
+  });
+
+  it("strips _id and amsSlots", () => {
+    const body = buildPrinterImportBody(
+      printer({ amsSlots: [{ spoolId: "s1" }] }),
+      nozzleMap,
+      bedTypeMap,
+    );
+    expect(body._id).toBeUndefined();
+    expect("amsSlots" in body).toBe(false);
+  });
+
+  it("remaps installedNozzles / installedBedTypes and drops unresolved entries", () => {
+    const body = buildPrinterImportBody(
+      printer({ installedNozzles: ["n_src", "gone"], installedBedTypes: ["b_src", "gone"] }),
+      nozzleMap,
+      bedTypeMap,
+    );
+    expect(body.installedNozzles).toEqual(["n_local"]);
+    expect(body.installedBedTypes).toEqual(["b_local"]);
+  });
+
+  it("leaves absent installed arrays untouched (no key invented)", () => {
+    const body = buildPrinterImportBody(printer({}), nozzleMap, bedTypeMap);
+    expect("installedNozzles" in body).toBe(false);
+    expect("installedBedTypes" in body).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #956.

The client-side shared-catalog import (`src/app/share/[slug]/page.tsx`) POSTed **source-DB ObjectIds** verbatim, so destination validation 400'd and silently dropped data.

## Two findings
- **956.1** — imported variants kept their **source** `parentId` → `POST /api/filaments` rejected with "Parent filament not found" (400). Filaments were also POSTed in array order, so a variant could precede its parent.
- **956.2** — printers were POSTed as raw lean docs still carrying source `installedNozzles`/`installedBedTypes`/`amsSlots` → printers POST 400'd → `printerMap` stayed empty → every printer-scoped calibration silently degraded to `printer: null`.

## Fix
- **Serialized ref import**: nozzles + bed types first, then printers — so a printer's installed refs are remapped through the fresh id maps. `amsSlots` is stripped (source spool ids are meaningless on the destination; the publish route already strips spools).
- **Two-phase filament import**: roots first (building a source→local id map), then variants with `parentId` remapped through it.
- **Orphan-variant policy** (your call): a variant whose parent wasn't imported is **skipped + surfaced as a conflict** — importing it standalone would drop every inherited value (new `share.public.orphanVariant` key, en+de).
- **Printer refs policy** (your call): installed nozzles/bed types are **remapped** through the id maps (unresolved dropped); amsSlots stripped.
- A root name-collision (409) resolves the existing local filament by name, so variants still attach to a parent the recipient already owns (mirrors the ref rehydrate's 409-reuse).

The pure transforms live in a new unit-tested `src/lib/shareImport.ts` (`partitionByParent`, `buildFilamentImportBody`, `buildPrinterImportBody`) — the component itself is a `"use client"` page with no route test, so the id-remap/strip logic is covered there.

Full suite green (3023 tests), coverage clears thresholds, lint + tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
