### PR TITLE
fix(slicer): round-trip data-loss & id-first addressing — from #950

### DIFF
--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -45,17 +45,24 @@ export async function GET(
       );
     }
 
-    // Find filament by name or ObjectId. `params.id` is ALREADY URL-decoded —
-    // re-decoding throws URIError on a name with a literal `%` (#671).
+    // GH #950 / #867: a 24-hex param is an ObjectId and is AUTHORITATIVE — try
+    // it FIRST, name lookup only when that _id misses (a preset legitimately
+    // NAMED with 24 hex chars). Name-first let such a name shadow another
+    // filament's real _id, so a slicer addressing this endpoint by id read the
+    // WRONG row's calibration — inconsistent with the id-first sync/export
+    // routes. `params.id` is ALREADY URL-decoded — do NOT re-decode (a literal
+    // `%` like "ABS 100%" throws URIError and 500s the request, #671).
     const decodedName = id;
-    let filament = await Filament.findOne({ name: decodedName, _deletedAt: null })
-      .populate("calibrations.nozzle")
-      .populate("calibrations.printer")
-      .populate("calibrations.bedType")
-      .lean();
+    let filament = /^[a-f0-9]{24}$/i.test(id)
+      ? await Filament.findOne({ _id: id, _deletedAt: null })
+          .populate("calibrations.nozzle")
+          .populate("calibrations.printer")
+          .populate("calibrations.bedType")
+          .lean()
+      : null;
 
