### PR TITLE
fix(nfc): tag codec correctness — 5 fixes from #952

### DIFF
--- a/src/lib/bambuTag.ts
+++ b/src/lib/bambuTag.ts
@@ -142,13 +142,17 @@ export function parseBambuBlocks(blocks: (Buffer | undefined)[]): BambuTagData {
   const b14 = block(14);
   const filamentLength = b14.readUInt16LE(4);
 
-  // Block 16: Format ID uint16 LE (0-1) + Color Count uint16 LE (2-3) + Second Color RGBA (4-7)
+  // Block 16: Format ID uint16 LE (0-1) + Color Count uint16 LE (2-3) + Second
+  // Color at 4-7. GH #952: the block-5 PRIMARY color is stored RGBA, but the
+  // Bambu-Research-Group RFID-Tag-Guide documents this block-16 SECONDARY color
+  // in REVERSE ABGR order — so read bytes 7..4 as [r,g,b,a]. (Reference-derived;
+  // pending on-hardware confirmation on a real dual-color Bambu spool.)
   const b16 = block(16);
   const formatId = b16.readUInt16LE(0);
   const colorCount = b16.readUInt16LE(2);
   const secondColorRGBA: [number, number, number, number] | null =
     formatId === 0x0002 && colorCount >= 2
-      ? [b16[4], b16[5], b16[6], b16[7]]
+      ? [b16[7], b16[6], b16[5], b16[4]]
       : null;
 
   return {

--- a/src/lib/openprinttag.ts
+++ b/src/lib/openprinttag.ts
@@ -515,8 +515,8 @@ export interface OpenPrintTagInput {
   weightGrams?: number | null; // nominal net weight in grams
   actualWeightGrams?: number | null; // actual remaining filament weight (key 17); omitted when null (spec resolves absent → nominal)
   emptySpoolWeight?: number | null; // empty spool/container weight in grams
-  countryOfOrigin?: string;    // ISO 3166-1 alpha-2, default "US"
-  spoolUid?: string | null;    // brand-specific instance ID (e.g. "2acc21072a")
+  countryOfOrigin?: string;    // ISO 3166-1 alpha-2; omitted from the tag when unset (#952)
+  spoolUid?: string | null;    // brand-specific instance ID (e.g. "2acc21072a"); omitted when >16 chars (#952)
   dryingTemperature?: number | null;  // °C
   dryingTime?: number | null;         // minutes
   transmissionDistance?: number | null; // HueForge TD value
@@ -753,9 +753,14 @@ function buildMainMap(input: OpenPrintTagInput): number[] {
   encodeCBORKey(buf, OPT_KEY.MATERIAL_ABBREVIATION);
   encodeCBORText(buf, deriveMaterialAbbreviation(input.materialType));
 
-  // country_of_origin (ISO 3166-1 alpha-2)
-  encodeCBORKey(buf, OPT_KEY.COUNTRY_OF_ORIGIN);
-  encodeCBORText(buf, (input.countryOfOrigin ?? "US").slice(0, 2));
+  // country_of_origin (ISO 3166-1 alpha-2). GH #952: emit ONLY when the caller
+  // supplies one — no production caller does (the Filament model has no country
+  // field), so the old `?? "US"` default stamped a fabricated "US" onto every
+  // tag/re-write. Omit the key when unset (like material_type's unspecified case).
+  if (input.countryOfOrigin) {
+    encodeCBORKey(buf, OPT_KEY.COUNTRY_OF_ORIGIN);
+    encodeCBORText(buf, input.countryOfOrigin.slice(0, 2));
+  }
 
   // transmission_distance – HueForge TD value (type: number)
   if (input.transmissionDistance != null && input.transmissionDistance > 0) {
@@ -810,10 +815,15 @@ function buildMainMap(input: OpenPrintTagInput): number[] {
     encodeCBORUint(buf, clampUint(input.dryingTime, 10080));
   }
 
-  // brand_specific_instance_id – unique spool/instance identifier (string, max 16 chars)
-  if (input.spoolUid) {
+  // brand_specific_instance_id – unique spool/instance identifier (string, max 16 chars).
+  // GH #952: OMIT it when it's too long rather than TRUNCATING — a truncated id
+  // reads back as a DIFFERENT id and breaks scan-back matching (matchFilament
+  // finds no spool, the detail-page own-tag check misfires). Auto-generated
+  // 10-hex ids always fit; only long custom/Prusament ids trip this. spoolUid is
+  // ASCII-validated (validateSpoolInstanceId), so char length == byte length.
+  if (input.spoolUid && input.spoolUid.length <= 16) {
     encodeCBORKey(buf, OPT_KEY.BRAND_SPECIFIC_INSTANCE_ID);
-    encodeCBORText(buf, input.spoolUid.slice(0, 16));
+    encodeCBORText(buf, input.spoolUid);
   }
 
   buf.push(0xff); // indefinite map end

--- a/src/lib/opentag3d-decode.ts
+++ b/src/lib/opentag3d-decode.ts
@@ -65,7 +65,14 @@ export function ot3dToDecodedTag(decoded: Ot3dDecoded): DecodedOpenPrintTag {
   const base = str(f.material_base);
   const mod = str(f.material_mod);
   const colorNameStr = str(f.color_name);
-  const materialType = base; // bare base material (e.g. "PLA") — the typed field
+  // GH #952: rejoin base + modifier into the typed materialType (the encoder
+  // splits "PC-ABS"/"PETG-CF" into the separate 5-byte base/mod slots). Dropping
+  // the modifier made the typed field a bare "PC"/"PETG", which broke the
+  // anchored (^type$) vendor+type match and the finish/arrangement derivation.
+  // Hyphen is the canonical rejoin separator, matching stored types like
+  // "PETG-CF"; a space-separated original ("TPU 95A") round-trips as "TPU-95A"
+  // (the encoder can't record which separator was used — accepted trade-off).
+  const materialType = mod ? `${base}-${mod}` : base;
   // Fold the color into the display/default NAME so two colors of the same
   // brand+material don't both default to the same (unique-constrained) filament
   // name on create — otherwise every Polar Filament PLA color decodes to "PLA"

--- a/src/lib/opentag3d-encode.ts
+++ b/src/lib/opentag3d-encode.ts
@@ -26,6 +26,7 @@ import {
   hexToRgba,
   OPENTAG3D_MIME,
   ot3dField,
+  uintCapacity,
   type Ot3dValue,
 } from "./opentag3d";
 import { buildMediaNdefRecord, buildNdefMessageTlv } from "./ndef";
@@ -107,10 +108,24 @@ function setStr(
 
 function setNum(
   out: Record<string, Ot3dValue>,
+  notices: string[],
   id: string,
   value: number | null | undefined,
 ): void {
   if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    // GH #952: the encoder clamps an over-capacity int to the field max
+    // (writeUintBE) rather than silently wrapping — surface a notice so the user
+    // knows a value was capped. The written raw value is `real / scaling`; check
+    // that against the field's byte capacity.
+    const field = ot3dField(id);
+    if (field.type === "int") {
+      const raw = Math.round(field.scaling ? value / field.scaling : value);
+      if (raw > uintCapacity(field.length)) {
+        notices.push(
+          `${id} value ${value} exceeds this tag's capacity and will be capped.`,
+        );
+      }
+    }
     out[id] = value;
   }
 }
@@ -157,27 +172,27 @@ export function filamentToOpenTag3DFields(
   }
 
   // ── physical ──
-  setNum(fields, "target_diameter", f.diameter);
-  setNum(fields, "target_weight", f.netFilamentWeight);
-  setNum(fields, "density", f.density);
-  setNum(fields, "empty_spool_weight", f.spoolWeight);
+  setNum(fields, notices, "target_diameter", f.diameter);
+  setNum(fields, notices, "target_weight", f.netFilamentWeight);
+  setNum(fields, notices, "density", f.density);
+  setNum(fields, notices, "empty_spool_weight", f.spoolWeight);
 
   // ── temperatures ── recommended on Core, range on Extended (decoder reads
   // nozzleTemp = max_print_temp ?? print_temp).
   const t = f.temperatures ?? {};
-  setNum(fields, "print_temp", t.nozzle);
-  setNum(fields, "min_print_temp", t.nozzleRangeMin);
-  setNum(fields, "max_print_temp", t.nozzleRangeMax);
-  setNum(fields, "bed_temp", t.bed);
+  setNum(fields, notices, "print_temp", t.nozzle);
+  setNum(fields, notices, "min_print_temp", t.nozzleRangeMin);
+  setNum(fields, notices, "max_print_temp", t.nozzleRangeMax);
+  setNum(fields, notices, "bed_temp", t.bed);
 
   // ── drying ── dryingTime is MINUTES; the tag stores HOURS (decoder ×60).
-  setNum(fields, "max_dry_temp", f.dryingTemperature);
+  setNum(fields, notices, "max_dry_temp", f.dryingTemperature);
   if (typeof f.dryingTime === "number" && Number.isFinite(f.dryingTime) && f.dryingTime > 0) {
     fields.dry_time = Math.round(f.dryingTime / 60);
   }
 
   // ── volumetric speed ── decoder reads maxVolumetricSpeed = max_vso ?? target_vso.
-  setNum(fields, "max_vso", f.maxVolumetricSpeed);
+  setNum(fields, notices, "max_vso", f.maxVolumetricSpeed);
 
   // ── identity / remaining ──
   // The serial drives EXACT per-spool matching on scan (decoder → spoolUid), so
@@ -196,7 +211,7 @@ export function filamentToOpenTag3DFields(
       fields.serial = serial;
     }
   }
-  setNum(fields, "measured_filament_weight", opts.actualWeightGrams);
+  setNum(fields, notices, "measured_filament_weight", opts.actualWeightGrams);
 
   return { fields, notices };
 }

--- a/src/lib/opentag3d.ts
+++ b/src/lib/opentag3d.ts
@@ -145,9 +145,20 @@ function readUintBE(buf: Uint8Array, start: number, length: number): number {
   return v;
 }
 
-/** Write an unsigned big-endian integer of `length` bytes (value clamped ≥ 0). */
+/** Max unsigned value representable in `length` bytes (256^length − 1). */
+export function uintCapacity(length: number): number {
+  return 256 ** length - 1;
+}
+
+/**
+ * Write an unsigned big-endian integer of `length` bytes. GH #952: clamp to the
+ * field's capacity (256^length − 1) as well as ≥ 0 — an over-width value used to
+ * silently WRAP (e.g. maxVolumetricSpeed 300 into a 1-byte field → 44). Clamping
+ * writes a wrong-but-bounded value instead of a garbage wrap; the mapping layer
+ * (`setNum`) surfaces a notice when it clamps.
+ */
 function writeUintBE(buf: Uint8Array, start: number, length: number, value: number): void {
-  let v = Math.max(0, Math.round(value));
+  let v = Math.min(uintCapacity(length), Math.max(0, Math.round(value)));
   for (let i = length - 1; i >= 0; i--) {
     buf[start + i] = v & 0xff;
     v = Math.floor(v / 256);

--- a/tests/bambu-tag.test.ts
+++ b/tests/bambu-tag.test.ts
@@ -165,19 +165,22 @@ describe("Bambu Tag Decoder", () => {
       expect(data.filamentLength).toBe(330);
     });
 
-    it("parses second color when format ID is 0x0002 and count >= 2", () => {
+    it("parses second color from REVERSE ABGR byte order (#952)", () => {
       const blocks = makeBlocks();
       blocks[16] = Buffer.alloc(16);
       blocks[16]!.writeUInt16LE(0x0002, 0);
       blocks[16]!.writeUInt16LE(2, 2);
-      blocks[16]![4] = 0x00;
-      blocks[16]![5] = 0xff;
-      blocks[16]![6] = 0x00;
-      blocks[16]![7] = 0xff;
+      // Tag stores the secondary color reverse-ABGR at bytes 4-7 = [A,B,G,R].
+      // For RGB (0x11,0x22,0x33) alpha 0xff → bytes [0xff,0x33,0x22,0x11].
+      blocks[16]![4] = 0xff; // A
+      blocks[16]![5] = 0x33; // B
+      blocks[16]![6] = 0x22; // G
+      blocks[16]![7] = 0x11; // R
 
       const data = parseBambuBlocks(blocks);
       expect(data.colorCount).toBe(2);
-      expect(data.secondColorRGBA).toEqual([0x00, 0xff, 0x00, 0xff]);
+      // Decoded back to RGBA order.
+      expect(data.secondColorRGBA).toEqual([0x11, 0x22, 0x33, 0xff]);
     });
 
     it("returns null second color when format ID is 0", () => {
@@ -259,14 +262,15 @@ describe("Bambu Tag Decoder", () => {
     // (Galaxy line etc.).
     it("forwards the parsed second color as secondaryColors", () => {
       const blocks = buildFullBlocks();
-      // Block 16: format 0x0002, count 2, green secondary
+      // Block 16: format 0x0002, count 2, green secondary in REVERSE ABGR
+      // ([A,B,G,R] = [0xff,0x00,0xff,0x00] → RGB #00ff00). GH #952.
       blocks[16] = Buffer.alloc(16);
       blocks[16]!.writeUInt16LE(0x0002, 0);
       blocks[16]!.writeUInt16LE(2, 2);
-      blocks[16]![4] = 0x00;
-      blocks[16]![5] = 0xff;
-      blocks[16]![6] = 0x00;
-      blocks[16]![7] = 0xff;
+      blocks[16]![4] = 0xff; // A
+      blocks[16]![5] = 0x00; // B
+      blocks[16]![6] = 0xff; // G
+      blocks[16]![7] = 0x00; // R
       const result = bambuToDecodedTag(parseBambuBlocks(blocks));
       expect(result.secondaryColors).toEqual(["#00ff00"]);
     });

--- a/tests/openprinttag.test.ts
+++ b/tests/openprinttag.test.ts
@@ -662,10 +662,24 @@ describe("generateOpenPrintTagBinary", () => {
     expect(text).toContain("PLA");
   });
 
-  it("includes country_of_origin defaulting to US", () => {
-    const result = generateOpenPrintTagBinary(minimalInput);
-    const text = new TextDecoder().decode(result);
-    expect(text).toContain("US");
+  it("#952: OMITS country_of_origin when the caller supplies none (no fabricated US)", () => {
+    const bytes = Array.from(generateOpenPrintTagBinary(minimalInput));
+    expect(findCBORKey(bytes, OPT_KEY.COUNTRY_OF_ORIGIN)).toBe(-1);
+  });
+
+  it("#952: writes a spoolUid that fits (<=16 chars)", () => {
+    const bytes = Array.from(
+      generateOpenPrintTagBinary({ ...minimalInput, spoolUid: "2acc21072a" }),
+    );
+    expect(findCBORKey(bytes, OPT_KEY.BRAND_SPECIFIC_INSTANCE_ID)).not.toBe(-1);
+  });
+
+  it("#952: OMITS an over-length spoolUid (>16) rather than truncating it", () => {
+    const bytes = Array.from(
+      generateOpenPrintTagBinary({ ...minimalInput, spoolUid: "custom-id-01234567890" }),
+    );
+    // A truncated id would read back as a DIFFERENT id → omit entirely.
+    expect(findCBORKey(bytes, OPT_KEY.BRAND_SPECIFIC_INSTANCE_ID)).toBe(-1);
   });
 
   it("encodes temperature fields when provided", () => {

--- a/tests/opentag3d-encode.test.ts
+++ b/tests/opentag3d-encode.test.ts
@@ -67,14 +67,24 @@ describe("filamentToOpenTag3DFields → encode → decode round-trip", () => {
     expect(decoded.secondaryColors).toEqual(["#112233", "#445566"]);
   });
 
-  it("splits a combined material type into base + modifier (PA12-CF → PA12 / CF)", () => {
+  it("splits a combined material type into base + modifier and rejoins it on decode (PA12-CF)", () => {
     const { fields, notices } = filamentToOpenTag3DFields({ type: "PA12-CF" });
     expect(fields.material_base).toBe("PA12");
     expect(fields.material_mod).toBe("CF");
     expect(notices).toEqual([]); // both fit their 5-byte slots → no truncation
     const decoded = decodeOpenTag3DTag(encodeOpenTag3D(fields));
-    expect(decoded.materialType).toBe("PA12"); // base
-    expect(decoded.materialName).toContain("CF"); // modifier rejoined into the name
+    // GH #952: base+mod rejoin into the typed field so the round-trip preserves
+    // the full type (was a bare "PA12", breaking match + finish).
+    expect(decoded.materialType).toBe("PA12-CF");
+    expect(decoded.materialName).toContain("CF"); // modifier also in the display name
+  });
+
+  it("#952: clamps an over-capacity int to the field max instead of wrapping, with a notice", () => {
+    // max_vso is a 1-byte field (cap 255); 300 used to wrap to 44 (300 % 256).
+    const { fields, notices } = filamentToOpenTag3DFields({ maxVolumetricSpeed: 300 });
+    expect(notices.some((n) => /capacity|cap/i.test(n))).toBe(true);
+    const decoded = decodeOpenTag3DTag(encodeOpenTag3D(fields));
+    expect(decoded.maxVolumetricSpeed).toBe(255); // clamped, NOT the wrapped 44
   });
 
   it("flags a no-separator material type longer than the 5-byte base slot", () => {

--- a/tests/opentag3d.test.ts
+++ b/tests/opentag3d.test.ts
@@ -217,7 +217,8 @@ describe("ot3dToDecodedTag mapping → DecodedOpenPrintTag", () => {
 
   it("stamps the opentag3d source and identity fields", () => {
     expect(tag.tagSource).toBe("opentag3d");
-    expect(tag.materialType).toBe("PLA"); // bare base material
+    // GH #952: base+mod rejoin into the typed field (was a bare "PLA").
+    expect(tag.materialType).toBe("PLA-Silk");
     // color folded into the name so colors don't collide on the unique name key
     expect(tag.materialName).toBe("PLA Silk Electric Watermelon");
     expect(tag.brandName).toBe("Polar Filament");


### PR DESCRIPTION
Addresses #952 — **5 of 6** sub-findings (952.4 deferred, see below). Each is a byte-level encode/decode correctness fix; unit tests updated/added.

| # | Fix |
|---|-----|
| **952.1** | Bambu dual-color: block-16 second color read **reverse-ABGR** (was RGBA), per the RFID-Tag-Guide. ⚠️ Reference-derived — **on-hardware confirmation on a real dual-color Bambu spool is still owed** (you approved shipping it flagged). |
| **952.2** | OPT: **omit** an over-length `spoolUid` (>16) instead of truncating — a truncated id reads back as a *different* id and breaks scan-back matching. |
| **952.3** | OpenTag3D: `writeUintBE` **clamps** to the field's byte capacity (was a silent wrap — maxVolumetricSpeed 300 → 44); `setNum` surfaces a notice. |
| **952.5** | OpenTag3D decode **rejoins** material base + modifier into the typed field (`PC-ABS` decoded as bare `PC`), fixing the anchored vendor+type match + finish. Hyphen-default separator (your call). |
| **952.6** | OPT: **omit** `country_of_origin` when unset — the old `?? "US"` stamped a fabricated `US` onto every tag/re-write. |

### 952.4 deferred (needs your call — the triage under-specified it)
The bed/nozzle first-layer round-trip fix is **not** in this PR. You approved "decode: everyday=MIN, first-layer=MAX", but on inspection the encoder **synthesizes `MIN_BED = everyday − 10`** when there's no first-layer temp — so a decode-only change would make every *no-first-layer* filament read its bed temp 10° low. The correct fix requires an **encode** change (write `MIN==MAX` when there's no first-layer), which then **mis-reads pre-fix hardware tags by 10°**. That's a wire-format tradeoff on physical tags I didn't want to make unilaterally. I'll implement it on your go — just confirm the pre-fix-tag drift is acceptable.

Full suite green (3017 tests), coverage clears thresholds, lint + tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
