### PR TITLE
fix: data-integrity remaining batch — 4 fixes from #954

### DIFF
--- a/src/app/api/filaments/[id]/spool-check/route.ts
+++ b/src/app/api/filaments/[id]/spool-check/route.ts
@@ -167,16 +167,17 @@ export async function GET(
       });
 
     if (spoolResults.length === 0) {
-      // GH #954: distinguish "no weight data at all" (genuinely can't check →
-      // ok:true) from "weight data exists but every such spool is RETIRED"
-      // (zero active stock). The retired exclusion above exists precisely to
-      // stop a retired spool from suppressing the slicer's insufficient-filament
-      // warning — so the all-retired case must warn (ok:false), not silently
-      // pass with the misleading "no data" message.
+      // GH #954: warn (ok:false) ONLY in the true zero-active-stock case —
+      // there are NO active spools AND the only weight data is on retired ones.
+      // If an ACTIVE spool exists but is simply unweighed, active stock exists
+      // (just unmeasured), so keep the original "no data → ok:true" behavior and
+      // don't emit a false warning (Codex). The retired exclusion still stops a
+      // retired spool from silently satisfying the check.
+      const hasActiveSpool = rawSpools.some((s) => !s.retired);
       const hasRetiredWeightData = rawSpools.some(
         (s) => s.totalWeight != null && s.retired,
       );
-      if (hasRetiredWeightData) {
+      if (!hasActiveSpool && hasRetiredWeightData) {
         return NextResponse.json({
           ok: false,
           filament: filament.name,

--- a/src/app/api/filaments/[id]/spool-check/route.ts
+++ b/src/app/api/filaments/[id]/spool-check/route.ts
@@ -131,16 +131,6 @@ export async function GET(
       });
     }
 
-    // If no spools or no spool weight configured, we can't check — assume OK
-    if (rawSpools.length === 0 || spoolWeight == null) {
-      return NextResponse.json({
-        ok: true,
-        filament: filament.name,
-        message: "No spool weight data available — skipping check",
-        spools: [],
-      });
-    }
-
     // Compute remaining length in meters from weight
     function weightToLengthM(weightG: number): number | null {
       if (!density || density <= 0 || !diameter || diameter <= 0) return null;
@@ -151,6 +141,42 @@ export async function GET(
     }
 
     const requiredLengthM = weightToLengthM(requiredWeight);
+
+    // GH #954 (Codex): the "all measured stock is retired" warning does NOT need
+    // the spool tare (it's a pure retired-vs-active question), so check it BEFORE
+    // the tare guard below — otherwise a filament with only retired weighed stock
+    // and a null/inherited-missing spoolWeight would hit the `spoolWeight == null`
+    // guard and return ok:true, silently suppressing PrusaSlicer's warning for
+    // null-tare legacy data. An active spool that is merely UNWEIGHED counts as
+    // active stock (just unmeasured), so `hasActiveSpool` keeps this from firing a
+    // false warning — that case falls through to the "no data → ok:true" guard.
+    const hasActiveSpool = rawSpools.some((s) => !s.retired);
+    const hasRetiredWeightData = rawSpools.some(
+      (s) => s.totalWeight != null && s.retired,
+    );
+    if (!hasActiveSpool && hasRetiredWeightData) {
+      return NextResponse.json({
+        ok: false,
+        filament: filament.name,
+        requiredWeightG: Math.round(requiredWeight * 10) / 10,
+        requiredLengthM:
+          requiredLengthM !== null ? Math.round(requiredLengthM * 100) / 100 : null,
+        warning: "No active spools — all spools with weight data are retired",
+        spools: [],
+      });
+    }
+
+    // If no spools or no spool weight configured, we can't check — assume OK.
+    // (An active-but-unweighed spool lands here too: active stock exists, just
+    // unmeasured — keep the original no-data → ok:true behavior, no false warning.)
+    if (rawSpools.length === 0 || spoolWeight == null) {
+      return NextResponse.json({
+        ok: true,
+        filament: filament.name,
+        message: "No spool weight data available — skipping check",
+        spools: [],
+      });
+    }
 
     // Check each spool. Retired spools are intentionally out of service
     // and must not satisfy the check (Codex review) — otherwise a
@@ -173,29 +199,9 @@ export async function GET(
         };
       });
 
+    // Active spools exist but none carries a totalWeight (the all-retired case was
+    // already handled before the tare guard above) → no measurable data → ok:true.
     if (spoolResults.length === 0) {
-      // GH #954: warn (ok:false) ONLY in the true zero-active-stock case —
-      // there are NO active spools AND the only weight data is on retired ones.
-      // If an ACTIVE spool exists but is simply unweighed, active stock exists
-      // (just unmeasured), so keep the original "no data → ok:true" behavior and
-      // don't emit a false warning (Codex). The retired exclusion still stops a
-      // retired spool from silently satisfying the check.
-      const hasActiveSpool = rawSpools.some((s) => !s.retired);
-      const hasRetiredWeightData = rawSpools.some(
-        (s) => s.totalWeight != null && s.retired,
-      );
-      if (!hasActiveSpool && hasRetiredWeightData) {
-        return NextResponse.json({
-          ok: false,
-          filament: filament.name,
-          requiredWeightG: Math.round(requiredWeight * 10) / 10,
-          requiredLengthM:
-            requiredLengthM !== null ? Math.round(requiredLengthM * 100) / 100 : null,
-          warning: "No active spools — all spools with weight data are retired",
-          spools: [],
-        });
-      }
-      // Genuinely no weight data on any spool — can't check, assume OK.
       return NextResponse.json({
         ok: true,
         filament: filament.name,

--- a/src/app/api/filaments/[id]/spool-check/route.ts
+++ b/src/app/api/filaments/[id]/spool-check/route.ts
@@ -166,8 +166,28 @@ export async function GET(
         };
       });
 
-    // If no spools had totalWeight set, assume OK
     if (spoolResults.length === 0) {
+      // GH #954: distinguish "no weight data at all" (genuinely can't check →
+      // ok:true) from "weight data exists but every such spool is RETIRED"
+      // (zero active stock). The retired exclusion above exists precisely to
+      // stop a retired spool from suppressing the slicer's insufficient-filament
+      // warning — so the all-retired case must warn (ok:false), not silently
+      // pass with the misleading "no data" message.
+      const hasRetiredWeightData = rawSpools.some(
+        (s) => s.totalWeight != null && s.retired,
+      );
+      if (hasRetiredWeightData) {
+        return NextResponse.json({
+          ok: false,
+          filament: filament.name,
+          requiredWeightG: Math.round(requiredWeight * 10) / 10,
+          requiredLengthM:
+            requiredLengthM !== null ? Math.round(requiredLengthM * 100) / 100 : null,
+          warning: "No active spools — all spools with weight data are retired",
+          spools: [],
+        });
+      }
+      // Genuinely no weight data on any spool — can't check, assume OK.
       return NextResponse.json({
         ok: true,
         filament: filament.name,

--- a/src/lib/exportFilaments.ts
+++ b/src/lib/exportFilaments.ts
@@ -55,6 +55,13 @@ export interface ExportRow {
    */
   parentName: string | null;
   variantCount: number;
+  /**
+   * GH #954: OpenPrintTag `optTags` (color-arrangement + finish) as a
+   * comma-separated list of numeric ids. Round-trips through the importer's
+   * split-on-comma parse. Without it a coextruded/gradient/finish filament
+   * collapses to a solid swatch on a create-path CSV round-trip.
+   */
+  optTags: string;
 }
 
 export const EXPORT_COLUMNS: { key: keyof ExportRow; header: string }[] = [
@@ -97,6 +104,9 @@ export const EXPORT_COLUMNS: { key: keyof ExportRow; header: string }[] = [
   // consumers that read columns by header index keep working.
   { key: "parentName", header: "Parent" },
   { key: "variantCount", header: "Variant Count" },
+  // GH #954: color arrangement + finish tags, comma-separated numeric ids.
+  // Appended last so header-index consumers keep working.
+  { key: "optTags", header: "Tags" },
 ];
 
 export async function getExportRows(): Promise<ExportRow[]> {
@@ -181,6 +191,9 @@ export async function getExportRows(): Promise<ExportRow[]> {
       // are 0 unless they have variants pointing at them.
       parentName: parentDoc?.name ?? null,
       variantCount: variantCountByParent.get(filament._id.toString()) ?? 0,
+      // GH #954: resolved so a variant exports its EFFECTIVE tags (matching
+      // secondaryColors), keeping the round-trip's arrangement/finish intact.
+      optTags: (resolved.optTags ?? []).join(","),
     };
   });
 }

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -51,6 +51,16 @@ export interface ImportRow {
    * "Create variant" / Clone-from-parent UI already covers the manual case.
    */
   parentName?: string | null;
+  /**
+   * GH #954: OpenPrintTag `optTags` (color arrangement + finish) as a
+   * comma-separated list of numeric ids, round-tripping the `Tags` export
+   * column. Honoured on CREATE/RESURRECT only — like the `Parent` column,
+   * re-writing tags on an existing filament from a re-import is surprising,
+   * and honouring it on the update path would need the same variant-inheritance
+   * split `secondaryColors` gets (out of scope; the create-path round-trip is
+   * the reported loss).
+   */
+  optTags?: string | null;
 }
 
 /** Map header text (case-insensitive) to ImportRow keys */
@@ -136,6 +146,10 @@ const HEADER_MAP: Record<string, keyof ImportRow | undefined> = {
   parentname: "parentName",
   "variant count": undefined,
   variantcount: undefined,
+  // GH #954: OpenPrintTag color-arrangement + finish tags (comma-separated ids).
+  tags: "optTags",
+  "opt tags": "optTags",
+  opttags: "optTags",
 };
 
 const NUM_FIELDS = new Set<keyof ImportRow>([
@@ -512,6 +526,20 @@ export function pruneInheritedCreateDoc(
     }
   }
 
+  // GH #954: optTags inherits as a WHOLE array too (empty === inherit), so a
+  // create/resurrect variant whose exported (resolved) tags equal the parent's
+  // must reset to [] rather than pin them — same rule as secondaryColors.
+  if (Array.isArray(out.optTags) && out.optTags.length > 0) {
+    const parentArr: unknown[] = Array.isArray(parent.optTags) ? parent.optTags : [];
+    const incoming = out.optTags as unknown[];
+    if (
+      parentArr.length === incoming.length &&
+      incoming.every((v, i) => v === parentArr[i])
+    ) {
+      out.optTags = [];
+    }
+  }
+
   return out;
 }
 
@@ -550,7 +578,7 @@ export async function upsertImportRows(
     "maxVolumetricSpeed spoolWeight netFilamentWeight dryingTemperature " +
     "dryingTime transmissionDistance glassTempTransition heatDeflectionTemp " +
     "shoreHardnessA shoreHardnessD shrinkageXY shrinkageZ minPrintSpeed " +
-    "maxPrintSpeed spoolType tdsUrl inherits temperatures secondaryColors";
+    "maxPrintSpeed spoolType tdsUrl inherits temperatures secondaryColors optTags";
 
   const allExisting = await Filament.find({ name: { $in: [...namesToLoad] } })
     .select(INHERITANCE_PROJECTION)
@@ -747,6 +775,24 @@ export async function upsertImportRows(
         }
       }
     }
+    // GH #954: parse the "Tags" column (comma-separated OpenPrintTag ids) into a
+    // numeric array. Mirrors the secondaryColors parse (only set when there are
+    // valid entries); the schema's sanitizeOptTags setter drops any stragglers.
+    // Honoured on CREATE/RESURRECT only — the update path deletes it below.
+    if (row.optTags !== undefined && row.optTags !== null) {
+      const raw = String(row.optTags).trim();
+      if (raw !== "") {
+        const tags = [
+          ...new Set(
+            raw
+              .split(",")
+              .map((tag) => Number(tag.trim()))
+              .filter((n) => Number.isInteger(n) && n >= 0),
+          ),
+        ];
+        if (tags.length > 0) doc.optTags = tags;
+      }
+    }
     if (row.diameter !== undefined && row.diameter !== null) {
       doc.diameter = row.diameter;
     }
@@ -793,6 +839,11 @@ export async function upsertImportRows(
       // sub-fields that weren't in the import
       const updateDoc = { ...doc };
       delete updateDoc.temperatures;
+      // GH #954: `optTags` (the Tags column) is honoured on CREATE/RESURRECT
+      // only — like the Parent column. Drop it from the update `$set` so a
+      // re-import can't re-pin a variant's tags (which would need the same
+      // whole-array inheritance split secondaryColors gets).
+      delete updateDoc.optTags;
       let $set: Record<string, unknown> = { ...updateDoc };
       for (const [tempKey, tempVal] of Object.entries(temps)) {
         $set[`temperatures.${tempKey}`] = tempVal;

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -776,22 +776,28 @@ export async function upsertImportRows(
       }
     }
     // GH #954: parse the "Tags" column (comma-separated OpenPrintTag ids) into a
-    // numeric array. Mirrors the secondaryColors parse (only set when there are
-    // valid entries); the schema's sanitizeOptTags setter drops any stragglers.
-    // Honoured on CREATE/RESURRECT only — the update path deletes it below.
-    if (row.optTags !== undefined && row.optTags !== null) {
-      const raw = String(row.optTags).trim();
-      if (raw !== "") {
-        const tags = [
-          ...new Set(
-            raw
-              .split(",")
-              .map((tag) => Number(tag.trim()))
-              .filter((n) => Number.isInteger(n) && n >= 0),
-          ),
-        ];
-        if (tags.length > 0) doc.optTags = tags;
-      }
+    // numeric array. Honoured on CREATE/RESURRECT only — the update path deletes
+    // it below. `rowToImport` maps a PRESENT-but-empty cell to `null` and an
+    // ABSENT column to `undefined`: when the column is present (incl. an empty
+    // cell) we always set `doc.optTags` (empty → []), so re-importing a
+    // solid/untagged row CLEARS a tombstone's tags on resurrect rather than
+    // leaving them untouched (Codex). Empty tokens are dropped BEFORE Number()
+    // so a trailing/double comma ("28,16," / "28,,16") can't become
+    // `Number("") === 0` and add a phantom tag 0 (glass-fiber).
+    if (row.optTags !== undefined) {
+      doc.optTags =
+        row.optTags == null
+          ? []
+          : [
+              ...new Set(
+                String(row.optTags)
+                  .split(",")
+                  .map((tag) => tag.trim())
+                  .filter((tag) => tag !== "")
+                  .map(Number)
+                  .filter((n) => Number.isInteger(n) && n >= 0),
+              ),
+            ];
     }
     if (row.diameter !== undefined && row.diameter !== null) {
       doc.diameter = row.diameter;

--- a/src/lib/inventoryStats.ts
+++ b/src/lib/inventoryStats.ts
@@ -44,13 +44,18 @@ export function getSpoolCount(f: InventoryFilament): number {
  * the calculation actually uses. */
 export function getRemainingGrams(f: InventoryFilament): number | null {
   if (f.spools && f.spools.length > 0) {
-    if (f.spoolWeight == null) return null;
+    // GH #954: fall back to a 0g tare when spoolWeight is unset, matching the
+    // 0-tare posture the by-location / dashboard / locations surfaces already
+    // use — so a legacy null-spoolWeight filament reports remaining grams (and
+    // can trip the home-list low-stock badge) instead of reading as "not
+    // weight-tracked" on the home list while every other surface counts it.
+    const tare = f.spoolWeight ?? 0;
     let grams = 0;
     let any = false;
     for (const s of f.spools) {
       if (s.retired) continue;
       if (s.totalWeight != null) {
-        grams += Math.max(0, s.totalWeight - f.spoolWeight);
+        grams += Math.max(0, s.totalWeight - tare);
         any = true;
       }
     }

--- a/src/lib/labelBitmap.ts
+++ b/src/lib/labelBitmap.ts
@@ -201,6 +201,17 @@ async function composeLabelCanvas(opts: RenderLabelOpts): Promise<HTMLCanvasElem
     }
   }
 
+  // GH #954: the 8px font floor (renderTextBlock) can make the text block
+  // taller than the 128-dot print head; the canvas height is fixed at
+  // PRINT_HEAD_DOTS and the centering offset would go negative, silently
+  // clipping the first/last lines. Fail loud instead — mirrors renderQr, and
+  // the print dialog already surfaces the thrown message.
+  if (textFootH > PRINT_HEAD_DOTS) {
+    throw new Error(
+      "Label text does not fit the tape at the minimum font size — reduce the number of fields/lines or shorten the text.",
+    );
+  }
+
   // Label length = padding + [QR + gap] + textFootW + padding.
   const qrSlot = qrCanvas ? qrDots + QR_TEXT_GAP_DOTS : 0;
   const labelWidthDots = Math.max(

--- a/src/lib/labelFormat.ts
+++ b/src/lib/labelFormat.ts
@@ -160,9 +160,16 @@ export function normalizeLabelFormat(input: unknown): LabelFormat {
   const font = (o.font ?? {}) as Record<string, unknown>;
 
   const rawLines = Array.isArray(o.lines) ? o.lines : DEFAULT_LABEL_FORMAT.lines;
-  const lines = (rawLines as unknown[]).filter(
-    (l): l is LabelFieldId => typeof l === "string" && (FIELD_IDS as string[]).includes(l),
-  );
+  // GH #954: dedupe (a field is either shown or not — never stacked) so a
+  // persisted/hand-edited format can't repeat a field N times and overflow the
+  // print head. A Set also caps the list at the number of valid field ids.
+  const lines = [
+    ...new Set(
+      (rawLines as unknown[]).filter(
+        (l): l is LabelFieldId => typeof l === "string" && (FIELD_IDS as string[]).includes(l),
+      ),
+    ),
+  ];
 
   return {
     qr: {

--- a/tests/Filament.test.ts
+++ b/tests/Filament.test.ts
@@ -512,7 +512,10 @@ describe("Spool subdocument persistence", () => {
     expect(getRemainingGrams(found!)).toBe(1070);
   });
 
-  it("getRemainingGrams returns null for a persisted filament with no spoolWeight", async () => {
+  it("getRemainingGrams uses a 0g tare for a persisted filament with no spoolWeight (#954)", async () => {
+    // GH #954: aligned with by-location/dashboard/locations — a missing tare
+    // falls back to 0g (gross weight) rather than suppressing the figure, so
+    // the home-list low-stock badge can fire.
     const filament = await Filament.create({
       name: "Null SpoolWeight PLA",
       vendor: "Test",
@@ -520,7 +523,7 @@ describe("Spool subdocument persistence", () => {
       spoolWeight: null,
       spools: [{ label: "Spool B", totalWeight: 850 }],
     });
-    expect(getRemainingGrams(filament)).toBeNull();
+    expect(getRemainingGrams(filament)).toBe(850);
   });
 
   it("getRemainingGrams clamps a near-empty persisted spool at zero", async () => {

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -267,6 +267,55 @@ describe("API route correctness", () => {
     expect(body.message).toBeUndefined();
   });
 
+  it("#954 (Codex): all-retired stock warns even with a null tare (retired check runs before the tare guard)", async () => {
+    // No spoolWeight anywhere (null tare, no parent) + the only weighed stock is
+    // retired. The tare guard would return ok:true first; the retired detection
+    // must run before it so PrusaSlicer still gets the warning.
+    const f = await Filament.create({
+      name: "Null-Tare Retired PLA",
+      vendor: "Prusa",
+      type: "PLA",
+      density: 1.24,
+      diameter: 1.75,
+      // spoolWeight intentionally omitted (null) — no tare.
+      spools: [{ label: "Old", totalWeight: 1000, retired: true }],
+    });
+    const res = await spoolCheck(
+      getReq(`http://localhost/api/filaments/${f._id}/spool-check?weight=100`),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.warning).toMatch(/retired/i);
+  });
+
+  it("#954 (Codex): an UNWEIGHED active spool + a weighed retired spool stays ok:true (no false warning)", async () => {
+    // Active stock exists — it's just unmeasured. The retired spool has weight but
+    // is out of service. This must NOT warn (active stock exists), it's a no-data case.
+    const f = await Filament.create({
+      name: "Unweighed-Active PLA",
+      vendor: "Prusa",
+      type: "PLA",
+      spoolWeight: 200,
+      density: 1.24,
+      diameter: 1.75,
+      spools: [
+        { label: "Fresh", retired: false }, // active but no totalWeight (unweighed)
+        { label: "Old", totalWeight: 1000, retired: true }, // weighed but retired
+      ],
+    });
+    const res = await spoolCheck(
+      getReq(`http://localhost/api/filaments/${f._id}/spool-check?weight=100`),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true); // active stock exists (unmeasured) → no false warning
+    expect(body.warning).toBeUndefined();
+    expect(body.message).toMatch(/no spool weight data/i);
+  });
+
   // ── #305: print history never debits a retired spool ───────────────
 
   it("#305 — print-history records spoolId:null rather than debiting a retired spool", async () => {

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -257,10 +257,14 @@ describe("API route correctness", () => {
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    // The only parent spool is retired → no usable stock → "no data",
-    // not a false ok-based-on-a-retired-spool.
+    // The only parent spool is retired → no usable stock. GH #954: this now
+    // warns (ok:false) instead of silently passing with a "no data" message —
+    // weight data EXISTS, it's just all retired, which is exactly the case the
+    // retired exclusion is meant to surface to the slicer.
     expect(body.spools).toHaveLength(0);
-    expect(body.message).toMatch(/no spool weight data/i);
+    expect(body.ok).toBe(false);
+    expect(body.warning).toMatch(/retired/i);
+    expect(body.message).toBeUndefined();
   });
 
   // ── #305: print history never debits a retired spool ───────────────

--- a/tests/exportFilaments.test.ts
+++ b/tests/exportFilaments.test.ts
@@ -76,6 +76,19 @@ describe("getExportRows", () => {
     expect(row.tdsUrl).toBe("https://example.com/tds.pdf");
   });
 
+  it("#954: exports optTags as a comma-separated Tags column", async () => {
+    await Filament.create({
+      name: "Coex PLA",
+      vendor: "V",
+      type: "PLA",
+      color: null,
+      secondaryColors: ["#ff0000", "#00ff00"],
+      optTags: [28, 16], // dual_color + matte
+    });
+    const rows = await getExportRows();
+    expect(rows[0].optTags).toBe("28,16");
+  });
+
   it("GH #955: spoolCount excludes retired spools (matches getSpoolCount / the UI)", async () => {
     await Filament.create({
       name: "Retired Count PLA",

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -1653,3 +1653,76 @@ describe("upsertImportRows — create/resurrect preserve inheritance (GH #951)",
     expect(resolveFilament(resurrected, freshParent).cost).toBe(33);
   });
 });
+
+/**
+ * GH #954: CSV/XLSX optTags round-trip (the `Tags` column). Honoured on
+ * CREATE/RESURRECT only (like the Parent column); the update path ignores it.
+ */
+describe("upsertImportRows — optTags round-trip (GH #954)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+  });
+
+  const COLS = ["Name", "Vendor", "Type", "Color", "Tags", "Parent"];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (rs: any[][]) => {
+    const mapping = mapHeaders(COLS);
+    return rs.map((r) => rowToImport(r, mapping));
+  };
+
+  it("CREATE parses the Tags column into optTags (dedup + integer-only)", async () => {
+    const res = await upsertImportRows(
+      rows([["Tagged PLA", "Acme", "PLA", "#112233", "28, 16, 28, x, -1", ""]]),
+    );
+    expect(res.created).toBe(1);
+    const f = await Filament.findOne({ name: "Tagged PLA" }).lean();
+    expect(f.optTags).toEqual([28, 16]); // deduped; "x"/-1 dropped
+  });
+
+  it("CREATE variant inheriting the parent's tags is not pinned (empty === inherit)", async () => {
+    const result = await upsertImportRows(
+      rows([
+        ["Tag Parent", "Acme", "PLA", "#808080", "28,16", ""],
+        // variant row carries the parent-resolved tags (flattened export)
+        ["Tag Parent — Red", "Acme", "PLA", "#FF0000", "28,16", "Tag Parent"],
+      ]),
+    );
+    expect(result.created).toBe(2);
+    const variant = await Filament.findOne({ name: "Tag Parent — Red" }).lean();
+    expect(variant.optTags ?? []).toEqual([]); // inherited, not pinned
+
+    // parent edit propagates through resolveFilament.
+    const parent = await Filament.findOne({ name: "Tag Parent" }).lean();
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    expect(resolveFilament(variant, parent).optTags).toEqual([28, 16]);
+  });
+
+  it("CREATE variant with DISTINCT tags keeps its own override", async () => {
+    const result = await upsertImportRows(
+      rows([
+        ["TagP2", "Acme", "PLA", "#808080", "28,16", ""],
+        ["TagP2 — Silk", "Acme", "PLA", "#00FF00", "22", "TagP2"], // 22 = sparkle
+      ]),
+    );
+    expect(result.created).toBe(2);
+    const variant = await Filament.findOne({ name: "TagP2 — Silk" }).lean();
+    expect(variant.optTags).toEqual([22]);
+  });
+
+  it("UPDATE ignores the Tags column (create/resurrect only)", async () => {
+    const f = await Filament.create({
+      name: "Existing Tagged",
+      vendor: "Acme",
+      type: "PLA",
+      optTags: [16],
+    });
+    const res = await upsertImportRows(
+      rows([["Existing Tagged", "Acme", "PLA", "#123456", "28,29", ""]]),
+    );
+    expect(res.updated).toBe(1);
+    const fresh = await Filament.findById(f._id).lean();
+    expect(fresh.optTags).toEqual([16]); // unchanged — Tags ignored on update
+  });
+});

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -1725,4 +1725,32 @@ describe("upsertImportRows — optTags round-trip (GH #954)", () => {
     const fresh = await Filament.findById(f._id).lean();
     expect(fresh.optTags).toEqual([16]); // unchanged — Tags ignored on update
   });
+
+  it("RESURRECT with an empty Tags cell CLEARS the tombstone's tags (Codex)", async () => {
+    const trashed = await Filament.create({
+      name: "Resurrect Tagged",
+      vendor: "Acme",
+      type: "PLA",
+      optTags: [28, 16], // coextruded + matte
+      _deletedAt: new Date(),
+    });
+    // Re-import a solid/untagged row (empty Tags cell) over the tombstone.
+    const res = await upsertImportRows(
+      rows([["Resurrect Tagged", "Acme", "PLA", "#123456", "", ""]]),
+    );
+    expect(res.updated).toBe(1);
+    const fresh = await Filament.findById(trashed._id).lean();
+    expect(fresh._deletedAt).toBeNull();
+    expect(fresh.optTags).toEqual([]); // cleared, not left tagged
+  });
+
+  it("ignores empty tokens from a trailing/double comma — no phantom tag 0 (Codex)", async () => {
+    const res = await upsertImportRows(
+      rows([["Comma Tags", "Acme", "PLA", "#123456", "28,16,", ""]]),
+    );
+    expect(res.created).toBe(1);
+    const f = await Filament.findOne({ name: "Comma Tags" }).lean();
+    // Number("") === 0 (a valid tag id) — the empty token must be dropped first.
+    expect(f.optTags).toEqual([28, 16]);
+  });
 });

--- a/tests/inventoryStats.test.ts
+++ b/tests/inventoryStats.test.ts
@@ -85,14 +85,19 @@ describe("inventoryStats", () => {
       expect(getRemainingGrams(f)).toBe(600);
     });
 
-    it("returns null when spoolWeight is missing but spools have weight", () => {
+    it("falls back to a 0g tare when spoolWeight is missing but spools have weight (#954)", () => {
+      // GH #954: aligns with the 0-tare posture in by-location / dashboard /
+      // locations so the home-list low-stock badge can fire for a legacy
+      // null-spoolWeight filament. Over-reports by the (unknown) empty-spool
+      // mass — the accepted trade-off for cross-surface consistency.
       const f: InventoryFilament = {
         spoolWeight: null,
         netFilamentWeight: 800,
         totalWeight: null,
-        spools: [{ totalWeight: 800 }],
+        spools: [{ totalWeight: 800 }, { totalWeight: 300, retired: true }],
       };
-      expect(getRemainingGrams(f)).toBeNull();
+      // 0-tare: 800 gross from the active spool; retired spool still excluded.
+      expect(getRemainingGrams(f)).toBe(800);
     });
 
     it("skips active spools with no weight but still totals the rest", () => {

--- a/tests/labelFormat.test.ts
+++ b/tests/labelFormat.test.ts
@@ -110,6 +110,12 @@ describe("normalizeLabelFormat", () => {
     expect(normalizeLabelFormat({ lines: [] }).lines).toEqual(DEFAULT_LABEL_FORMAT.lines);
   });
 
+  it("dedupes repeated line ids so a field can't stack and overflow the head (#954)", () => {
+    expect(
+      normalizeLabelFormat({ lines: ["name", "name", "vendor", "name", "vendor"] }).lines,
+    ).toEqual(["name", "vendor"]);
+  });
+
   it("round-trips a valid format through JSON", () => {
     const f: LabelFormat = {
       qr: { enabled: false, placement: "right" },

--- a/tests/variant-inheritance-routes.test.ts
+++ b/tests/variant-inheritance-routes.test.ts
@@ -81,6 +81,51 @@ describe("GH #223 — variant inheritance in slicer + analytics + restore routes
     expect(body.message).toBeUndefined();
   });
 
+  it("spool-check warns (ok:false) when every weighted spool is retired (#954)", async () => {
+    const f = await Filament.create({
+      name: "SpoolCheck-AllRetired",
+      vendor: "V",
+      type: "PLA",
+      spoolWeight: 250,
+      // both spools have weight data but are RETIRED → zero active stock
+      spools: [
+        { label: "r1", totalWeight: 900, retired: true },
+        { label: "r2", totalWeight: 900, retired: true },
+      ],
+    });
+    const req = new NextRequest(
+      `http://localhost/api/filaments/${f._id}/spool-check?weight=100`,
+    );
+    const res = await spoolCheck(req, {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Pre-fix: ok:true "no data — skipping check", suppressing the warning.
+    expect(body.ok).toBe(false);
+    expect(body.warning).toMatch(/retired/i);
+    expect(body.message).toBeUndefined();
+  });
+
+  it("spool-check still returns ok:true when NO spool has weight data at all (#954)", async () => {
+    const f = await Filament.create({
+      name: "SpoolCheck-NoData",
+      vendor: "V",
+      type: "PLA",
+      spoolWeight: 250,
+      spools: [{ label: "s1" }], // no totalWeight anywhere
+    });
+    const req = new NextRequest(
+      `http://localhost/api/filaments/${f._id}/spool-check?weight=100`,
+    );
+    const res = await spoolCheck(req, {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.message).toMatch(/no spool weight data/i);
+  });
+
   // ---------------------------------------------------------------------
   // 2. analytics
   // ---------------------------------------------------------------------

--- a/tests/variant-inheritance-routes.test.ts
+++ b/tests/variant-inheritance-routes.test.ts
@@ -107,6 +107,30 @@ describe("GH #223 — variant inheritance in slicer + analytics + restore routes
     expect(body.message).toBeUndefined();
   });
 
+  it("spool-check does NOT warn when an active (unweighed) spool exists alongside a retired weighed one (#954, Codex)", async () => {
+    const f = await Filament.create({
+      name: "SpoolCheck-ActiveUnweighed",
+      vendor: "V",
+      type: "PLA",
+      spoolWeight: 250,
+      spools: [
+        { label: "active" }, // no totalWeight — unmeasured active stock
+        { label: "old", totalWeight: 900, retired: true },
+      ],
+    });
+    const req = new NextRequest(
+      `http://localhost/api/filaments/${f._id}/spool-check?weight=100`,
+    );
+    const res = await spoolCheck(req, {
+      params: Promise.resolve({ id: String(f._id) }),
+    });
+    const body = await res.json();
+    // Active stock exists (just unmeasured) → no false warning.
+    expect(body.ok).toBe(true);
+    expect(body.message).toMatch(/no spool weight data/i);
+    expect(body.warning).toBeUndefined();
+  });
+
   it("spool-check still returns ok:true when NO spool has weight data at all (#954)", async () => {
     const f = await Filament.create({
       name: "SpoolCheck-NoData",


### PR DESCRIPTION
Fixes #954 — the four still-open sub-findings (the other five shipped in #959 / #960 / #961; the triage verified those against HEAD).

| # | Fix |
|---|-----|
| **954.1** | `getRemainingGrams` returned `null` on a null `spoolWeight`, so the home-list low-stock badge/filter never fired for legacy filaments — while by-location/dashboard/locations already fall back to a **0g tare**. Aligned the `spools[]` branch to the 0g-tare posture. |
| **954.5** | The 8px font floor could make the text block taller than the 128-dot print head, silently clipping lines. Now **throws** (fail-loud, like `renderQr`) when the text footprint exceeds the head, and `normalizeLabelFormat` **dedupes** its `lines` so a persisted format can't stack a field N times. |
| **954.8** | `spool-check` returned `ok:true` "no data" when every weighted spool was **retired**, suppressing PrusaSlicer's insufficient-filament warning. Now distinguishes "no weight data at all" (`ok:true`) from "all weighted spools retired" (`ok:false` + `warning`). |
| **954.9** | CSV/XLSX dropped `optTags`, so a coextruded/gradient/finish filament collapsed to solid on a create-path round-trip. Added a **`Tags`** column, parsed on CREATE/RESURRECT only (like `Parent`), with `optTags` added to `pruneInheritedCreateDoc`'s whole-array inheritance so a variant's tags aren't pinned. |

Product/UX calls were confirmed with the maintainer (0g-tare; throw; ok:false; add Tags column).

Two existing tests updated to the intended new behavior (`getRemainingGrams` 0g-tare; the #273 retired-parent-spool spool-check now warns instead of silently passing — a strict improvement).

Full suite green (3022 tests), coverage clears thresholds, lint + tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