-    if (!filament && /^[a-f0-9]{24}$/i.test(id)) {
-      filament = await Filament.findOne({ _id: id, _deletedAt: null })
+    if (!filament) {
+      filament = await Filament.findOne({ name: decodedName, _deletedAt: null })
         .populate("calibrations.nozzle")
         .populate("calibrations.printer")
         .populate("calibrations.bedType")

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -240,7 +240,12 @@ export async function POST(
       return errorResponse(merge.error, 400);
     }
     const settingsAdded = merge.added;
-    if (settingsAdded.length > 0) {
+    // GH #950 (Codex P2 on PR #968 r5): also write when the merge PURGED a stale
+    // structured key from the existing bag (`removed`) — otherwise a sync that
+    // only changes structured fields discards the cleaned bag and the stale
+    // shadow (e.g. a legacy filament_settings_id) survives to shadow the
+    // re-derived export value.
+    if (settingsAdded.length > 0 || merge.removed.length > 0) {
       update.settings = merge.settings;
     }
 

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -131,13 +131,17 @@ export async function POST(
     await dbConnect();
     const { id } = await params;
 
-    // Find filament by name or ObjectId. The App Router `params.id` is ALREADY
-    // URL-decoded — re-decoding throws URIError on a name with a literal `%`
-    // ("ABS 100%") and 500s the sync-back (#671; cf. resolveFilamentForExport).
+    // GH #950 / #867: a 24-hex param is an ObjectId and is AUTHORITATIVE — try it
+    // FIRST, name lookup only when that _id misses (a preset named with 24 hex
+    // chars). Name-first let such a name shadow another filament's real _id. The
+    // App Router `params.id` is ALREADY URL-decoded — do NOT re-decode (a literal
+    // `%` like "ABS 100%" would throw URIError and 500 the sync, #671).
     const decodedName = id;
-    let filament = await Filament.findOne({ name: decodedName, _deletedAt: null });
-    if (!filament && /^[a-f0-9]{24}$/i.test(id)) {
-      filament = await Filament.findOne({ _id: id, _deletedAt: null });
+    let filament = /^[a-f0-9]{24}$/i.test(id)
+      ? await Filament.findOne({ _id: id, _deletedAt: null })
+      : null;
+    if (!filament) {
+      filament = await Filament.findOne({ name: decodedName, _deletedAt: null });
     }
 
     if (!filament) {

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -469,6 +469,22 @@ export async function POST(
         filament = await Filament.findOne({ name: decodedName, _deletedAt: null });
         if (filament) matchedBy = "name";
       }
+      // GH #950: a #872 per-nozzle preset is named "<base> <Ø type [HF]>". When
+      // its filamentdb_id is stale/absent (DB-instance-specific) AND the full
+      // suffixed name misses, retry the BASE name (decodedName minus the hint)
+      // so the sync updates the base filament instead of 404 → the fork spawning
+      // a "<base> <hint>" orphan that swallows every later edit.
+      if (!filament) {
+        const hint =
+          typeof config.filamentdb_nozzle === "string" ? config.filamentdb_nozzle.trim() : "";
+        if (hint && decodedName.endsWith(` ${hint}`)) {
+          const baseName = decodedName.slice(0, -(hint.length + 1)).trim();
+          if (baseName) {
+            filament = await Filament.findOne({ name: baseName, _deletedAt: null });
+            if (filament) matchedBy = "name";
+          }
+        }
+      }
     }
 
     if (!filament) {
@@ -594,9 +610,10 @@ export async function POST(
     if (config.filament_shrinkage_compensation_xy) { const v = parseFloat(config.filament_shrinkage_compensation_xy); if (!isNaN(v)) update.shrinkageXY = v; }
     if (config.filament_shrinkage_compensation_z) { const v = parseFloat(config.filament_shrinkage_compensation_z); if (!isNaN(v)) update.shrinkageZ = v; }
 
-    // Flags
-    if (config.filament_soluble) update.soluble = config.filament_soluble === "1";
-    if (config.filament_abrasive) update.abrasive = config.filament_abrasive === "1";
+    // GH #950: filament_soluble / filament_abrasive are NOT written as structured
+    // fields (the schema has no such columns — a Mongoose strict write dropped
+    // them). They now ride the settings bag (removed from STRUCTURED_KEYS below),
+    // which the slicer exports' settings seed and the OPT encoder read.
 
     // #859: write ONLY the temperature keys PrusaSlicer actually sent, as
     // dotted paths — never a $set of the whole `temperatures` object. #645 added
@@ -815,7 +832,12 @@ export async function POST(
       "filament_max_volumetric_speed", "temperature", "first_layer_temperature",
       "bed_temperature", "first_layer_bed_temperature",
       "filament_shrinkage_compensation_xy", "filament_shrinkage_compensation_z",
-      "filament_soluble", "filament_abrasive", "filament_settings_id",
+      // GH #950: filament_soluble / filament_abrasive are NOT structured — the
+      // Filament schema has no such fields, so a sync that pulled them out here
+      // (and wrote a stripped-by-Mongoose update.soluble) persisted them
+      // NOWHERE. Let them ride the settings bag, which is where the exports'
+      // settings seed and the OPT encoder already read them from.
+      "filament_settings_id",
       // #867: a routing hint, not filament data — consumed for id-first matching
       // above and re-emitted from the row's _id on export, so never stored in
       // the settings bag (avoids a stale duplicate of the canonical _id).

--- a/src/app/api/filaments/[id]/spool-check/route.ts
+++ b/src/app/api/filaments/[id]/spool-check/route.ts
@@ -42,12 +42,19 @@ export async function GET(
       return errorResponse("weight must be a non-negative number", 400);
     }
 
-    // Find filament by name or ObjectId. `params.id` is ALREADY URL-decoded —
-    // re-decoding throws URIError on a name with a literal `%` (#671).
+    // GH #950 / #867: a 24-hex param is an ObjectId and is AUTHORITATIVE — try
+    // it FIRST, name lookup only when that _id misses (a preset legitimately
+    // NAMED with 24 hex chars). Name-first let such a name shadow another
+    // filament's real _id, so a slicer addressing this endpoint by id checked
+    // the WRONG row's spool availability — inconsistent with the id-first
+    // sync/export routes. `params.id` is ALREADY URL-decoded — do NOT re-decode
+    // (a literal `%` like "ABS 100%" throws URIError and 500s the request, #671).
     const decodedName = id;
-    let filament = await Filament.findOne({ name: decodedName, _deletedAt: null }).lean();
-    if (!filament && /^[a-f0-9]{24}$/i.test(id)) {
-      filament = await Filament.findOne({ _id: id, _deletedAt: null }).lean();
+    let filament = /^[a-f0-9]{24}$/i.test(id)
+      ? await Filament.findOne({ _id: id, _deletedAt: null }).lean()
+      : null;
+    if (!filament) {
+      filament = await Filament.findOne({ name: decodedName, _deletedAt: null }).lean();
     }
 
     if (!filament) {

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -180,15 +180,28 @@ export async function prepareBambuUpdate(
   // filament_soluble / slicer options. `settingsResult.settings` is always the
   // full {existing, ...incoming} bag. Skip when the merge errored (the route 400s
   // on it anyway) so we never build on a partial bag.
-  if (
-    parsed.calibrationHints.chamberTemp != null &&
-    !calibrationOutcome.applied &&
-    !settingsResult.error
-  ) {
-    const settings = { ...settingsResult.settings };
-    settings.chamber_temperature = String(parsed.calibrationHints.chamberTemp);
-    settings.activate_chamber_temp_control = "1";
-    update.settings = settings;
+  if (parsed.calibrationHints.chamberTemp != null && !settingsResult.error) {
+    if (!calibrationOutcome.applied) {
+      // Unresolved: no structural home → preserve the raw chamber keys in the bag.
+      const settings = { ...settingsResult.settings };
+      settings.chamber_temperature = String(parsed.calibrationHints.chamberTemp);
+      settings.activate_chamber_temp_control = "1";
+      update.settings = settings;
+    } else if (
+      "chamber_temperature" in settingsResult.settings ||
+      "activate_chamber_temp_control" in settingsResult.settings
+    ) {
+      // Codex P2 on PR #968 r4: the chamber value went to calibrations[].chamberTemp
+      // (authoritative, per-nozzle). Strip any STALE raw chamber keys the merged bag
+      // carried over from a PRIOR unresolved/disabled import — otherwise they'd
+      // re-export as a filament-global chamber value that double-counts the
+      // calibration. The parser already excludes the INCOMING chamber keys from the
+      // bag, so this only clears a carried-over value from `existing`.
+      const settings = { ...settingsResult.settings };
+      delete settings.chamber_temperature;
+      delete settings.activate_chamber_temp_control;
+      update.settings = settings;
+    }
   }
 
   // GH #892: reject an inverted nozzle range, mirroring the OrcaSlicer sync

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -404,12 +404,16 @@ export async function resolveAndApplyCalibration(
     return { applied: false, unresolved: hints.hasAnyHint };
   }
 
-  // GH #950 (Codex r5/r6): a "chamber-disable-only" sync — an explicit chamber
+  // GH #950 (Codex r5/r6/r7): a "chamber-disable-only" sync — an explicit chamber
   // disable with NO real calibration hint and no new chamber temp. Its ONLY job is
-  // to clear a pre-existing calibrations[].chamberTemp; it must NOT fabricate a new
-  // per-nozzle calibration row out of the profile's ordinary top-level temps
-  // (those already land on the filament via buildStructuredUpdate, and a fabricated
-  // row would later shadow user-edited top-level temps in /calibration).
+  // to CLEAR a pre-existing calibrations[].chamberTemp. It must therefore carry
+  // JUST the chamber clear: it must not fabricate a new per-nozzle calibration, nor
+  // update an existing row's OTHER fields. Every non-chamber value the profile
+  // carries (ordinary temps, and maxVolumetricSpeed — which is excluded from
+  // hasAnyHint precisely because it has a top-level home) already lands on the
+  // filament via buildStructuredUpdate, so gating ALL of them behind
+  // !chamberClearOnly is the root fix that closes this whole leak class at once
+  // (each round Codex found another individual field slipping through).
   const chamberClearOnly =
     hints.chamberDisabled === true && !hints.hasAnyHint && hints.chamberTemp == null;
 
@@ -417,23 +421,20 @@ export async function resolveAndApplyCalibration(
     printer: ctx.printerId,
     nozzle: ctx.nozzleId,
   };
-  if (hints.extrusionMultiplier != null) row.extrusionMultiplier = hints.extrusionMultiplier;
-  if (hints.maxVolumetricSpeed != null) row.maxVolumetricSpeed = hints.maxVolumetricSpeed;
-  if (hints.pressureAdvance != null) row.pressureAdvance = hints.pressureAdvance;
-  if (hints.retractLength != null) row.retractLength = hints.retractLength;
-  if (hints.retractSpeed != null) row.retractSpeed = hints.retractSpeed;
-  if (hints.retractLift != null) row.retractLift = hints.retractLift;
-  if (hints.fanMinSpeed != null) row.fanMinSpeed = hints.fanMinSpeed;
-  if (hints.fanMaxSpeed != null) row.fanMaxSpeed = hints.fanMaxSpeed;
-  if (hints.fanBridgeSpeed != null) row.fanBridgeSpeed = hints.fanBridgeSpeed;
+  // Chamber: write a new value, or (on an explicit disable) null to clear it.
   if (hints.chamberTemp != null) row.chamberTemp = hints.chamberTemp; // GH #950
-  // GH #950 (Codex r5): an explicit disable with no new temp CLEARS the chamber
-  // value on the matched row (null = the schema default / "off").
   else if (hints.chamberDisabled === true) row.chamberTemp = null;
-  // Copy top-level temps into the calibration only for a REAL calibration write —
-  // NOT a chamber-disable-only sync (Codex r6), so `row` then carries only the
-  // chamber clear and never fabricates a temp-bearing row.
+  // All non-chamber calibration values — ONLY for a real calibration write.
   if (!chamberClearOnly) {
+    if (hints.extrusionMultiplier != null) row.extrusionMultiplier = hints.extrusionMultiplier;
+    if (hints.maxVolumetricSpeed != null) row.maxVolumetricSpeed = hints.maxVolumetricSpeed;
+    if (hints.pressureAdvance != null) row.pressureAdvance = hints.pressureAdvance;
+    if (hints.retractLength != null) row.retractLength = hints.retractLength;
+    if (hints.retractSpeed != null) row.retractSpeed = hints.retractSpeed;
+    if (hints.retractLift != null) row.retractLift = hints.retractLift;
+    if (hints.fanMinSpeed != null) row.fanMinSpeed = hints.fanMinSpeed;
+    if (hints.fanMaxSpeed != null) row.fanMaxSpeed = hints.fanMaxSpeed;
+    if (hints.fanBridgeSpeed != null) row.fanBridgeSpeed = hints.fanBridgeSpeed;
     if (parsed.temperatures.nozzle != null) row.nozzleTemp = parsed.temperatures.nozzle;
     if (parsed.temperatures.nozzleFirstLayer != null) row.nozzleTempFirstLayer = parsed.temperatures.nozzleFirstLayer;
     if (parsed.temperatures.bed != null) row.bedTemp = parsed.temperatures.bed;

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -183,10 +183,19 @@ export async function prepareBambuUpdate(
   if (parsed.calibrationHints.chamberTemp != null && !settingsResult.error) {
     if (!calibrationOutcome.applied) {
       // Unresolved: no structural home → preserve the raw chamber keys in the bag.
-      const settings = { ...settingsResult.settings };
-      settings.chamber_temperature = String(parsed.calibrationHints.chamberTemp);
-      settings.activate_chamber_temp_control = "1";
-      update.settings = settings;
+      // Route them through the CAPPED merge (Codex r7) so appending them can't
+      // bypass MAX_SETTINGS_KEYS; a genuinely over-cap result surfaces as
+      // settingsResult.error → the route 400s instead of silently over-filling.
+      const chamberMerge = mergeSlicerSettings(
+        settingsResult.settings,
+        {
+          chamber_temperature: String(parsed.calibrationHints.chamberTemp),
+          activate_chamber_temp_control: "1",
+        },
+        new Set(),
+      );
+      if (chamberMerge.error) settingsResult.error = chamberMerge.error;
+      else update.settings = chamberMerge.settings;
     } else if (
       "chamber_temperature" in settingsResult.settings ||
       "activate_chamber_temp_control" in settingsResult.settings

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -418,28 +418,24 @@ export async function resolveAndApplyCalibration(
     return { applied: false, unresolved: hints.hasAnyHint };
   }
 
-  // GH #950 (Codex r5/r6/r7): a "chamber-disable-only" sync — an explicit chamber
-  // disable with NO real calibration hint and no new chamber temp. Its ONLY job is
-  // to CLEAR a pre-existing calibrations[].chamberTemp. It must therefore carry
-  // JUST the chamber clear: it must not fabricate a new per-nozzle calibration, nor
-  // update an existing row's OTHER fields. Every non-chamber value the profile
-  // carries (ordinary temps, and maxVolumetricSpeed — which is excluded from
-  // hasAnyHint precisely because it has a top-level home) already lands on the
-  // filament via buildStructuredUpdate, so gating ALL of them behind
-  // !chamberClearOnly is the root fix that closes this whole leak class at once
-  // (each round Codex found another individual field slipping through).
-  const chamberClearOnly =
-    hints.chamberDisabled === true && !hints.hasAnyHint && hints.chamberTemp == null;
-
   const row: Record<string, unknown> = {
     printer: ctx.printerId,
     nozzle: ctx.nozzleId,
   };
-  // Chamber: write a new value, or (on an explicit disable) null to clear it.
+  // Chamber: write a new value, or (on an explicit disable) null to clear it. This
+  // is the ONE thing a chamber-only sync (enabled or disabled) writes to the row.
   if (hints.chamberTemp != null) row.chamberTemp = hints.chamberTemp; // GH #950
   else if (hints.chamberDisabled === true) row.chamberTemp = null;
-  // All non-chamber calibration values — ONLY for a real calibration write.
-  if (!chamberClearOnly) {
+  // All NON-chamber calibration values + ordinary temps: copied ONLY when there's
+  // a real per-nozzle hint (`hasAnyHint`). GH #950 (Codex r6/r7/r11): a chamber-only
+  // sync — whether it ENABLES chamber (chamberTemp != null) or disables it — must
+  // NOT pin the profile's top-level-homed temps / max-vol into calibrations[].
+  // Those already land on the filament via buildStructuredUpdate; a fabricated
+  // per-nozzle override would later shadow user-edited top-level values. Gating on
+  // `hasAnyHint` (not merely "chamber present") closes the enabled + disabled cases
+  // together — max-vol is excluded from hasAnyHint precisely because it has a
+  // top-level home, so a chamber+max-vol-only sync leaves max-vol at the top level.
+  if (hints.hasAnyHint) {
     if (hints.extrusionMultiplier != null) row.extrusionMultiplier = hints.extrusionMultiplier;
     if (hints.maxVolumetricSpeed != null) row.maxVolumetricSpeed = hints.maxVolumetricSpeed;
     if (hints.pressureAdvance != null) row.pressureAdvance = hints.pressureAdvance;
@@ -475,17 +471,15 @@ export async function resolveAndApplyCalibration(
   );
   const merged = [...existingRows];
   if (idx >= 0) {
-    // A chamber-disable-only sync merges ONLY `{ chamberTemp: null }` here — it
-    // clears the matched row's chamber value and leaves its temps/EM/PA intact.
+    // A chamber-only sync merges just its chamber value here (a real hint also
+    // brings its calibration fields); the matched row's other fields stay intact.
     merged[idx] = { ...merged[idx], ...row };
   } else {
-    // GH #950 (Codex r5/r6): a chamber-disable-only sync that matches NO existing
-    // row has nothing to clear — do NOT create a calibration row. `row` carries
-    // only identity + a null chamber (ordinary temps were intentionally not copied
-    // above), so this never drops real calibration data; the pre-existing
-    // "resolved, row carries only identity" behaviour for non-chamber syncs is
-    // unchanged.
-    if (chamberClearOnly) {
+    // GH #950 (Codex r5/r6/r11): create a row only when there's real data to store
+    // — a per-nozzle hint, or an ENABLED chamber value (chamberTemp != null, its
+    // structured home). A bare chamber CLEAR (chamberTemp === null) with no
+    // matching row has nothing to clear, so don't fabricate an empty row.
+    if (!hints.hasAnyHint && row.chamberTemp == null) {
       return { applied: false, unresolved: false };
     }
     merged.push(row);

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -171,8 +171,21 @@ export async function prepareBambuUpdate(
   // same no-data-loss guarantee maxVolumetricSpeed gets via its top-level field.
   // A RESOLVED profile keeps chamber cleanly in calibrations[].chamberTemp and
   // out of the filament-global bag (the #950 fix's whole point).
-  if (parsed.calibrationHints.chamberTemp != null && !calibrationOutcome.applied) {
-    const settings = { ...((update.settings as Record<string, unknown>) || {}) };
+  //
+  // Codex P1 on PR #968: base on the MERGED settings bag (existing + incoming
+  // passthrough), NOT `update.settings` — which is only assigned when
+  // `settingsResult.added.length > 0`, so for an existing filament whose profile
+  // adds no passthrough keys it is undefined here, and starting from {} would make
+  // the later `$set` REPLACE the whole bag, dropping existing filament_notes /
+  // filament_soluble / slicer options. `settingsResult.settings` is always the
+  // full {existing, ...incoming} bag. Skip when the merge errored (the route 400s
+  // on it anyway) so we never build on a partial bag.
+  if (
+    parsed.calibrationHints.chamberTemp != null &&
+    !calibrationOutcome.applied &&
+    !settingsResult.error
+  ) {
+    const settings = { ...settingsResult.settings };
     settings.chamber_temperature = String(parsed.calibrationHints.chamberTemp);
     settings.activate_chamber_temp_control = "1";
     update.settings = settings;
@@ -355,13 +368,23 @@ export async function resolveAndApplyCalibration(
   update: Record<string, unknown>,
   existing: { calibrations?: unknown[] } | null,
 ): Promise<CalibrationOutcome> {
-  if (!hints.hasAnyHint) {
+  // GH #950 (Codex P2 on PR #968): decouple "attempt resolution" from "warn".
+  // chamber_temperature has a structured home too — calibrations[].chamberTemp —
+  // so we must TRY to resolve a printer/nozzle whenever a chamber temp is present,
+  // even though chamber is excluded from `hasAnyHint`. The UNRESOLVED WARNING,
+  // however, stays gated on `hasAnyHint`: chamber has a settings-bag fallback (see
+  // prepareBambuUpdate), so a chamber-only profile that can't resolve loses
+  // nothing and must not surface a misleading "calibration unresolved" toast.
+  const wantsResolution = hints.hasAnyHint || hints.chamberTemp != null;
+  if (!wantsResolution) {
     return { applied: false, unresolved: false };
   }
 
   const ctx = await matchPrinterNozzle(hints);
   if (!ctx) {
-    return { applied: false, unresolved: true };
+    // Per-nozzle hints (if any) are dropped → warn. A chamber-only profile has
+    // its settings-bag fallback, so its presence alone does NOT warn.
+    return { applied: false, unresolved: hints.hasAnyHint };
   }
 
   const row: Record<string, unknown> = {

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -159,6 +159,25 @@ export async function prepareBambuUpdate(
     existing,
   );
 
+  // GH #950 (Codex P2 on PR #968): chamber_temperature has NO top-level filament
+  // field — its only structured home is calibrations[].chamberTemp, which
+  // `resolveAndApplyCalibration` writes ONLY when it resolves a printer/nozzle
+  // context. Because the parser excludes chamber_temperature/activate_chamber_
+  // temp_control from the settings passthrough bag (they're in CALIBRATION_KEYS),
+  // a standalone profile whose calibration context can't be resolved would
+  // silently DROP the value. When no calibration row was written, fall back to
+  // preserving the raw chamber keys in the settings bag — the "misfiled but
+  // survives" state the #950 finding explicitly rates acceptable (P2), and the
+  // same no-data-loss guarantee maxVolumetricSpeed gets via its top-level field.
+  // A RESOLVED profile keeps chamber cleanly in calibrations[].chamberTemp and
+  // out of the filament-global bag (the #950 fix's whole point).
+  if (parsed.calibrationHints.chamberTemp != null && !calibrationOutcome.applied) {
+    const settings = { ...((update.settings as Record<string, unknown>) || {}) };
+    settings.chamber_temperature = String(parsed.calibrationHints.chamberTemp);
+    settings.activate_chamber_temp_control = "1";
+    update.settings = settings;
+  }
+
   // GH #892: reject an inverted nozzle range, mirroring the OrcaSlicer sync
   // route. `update.temperatures` is a full replace (built from existing +
   // parsed), so it IS the effective own range; the variant inherits any null

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -404,6 +404,15 @@ export async function resolveAndApplyCalibration(
     return { applied: false, unresolved: hints.hasAnyHint };
   }
 
+  // GH #950 (Codex r5/r6): a "chamber-disable-only" sync — an explicit chamber
+  // disable with NO real calibration hint and no new chamber temp. Its ONLY job is
+  // to clear a pre-existing calibrations[].chamberTemp; it must NOT fabricate a new
+  // per-nozzle calibration row out of the profile's ordinary top-level temps
+  // (those already land on the filament via buildStructuredUpdate, and a fabricated
+  // row would later shadow user-edited top-level temps in /calibration).
+  const chamberClearOnly =
+    hints.chamberDisabled === true && !hints.hasAnyHint && hints.chamberTemp == null;
+
   const row: Record<string, unknown> = {
     printer: ctx.printerId,
     nozzle: ctx.nozzleId,
@@ -421,10 +430,15 @@ export async function resolveAndApplyCalibration(
   // GH #950 (Codex r5): an explicit disable with no new temp CLEARS the chamber
   // value on the matched row (null = the schema default / "off").
   else if (hints.chamberDisabled === true) row.chamberTemp = null;
-  if (parsed.temperatures.nozzle != null) row.nozzleTemp = parsed.temperatures.nozzle;
-  if (parsed.temperatures.nozzleFirstLayer != null) row.nozzleTempFirstLayer = parsed.temperatures.nozzleFirstLayer;
-  if (parsed.temperatures.bed != null) row.bedTemp = parsed.temperatures.bed;
-  if (parsed.temperatures.bedFirstLayer != null) row.bedTempFirstLayer = parsed.temperatures.bedFirstLayer;
+  // Copy top-level temps into the calibration only for a REAL calibration write —
+  // NOT a chamber-disable-only sync (Codex r6), so `row` then carries only the
+  // chamber clear and never fabricates a temp-bearing row.
+  if (!chamberClearOnly) {
+    if (parsed.temperatures.nozzle != null) row.nozzleTemp = parsed.temperatures.nozzle;
+    if (parsed.temperatures.nozzleFirstLayer != null) row.nozzleTempFirstLayer = parsed.temperatures.nozzleFirstLayer;
+    if (parsed.temperatures.bed != null) row.bedTemp = parsed.temperatures.bed;
+    if (parsed.temperatures.bedFirstLayer != null) row.bedTempFirstLayer = parsed.temperatures.bedFirstLayer;
+  }
 
   // Normalize to PLAIN objects before spreading: the bulk/per-id routes pass a
   // HYDRATED Mongoose doc, so `existing.calibrations[i]` are Mongoose subdocuments
@@ -446,19 +460,17 @@ export async function resolveAndApplyCalibration(
   );
   const merged = [...existingRows];
   if (idx >= 0) {
+    // A chamber-disable-only sync merges ONLY `{ chamberTemp: null }` here — it
+    // clears the matched row's chamber value and leaves its temps/EM/PA intact.
     merged[idx] = { ...merged[idx], ...row };
   } else {
-    // GH #950 (Codex r5): a chamber-DISABLE-only profile (no hints/temp, resolved
-    // purely to clear chamber) that matches NO existing row has nothing to clear —
-    // don't create an empty {printer,nozzle,chamberTemp:null} row. Scoped strictly
-    // to that case so the pre-existing "resolved, row carries only identity"
-    // behaviour (e.g. a printer-match with no concrete values) is unchanged.
-    const chamberClearOnly =
-      hints.chamberDisabled === true && !hints.hasAnyHint && hints.chamberTemp == null;
-    const carriesData = Object.entries(row).some(
-      ([k, v]) => k !== "printer" && k !== "nozzle" && !(k === "chamberTemp" && v == null),
-    );
-    if (chamberClearOnly && !carriesData) {
+    // GH #950 (Codex r5/r6): a chamber-disable-only sync that matches NO existing
+    // row has nothing to clear — do NOT create a calibration row. `row` carries
+    // only identity + a null chamber (ordinary temps were intentionally not copied
+    // above), so this never drops real calibration data; the pre-existing
+    // "resolved, row carries only identity" behaviour for non-chamber syncs is
+    // unchanged.
+    if (chamberClearOnly) {
       return { applied: false, unresolved: false };
     }
     merged.push(row);

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -148,7 +148,12 @@ export async function prepareBambuUpdate(
     // to strip).
     new Set<string>(),
   );
-  if (settingsResult.added.length > 0) {
+  // GH #950 (Codex r10): also write when the merge PURGED a never-baggable key
+  // from the existing bag (`removed`) — matching the OrcaSlicer route. Otherwise a
+  // Bambu sync that only updates structured fields on a row with a stale
+  // filament_settings_id/filamentdb_id returns 200 but never persists the cleaned
+  // bag, so the stale key keeps shadowing the re-derived name/id on later exports.
+  if (settingsResult.added.length > 0 || settingsResult.removed.length > 0) {
     update.settings = settingsResult.settings;
   }
 

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -388,7 +388,11 @@ export async function resolveAndApplyCalibration(
   // however, stays gated on `hasAnyHint`: chamber has a settings-bag fallback (see
   // prepareBambuUpdate), so a chamber-only profile that can't resolve loses
   // nothing and must not surface a misleading "calibration unresolved" toast.
-  const wantsResolution = hints.hasAnyHint || hints.chamberTemp != null;
+  // GH #950 (Codex r5): also attempt resolution when the profile DISABLES chamber
+  // heating — a resolved context lets us CLEAR a pre-existing calibrations[].
+  // chamberTemp so the disable actually takes (else /calibration re-enables it).
+  const wantsResolution =
+    hints.hasAnyHint || hints.chamberTemp != null || hints.chamberDisabled === true;
   if (!wantsResolution) {
     return { applied: false, unresolved: false };
   }
@@ -414,12 +418,28 @@ export async function resolveAndApplyCalibration(
   if (hints.fanMaxSpeed != null) row.fanMaxSpeed = hints.fanMaxSpeed;
   if (hints.fanBridgeSpeed != null) row.fanBridgeSpeed = hints.fanBridgeSpeed;
   if (hints.chamberTemp != null) row.chamberTemp = hints.chamberTemp; // GH #950
+  // GH #950 (Codex r5): an explicit disable with no new temp CLEARS the chamber
+  // value on the matched row (null = the schema default / "off").
+  else if (hints.chamberDisabled === true) row.chamberTemp = null;
   if (parsed.temperatures.nozzle != null) row.nozzleTemp = parsed.temperatures.nozzle;
   if (parsed.temperatures.nozzleFirstLayer != null) row.nozzleTempFirstLayer = parsed.temperatures.nozzleFirstLayer;
   if (parsed.temperatures.bed != null) row.bedTemp = parsed.temperatures.bed;
   if (parsed.temperatures.bedFirstLayer != null) row.bedTempFirstLayer = parsed.temperatures.bedFirstLayer;
 
-  const existingRows = (existing?.calibrations as Array<Record<string, unknown>>) || [];
+  // Normalize to PLAIN objects before spreading: the bulk/per-id routes pass a
+  // HYDRATED Mongoose doc, so `existing.calibrations[i]` are Mongoose subdocuments
+  // whose schema-field data lives in `_doc` (exposed via prototype getters, NOT own
+  // enumerable props). `{ ...subdoc }` would drop that data, so merging a new value
+  // onto an existing row silently lost the row's other fields (latent pre-#950 bug,
+  // only reachable when a re-sync updates an EXISTING calibration row — now exercised
+  // by the chamber-disable clear). `.toObject()` materialises the real data; plain
+  // objects (unit tests) have no toObject and pass through unchanged.
+  const existingRows = ((existing?.calibrations as Array<Record<string, unknown>>) || []).map(
+    (c) => {
+      const maybe = c as { toObject?: () => Record<string, unknown> };
+      return typeof maybe?.toObject === "function" ? maybe.toObject() : c;
+    },
+  );
   const idx = existingRows.findIndex(
     (c) =>
       String(c.printer) === ctx.printerId && String(c.nozzle) === ctx.nozzleId,
@@ -428,6 +448,19 @@ export async function resolveAndApplyCalibration(
   if (idx >= 0) {
     merged[idx] = { ...merged[idx], ...row };
   } else {
+    // GH #950 (Codex r5): a chamber-DISABLE-only profile (no hints/temp, resolved
+    // purely to clear chamber) that matches NO existing row has nothing to clear —
+    // don't create an empty {printer,nozzle,chamberTemp:null} row. Scoped strictly
+    // to that case so the pre-existing "resolved, row carries only identity"
+    // behaviour (e.g. a printer-match with no concrete values) is unchanged.
+    const chamberClearOnly =
+      hints.chamberDisabled === true && !hints.hasAnyHint && hints.chamberTemp == null;
+    const carriesData = Object.entries(row).some(
+      ([k, v]) => k !== "printer" && k !== "nozzle" && !(k === "chamberTemp" && v == null),
+    );
+    if (chamberClearOnly && !carriesData) {
+      return { applied: false, unresolved: false };
+    }
     merged.push(row);
   }
   update.calibrations = merged;

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -358,6 +358,7 @@ export async function resolveAndApplyCalibration(
   if (hints.fanMinSpeed != null) row.fanMinSpeed = hints.fanMinSpeed;
   if (hints.fanMaxSpeed != null) row.fanMaxSpeed = hints.fanMaxSpeed;
   if (hints.fanBridgeSpeed != null) row.fanBridgeSpeed = hints.fanBridgeSpeed;
+  if (hints.chamberTemp != null) row.chamberTemp = hints.chamberTemp; // GH #950
   if (parsed.temperatures.nozzle != null) row.nozzleTemp = parsed.temperatures.nozzle;
   if (parsed.temperatures.nozzleFirstLayer != null) row.nozzleTempFirstLayer = parsed.temperatures.nozzleFirstLayer;
   if (parsed.temperatures.bed != null) row.bedTemp = parsed.temperatures.bed;

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -384,7 +384,19 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
   // (in the route) applies size caps; here we just stringify.
   for (const [key, value] of Object.entries(json)) {
     if (STRUCTURED_KEYS.has(key)) continue;
-    if (CALIBRATION_KEYS.has(key)) continue;
+    if (CALIBRATION_KEYS.has(key)) {
+      // GH #950 (Codex P1 on PR #968 r2): the chamber keys are normally excluded
+      // here and routed structurally (calibrations[].chamberTemp) or via the
+      // applier's settings-bag fallback — but BOTH require an EFFECTIVE chamberTemp.
+      // When the chamber is DISABLED (activate_chamber_temp_control="0"), the parse
+      // above clears chamberTemp, so neither path carries the value and the settings
+      // bag is its ONLY home. Keep the raw chamber keys in the bag in that case so a
+      // disabled-chamber profile still round-trips (they rode the bag pre-#950.3).
+      const isChamberKey =
+        key === "chamber_temperature" || key === "activate_chamber_temp_control";
+      if (!isChamberKey || calibrationHints.chamberTemp != null) continue;
+      // else: disabled/ineffective chamber → fall through and store the raw key.
+    }
     // NOTE (#678, deferred): unwrap() collapses a multi-element array to its
     // first element, so a multi-printer `compatible_printers` loses the rest on
     // a Bambu/Orca round-trip. A faithful fix can't just store the array here —

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -235,6 +235,11 @@ export interface CalibrationHints {
   /** GH #950: chamber temperature → calibrations[].chamberTemp. The export
    * emits it (orcaSlicerBundle), so parse it back for a lossless round-trip. */
   chamberTemp?: number;
+  /** GH #950 (Codex r5): the profile EXPLICITLY disabled chamber heating
+   * (activate_chamber_temp_control="0"). Distinct from chamberTemp being absent —
+   * a disable must CLEAR a pre-existing calibrations[].chamberTemp on the resolved
+   * path, else /calibration re-enables chamber heat on the next round-trip. */
+  chamberDisabled?: boolean;
   /** True when at least one calibration-relevant value was present. The
    * route uses this to decide whether to upsert a calibrations[] row vs
    * leave the filament's calibration data alone. */
@@ -349,6 +354,9 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
       unwrap(json.activate_chamber_temp_control) === "0"
         ? undefined
         : num(json.chamber_temperature),
+    // GH #950 (Codex r5): record an explicit disable so the applier can CLEAR a
+    // pre-existing calibrations[].chamberTemp (a bare absence must not clear).
+    chamberDisabled: unwrap(json.activate_chamber_temp_control) === "0",
     hasAnyHint: false,
   };
   // Codex P3 on PR #387 round 6: `maxVolumetricSpeed` is the ONE

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -148,6 +148,8 @@ const CALIBRATION_KEYS = new Set<string>([
   "fan_min_speed",
   "fan_max_speed",
   "bridge_fan_speed",
+  "chamber_temperature",
+  "activate_chamber_temp_control",
 ]);
 
 /**
@@ -230,6 +232,9 @@ export interface CalibrationHints {
   fanMinSpeed?: number;
   fanMaxSpeed?: number;
   fanBridgeSpeed?: number;
+  /** GH #950: chamber temperature → calibrations[].chamberTemp. The export
+   * emits it (orcaSlicerBundle), so parse it back for a lossless round-trip. */
+  chamberTemp?: number;
   /** True when at least one calibration-relevant value was present. The
    * route uses this to decide whether to upsert a calibrations[] row vs
    * leave the filament's calibration data alone. */
@@ -337,6 +342,13 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
     fanMaxSpeed:
       num(json.additional_cooling_fan_speed) ?? num(json.fan_max_speed),
     fanBridgeSpeed: num(json.bridge_fan_speed),
+    // GH #950: honor the enable flag — activate_chamber_temp_control="0" means
+    // chamber heating is OFF, so don't import the temperature (matches the
+    // exporter, which only emits chamber_temperature when chamberTemp != null).
+    chamberTemp:
+      unwrap(json.activate_chamber_temp_control) === "0"
+        ? undefined
+        : num(json.chamber_temperature),
     hasAnyHint: false,
   };
   // Codex P3 on PR #387 round 6: `maxVolumetricSpeed` is the ONE
@@ -356,7 +368,8 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
     calibrationHints.retractLift != null ||
     calibrationHints.fanMinSpeed != null ||
     calibrationHints.fanMaxSpeed != null ||
-    calibrationHints.fanBridgeSpeed != null;
+    calibrationHints.fanBridgeSpeed != null ||
+    calibrationHints.chamberTemp != null;
 
   // ── Settings bag passthrough ────────────────────────────────────────
   // Anything we didn't pluck into a structured field OR a calibration

--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -360,6 +360,14 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
   // warning toast on successful imports. Exclude it from `hasAnyHint`
   // so we only enter the unresolved path when there's per-nozzle data
   // that would actually be dropped.
+  //
+  // GH #950 (Codex P2 on PR #968): `chamberTemp` is EXCLUDED for the same
+  // reason. Its structured home (calibrations[].chamberTemp) needs a resolved
+  // printer/nozzle, but when that can't be resolved `prepareBambuUpdate` falls
+  // back to preserving the raw chamber keys in the settings passthrough bag
+  // (the "misfiled but survives" state #950 rates acceptable) — so a
+  // chamber-only standalone profile loses nothing and must NOT trip the
+  // unresolved warning.
   calibrationHints.hasAnyHint =
     calibrationHints.extrusionMultiplier != null ||
     calibrationHints.pressureAdvance != null ||
@@ -368,8 +376,7 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
     calibrationHints.retractLift != null ||
     calibrationHints.fanMinSpeed != null ||
     calibrationHints.fanMaxSpeed != null ||
-    calibrationHints.fanBridgeSpeed != null ||
-    calibrationHints.chamberTemp != null;
+    calibrationHints.fanBridgeSpeed != null;
 
   // ── Settings bag passthrough ────────────────────────────────────────
   // Anything we didn't pluck into a structured field OR a calibration

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -146,6 +146,28 @@ export async function upsertIniFilament(
   const collapsed = stripStructuredSettings(section);
   const name = collapsed.name;
 
+  // GH #950: id-first refuse-ambiguous. When the section round-trips a
+  // `filamentdb_id` (the filament _id) that resolves to an ACTIVE filament whose
+  // stored name DIFFERS from the section name, the case is ambiguous — a renamed
+  // preset (id right) vs a copied/stale id pointing at the wrong row,
+  // indistinguishable here. Refuse (throw → per-row skip) rather than silently
+  // renaming/mutating the wrong filament OR creating an orphan under the section
+  // name. Mirrors the per-id sync route's name_id_mismatch conservatism. A
+  // matching name — or a stale/absent id — falls through to the name-based
+  // upsert below.
+  const fid = collapsed.filamentdbId;
+  if (fid && /^[a-f0-9]{24}$/i.test(fid)) {
+    const byId = await Filament.findOne({ _id: fid, _deletedAt: null })
+      .select("_id name")
+      .lean();
+    if (byId && byId.name !== name) {
+      throw new Error(
+        `filamentdb_id ${fid} resolves to "${byId.name}", but this section is named ` +
+          `"${name}" — not imported (rename the section to match, or resolve the id/name conflict).`,
+      );
+    }
+  }
+
   // Phase 1 — update an existing ACTIVE row.
   const existingActive = await Filament.findOne({ name, _deletedAt: null })
     .select(INI_INHERITANCE_PROJECTION)

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -122,8 +122,9 @@ export function filamentToOrcaSlicerKeys(
     set("filament_notes", filament.notes);
   }
 
-  // Soluble flag
-  if (filament.soluble != null) set("filament_soluble", filament.soluble ? "1" : "0");
+  // GH #950: filament_soluble lives only in the settings bag (no schema field);
+  // the settings passthrough above already carries it. The old
+  // `set(..., filament.soluble)` read an always-undefined field — removed.
 
   // Shrinkage
   if (filament.shrinkageXY != null) set("filament_shrink", String(filament.shrinkageXY) + "%");

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -237,7 +237,15 @@ export function collapsePerNozzleImportSections(
       // round-trips there.)
       if (k === "compatible_printers_condition") {
         const v = settings[k];
-        const isDerived = typeof v === "string" && v.includes("nozzle_diameter[");
+        // Codex P2 on PR #968 r4: match ONLY the exact auto-derived shape — one or
+        // more `nozzle_diameter[<n>]==<number>` terms joined by ` or ` (the
+        // calibration bake emits a single term, the non-calibration derivation an
+        // ` or `-joined set). A substring test would wrongly strip a legitimate
+        // user pin that merely REFERENCES a nozzle diameter, e.g.
+        // `printer_model==MK4 and nozzle_diameter[0]==0.4`.
+        const isDerived =
+          typeof v === "string" &&
+          /^nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: or nozzle_diameter\[\d+\]==\d+(?:\.\d+)?)*$/.test(v);
         const isEmpty = v === "" || v === undefined;
         if (isDerived || isEmpty) delete settings[k];
         // else: user pin (non-derived string) or nil (null) → keep for round-trip.

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -142,6 +142,14 @@ const PER_NOZZLE_BAKED_SETTING_KEYS = [
 const IMPORT_ROUTING_HINT_KEYS = ["filamentdb_id", "filamentdb_nozzle"];
 
 /**
+ * Keys stripped from a collapsed section's stored settings bag: the routing
+ * hints (never data) plus `filament_settings_id` — GH #950: the export
+ * re-derives filament_settings_id from the filament's CURRENT name, so keeping a
+ * stale copy in the bag would make a renamed filament export its old name.
+ */
+const SETTINGS_STRIP_KEYS = [...IMPORT_ROUTING_HINT_KEYS, "filament_settings_id"];
+
+/**
  * A parsed INI section after collapsing. `temperatures`/`maxVolumetricSpeed` are
  * OPTIONAL because a collapsed per-nozzle section omits them (they were baked
  * per-nozzle, so an UPDATE must not overwrite the base filament's shared values).
@@ -158,6 +166,10 @@ export type CollapsedFilamentData = Omit<
   color?: string;
   vendor?: string;
   type?: string;
+  /** GH #950: the section's round-tripped `filamentdb_id` routing hint (the
+   *  filament _id). Carried for id-first resolution in `upsertIniFilament`;
+   *  NEVER persisted (stripped from the settings bag above). */
+  filamentdbId?: string;
 };
 
 /**
@@ -180,10 +192,26 @@ export function collapsePerNozzleImportSections(
   for (const f of filaments) {
     const hint = (f.settings.filamentdb_nozzle ?? "").trim();
     if (!hint) {
-      // Pass through, but never persist routing hints as settings data.
+      // Pass through, but never persist routing hints / re-derived keys.
       const settings = { ...f.settings };
-      for (const k of IMPORT_ROUTING_HINT_KEYS) delete settings[k];
-      out.push({ ...f, settings });
+      for (const k of SETTINGS_STRIP_KEYS) delete settings[k];
+      const collapsed: CollapsedFilamentData = { ...f, settings };
+      // GH #950: leave-when-omitted. parseIni fills absent fields with defaults
+      // (null / "#808080" / 1.75 / "Unknown"); $set-ing those over a name-matched
+      // existing filament CLOBBERS its real values on a partial/hand-crafted
+      // section. Drop each field the section didn't actually supply (same idiom
+      // the hinted branch below uses). The normal export writes all of them, so
+      // a full round-trip is unaffected.
+      if (!("filament_cost" in f.settings)) delete collapsed.cost;
+      if (!("filament_density" in f.settings)) delete collapsed.density;
+      if (!("filament_diameter" in f.settings)) delete collapsed.diameter;
+      if (!("filament_colour" in f.settings)) delete collapsed.color;
+      if (!("filament_vendor" in f.settings)) delete collapsed.vendor;
+      if (!("filament_type" in f.settings)) delete collapsed.type;
+      if (!("filament_max_volumetric_speed" in f.settings)) delete collapsed.maxVolumetricSpeed;
+      const fid = (f.settings.filamentdb_id ?? "").trim();
+      if (fid) collapsed.filamentdbId = fid; // GH #950: id-first resolution hint
+      out.push(collapsed);
       continue;
     }
     // Per-nozzle suffixed section → fold back into its base filament.
@@ -195,7 +223,7 @@ export function collapsePerNozzleImportSections(
     if (seenGroups.has(groupKey)) continue; // a sibling already represents the base
     seenGroups.add(groupKey);
     const settings = { ...f.settings };
-    for (const k of [...PER_NOZZLE_BAKED_SETTING_KEYS, ...IMPORT_ROUTING_HINT_KEYS]) {
+    for (const k of [...PER_NOZZLE_BAKED_SETTING_KEYS, ...SETTINGS_STRIP_KEYS]) {
       delete settings[k];
     }
     // Drop temperatures + maxVolumetricSpeed (baked per-nozzle): omitting the keys
@@ -204,6 +232,7 @@ export function collapsePerNozzleImportSections(
     void temperatures;
     void maxVolumetricSpeed;
     const collapsed: CollapsedFilamentData = { ...sharedFields, name: baseName, settings };
+    if (id) collapsed.filamentdbId = id; // GH #950: id-first resolution hint
     // Carry a shared field ONLY when the suffixed section actually SUPPLIED it (the
     // source INI key is present) — otherwise parseIni's defaults (null / "#808080" /
     // 1.75 / "Unknown") would $set over the base filament's real cost/density/color/
@@ -293,9 +322,10 @@ export function filamentToSlicerKeys(
     keys.filament_notes = filament.notes;
   }
 
-  // Soluble / abrasive flags
-  if (filament.soluble != null) set("filament_soluble", filament.soluble ? "1" : "0");
-  if (filament.abrasive != null) set("filament_abrasive", filament.abrasive ? "1" : "0");
+  // GH #950: filament_soluble / filament_abrasive live ONLY in the settings bag
+  // (the schema has no such fields), and the `keys` seed above already carries
+  // them from `filament.settings`. The old `set(..., filament.soluble)` read a
+  // field that's always undefined — a dead no-op — so it's removed.
 
   // Shrinkage
   if (filament.shrinkageXY != null)
@@ -328,7 +358,17 @@ export function filamentToSlicerKeys(
     set("bridge_fan_speed", calibration.fanBridgeSpeed);
     const nz = calibration.nozzle;
     if (nz && typeof nz === "object" && nz.diameter != null) {
-      keys.compatible_printers_condition = `nozzle_diameter[0]==${nz.diameter}`;
+      // GH #950: gate the baked condition the same way the non-calibration
+      // derivation below is — a round-tripped user pin (non-empty string) or the
+      // `nil` inheritance marker (null) must win. Only set when the key is absent
+      // or an empty-string "no restriction". `filamentdb_nozzle` stays
+      // unconditional — it's a routing hint for THIS nozzle, not a user setting.
+      if (
+        !("compatible_printers_condition" in keys) ||
+        keys.compatible_printers_condition === ""
+      ) {
+        keys.compatible_printers_condition = `nozzle_diameter[0]==${nz.diameter}`;
+      }
       keys.filamentdb_nozzle = nozzleSuffix(nz);
     }
   }

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -224,6 +224,25 @@ export function collapsePerNozzleImportSections(
     seenGroups.add(groupKey);
     const settings = { ...f.settings };
     for (const k of [...PER_NOZZLE_BAKED_SETTING_KEYS, ...SETTINGS_STRIP_KEYS]) {
+      // GH #950 (Codex P2 on PR #968 r3): compatible_printers_condition is
+      // normally "baked" (an auto-derived nozzle_diameter[...] value, different per
+      // suffixed section) so it's stripped and re-derived on the next export. But
+      // the 950.2 export now also carries a USER PIN (a non-derived restriction) or
+      // the `nil` inheritance marker through the per-nozzle sections — and since the
+      // importer $set-s the WHOLE settings bag, unconditionally stripping those
+      // would DESTROY the pin on export→import (lossy). Strip ONLY the auto-derived
+      // shape (contains `nozzle_diameter[`) or an empty "no restriction"; preserve a
+      // user pin (any other non-empty string) and nil (null) so they round-trip.
+      // (The single-nozzle / non-hinted branch never strips this key, so it already
+      // round-trips there.)
+      if (k === "compatible_printers_condition") {
+        const v = settings[k];
+        const isDerived = typeof v === "string" && v.includes("nozzle_diameter[");
+        const isEmpty = v === "" || v === undefined;
+        if (isDerived || isEmpty) delete settings[k];
+        // else: user pin (non-derived string) or nil (null) → keep for round-trip.
+        continue;
+      }
       delete settings[k];
     }
     // Drop temperatures + maxVolumetricSpeed (baked per-nozzle): omitting the keys

--- a/src/lib/singleFilamentExport.ts
+++ b/src/lib/singleFilamentExport.ts
@@ -51,15 +51,19 @@ export async function resolveFilamentForExport(
   // dangling `%` — turning a valid export into a 500 (Codex P2 on
   // PR #247).
 
-  // Name lookup first (the slicer modules address filaments by name),
-  // then ObjectId fallback when the param looks like one.
-  let filament = (await withPopulate(
-    Filament.findOne({ name: idOrName, _deletedAt: null }),
-  ).lean()) as FilamentDoc | null;
-
-  if (!filament && /^[a-f0-9]{24}$/i.test(idOrName)) {
+  // GH #950 / #867: a 24-hex param is an ObjectId and is AUTHORITATIVE — try it
+  // FIRST, falling back to a name lookup only when that _id misses (a preset
+  // legitimately NAMED with 24 hex chars). Name-first would let such a name
+  // shadow another filament's real _id.
+  let filament: FilamentDoc | null = null;
+  if (/^[a-f0-9]{24}$/i.test(idOrName)) {
     filament = (await withPopulate(
       Filament.findOne({ _id: idOrName, _deletedAt: null }),
+    ).lean()) as FilamentDoc | null;
+  }
+  if (!filament) {
+    filament = (await withPopulate(
+      Filament.findOne({ name: idOrName, _deletedAt: null }),
     ).lean()) as FilamentDoc | null;
   }
 

--- a/src/lib/slicerSettings.ts
+++ b/src/lib/slicerSettings.ts
@@ -42,6 +42,20 @@ export function mergeSlicerSettings(
   structuredKeys: Set<string>,
 ): SettingsMergeResult {
   const settings: Record<string, unknown> = { ...existing };
+  // GH #950 (adversarial sweep on PR #968): a structured-owned key must never
+  // live in the settings bag — it's authoritative as a structured field, is
+  // re-derived on export (e.g. `filament_settings_id` from the CURRENT name), or
+  // is a pure routing hint (`filamentdb_id`/`filamentdb_nozzle`). The incoming
+  // loop below already skips these, but a STALE copy carried in `existing`
+  // (legacy data written before this rule) would otherwise survive the merge and
+  // shadow the structured value on the next export — the exact 950.5 leak, closed
+  // on the INI bulk-import path (which full-replaces a stripped bag) but not on
+  // the per-id merge paths. Strip them from the seeded `existing` bag too so the
+  // merge is source-agnostic. (Takes full effect where the caller writes
+  // update.settings unconditionally — the PrusaSlicer per-id sync; the OrcaSlicer
+  // per-id sync gates on `added`, so its purge lands whenever the sync also adds a
+  // passthrough key. Bambu passes an empty structuredKeys set → no-op there.)
+  for (const key of structuredKeys) delete settings[key];
   const added: string[] = [];
 
   for (const [key, value] of Object.entries(incoming)) {

--- a/src/lib/slicerSettings.ts
+++ b/src/lib/slicerSettings.ts
@@ -26,6 +26,14 @@ export interface SettingsMergeResult {
   settings: Record<string, unknown>;
   /** Keys that were added/updated from `incoming`. */
   added: string[];
+  /**
+   * Structured-owned keys that were PURGED from the seeded `existing` bag
+   * (GH #950 sweep). A caller that only conditionally writes `update.settings`
+   * (e.g. the OrcaSlicer per-id sync gates on `added`) MUST also write when
+   * `removed` is non-empty, or the cleaned bag is discarded and the stale
+   * shadow survives.
+   */
+  removed: string[];
   /** Non-null when a cap was exceeded — the caller should reject with 400. */
   error: string | null;
 }
@@ -51,11 +59,17 @@ export function mergeSlicerSettings(
   // shadow the structured value on the next export — the exact 950.5 leak, closed
   // on the INI bulk-import path (which full-replaces a stripped bag) but not on
   // the per-id merge paths. Strip them from the seeded `existing` bag too so the
-  // merge is source-agnostic. (Takes full effect where the caller writes
-  // update.settings unconditionally — the PrusaSlicer per-id sync; the OrcaSlicer
-  // per-id sync gates on `added`, so its purge lands whenever the sync also adds a
-  // passthrough key. Bambu passes an empty structuredKeys set → no-op there.)
-  for (const key of structuredKeys) delete settings[key];
+  // merge is source-agnostic, and report them in `removed` so a caller that only
+  // conditionally writes update.settings (the OrcaSlicer per-id sync gates on
+  // `added`) still persists the purge. Bambu passes an empty structuredKeys set →
+  // no-op there.
+  const removed: string[] = [];
+  for (const key of structuredKeys) {
+    if (key in settings) {
+      delete settings[key];
+      removed.push(key);
+    }
+  }
   const added: string[] = [];
 
   for (const [key, value] of Object.entries(incoming)) {
@@ -65,6 +79,7 @@ export function mergeSlicerSettings(
       return {
         settings,
         added,
+        removed,
         error: `settings.${key} value exceeds the ${MAX_SETTING_VALUE_LENGTH}-character limit`,
       };
     }
@@ -76,9 +91,10 @@ export function mergeSlicerSettings(
     return {
       settings,
       added,
+      removed,
       error: `settings bag exceeds the ${MAX_SETTINGS_KEYS}-key limit`,
     };
   }
 
-  return { settings, added, error: null };
+  return { settings, added, removed, error: null };
 }

--- a/src/lib/slicerSettings.ts
+++ b/src/lib/slicerSettings.ts
@@ -39,6 +39,28 @@ export interface SettingsMergeResult {
 }
 
 /**
+ * Keys that must NEVER persist in the settings bag, regardless of the caller's
+ * `structuredKeys`: `filament_settings_id` is re-derived from the filament's
+ * CURRENT name on export, and `filamentdb_id`/`filamentdb_nozzle` are pure routing
+ * hints. A STALE copy of any of these in `existing` shadows the re-derived value
+ * on the next export (the 950.5 leak), so they are purged from the seeded bag.
+ *
+ * This is DELIBERATELY narrower than `structuredKeys`. GH #950 Codex r8: the Prusa
+ * per-id calibration sync adds context-only keys (`extrusion_multiplier`,
+ * retraction, fan speeds) to its `structuredKeys` — but those have NO top-level
+ * filament home and can legitimately live in the bag as shared filament-wide
+ * defaults, so purging the whole `structuredKeys` set erased them on every
+ * per-nozzle sync. Purge ONLY the truly never-baggable keys here; the other
+ * structured keys either have a top-level field that overrides any stale bag
+ * shadow on export (harmless) or are legit shared defaults (must survive).
+ */
+export const NEVER_BAGGED_KEYS = new Set([
+  "filament_settings_id",
+  "filamentdb_id",
+  "filamentdb_nozzle",
+]);
+
+/**
  * Merge `incoming` config keys into a copy of `existing`, skipping any
  * key in `structuredKeys` (those map to first-class Filament fields).
  * Enforces {@link MAX_SETTING_VALUE_LENGTH} per value and
@@ -50,21 +72,16 @@ export function mergeSlicerSettings(
   structuredKeys: Set<string>,
 ): SettingsMergeResult {
   const settings: Record<string, unknown> = { ...existing };
-  // GH #950 (adversarial sweep on PR #968): a structured-owned key must never
-  // live in the settings bag — it's authoritative as a structured field, is
-  // re-derived on export (e.g. `filament_settings_id` from the CURRENT name), or
-  // is a pure routing hint (`filamentdb_id`/`filamentdb_nozzle`). The incoming
-  // loop below already skips these, but a STALE copy carried in `existing`
-  // (legacy data written before this rule) would otherwise survive the merge and
-  // shadow the structured value on the next export — the exact 950.5 leak, closed
-  // on the INI bulk-import path (which full-replaces a stripped bag) but not on
-  // the per-id merge paths. Strip them from the seeded `existing` bag too so the
-  // merge is source-agnostic, and report them in `removed` so a caller that only
-  // conditionally writes update.settings (the OrcaSlicer per-id sync gates on
-  // `added`) still persists the purge. Bambu passes an empty structuredKeys set →
-  // no-op there.
+  // GH #950 (sweep + Codex r8): purge only the truly never-baggable keys
+  // ({@link NEVER_BAGGED_KEYS}) from the seeded `existing` bag — a stale copy of
+  // those shadows the re-derived export value. Report them in `removed` so a
+  // caller that only conditionally writes update.settings (the OrcaSlicer per-id
+  // sync gates on `added`) still persists the purge. Crucially this does NOT strip
+  // the whole `structuredKeys` set: per-id calibration syncs list context keys
+  // (extrusion_multiplier / retraction / fans) there which can be legit shared
+  // bag defaults and must survive.
   const removed: string[] = [];
-  for (const key of structuredKeys) {
+  for (const key of NEVER_BAGGED_KEYS) {
     if (key in settings) {
       delete settings[key];
       removed.push(key);

--- a/src/lib/slicerSettings.ts
+++ b/src/lib/slicerSettings.ts
@@ -90,7 +90,13 @@ export function mergeSlicerSettings(
   const added: string[] = [];
 
   for (const [key, value] of Object.entries(incoming)) {
-    if (structuredKeys.has(key)) continue;
+    // Skip caller-structured keys AND the never-baggable keys (GH #950 Codex r9):
+    // purging them only from `existing` is not enough — a caller whose
+    // structuredKeys omits e.g. `filament_settings_id` (the OrcaSlicer per-id sync)
+    // would otherwise re-add an incoming copy to the bag, re-shadowing the
+    // re-derived export value. Keeping them out of BOTH sources makes the
+    // never-baggable guarantee hold regardless of the caller's structured set.
+    if (structuredKeys.has(key) || NEVER_BAGGED_KEYS.has(key)) continue;
     const serialized = JSON.stringify(value ?? null);
     if (serialized.length > MAX_SETTING_VALUE_LENGTH) {
       return {

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1601,6 +1601,29 @@ describe("API route correctness", () => {
       expect(fresh.density).toBe(1.24); // structured field still applied
     });
 
+    it("950.5 (sweep r5) — an orca sync changing ONLY structured fields still purges a stale structured shadow from the bag", async () => {
+      // The orca per-id route gates its settings write on `added`; without honoring
+      // `removed`, a structured-only sync discards the purge and the stale shadow
+      // survives. Pin that the purge lands even with no incoming passthrough key.
+      const f = await Filament.create({
+        name: "Orca Sweep PLA",
+        vendor: "X",
+        type: "PLA",
+        settings: { density: "9.9", filament_notes: "keep" },
+      });
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, { type: "PETG" }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id).lean();
+      // Stale structured shadow purged despite no passthrough key being added.
+      expect(fresh.settings?.density).toBeUndefined();
+      // Real passthrough survives; the structured field is applied.
+      expect(fresh.settings?.filament_notes).toBe("keep");
+      expect(fresh.type).toBe("PETG");
+    });
+
     it("950.6 — spool-check resolves a 24-hex URL by _id FIRST, not a name that looks like an id", async () => {
       // The slicer-facing GET routes must resolve the same way as the id-first
       // sync/export routes, or a slicer addressing by id reads the WRONG row.

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1575,6 +1575,32 @@ describe("API route correctness", () => {
       expect(res.status).toBe(404);
     });
 
+    it("950.5 (sweep) — a per-id sync PURGES a stale structured key (filament_settings_id) from the existing settings bag", async () => {
+      // Latent 950.5 leak on the merge path: a legacy bag carrying a structured
+      // key would survive the merge (mergeSlicerSettings only skipped it from the
+      // INCOMING config) and shadow the re-derived value on the next export. The
+      // fix strips structured keys from the seeded existing bag too.
+      const f = await Filament.create({
+        name: "Sweep PLA",
+        vendor: "X",
+        type: "PLA",
+        settings: { filament_settings_id: "Stale Old Name", some_passthrough: "keep" },
+      });
+      const res = await slicerSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}`, {
+          config: { filament_density: "1.24" },
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id).lean();
+      // Stale structured shadow purged (export re-derives filament_settings_id from name).
+      expect(fresh.settings?.filament_settings_id).toBeUndefined();
+      // Genuine passthrough keys survive.
+      expect(fresh.settings?.some_passthrough).toBe("keep");
+      expect(fresh.density).toBe(1.24); // structured field still applied
+    });
+
     it("950.6 — spool-check resolves a 24-hex URL by _id FIRST, not a name that looks like an id", async () => {
       // The slicer-facing GET routes must resolve the same way as the id-first
       // sync/export routes, or a slicer addressing by id reads the WRONG row.

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1535,6 +1535,38 @@ describe("API route correctness", () => {
       expect(fresh.density).toBe(1.23);
     });
 
+    it("950.5 (sweep r8) — a per-nozzle sync PRESERVES a shared calibration default in the settings bag", async () => {
+      // The per-id calibration sync adds context keys (extrusion_multiplier /
+      // retraction / fans) to STRUCTURED_KEYS. A prior over-broad purge stripped
+      // ALL structuredKeys from the existing bag, erasing a filament-wide shared EM
+      // default on every per-nozzle sync. The purge is now narrow (never-baggable
+      // only), so shared bag defaults the incoming preset didn't touch survive.
+      const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
+      const f = await Filament.create({
+        name: "PLA",
+        vendor: "X",
+        type: "PLA",
+        compatibleNozzles: [brass._id],
+        settings: { extrusion_multiplier: "0.98", some_passthrough: "keep" },
+      });
+      const res = await slicerSync(
+        jsonReq("http://localhost/api/filaments/PLA%200.4%20Brass", {
+          config: {
+            filamentdb_id: String(f._id),
+            filamentdb_nozzle: "0.4 Brass",
+            pressure_advance: "0.03", // routes to the calibration entry, not the bag
+          },
+        }),
+        { params: Promise.resolve({ id: "PLA 0.4 Brass" }) },
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id).lean();
+      // The shared EM default (a structuredKey in calibration mode, but with no
+      // top-level home) is NOT erased by the per-nozzle sync.
+      expect(fresh.settings?.extrusion_multiplier).toBe("0.98");
+      expect(fresh.settings?.some_passthrough).toBe("keep");
+    });
+
     it("950.7 — a per-nozzle preset sync with an absent filamentdb_id falls back to the BASE name (no orphan)", async () => {
       const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
       const f = await Filament.create({
@@ -1601,15 +1633,16 @@ describe("API route correctness", () => {
       expect(fresh.density).toBe(1.24); // structured field still applied
     });
 
-    it("950.5 (sweep r5) — an orca sync changing ONLY structured fields still purges a stale structured shadow from the bag", async () => {
+    it("950.5 (sweep r5/r8) — an orca sync purges a stale filament_settings_id even with no new passthrough key, but preserves other bag keys", async () => {
       // The orca per-id route gates its settings write on `added`; without honoring
-      // `removed`, a structured-only sync discards the purge and the stale shadow
-      // survives. Pin that the purge lands even with no incoming passthrough key.
+      // `removed`, a structured-only sync discards the purge and the stale
+      // never-baggable key survives. And per r8 the purge must be NARROW — a
+      // non-never-baggable stale shadow (density) must survive.
       const f = await Filament.create({
         name: "Orca Sweep PLA",
         vendor: "X",
         type: "PLA",
-        settings: { density: "9.9", filament_notes: "keep" },
+        settings: { filament_settings_id: "Stale Name", density: "9.9", filament_notes: "keep" },
       });
       const res = await orcaSync(
         jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, { type: "PETG" }),
@@ -1617,9 +1650,10 @@ describe("API route correctness", () => {
       );
       expect(res.status).toBe(200);
       const fresh = await Filament.findById(f._id).lean();
-      // Stale structured shadow purged despite no passthrough key being added.
-      expect(fresh.settings?.density).toBeUndefined();
-      // Real passthrough survives; the structured field is applied.
+      // Never-baggable key purged despite no passthrough key being added...
+      expect(fresh.settings?.filament_settings_id).toBeUndefined();
+      // ...but a non-never-baggable shadow + real passthrough survive (narrow purge).
+      expect(fresh.settings?.density).toBe("9.9");
       expect(fresh.settings?.filament_notes).toBe("keep");
       expect(fresh.type).toBe("PETG");
     });

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1633,6 +1633,23 @@ describe("API route correctness", () => {
       expect(fresh.density).toBe(1.24); // structured field still applied
     });
 
+    it("950.5 (sweep r9) — an orca sync does NOT persist an INCOMING filament_settings_id into the bag", async () => {
+      // orca's STRUCTURED_KEYS omits filament_settings_id, so without skipping
+      // never-baggable keys from incoming, the exported preset-name key would land
+      // in the bag and shadow the re-derived name on the next export.
+      const f = await Filament.create({ name: "Orca Incoming PLA", vendor: "X", type: "PLA" });
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, {
+          type: "PLA",
+          filament_settings_id: "Some Preset Name", // incoming never-baggable key
+        }),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id).lean();
+      expect(fresh.settings?.filament_settings_id).toBeUndefined(); // not persisted
+    });
+
     it("950.5 (sweep r5/r8) — an orca sync purges a stale filament_settings_id even with no new passthrough key, but preserves other bag keys", async () => {
       // The orca per-id route gates its settings write on `added`; without honoring
       // `removed`, a structured-only sync discards the purge and the stale

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1512,4 +1512,115 @@ describe("API route correctness", () => {
       expect(res.status).toBe(400);
     });
   });
+
+  // ── #950: slicer round-trip fidelity + id-first addressing ──────────
+
+  describe("#950 — slicer round-trip fidelity + id-first addressing", () => {
+    it("950.1 — a per-id sync keeps filament_soluble/abrasive in the settings bag (no dead structured write)", async () => {
+      const f = await Filament.create({ name: "PVA", vendor: "X", type: "PVA" });
+      const res = await slicerSync(
+        jsonReq("http://localhost/api/filaments/PVA", {
+          config: { filament_soluble: "1", filament_abrasive: "0", filament_density: "1.23" },
+        }),
+        { params: Promise.resolve({ id: "PVA" }) },
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id).lean();
+      // The schema has no soluble/abrasive columns, so the old structured write
+      // dropped them into the void. They now ride the settings bag, so a later
+      // slicer export re-emits them (round-trip preserved).
+      expect(fresh.settings?.filament_soluble).toBe("1");
+      expect(fresh.settings?.filament_abrasive).toBe("0");
+      // A genuinely structured key still lands on its top-level field.
+      expect(fresh.density).toBe(1.23);
+    });
+
+    it("950.7 — a per-nozzle preset sync with an absent filamentdb_id falls back to the BASE name (no orphan)", async () => {
+      const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
+      const f = await Filament.create({
+        name: "PLA",
+        vendor: "X",
+        type: "PLA",
+        compatibleNozzles: [brass._id],
+      });
+      // Suffixed URL, filamentdb_nozzle hint, but NO filamentdb_id (DB-instance-
+      // specific; stale/absent after a fresh install). Pre-fix the full suffixed
+      // name missed → 404 → the fork spawned a "PLA 0.4 Brass" orphan.
+      const res = await slicerSync(
+        jsonReq("http://localhost/api/filaments/PLA%200.4%20Brass", {
+          config: { filamentdb_nozzle: "0.4 Brass", extrusion_multiplier: "1.03" },
+        }),
+        { params: Promise.resolve({ id: "PLA 0.4 Brass" }) },
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).matchedBy).toBe("name");
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.name).toBe("PLA"); // base filament resolved + name untouched
+      expect(fresh.calibrations).toHaveLength(1);
+      expect(fresh.calibrations[0].extrusionMultiplier).toBe(1.03);
+      expect(String(fresh.calibrations[0].nozzle)).toBe(String(brass._id));
+      // No orphan created under the suffixed name.
+      expect(await Filament.findOne({ name: "PLA 0.4 Brass" })).toBeNull();
+    });
+
+    it("950.7 — a suffixed name whose base ALSO misses still 404s (no false base match)", async () => {
+      // No "PLA" filament exists; the base-name retry finds nothing → 404, and the
+      // fork's create path is the correct outcome here (genuinely new preset).
+      const res = await slicerSync(
+        jsonReq("http://localhost/api/filaments/PLA%200.4%20Brass", {
+          config: { filamentdb_nozzle: "0.4 Brass", extrusion_multiplier: "1.03" },
+        }),
+        { params: Promise.resolve({ id: "PLA 0.4 Brass" }) },
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("950.6 — spool-check resolves a 24-hex URL by _id FIRST, not a name that looks like an id", async () => {
+      // The slicer-facing GET routes must resolve the same way as the id-first
+      // sync/export routes, or a slicer addressing by id reads the WRONG row.
+      const real = await Filament.create({
+        name: "Real Spool PLA",
+        vendor: "X",
+        type: "PLA",
+        totalWeight: 1000,
+        spoolWeight: 200,
+      });
+      // A DIFFERENT filament NAMED with the real one's 24-hex _id, with NO stock.
+      await Filament.create({
+        name: String(real._id),
+        vendor: "X",
+        type: "ABS",
+        totalWeight: 0,
+        spoolWeight: 200,
+      });
+      const res = await spoolCheck(
+        getReq(`http://localhost/api/filaments/${real._id}/spool-check?weight=100`),
+        { params: Promise.resolve({ id: String(real._id) }) },
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // The _id lookup wins: we check the real (stocked) filament, not the empty decoy.
+      expect(body.ok).toBe(true);
+      expect(body.spools.length).toBe(1);
+    });
+
+    it("950.6 — orcaslicer sync resolves a 24-hex URL by _id FIRST, not a name that looks like an id", async () => {
+      const real = await Filament.create({ name: "Real PLA", vendor: "X", type: "PLA" });
+      // A DIFFERENT filament whose NAME happens to be the real one's 24-hex _id.
+      await Filament.create({ name: String(real._id), vendor: "X", type: "ABS" });
+      const res = await orcaSync(
+        jsonReq(`http://localhost/api/filaments/${real._id}/orcaslicer`, {
+          filament_settings_id: String(real._id),
+          name: String(real._id),
+          type: "PETG",
+        }),
+        { params: Promise.resolve({ id: String(real._id) }) },
+      );
+      expect(res.status).toBe(200);
+      // The _id lookup wins: the sync targets "Real PLA", not the hex-named decoy.
+      expect((await res.json()).filament).toBe("Real PLA");
+      expect((await Filament.findById(real._id)).type).toBe("PETG");
+      expect((await Filament.findOne({ name: String(real._id) })).type).toBe("ABS"); // decoy untouched
+    });
+  });
 });

--- a/tests/bambuStudioApply.test.ts
+++ b/tests/bambuStudioApply.test.ts
@@ -516,6 +516,7 @@ describe("resolveAndApplyCalibration (DB-backed)", () => {
         fanMinSpeed: 20,
         fanMaxSpeed: 100,
         fanBridgeSpeed: 80,
+        chamberTemp: 45, // GH #950
       }),
       update,
       null,
@@ -540,6 +541,7 @@ describe("resolveAndApplyCalibration (DB-backed)", () => {
     expect(row.fanMinSpeed).toBe(20);
     expect(row.fanMaxSpeed).toBe(100);
     expect(row.fanBridgeSpeed).toBe(80);
+    expect(row.chamberTemp).toBe(45); // GH #950
     expect(row.nozzleTemp).toBe(210);
     expect(row.nozzleTempFirstLayer).toBe(215);
     expect(row.bedTemp).toBe(60);

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -266,6 +266,20 @@ describe("parseBambuStudioProfile", () => {
       activate_chamber_temp_control: ["1"],
     });
     expect(calibrationHints.chamberTemp).toBe(45);
+    // chamber alone does NOT trip hasAnyHint (Codex P2 PR #968): it has a
+    // settings-bag fallback when calibration can't resolve, so a chamber-only
+    // profile must not surface a misleading "calibration unresolved" warning —
+    // same posture as maxVolumetricSpeed.
+    expect(calibrationHints.hasAnyHint).toBe(false);
+  });
+
+  it("GH #950: chamber_temperature ALONGSIDE a real per-nozzle hint still trips hasAnyHint", () => {
+    const { calibrationHints } = parseBambuStudioProfile({
+      name: ["X"],
+      chamber_temperature: ["45"],
+      pressure_advance: ["0.02"], // a genuine per-nozzle value with no other home
+    });
+    expect(calibrationHints.chamberTemp).toBe(45);
     expect(calibrationHints.hasAnyHint).toBe(true);
   });
 
@@ -286,7 +300,7 @@ describe("parseBambuStudioProfile", () => {
       chamber_temperature: ["50"],
     });
     expect(calibrationHints.chamberTemp).toBe(50);
-    expect(calibrationHints.hasAnyHint).toBe(true);
+    expect(calibrationHints.hasAnyHint).toBe(false); // chamber alone → no unresolved warning
   });
 
   it("GH #950: round-trips chamberTemp via calibrationToOrcaSlicerKeys", async () => {

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -259,6 +259,43 @@ describe("parseBambuStudioProfile", () => {
     expect(calibrationHints.fanBridgeSpeed).toBe(original.fanBridgeSpeed);
   });
 
+  it("GH #950: parses chamber_temperature into a chamberTemp calibration hint", () => {
+    const { calibrationHints } = parseBambuStudioProfile({
+      name: ["X"],
+      chamber_temperature: ["45"],
+      activate_chamber_temp_control: ["1"],
+    });
+    expect(calibrationHints.chamberTemp).toBe(45);
+    expect(calibrationHints.hasAnyHint).toBe(true);
+  });
+
+  it("GH #950: honors activate_chamber_temp_control='0' — chamber heating OFF, temp not imported", () => {
+    const { calibrationHints } = parseBambuStudioProfile({
+      name: ["X"],
+      chamber_temperature: ["45"], // stale value with heating disabled
+      activate_chamber_temp_control: ["0"],
+    });
+    expect(calibrationHints.chamberTemp).toBeUndefined();
+    // chamber is the ONLY would-be hint and it's suppressed → no calibration row.
+    expect(calibrationHints.hasAnyHint).toBe(false);
+  });
+
+  it("GH #950: parses chamber_temperature when the enable flag is absent (defaults to on)", () => {
+    const { calibrationHints } = parseBambuStudioProfile({
+      name: ["X"],
+      chamber_temperature: ["50"],
+    });
+    expect(calibrationHints.chamberTemp).toBe(50);
+    expect(calibrationHints.hasAnyHint).toBe(true);
+  });
+
+  it("GH #950: round-trips chamberTemp via calibrationToOrcaSlicerKeys", async () => {
+    const { calibrationToOrcaSlicerKeys } = await import("@/lib/orcaSlicerBundle");
+    const exported = calibrationToOrcaSlicerKeys({ chamberTemp: 55 });
+    const { calibrationHints } = parseBambuStudioProfile({ name: ["X"], ...exported });
+    expect(calibrationHints.chamberTemp).toBe(55);
+  });
+
   it("stashes unknown keys in the settings passthrough bag", () => {
     const { filament } = parseBambuStudioProfile({
       name: ["X"],

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -273,6 +273,19 @@ describe("parseBambuStudioProfile", () => {
     expect(calibrationHints.hasAnyHint).toBe(false);
   });
 
+  it("GH #950: an ENABLED chamber_temperature is EXCLUDED from the settings bag (routed structurally)", () => {
+    const { calibrationHints, filament } = parseBambuStudioProfile({
+      name: ["X"],
+      chamber_temperature: ["45"],
+      activate_chamber_temp_control: ["1"],
+    });
+    expect(calibrationHints.chamberTemp).toBe(45);
+    // Enabled → the applier routes it (calibrations[].chamberTemp or settings
+    // fallback), so it must NOT also linger raw in the bag (would double-store).
+    expect(filament.settings.chamber_temperature).toBeUndefined();
+    expect(filament.settings.activate_chamber_temp_control).toBeUndefined();
+  });
+
   it("GH #950: chamber_temperature ALONGSIDE a real per-nozzle hint still trips hasAnyHint", () => {
     const { calibrationHints } = parseBambuStudioProfile({
       name: ["X"],
@@ -284,14 +297,20 @@ describe("parseBambuStudioProfile", () => {
   });
 
   it("GH #950: honors activate_chamber_temp_control='0' — chamber heating OFF, temp not imported", () => {
-    const { calibrationHints } = parseBambuStudioProfile({
+    const { calibrationHints, filament } = parseBambuStudioProfile({
       name: ["X"],
-      chamber_temperature: ["45"], // stale value with heating disabled
+      chamber_temperature: ["45"], // stored value with heating disabled
       activate_chamber_temp_control: ["0"],
     });
     expect(calibrationHints.chamberTemp).toBeUndefined();
     // chamber is the ONLY would-be hint and it's suppressed → no calibration row.
     expect(calibrationHints.hasAnyHint).toBe(false);
+    // GH #950 (Codex P1 r2): a DISABLED chamber has NO structural home (chamberTemp
+    // is cleared, so neither the calibration row nor the applier fallback carries
+    // it) — the raw keys must ride the settings bag so the profile round-trips
+    // instead of silently dropping "chamber temp 45 but off".
+    expect(filament.settings.chamber_temperature).toBe("45");
+    expect(filament.settings.activate_chamber_temp_control).toBe("0");
   });
 
   it("GH #950: parses chamber_temperature when the enable flag is absent (defaults to on)", () => {

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -305,12 +305,25 @@ describe("parseBambuStudioProfile", () => {
     expect(calibrationHints.chamberTemp).toBeUndefined();
     // chamber is the ONLY would-be hint and it's suppressed → no calibration row.
     expect(calibrationHints.hasAnyHint).toBe(false);
+    // GH #950 (Codex r5): the explicit disable is recorded so the applier can
+    // CLEAR a pre-existing calibrations[].chamberTemp (a bare absence must not).
+    expect(calibrationHints.chamberDisabled).toBe(true);
     // GH #950 (Codex P1 r2): a DISABLED chamber has NO structural home (chamberTemp
     // is cleared, so neither the calibration row nor the applier fallback carries
     // it) — the raw keys must ride the settings bag so the profile round-trips
     // instead of silently dropping "chamber temp 45 but off".
     expect(filament.settings.chamber_temperature).toBe("45");
     expect(filament.settings.activate_chamber_temp_control).toBe("0");
+  });
+
+  it("GH #950 (Codex r5): chamberDisabled is false when chamber is enabled or the flag is absent", () => {
+    expect(
+      parseBambuStudioProfile({ name: ["X"], chamber_temperature: ["45"], activate_chamber_temp_control: ["1"] })
+        .calibrationHints.chamberDisabled,
+    ).toBe(false);
+    expect(
+      parseBambuStudioProfile({ name: ["X"], chamber_temperature: ["45"] }).calibrationHints.chamberDisabled,
+    ).toBe(false);
   });
 
   it("GH #950: parses chamber_temperature when the enable flag is absent (defaults to on)", () => {

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -360,6 +360,57 @@ describe("Bambu Studio importer routes", () => {
       expect(cal.retractLength).toBe(0.8);
     });
 
+    it("GH #950: a resolved chamber_temperature lands in calibrations[].chamberTemp, NOT the settings bag", async () => {
+      const { printer, nozzle } = await seedPrinterWithNozzle();
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+            pressure_advance: ["0.028"], // a real per-nozzle hint so calibration resolves
+            chamber_temperature: ["45"],
+            activate_chamber_temp_control: ["1"],
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      const cal = stored.calibrations.find(
+        (c: { printer: unknown; nozzle: unknown }) =>
+          String(c.printer) === String(printer._id) && String(c.nozzle) === String(nozzle._id),
+      );
+      expect(cal.chamberTemp).toBe(45); // structured per-nozzle home
+      // Out of the filament-global settings bag (the #950 fix's whole point).
+      expect(stored.settings?.chamber_temperature).toBeUndefined();
+      expect(stored.settings?.activate_chamber_temp_control).toBeUndefined();
+    });
+
+    it("GH #950 (Codex P2): an UNRESOLVED chamber_temperature falls back to the settings bag (not dropped)", async () => {
+      // Standalone profile: chamber temp present, no matchable printer → no
+      // calibration row. Pre-fix this silently DROPPED the value (it was pulled
+      // out of the passthrough bag but never written anywhere). It must survive.
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            chamber_temperature: ["50"],
+            activate_chamber_temp_control: ["1"],
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // chamber alone must NOT trip the unresolved warning (it has a fallback home).
+      expect(body.calibrationUnresolved).toBeFalsy();
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      expect(stored.settings?.chamber_temperature).toBe("50"); // preserved for round-trip
+      expect(stored.settings?.activate_chamber_temp_control).toBe("1");
+      // No calibration row was invented (nothing to attach it to).
+      expect(stored.calibrations ?? []).toHaveLength(0);
+    });
+
     it("flags calibrationUnresolved when no printer matches the hint", async () => {
       const { POST } = await import("@/app/api/filaments/bambustudio/route");
       const res = await POST(

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -486,6 +486,42 @@ describe("Bambu Studio importer routes", () => {
       expect(cal.pressureAdvance).toBe(0.02); // unrelated calibration data preserved
     });
 
+    it("GH #950 (Codex P2 r7): a chamber-disable-only sync carrying max-vol does NOT touch an existing calibration's other fields", async () => {
+      // maxVolumetricSpeed is excluded from hasAnyHint (it has a top-level home), so
+      // a disable-only profile carrying it is still chamberClearOnly. The row must
+      // carry JUST the chamber clear — it must NOT overwrite the existing row's
+      // max-vol. The profile's max-vol lands on the filament top level instead.
+      const { printer, nozzle } = await seedPrinterWithNozzle();
+      await Filament.create({
+        name: "QA Bambu PLA",
+        vendor: "QA Labs",
+        type: "PLA",
+        calibrations: [
+          { printer: printer._id, nozzle: nozzle._id, chamberTemp: 45, maxVolumetricSpeed: 12 },
+        ],
+      });
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+            activate_chamber_temp_control: ["0"], // disable only
+            filament_max_volumetric_speed: ["20"], // excluded from hasAnyHint → stays chamberClearOnly
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      const cal = stored.calibrations.find(
+        (c: { printer: unknown; nozzle: unknown }) =>
+          String(c.printer) === String(printer._id) && String(c.nozzle) === String(nozzle._id),
+      );
+      expect(cal.chamberTemp ?? null).toBeNull(); // chamber cleared
+      expect(cal.maxVolumetricSpeed).toBe(12); // existing calibration max-vol UNTOUCHED (not 20)
+      expect(stored.maxVolumetricSpeed).toBe(20); // profile's max-vol landed on the top level
+    });
+
     it("GH #950 (Codex P2 r6): a disable-only profile WITH temps but no existing row does not fabricate a calibration", async () => {
       // Typical Bambu profiles carry nozzle/bed temps. A chamber-disable-only sync
       // must NOT turn those into a per-nozzle calibration row (they belong on the

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import mongoose from "mongoose";
 import { NextRequest } from "next/server";
+import { MAX_SETTINGS_KEYS } from "@/lib/slicerSettings";
 
 /**
  * Route-level tests for the Bambu Studio importer (`POST
@@ -544,6 +545,36 @@ describe("Bambu Studio importer routes", () => {
       // The temps landed on the filament top level instead.
       expect(stored.temperatures.nozzle).toBe(210);
       expect(stored.settings.activate_chamber_temp_control).toBe("0"); // disable marker in bag
+    });
+
+    it("GH #950 (Codex P2 r7): the unresolved chamber fallback respects the settings-bag cap", async () => {
+      // The chamber-fallback keys are appended after mergeSlicerSettings enforced
+      // the cap; routing them through a capped merge means an at-cap bag + chamber
+      // fallback rejects with 400 instead of silently over-filling the bag.
+      const bigSettings: Record<string, string> = {};
+      for (let i = 0; i < MAX_SETTINGS_KEYS; i++) bigSettings[`k_${i}`] = "v";
+      await Filament.create({
+        name: "QA Cap PLA",
+        vendor: "QA Labs",
+        type: "PLA",
+        settings: bigSettings, // exactly at the cap
+      });
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq("http://localhost/api/filaments/bambustudio", {
+          type: "filament",
+          from: "User",
+          filament_settings_id: ["QA Cap PLA"],
+          filament_type: ["PLA"],
+          filament_vendor: ["QA Labs"],
+          chamber_temperature: ["50"], // unresolved (no printer) → fallback would push over the cap
+        }),
+      );
+      expect(res.status).toBe(400); // rejected, not silently over-filled
+      // The saved row is unchanged (still at the cap, no chamber key sneaked in).
+      const stored = await Filament.findOne({ name: "QA Cap PLA" });
+      expect(Object.keys(stored.settings).length).toBe(MAX_SETTINGS_KEYS);
+      expect(stored.settings.chamber_temperature).toBeUndefined();
     });
 
     it("GH #950 (Codex P2 r5): a disable-only profile matching NO existing row does not create an empty calibration row", async () => {

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -454,6 +454,61 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.settings.filament_notes).toBe("keep me");
     });
 
+    it("GH #950 (Codex P2 r5): a DISABLED chamber import CLEARS a pre-existing calibrations[].chamberTemp", async () => {
+      const { printer, nozzle } = await seedPrinterWithNozzle();
+      // Existing filament with a resolved chamber calibration (from a prior enabled import).
+      await Filament.create({
+        name: "QA Bambu PLA",
+        vendor: "QA Labs",
+        type: "PLA",
+        calibrations: [
+          { printer: printer._id, nozzle: nozzle._id, chamberTemp: 45, pressureAdvance: 0.02 },
+        ],
+      });
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+            chamber_temperature: ["45"],
+            activate_chamber_temp_control: ["0"], // disabled → must clear the calibration value
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      const cal = stored.calibrations.find(
+        (c: { printer: unknown; nozzle: unknown }) =>
+          String(c.printer) === String(printer._id) && String(c.nozzle) === String(nozzle._id),
+      );
+      expect(cal.chamberTemp ?? null).toBeNull(); // cleared, not left at 45 (no re-enable on round-trip)
+      expect(cal.pressureAdvance).toBe(0.02); // unrelated calibration data preserved
+    });
+
+    it("GH #950 (Codex P2 r5): a disable-only profile matching NO existing row does not create an empty calibration row", async () => {
+      await seedPrinterWithNozzle();
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      // Bare profile: a resolvable printer + disable flag, but NO temps / hints and
+      // no pre-existing calibration to clear → nothing to persist.
+      const res = await POST(
+        jsonReq("http://localhost/api/filaments/bambustudio", {
+          type: "filament",
+          from: "User",
+          filament_settings_id: ["QA Guard PLA"],
+          filament_type: ["PLA"],
+          filament_vendor: ["QA Labs"],
+          printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+          activate_chamber_temp_control: ["0"],
+        }),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Guard PLA" });
+      expect(stored.calibrations ?? []).toHaveLength(0); // no empty row created
+      // The disable marker still rides the settings bag for round-trip.
+      expect(stored.settings.activate_chamber_temp_control).toBe("0");
+    });
+
     it("GH #950 (Codex P1 r2): the unresolved chamber fallback PRESERVES existing settings", async () => {
       // Regression guard: an existing filament with settings, updated by an
       // unresolved chamber-only profile that adds NO passthrough keys. Pre-fix the

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -486,6 +486,30 @@ describe("Bambu Studio importer routes", () => {
       expect(cal.pressureAdvance).toBe(0.02); // unrelated calibration data preserved
     });
 
+    it("GH #950 (Codex P2 r6): a disable-only profile WITH temps but no existing row does not fabricate a calibration", async () => {
+      // Typical Bambu profiles carry nozzle/bed temps. A chamber-disable-only sync
+      // must NOT turn those into a per-nozzle calibration row (they belong on the
+      // filament top level; a fabricated row would later shadow user-edited temps
+      // in /calibration). minimalProfile includes nozzle_temperature + hot_plate_temp.
+      await seedPrinterWithNozzle();
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+            activate_chamber_temp_control: ["0"], // disable only — no EM/PA/chamber temp
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      expect(stored.calibrations ?? []).toHaveLength(0); // no fabricated per-nozzle row
+      // The temps landed on the filament top level instead.
+      expect(stored.temperatures.nozzle).toBe(210);
+      expect(stored.settings.activate_chamber_temp_control).toBe("0"); // disable marker in bag
+    });
+
     it("GH #950 (Codex P2 r5): a disable-only profile matching NO existing row does not create an empty calibration row", async () => {
       await seedPrinterWithNozzle();
       const { POST } = await import("@/app/api/filaments/bambustudio/route");

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -414,6 +414,46 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.settings?.chamber_temperature).toBeUndefined();
     });
 
+    it("GH #950 (Codex P2 r4): a resolved chamber import CLEARS a stale settings-bag chamber from a prior import", async () => {
+      const { printer, nozzle } = await seedPrinterWithNozzle();
+      // Existing filament carrying a STALE raw chamber value (from a prior
+      // unresolved/disabled import) plus an unrelated setting.
+      await Filament.create({
+        name: "QA Bambu PLA",
+        vendor: "QA Labs",
+        type: "PLA",
+        settings: {
+          chamber_temperature: "50",
+          activate_chamber_temp_control: "1",
+          filament_notes: "keep me",
+        },
+      });
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+            pressure_advance: ["0.028"], // ensures a calibration row resolves
+            chamber_temperature: ["45"],
+            activate_chamber_temp_control: ["1"],
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      const cal = stored.calibrations.find(
+        (c: { printer: unknown; nozzle: unknown }) =>
+          String(c.printer) === String(printer._id) && String(c.nozzle) === String(nozzle._id),
+      );
+      expect(cal.chamberTemp).toBe(45); // authoritative per-nozzle value
+      // The stale filament-global chamber keys are removed (no double-count on export).
+      expect(stored.settings.chamber_temperature).toBeUndefined();
+      expect(stored.settings.activate_chamber_temp_control).toBeUndefined();
+      // Unrelated existing settings are preserved.
+      expect(stored.settings.filament_notes).toBe("keep me");
+    });
+
     it("GH #950 (Codex P1 r2): the unresolved chamber fallback PRESERVES existing settings", async () => {
       // Regression guard: an existing filament with settings, updated by an
       // unresolved chamber-only profile that adds NO passthrough keys. Pre-fix the

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -577,6 +577,29 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.settings.chamber_temperature).toBeUndefined();
     });
 
+    it("GH #950 (Codex P2 r10): a bambu sync persists a never-baggable purge even with no new passthrough key", async () => {
+      // The bambu path gated its settings write on `added`; without honoring
+      // `removed`, a sync that only updates structured fields discards the purge
+      // and a stale filament_settings_id survives to shadow the re-derived name.
+      await Filament.create({
+        name: "QA Bambu PLA",
+        vendor: "QA Labs",
+        type: "PLA",
+        settings: { filament_settings_id: "Stale Name", filament_notes: "keep" },
+      });
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({ nozzle_temperature: ["225"] }), // structured only; no passthrough added
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      expect(stored.settings.filament_settings_id).toBeUndefined(); // stale never-baggable purged
+      expect(stored.settings.filament_notes).toBe("keep"); // real passthrough preserved
+    });
+
     it("GH #950 (Codex P2 r5): a disable-only profile matching NO existing row does not create an empty calibration row", async () => {
       await seedPrinterWithNozzle();
       const { POST } = await import("@/app/api/filaments/bambustudio/route");

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -415,6 +415,36 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.settings?.chamber_temperature).toBeUndefined();
     });
 
+    it("GH #950 (Codex P2 r11): a chamber-ENABLED-only sync does NOT pin ordinary temps into the calibration", async () => {
+      // A chamber-only profile carries normal nozzle/bed temps. Chamber goes to the
+      // calibration (its structured home), but the ordinary temps must NOT be pinned
+      // there (they belong on the filament top level; a per-nozzle override would
+      // later shadow user-edited top-level temps). minimalProfile has
+      // nozzle_temperature=210 + hot_plate_temp=60, and NO real per-nozzle hint.
+      const { printer, nozzle } = await seedPrinterWithNozzle();
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+            chamber_temperature: ["48"],
+            activate_chamber_temp_control: ["1"], // enabled, no EM/PA
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      const cal = stored.calibrations.find(
+        (c: { printer: unknown; nozzle: unknown }) =>
+          String(c.printer) === String(printer._id) && String(c.nozzle) === String(nozzle._id),
+      );
+      expect(cal.chamberTemp).toBe(48); // chamber IS in the calibration (its home)
+      expect(cal.nozzleTemp ?? null).toBeNull(); // ordinary temps NOT pinned into the calibration
+      expect(cal.bedTemp ?? null).toBeNull();
+      expect(stored.temperatures.nozzle).toBe(210); // temps landed on the filament top level
+    });
+
     it("GH #950 (Codex P2 r4): a resolved chamber import CLEARS a stale settings-bag chamber from a prior import", async () => {
       const { printer, nozzle } = await seedPrinterWithNozzle();
       // Existing filament carrying a STALE raw chamber value (from a prior

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -386,6 +386,64 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.settings?.activate_chamber_temp_control).toBeUndefined();
     });
 
+    it("GH #950 (Codex P2 r2): a chamber-ONLY profile with a resolvable printer lands in calibrations[].chamberTemp", async () => {
+      // Decoupling resolution from the warning: chamber is excluded from
+      // hasAnyHint (so it never spuriously warns), but when a printer context IS
+      // available the structured home must still be used — not the settings bag.
+      const { printer, nozzle } = await seedPrinterWithNozzle();
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            printer_settings_id: ["Bambu Lab P1S 0.4 nozzle"],
+            chamber_temperature: ["48"], // the ONLY calibration-ish value
+            activate_chamber_temp_control: ["1"],
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.calibrationUnresolved).toBeFalsy(); // resolved → no warning
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      const cal = stored.calibrations.find(
+        (c: { printer: unknown; nozzle: unknown }) =>
+          String(c.printer) === String(printer._id) && String(c.nozzle) === String(nozzle._id),
+      );
+      expect(cal.chamberTemp).toBe(48); // structured home used, not the bag
+      expect(stored.settings?.chamber_temperature).toBeUndefined();
+    });
+
+    it("GH #950 (Codex P1 r2): the unresolved chamber fallback PRESERVES existing settings", async () => {
+      // Regression guard: an existing filament with settings, updated by an
+      // unresolved chamber-only profile that adds NO passthrough keys. Pre-fix the
+      // fallback started from an undefined update.settings ({}), so the $set
+      // REPLACED the whole bag and dropped existing filament_notes/soluble.
+      await Filament.create({
+        name: "QA Bambu PLA",
+        vendor: "QA Labs",
+        type: "PLA",
+        settings: { filament_notes: "keep me", filament_soluble: "1" },
+      });
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            chamber_temperature: ["50"], // no printer_settings_id → unresolved
+            activate_chamber_temp_control: ["1"],
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      // Existing settings survive AND the chamber keys are added.
+      expect(stored.settings.filament_notes).toBe("keep me");
+      expect(stored.settings.filament_soluble).toBe("1");
+      expect(stored.settings.chamber_temperature).toBe("50");
+      expect(stored.settings.activate_chamber_temp_control).toBe("1");
+    });
+
     it("GH #950 (Codex P2): an UNRESOLVED chamber_temperature falls back to the settings bag (not dropped)", async () => {
       // Standalone profile: chamber temp present, no matchable printer → no
       // calibration row. Pre-fix this silently DROPPED the value (it was pulled
@@ -409,6 +467,29 @@ describe("Bambu Studio importer routes", () => {
       expect(stored.settings?.activate_chamber_temp_control).toBe("1");
       // No calibration row was invented (nothing to attach it to).
       expect(stored.calibrations ?? []).toHaveLength(0);
+    });
+
+    it("GH #950 (Codex P1 r2): a DISABLED chamber (activate=0) round-trips via the settings bag", async () => {
+      // chamber temp present but heating OFF → chamberTemp is cleared, so it has
+      // no structural home; the raw keys must survive in the settings bag rather
+      // than being dropped (they rode the bag before the #950.3 change).
+      const { POST } = await import("@/app/api/filaments/bambustudio/route");
+      const res = await POST(
+        jsonReq(
+          "http://localhost/api/filaments/bambustudio",
+          minimalProfile({
+            chamber_temperature: ["45"],
+            activate_chamber_temp_control: ["0"], // disabled
+          }),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.calibrationUnresolved).toBeFalsy();
+      const stored = await Filament.findOne({ name: "QA Bambu PLA" });
+      expect(stored.settings.chamber_temperature).toBe("45");
+      expect(stored.settings.activate_chamber_temp_control).toBe("0");
+      expect(stored.calibrations ?? []).toHaveLength(0); // nothing structured
     });
 
     it("flags calibrationUnresolved when no printer matches the hint", async () => {

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -173,4 +173,34 @@ describe("GET /api/filaments/[id]/calibration", () => {
     const json = await res.json();
     expect(json.available).toEqual([{ diameter: 0.4, name: "0.4 Brass", type: "Brass", highFlow: false }]);
   });
+
+  it("GH #950: a 24-hex id param resolves by _id FIRST, not a name that looks like an id", async () => {
+    // The slicer calls this endpoint by the same {id} the id-first sync/export
+    // routes use — so it must resolve id-first too, or the slicer reads the
+    // WRONG filament's per-nozzle calibration (silently mis-calibrating).
+    const noz = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
+    const real = await Filament.create({
+      name: "Real Cal PLA",
+      vendor: "X",
+      type: "PLA",
+      calibrations: [{ nozzle: noz._id, pressureAdvance: 0.042, extrusionMultiplier: 0.97 }],
+    });
+    // A DIFFERENT filament NAMED with the real one's 24-hex _id, with its OWN
+    // (distinct) calibration — the decoy the name-first lookup would have hit.
+    await Filament.create({
+      name: String(real._id),
+      vendor: "X",
+      type: "ABS",
+      calibrations: [{ nozzle: noz._id, pressureAdvance: 0.099, extrusionMultiplier: 1.5 }],
+    });
+    const res = await getCalibration(
+      getReq(`http://localhost/api/filaments/${real._id}/calibration?nozzle_diameter=0.4`),
+      { params: Promise.resolve({ id: String(real._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // The _id lookup wins: we read the real filament's PA, not the decoy's 0.099.
+    expect(json.calibration.pressureAdvance).toBe(0.042);
+    expect(json.calibration.extrusionMultiplier).toBe(0.97);
+  });
 });

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -664,7 +664,10 @@ filament_shrinkage_compensation_xy = 0.3%
       // No top-level home in the INI mapping → must remain in the settings bag.
       expect(vs.filament_soluble).toBe("1");
       expect(vs.filament_notes).toBe("keep me");
-      expect(vs.filament_settings_id).toBe("MyPreset");
+      // GH #950: filament_settings_id is re-derived from the filament's current
+      // name on export, so it's stripped from the stored bag (a stale copy would
+      // make a renamed filament export its old name).
+      expect(vs.filament_settings_id).toBeUndefined();
       // GH #951 (R3): spool weight + shrinkage now HAVE a top-level home, so they
       // are stripped from the settings bag and stored as structured fields.
       expect(vs.filament_spool_weight).toBeUndefined();

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -151,4 +151,66 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
     // no duplicate created
     expect(await Filament.countDocuments({ name: "Plain PLA" })).toBe(1);
   });
+
+  // ── GH #950: id-first refuse-ambiguous. A section round-tripping a
+  //    filamentdb_id that resolves to an ACTIVE filament with a DIFFERENT stored
+  //    name is ambiguous (rename vs copied/stale id) → refuse, don't guess. ────
+  describe("id-first refuse-ambiguous (GH #950)", () => {
+    it("refuses when filamentdb_id resolves to an active filament with a different name", async () => {
+      const target = await Filament.create({ name: "Real Name", vendor: "Acme", type: "PLA" });
+      // Section is NAMED differently but carries the target's id.
+      await expect(
+        upsertIniFilament({ ...section("Different Name"), filamentdbId: String(target._id) }),
+      ).rejects.toThrow(/resolves to "Real Name"/);
+      // Nothing mutated / created.
+      expect(await Filament.findById(target._id).lean()).toMatchObject({ name: "Real Name" });
+      expect(await Filament.findOne({ name: "Different Name" })).toBeNull();
+    });
+
+    it("proceeds normally when filamentdb_id resolves to a filament of the SAME name (a plain update)", async () => {
+      const target = await Filament.create({ name: "Match", vendor: "Old", type: "PLA" });
+      const outcome = await upsertIniFilament({
+        ...section("Match"),
+        vendor: "New",
+        filamentdbId: String(target._id),
+      });
+      expect(outcome).toBe("updated");
+      expect((await Filament.findById(target._id).lean()).vendor).toBe("New");
+    });
+
+    it("falls through to the name-based upsert when filamentdb_id is stale (resolves to nothing)", async () => {
+      const staleId = "64b0000000000000000000ff"; // no such filament
+      const outcome = await upsertIniFilament({
+        ...section("Fresh PLA"),
+        filamentdbId: staleId,
+      });
+      expect(outcome).toBe("created");
+      expect(await Filament.findOne({ name: "Fresh PLA", _deletedAt: null })).not.toBeNull();
+    });
+
+    it("ignores a non-24-hex filamentdb_id (no id-first check) and upserts by name", async () => {
+      const outcome = await upsertIniFilament({
+        ...section("Weird Id PLA"),
+        filamentdbId: "not-an-objectid",
+      });
+      expect(outcome).toBe("created");
+    });
+
+    it("does NOT refuse against a TRASHED id-match (only active rows are id-authoritative)", async () => {
+      // filamentdb_id points at a trashed row of a different name — the id-first
+      // check filters `_deletedAt: null`, so it doesn't fire; the name path wins.
+      const trashed = await Filament.create({
+        name: "Trashed Real",
+        vendor: "Acme",
+        type: "PLA",
+        _deletedAt: new Date(),
+      });
+      const outcome = await upsertIniFilament({
+        ...section("Live Name"),
+        filamentdbId: String(trashed._id),
+      });
+      expect(outcome).toBe("created");
+      expect(await Filament.findOne({ name: "Live Name", _deletedAt: null })).not.toBeNull();
+    });
+  });
 });

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -250,37 +250,56 @@ describe("filamentToOrcaSlicerKeys", () => {
     expect(Object.keys(keys).filter(k => k.includes("plate_temp"))).toHaveLength(0);
   });
 
-  it("maps soluble flag", () => {
+  it("GH #950: round-trips filament_soluble through the settings bag", () => {
+    // No schema field — the old top-level `soluble` boolean was never persisted,
+    // so the exporter's `set(..., filament.soluble)` was a no-op. It now rides the
+    // settings passthrough bag verbatim.
     const filament = {
       name: "PVA",
       vendor: "Test",
       type: "PVA",
       color: "#FFFFFF",
       diameter: 1.75,
-      soluble: true,
       temperatures: {},
-      settings: {},
+      settings: { filament_soluble: "1" },
     };
 
     const keys = filamentToOrcaSlicerKeys(filament);
     expect(keys.filament_soluble).toEqual(["1"]);
   });
 
-  it("maps soluble=false to filament_soluble '0'", () => {
+  it("GH #950: passes filament_soluble '0' through the settings bag", () => {
     const filament = {
       name: "Not Soluble",
       vendor: "Test",
       type: "PLA",
       color: "#FFFFFF",
       diameter: 1.75,
-      soluble: false,
       temperatures: {},
-      settings: {},
+      settings: { filament_soluble: "0" },
     };
 
     const keys = filamentToOrcaSlicerKeys(filament);
-    // false is non-null so the flag is emitted, and false → "0"
     expect(keys.filament_soluble).toEqual(["0"]);
+  });
+
+  it("GH #950: does NOT read a (dead) top-level soluble field — settings bag is authoritative", () => {
+    // Regression guard: no schema column, so the old
+    // `set("filament_soluble", filament.soluble ? "1" : "0")` reader was dead.
+    // If restored, a top-level flag would clobber the settings-bag value.
+    const filament = {
+      name: "Conflict",
+      vendor: "Test",
+      type: "PVA",
+      color: "#FFFFFF",
+      diameter: 1.75,
+      temperatures: {},
+      soluble: true, // dead field — must be ignored
+      settings: { filament_soluble: "0" },
+    };
+
+    const keys = filamentToOrcaSlicerKeys(filament);
+    expect(keys.filament_soluble).toEqual(["0"]); // settings wins; top-level ignored
   });
 
   it("emits filament_notes from the notes field", () => {

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -1333,6 +1333,25 @@ describe("collapsePerNozzleImportSections (#872)", () => {
     expect(base.settings.compatible_printers_condition).toBeNull();
   });
 
+  it("#950 (Codex r4): KEEPS a user pin that merely REFERENCES nozzle_diameter (not the exact derived shape)", () => {
+    // A substring test would wrongly strip this legitimate compound restriction.
+    const parsed = parseIniFilaments(
+      `[filament:PLA 0.4 Brass]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass\ncompatible_printers_condition = printer_model==MK4 and nozzle_diameter[0]==0.4\n`,
+    );
+    const base = collapsePerNozzleImportSections(parsed)[0];
+    expect(base.settings.compatible_printers_condition).toBe(
+      "printer_model==MK4 and nozzle_diameter[0]==0.4",
+    );
+  });
+
+  it("#950 (Codex r4): STRIPS a multi-term auto-derived condition (nozzle_diameter or-joined)", () => {
+    const parsed = parseIniFilaments(
+      `[filament:PLA 0.4 Brass]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass\ncompatible_printers_condition = nozzle_diameter[0]==0.4 or nozzle_diameter[0]==0.6\n`,
+    );
+    const base = collapsePerNozzleImportSections(parsed)[0];
+    expect("compatible_printers_condition" in base.settings).toBe(false);
+  });
+
   it("#950 (Codex r3): a pinned condition survives a full multi-nozzle export→parse→collapse round-trip", () => {
     const filament = {
       name: "PLA",

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -229,6 +229,55 @@ describe("filamentToSlicerKeys", () => {
     expect(keys.compatible_printers_condition).toBe("");
   });
 
+  it("#950: a per-nozzle calibration bake derives the nozzle-diameter condition when unpinned", () => {
+    const keys = filamentToSlicerKeys(
+      {
+        name: "PLA",
+        vendor: "X",
+        type: "PLA",
+        diameter: 1.75,
+        temperatures: {},
+        settings: {},
+      },
+      { nozzle: { diameter: 0.4, type: "Brass" }, extrusionMultiplier: 1.02 } as never,
+    );
+    expect(keys.compatible_printers_condition).toBe("nozzle_diameter[0]==0.4");
+    expect(keys.filamentdb_nozzle).toBe("0.4 Brass");
+  });
+
+  it("#950: a user-pinned condition survives the per-nozzle calibration bake (not overwritten)", () => {
+    const keys = filamentToSlicerKeys(
+      {
+        name: "PLA",
+        vendor: "X",
+        type: "PLA",
+        diameter: 1.75,
+        temperatures: {},
+        // A round-tripped user pin — the calibration bake must NOT clobber it.
+        settings: { compatible_printers_condition: "printer_model==MK4" },
+      },
+      { nozzle: { diameter: 0.4, type: "Brass" }, extrusionMultiplier: 1.02 } as never,
+    );
+    expect(keys.compatible_printers_condition).toBe("printer_model==MK4");
+    // The routing hint is still emitted (it's a hint for THIS nozzle, not a user setting).
+    expect(keys.filamentdb_nozzle).toBe("0.4 Brass");
+  });
+
+  it("#950: a nil (inherit) condition survives the per-nozzle calibration bake", () => {
+    const keys = filamentToSlicerKeys(
+      {
+        name: "PLA",
+        vendor: "X",
+        type: "PLA",
+        diameter: 1.75,
+        temperatures: {},
+        settings: { compatible_printers_condition: null },
+      },
+      { nozzle: { diameter: 0.4, type: "Brass" }, extrusionMultiplier: 1.02 } as never,
+    );
+    expect(keys.compatible_printers_condition).toBeNull();
+  });
+
   it("preserves a user-set compatible_printers from the settings bag", () => {
     // If a previous import (or hand-edit) pinned the preset to a
     // specific printer, the default-blanking must NOT clobber that.
@@ -435,15 +484,17 @@ describe("filamentToSlicerKeys", () => {
     expect(keys.filament_notes).toBe("preset notes win");
   });
 
-  it("emits filament_soluble / filament_abrasive from the boolean flags (lines 297-298)", () => {
+  it("GH #950: round-trips filament_soluble / filament_abrasive through the settings bag", () => {
+    // These keys have no schema field — the old top-level `soluble`/`abrasive`
+    // booleans were never persisted (Mongoose stripped them) so the exporter's
+    // `set(..., filament.soluble)` was always a no-op. They now ride the settings
+    // passthrough bag verbatim, so an import→export round-trip preserves them.
     const solubleTrue = filamentToSlicerKeys({
       name: "PVA",
       vendor: "V",
       type: "PVA",
-      soluble: true,
-      abrasive: false,
       temperatures: {},
-      settings: {},
+      settings: { filament_soluble: "1", filament_abrasive: "0" },
     });
     expect(solubleTrue.filament_soluble).toBe("1");
     expect(solubleTrue.filament_abrasive).toBe("0");
@@ -452,16 +503,14 @@ describe("filamentToSlicerKeys", () => {
       name: "CF",
       vendor: "V",
       type: "PA-CF",
-      soluble: false,
-      abrasive: true,
       temperatures: {},
-      settings: {},
+      settings: { filament_soluble: "0", filament_abrasive: "1" },
     });
     expect(abrasiveTrue.filament_soluble).toBe("0");
     expect(abrasiveTrue.filament_abrasive).toBe("1");
   });
 
-  it("omits soluble/abrasive keys entirely when the flags are absent (297-298 false branch)", () => {
+  it("GH #950: omits soluble/abrasive keys entirely when the settings bag has neither", () => {
     const keys = filamentToSlicerKeys({
       name: "Plain",
       vendor: "V",
@@ -471,6 +520,24 @@ describe("filamentToSlicerKeys", () => {
     });
     expect(keys).not.toHaveProperty("filament_soluble");
     expect(keys).not.toHaveProperty("filament_abrasive");
+  });
+
+  it("GH #950: does NOT read a (dead) top-level soluble/abrasive field — settings bag is authoritative", () => {
+    // Regression guard: the schema has no soluble/abrasive column, so the old
+    // `set("filament_soluble", filament.soluble ? "1" : "0")` reader was dead.
+    // If it were restored, a top-level flag would CLOBBER the settings-bag value.
+    // Pin the settings bag as authoritative so a revert fails here.
+    const keys = filamentToSlicerKeys({
+      name: "Conflict",
+      vendor: "V",
+      type: "PVA",
+      temperatures: {},
+      soluble: true, // dead field — must be ignored
+      abrasive: true, // dead field — must be ignored
+      settings: { filament_soluble: "0", filament_abrasive: "0" },
+    });
+    expect(keys.filament_soluble).toBe("0"); // settings wins; top-level ignored
+    expect(keys.filament_abrasive).toBe("0");
   });
 
   it("emits shrinkage compensation keys from shrinkageXY / shrinkageZ (lines 301-304)", () => {
@@ -1131,6 +1198,57 @@ describe("collapsePerNozzleImportSections (#872)", () => {
     expect(collapsed[0].name).toBe("PLA");
   });
 
+  it("#950: strips filament_settings_id from a non-hinted section's settings bag", () => {
+    // filament_settings_id is re-derived from the filament name on export; a stale
+    // copy in the bag would make a renamed filament export its old name.
+    const parsed = parseIniFilaments(
+      `[filament:Plain PLA]\nfilament_type = PLA\nfilament_vendor = Acme\nfilament_settings_id = Plain PLA\ncooling = 1\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect(f.settings.filament_settings_id).toBeUndefined();
+    expect(f.settings.cooling).toBe("1"); // genuine passthrough key survives
+  });
+
+  it("#950: a non-hinted section drops scalar fields it did NOT supply (leave-when-omitted)", () => {
+    // A hand-crafted / partial section that supplies only identity: parseIni
+    // defaults cost/density/color/diameter/max-vol, but $set-ing those defaults
+    // over a name-matched existing filament would CLOBBER its real values.
+    const parsed = parseIniFilaments(
+      `[filament:Plain PLA]\nfilament_type = PLA\nfilament_vendor = Acme\ntemperature = 210\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect("cost" in f).toBe(false);
+    expect("density" in f).toBe(false);
+    expect("color" in f).toBe(false);
+    expect("diameter" in f).toBe(false);
+    expect("maxVolumetricSpeed" in f).toBe(false);
+    // Supplied identity + temps are kept.
+    expect(f.vendor).toBe("Acme");
+    expect(f.type).toBe("PLA");
+    expect(f.temperatures?.nozzle).toBe(210);
+  });
+
+  it("#950: a non-hinted section KEEPS scalars it DID supply (normal full export)", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Full PLA]\nfilament_type = PLA\nfilament_vendor = Acme\nfilament_cost = 22\nfilament_density = 1.24\nfilament_colour = #445566\nfilament_diameter = 1.75\nfilament_max_volumetric_speed = 15\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect(f.cost).toBe(22);
+    expect(f.density).toBe(1.24);
+    expect(f.color).toBe("#445566");
+    expect(f.diameter).toBe(1.75);
+    expect(f.maxVolumetricSpeed).toBe(15);
+  });
+
+  it("#950: captures a non-hinted section's filamentdb_id as filamentdbId (routing hint, not settings data)", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Plain PLA]\nfilament_type = PLA\nfilamentdb_id = 64b000000000000000000abc\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect(f.filamentdbId).toBe("64b000000000000000000abc"); // captured for id-first resolution
+    expect(f.settings.filamentdb_id).toBeUndefined(); // never stored as data
+  });
+
   it("omits a shared scalar a collapsed section did NOT supply (no clobber of base cost/density/color/diameter)", () => {
     // A hint-only suffixed section that omits filament_cost/density/colour/diameter:
     // parseIni would default them (null / null / #808080 / 1.75), but the collapse
@@ -1148,6 +1266,9 @@ describe("collapsePerNozzleImportSections (#872)", () => {
     // Identity that WAS supplied is kept.
     expect(base.vendor).toBe("Generic");
     expect(base.type).toBe("PLA");
+    // GH #950: the hinted branch also captures filamentdb_id for id-first resolution.
+    expect(base.filamentdbId).toBe("64b000000000000000000002");
+    expect(base.settings.filamentdb_id).toBeUndefined();
   });
 
   it("omits vendor/type a collapsed section did NOT supply (no clobber of base identity)", () => {

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -1302,6 +1302,57 @@ describe("collapsePerNozzleImportSections (#872)", () => {
     expect(base.density).toBe(1.24);
     expect(base.diameter).toBe(1.75);
   });
+
+  it("#950 (Codex r3): KEEPS a user-pinned compatible_printers_condition on a hinted collapse (round-trip)", () => {
+    // 950.2 makes the export carry a user pin through per-nozzle sections; the
+    // import must NOT strip it (the $set replaces the whole bag), else the pin is
+    // destroyed on export→import.
+    const parsed = parseIniFilaments(
+      `[filament:PLA 0.4 Brass]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass\ncompatible_printers_condition = printer_model==MK4\n`,
+    );
+    const base = collapsePerNozzleImportSections(parsed)[0];
+    expect(base.settings.compatible_printers_condition).toBe("printer_model==MK4");
+  });
+
+  it("#950 (Codex r3): STRIPS an auto-derived nozzle_diameter condition on a hinted collapse (re-derived on export)", () => {
+    // The baked per-nozzle value differs per section, so pinning it onto the base
+    // would be wrong — it's stripped and re-derived from compatibleNozzles.
+    const parsed = parseIniFilaments(
+      `[filament:PLA 0.4 Brass]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass\ncompatible_printers_condition = nozzle_diameter[0]==0.4\n`,
+    );
+    const base = collapsePerNozzleImportSections(parsed)[0];
+    expect("compatible_printers_condition" in base.settings).toBe(false);
+  });
+
+  it("#950 (Codex r3): KEEPS a nil (inherit) compatible_printers_condition on a hinted collapse", () => {
+    const parsed = parseIniFilaments(
+      `[filament:PLA 0.4 Brass]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass\ncompatible_printers_condition = nil\n`,
+    );
+    const base = collapsePerNozzleImportSections(parsed)[0];
+    // nil parses to null (the inheritance marker) and must survive the collapse.
+    expect(base.settings.compatible_printers_condition).toBeNull();
+  });
+
+  it("#950 (Codex r3): a pinned condition survives a full multi-nozzle export→parse→collapse round-trip", () => {
+    const filament = {
+      name: "PLA",
+      vendor: "Generic",
+      type: "PLA",
+      _id: "64b000000000000000000010",
+      temperatures: { nozzle: 210, bed: 60 },
+      // User pin at filament scope.
+      settings: { compatible_printers_condition: "printer_model==MK4" },
+      calibrations: [
+        { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95, nozzleTemp: 205 },
+        { nozzle: { name: "0.6 Brass", diameter: 0.6, type: "Brass" }, printer: null, maxVolumetricSpeed: 20, nozzleTemp: 215 },
+      ],
+    };
+    const bundle = generatePrusaSlicerBundle([filament]);
+    // The export carries the user pin (not the derived diameter condition) in each section.
+    expect(bundle).toContain("compatible_printers_condition = printer_model==MK4");
+    const base = collapsePerNozzleImportSections(parseIniFilaments(bundle))[0];
+    expect(base.settings.compatible_printers_condition).toBe("printer_model==MK4"); // survived
+  });
 });
 
 describe("resolveSyncBackColor (#883)", () => {

--- a/tests/single-filament-slicer-export.test.ts
+++ b/tests/single-filament-slicer-export.test.ts
@@ -177,6 +177,32 @@ describe("single-filament slicer export routes", () => {
     expect(byId.status).toBe(200);
   });
 
+  it("GH #950: a 24-hex id param resolves by _id FIRST, not a name that looks like an id", async () => {
+    const real = await Filament.create({
+      name: "Real Export PLA",
+      vendor: "TestCo",
+      type: "PLA",
+      temperatures: { nozzle: 211, bed: 60 },
+    });
+    // A DIFFERENT filament NAMED with the real one's 24-hex _id. Pre-fix the
+    // name lookup ran first and this decoy would shadow the real _id.
+    await Filament.create({
+      name: String(real._id),
+      vendor: "TestCo",
+      type: "ABS",
+      temperatures: { nozzle: 255, bed: 100 },
+    });
+    const res = await exportPrusa(req(String(real._id)), {
+      params: Promise.resolve({ id: String(real._id) }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // The _id lookup wins: we export "Real Export PLA", not the ABS decoy.
+    expect(body).toContain("[filament:Real Export PLA]");
+    expect(body).toContain("filament_type = PLA");
+    expect(body).not.toContain("filament_type = ABS");
+  });
+
   // ── Variant inheritance ───────────────────────────────────────────
 
   it("resolves variant inheritance — an exported variant carries the parent's values", async () => {

--- a/tests/slicerSettings.test.ts
+++ b/tests/slicerSettings.test.ts
@@ -43,6 +43,28 @@ describe("mergeSlicerSettings", () => {
     expect(existing).toEqual({ keep: "alpha" });
   });
 
+  it("#950: strips a STALE structured key already sitting in existing (not just incoming)", () => {
+    // A legacy bag can carry a structured-owned key (a shadow of a first-class
+    // field / re-derived export key). It must be purged from the seeded existing
+    // bag too, or it survives the merge and shadows the structured value on export.
+    const result = mergeSlicerSettings(
+      { compatible_printers: "Stale MK4", keep: "alpha" },
+      { add: "value" },
+      STRUCTURED,
+    );
+    expect(result.error).toBeNull();
+    expect("compatible_printers" in result.settings).toBe(false); // purged from existing
+    expect(result.settings).toEqual({ keep: "alpha", add: "value" });
+    // Stripping a stale existing key is not counted as an "added" incoming key.
+    expect(result.added).toEqual(["add"]);
+  });
+
+  it("#950: does not mutate the existing object when stripping a stale structured key", () => {
+    const existing: Record<string, unknown> = { compatible_printers: "Stale", keep: "alpha" };
+    mergeSlicerSettings(existing, {}, STRUCTURED);
+    expect(existing).toEqual({ compatible_printers: "Stale", keep: "alpha" }); // untouched
+  });
+
   it("preserves an incoming key over an existing key with the same name (last write wins)", () => {
     const result = mergeSlicerSettings(
       { shared: "old" },

--- a/tests/slicerSettings.test.ts
+++ b/tests/slicerSettings.test.ts
@@ -61,6 +61,22 @@ describe("mergeSlicerSettings", () => {
     expect(result.removed).toEqual(["filament_settings_id"]);
   });
 
+  it("#950 (Codex r9): skips a never-baggable key from INCOMING even when the caller's structuredKeys omits it", () => {
+    // The OrcaSlicer per-id route's structured set does not include
+    // filament_settings_id, so without this the incoming copy would be added to the
+    // bag and shadow the re-derived export value. Never-baggable keys stay out of
+    // the bag regardless of source.
+    const result = mergeSlicerSettings(
+      { keep: "alpha" },
+      { filament_settings_id: "Incoming Name", add: "value" },
+      new Set(), // caller lists NO structured keys
+    );
+    expect(result.error).toBeNull();
+    expect("filament_settings_id" in result.settings).toBe(false); // not added from incoming
+    expect(result.settings).toEqual({ keep: "alpha", add: "value" });
+    expect(result.added).toEqual(["add"]); // filament_settings_id not counted as added
+  });
+
   it("#950 (Codex r8): does NOT purge a structuredKey that is not never-baggable — shared bag defaults survive", () => {
     // The per-id calibration sync lists context keys (extrusion_multiplier,
     // retraction, fans) in structuredKeys, but those have no top-level home and can

--- a/tests/slicerSettings.test.ts
+++ b/tests/slicerSettings.test.ts
@@ -43,33 +43,48 @@ describe("mergeSlicerSettings", () => {
     expect(existing).toEqual({ keep: "alpha" });
   });
 
-  it("#950: strips a STALE structured key already sitting in existing (not just incoming)", () => {
-    // A legacy bag can carry a structured-owned key (a shadow of a first-class
-    // field / re-derived export key). It must be purged from the seeded existing
-    // bag too, or it survives the merge and shadows the structured value on export.
+  it("#950: purges a never-baggable key (filament_settings_id) already sitting in existing", () => {
+    // filament_settings_id is re-derived from the filament name on export, so a
+    // stale copy in the bag shadows it. It must be purged from the seeded existing
+    // bag regardless of the caller's structuredKeys (NEVER_BAGGED_KEYS).
     const result = mergeSlicerSettings(
-      { compatible_printers: "Stale MK4", keep: "alpha" },
+      { filament_settings_id: "Stale Name", keep: "alpha" },
       { add: "value" },
       STRUCTURED,
     );
     expect(result.error).toBeNull();
-    expect("compatible_printers" in result.settings).toBe(false); // purged from existing
+    expect("filament_settings_id" in result.settings).toBe(false); // purged from existing
     expect(result.settings).toEqual({ keep: "alpha", add: "value" });
-    // Stripping a stale existing key is not counted as an "added" incoming key.
+    // Purging a stale existing key is not counted as an "added" incoming key.
     expect(result.added).toEqual(["add"]);
     // …but it IS reported in `removed` so a conditional-writing caller persists it.
-    expect(result.removed).toEqual(["compatible_printers"]);
+    expect(result.removed).toEqual(["filament_settings_id"]);
   });
 
-  it("#950: reports an empty `removed` when existing carried no structured key", () => {
+  it("#950 (Codex r8): does NOT purge a structuredKey that is not never-baggable — shared bag defaults survive", () => {
+    // The per-id calibration sync lists context keys (extrusion_multiplier,
+    // retraction, fans) in structuredKeys, but those have no top-level home and can
+    // be legit shared filament-wide defaults in the bag — they must NOT be purged.
+    const result = mergeSlicerSettings(
+      { compatible_printers: "MK4", extrusion_multiplier: "0.98", keep: "alpha" },
+      { add: "value" },
+      new Set(["compatible_printers", "extrusion_multiplier"]),
+    );
+    expect(result.error).toBeNull();
+    expect(result.settings.compatible_printers).toBe("MK4"); // preserved
+    expect(result.settings.extrusion_multiplier).toBe("0.98"); // preserved (shared default)
+    expect(result.removed).toEqual([]); // nothing never-baggable was present
+  });
+
+  it("#950: reports an empty `removed` when existing carried no never-baggable key", () => {
     const result = mergeSlicerSettings({ keep: "alpha" }, { add: "value" }, STRUCTURED);
     expect(result.removed).toEqual([]);
   });
 
-  it("#950: does not mutate the existing object when stripping a stale structured key", () => {
-    const existing: Record<string, unknown> = { compatible_printers: "Stale", keep: "alpha" };
+  it("#950: does not mutate the existing object when purging a never-baggable key", () => {
+    const existing: Record<string, unknown> = { filament_settings_id: "Stale", keep: "alpha" };
     mergeSlicerSettings(existing, {}, STRUCTURED);
-    expect(existing).toEqual({ compatible_printers: "Stale", keep: "alpha" }); // untouched
+    expect(existing).toEqual({ filament_settings_id: "Stale", keep: "alpha" }); // untouched
   });
 
   it("preserves an incoming key over an existing key with the same name (last write wins)", () => {

--- a/tests/slicerSettings.test.ts
+++ b/tests/slicerSettings.test.ts
@@ -57,6 +57,13 @@ describe("mergeSlicerSettings", () => {
     expect(result.settings).toEqual({ keep: "alpha", add: "value" });
     // Stripping a stale existing key is not counted as an "added" incoming key.
     expect(result.added).toEqual(["add"]);
+    // …but it IS reported in `removed` so a conditional-writing caller persists it.
+    expect(result.removed).toEqual(["compatible_printers"]);
+  });
+
+  it("#950: reports an empty `removed` when existing carried no structured key", () => {
+    const result = mergeSlicerSettings({ keep: "alpha" }, { add: "value" }, STRUCTURED);
+    expect(result.removed).toEqual([]);
   });
 
   it("#950: does not mutate the existing object when stripping a stale structured key", () => {


### PR DESCRIPTION
Addresses #950 — slicer round-trip data-loss & addressing bugs. **8 of 10 findings fixed; 950.4 + 950.8b deferred** (see below), so this does not auto-close the issue.

## Fixes

### 950.1 — `filament_soluble` / `filament_abrasive` silently dropped
The Filament schema has no `soluble`/`abrasive` columns, so the per-id sync route pulled these keys out of the settings bag and wrote them to a dead `update.soluble`/`update.abrasive` that Mongoose stripped — persisting them **nowhere**, and the exporter's `set("filament_soluble", filament.soluble)` was a permanent no-op. Removed from `STRUCTURED_KEYS` and dropped the dead export reads (PrusaSlicer + OrcaSlicer) so both keys ride the settings passthrough bag and a slicer round-trip preserves them.

### 950.2 — per-nozzle calibration bake clobbered a user-pinned `compatible_printers_condition`
The `#872` per-nozzle bake set `keys.compatible_printers_condition = nozzle_diameter[0]==<Ø>` **unconditionally**, overwriting a round-tripped user pin or the `nil` inheritance marker. Gated it the same way the non-calibration derivation already is — only set when absent or an empty-string "no restriction". `filamentdb_nozzle` stays unconditional (it's a routing hint for that nozzle, not a user setting).

### 950.3 — chamber temperature dropped on Bambu Studio import
`orcaSlicerBundle` exports `chamber_temperature` + `activate_chamber_temp_control`, but the Bambu importer never parsed them back → every export→calibrate→re-import cycle lost the chamber temp. Added `chamberTemp` to `CalibrationHints` + `CALIBRATION_KEYS`, honoring `activate_chamber_temp_control="0"` (heating off → don't import), and applied it onto `calibrations[].chamberTemp`.

### 950.5 — stale `filament_settings_id` re-exported after a rename
The INI bulk importer dumped every `key=value` line into the settings bag, so `filament_settings_id` survived verbatim. Since the export re-derives it from the filament's **current** name, a stale copy made a renamed filament export its old preset name. Added it to `SETTINGS_STRIP_KEYS` (alongside the routing hints) so it's stripped from the stored bag and always re-derived.

### 950.6 — slicer-facing routes resolved by name before _id (`_id`-shadow)
`resolveFilamentForExport` and the per-id OrcaSlicer sync tried a **name** lookup first, so a filament legitimately NAMED with 24 hex chars would shadow another filament's real `_id`. Made a 24-hex param authoritative (try `_id` first, fall back to name only on a miss) — matching the `#867` per-id sync semantics. **An adversarial-verification pass found two sibling slicer-facing GET routes with the same name-first ordering** — `GET /api/filaments/{id}/calibration` and `GET /api/filaments/{id}/spool-check` — which was *worse* than a plain shadow: the sync/export routes now resolve id-first while these read by-name, so a slicer round-trip on a 24-hex-named-decoy would write one filament and read another's calibration / spool availability. Both flipped to id-first for consistency.

### 950.7 — per-nozzle preset with a stale `filamentdb_id` 404'd → orphan
A `#872` preset is named `<base> <Ø type [HF]>`. When its `filamentdb_id` was stale/absent (it's DB-instance-specific) AND the full suffixed name missed, the sync 404'd and the fork spawned a `<base> <hint>` orphan that swallowed every later edit. Added a base-name retry (suffixed name minus the `filamentdb_nozzle` hint) before the 404.

### 950.8a — INI import clobbered base fields with parseIni defaults (non-hinted branch)
`parseIni` fills absent fields with defaults (`null` / `#808080` / `1.75` / `Unknown`); `$set`-ing those over a name-matched existing filament wiped its real cost/density/color/diameter/vendor/type/max-vol on a partial or hand-crafted section. Extended the "leave-when-omitted" idiom (already used by the hinted branch) to the non-hinted pass-through branch — drop each field the section didn't actually supply.

### 950.9 — INI import id/name mismatch resolved ambiguously
Captured the section's round-tripped `filamentdb_id` (`CollapsedFilamentData.filamentdbId`, never persisted) and added an id-first **refuse-ambiguous** pre-check to `upsertIniFilament`: when the id resolves to an ACTIVE filament whose stored name differs from the section name, the case is ambiguous (renamed preset vs copied/stale id), so it throws → per-row skip rather than silently mutating the wrong row or spawning an orphan. Mirrors the per-id sync route's `name_id_mismatch` conservatism.

## Deferred (not in this PR)
- **950.4** — deferred as an enhancement (per triage decision).
- **950.8b** — deferred (per triage decision).

## Tests
New coverage for every shipped finding across `prusaSlicerBundle`, `orcaSlicerBundle`, `iniImportApply`, `bambuStudioImport`, `bambuStudioApply`, `single-filament-slicer-export`, `calibration-route`, and the per-id sync + orcaslicer + spool-check routes (`api-route-correctness`). Existing tests that asserted the removed dead-field behavior were updated to the new settings-bag round-trip contract, plus a **regression guard** proving the exporter no longer reads a dead top-level `soluble`/`abrasive` field (settings bag is authoritative — a revert now fails a test).

## Verification
An adversarial multi-agent verification pass ran one skeptic per finding plus a completeness/scope critic and a test-quality critic. 6/8 findings passed clean; it surfaced the 950.6 scope gap (calibration + spool-check routes, now fixed) and the missing exporter regression guard (now added). Full `tsc`, `lint`, and coverage gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
