### PR TITLE
fix(slicer): bake calibration into Orca/Bambu export + merge INI settings (closes #950)

### DIFF
--- a/src/app/api/filaments/[id]/bambustudio/route.ts
+++ b/src/app/api/filaments/[id]/bambustudio/route.ts
@@ -56,7 +56,9 @@ export async function GET(
       return errorResponse("Filament not found", 404);
     }
 
-    const profile = generateOrcaSlicerProfiles([filament])[0];
+    // bakeCalibration: stock Bambu Studio has no dynamic calibration module, so
+    // bake the representative calibration into this single preset (GH #950.4 / #969 r5).
+    const profile = generateOrcaSlicerProfiles([filament], { bakeCalibration: true })[0];
     // Bambu-specific: mark as a user preset so Bambu Studio files it
     // under the user's custom filaments on import.
     profile.from = "User";

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -84,8 +84,10 @@ export async function GET(
 
     // generateOrcaSlicerProfiles works on an array — take the single
     // profile object, not the [obj] wrapper, so the file imports as one
-    // preset rather than a list.
-    const profile = generateOrcaSlicerProfiles([filament])[0];
+    // preset rather than a list. bakeCalibration: this single-preset download is
+    // a manual import with no dynamic calibration module, so bake the
+    // representative calibration in (GH #950.4 / #969 r5).
+    const profile = generateOrcaSlicerProfiles([filament], { bakeCalibration: true })[0];
     const stem = exportFilenameStem(filament.name);
 
     return new NextResponse(JSON.stringify(profile, null, 2), {

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -1117,17 +1117,13 @@ function FilamentDetail() {
   const inherited = new Set(filament._inherited || []);
   const isVariant = !!filament.parentId;
   const isParent = (filament._variants?.length ?? 0) > 0;
-  // GH #950.4: the single Orca/Bambu .json export bakes only ONE representative
-  // calibration (the any-printer/any-bed default). Warn when >1 DISTINCT nozzle
-  // calibration exists so the user knows the others' tuning is dropped. Mirrors
-  // distinctNozzleCalibrationCount in src/lib/orcaSlicerBundle.ts (kept inline to
+  // GH #950.4 / #969 (Codex round 3): the single Orca/Bambu .json export bakes
+  // only ONE representative calibration (the any-printer/any-bed default), so any
+  // other calibration is dropped — whether on a different nozzle OR the same
+  // nozzle with a different bed type / printer. Warn whenever ≥1 is dropped.
+  // Mirrors droppedCalibrationCount in src/lib/orcaSlicerBundle.ts (kept inline to
   // avoid pulling the export lib into the client bundle).
-  const distinctNozzleCalibrations = new Set(
-    (filament.calibrations ?? [])
-      .map((c) => c.nozzle)
-      .filter((nz) => nz && nz.diameter != null)
-      .map((nz) => `${nz.diameter}|${(nz.type ?? "").trim().toLowerCase()}|${nz.highFlow ? "HF" : ""}`),
-  ).size;
+  const droppedCalibrations = Math.max(0, (filament.calibrations?.length ?? 0) - 1);
   // Parents are finish-agnostic — only variants/standalones carry a
   // texture treatment + chip. resolveFilament() doesn't inherit optTags,
   // so a variant only shows a finish when its own optTags include one
@@ -1298,9 +1294,9 @@ function FilamentDetail() {
                   {t("detail.slicerExport.multiColorNotice")}
                 </p>
               )}
-              {distinctNozzleCalibrations > 1 && (
+              {droppedCalibrations > 0 && (
                 <p className="px-3 py-2 my-1 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 border-y border-amber-200 dark:border-amber-800">
-                  {t("detail.slicerExport.multiNozzleNotice")}
+                  {t("detail.slicerExport.multiCalibrationNotice")}
                 </p>
               )}
               {([

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -1117,6 +1117,17 @@ function FilamentDetail() {
   const inherited = new Set(filament._inherited || []);
   const isVariant = !!filament.parentId;
   const isParent = (filament._variants?.length ?? 0) > 0;
+  // GH #950.4: the single Orca/Bambu .json export bakes only ONE representative
+  // calibration (the any-printer/any-bed default). Warn when >1 DISTINCT nozzle
+  // calibration exists so the user knows the others' tuning is dropped. Mirrors
+  // distinctNozzleCalibrationCount in src/lib/orcaSlicerBundle.ts (kept inline to
+  // avoid pulling the export lib into the client bundle).
+  const distinctNozzleCalibrations = new Set(
+    (filament.calibrations ?? [])
+      .map((c) => c.nozzle)
+      .filter((nz) => nz && nz.diameter != null)
+      .map((nz) => `${nz.diameter}|${(nz.type ?? "").trim().toLowerCase()}|${nz.highFlow ? "HF" : ""}`),
+  ).size;
   // Parents are finish-agnostic — only variants/standalones carry a
   // texture treatment + chip. resolveFilament() doesn't inherit optTags,
   // so a variant only shows a finish when its own optTags include one
@@ -1285,6 +1296,11 @@ function FilamentDetail() {
               {(filament.secondaryColors && filament.secondaryColors.length > 0) && (
                 <p className="px-3 py-2 my-1 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 border-y border-amber-200 dark:border-amber-800">
                   {t("detail.slicerExport.multiColorNotice")}
+                </p>
+              )}
+              {distinctNozzleCalibrations > 1 && (
+                <p className="px-3 py-2 my-1 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 border-y border-amber-200 dark:border-amber-800">
+                  {t("detail.slicerExport.multiNozzleNotice")}
                 </p>
               )}
               {([

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -891,6 +891,7 @@
   "detail.slicerExport.orca": "OrcaSlicer-Filamentvorlage",
   "detail.slicerExport.bambu": "Bambu Studio-Filamentvorlage",
   "detail.slicerExport.multiColorNotice": "Slicer-Voreinstellungen unterstützen nur eine Farbe. Die Primärfarbe wird exportiert; Sekundärfarben werden verworfen.",
+  "detail.slicerExport.multiNozzleNotice": "Dieses Filament hat Kalibrierungen für mehr als eine Düse. Die einzelne Orca-/Bambu-Voreinstellung übernimmt nur die Abstimmung der Standarddüse; die anderen werden verworfen.",
   "detail.exportMenu": "Export",
   "detail.exportMenu.title": "Dieses Filament exportieren — Etikett drucken, auf NFC schreiben oder Slicer-Voreinstellung herunterladen",
   "detail.exportMenu.slicerSection": "Slicer-Voreinstellungen",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -891,7 +891,7 @@
   "detail.slicerExport.orca": "OrcaSlicer-Filamentvorlage",
   "detail.slicerExport.bambu": "Bambu Studio-Filamentvorlage",
   "detail.slicerExport.multiColorNotice": "Slicer-Voreinstellungen unterstützen nur eine Farbe. Die Primärfarbe wird exportiert; Sekundärfarben werden verworfen.",
-  "detail.slicerExport.multiNozzleNotice": "Dieses Filament hat Kalibrierungen für mehr als eine Düse. Die einzelne Orca-/Bambu-Voreinstellung übernimmt nur die Abstimmung der Standarddüse; die anderen werden verworfen.",
+  "detail.slicerExport.multiCalibrationNotice": "Dieses Filament hat mehr als eine Kalibrierung. Die einzelne Orca-/Bambu-Voreinstellung übernimmt nur die Standardkalibrierung (beliebiger Drucker/beliebiges Bett); die anderen Drucker-, Bett- und Düsen-Abstimmungen werden verworfen.",
   "detail.exportMenu": "Export",
   "detail.exportMenu.title": "Dieses Filament exportieren — Etikett drucken, auf NFC schreiben oder Slicer-Voreinstellung herunterladen",
   "detail.exportMenu.slicerSection": "Slicer-Voreinstellungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -891,7 +891,7 @@
   "detail.slicerExport.orca": "OrcaSlicer filament preset",
   "detail.slicerExport.bambu": "Bambu Studio filament preset",
   "detail.slicerExport.multiColorNotice": "Slicer presets only support one color. The primary will be exported; secondaries are dropped.",
-  "detail.slicerExport.multiNozzleNotice": "This filament has calibrations for more than one nozzle. The single Orca/Bambu preset bakes only the default nozzle's tuning; the others are dropped.",
+  "detail.slicerExport.multiCalibrationNotice": "This filament has more than one calibration. The single Orca/Bambu preset bakes only the default (any-printer/any-bed) one; the other printer, bed-type, and nozzle tuning contexts are dropped.",
   "detail.exportMenu": "Export",
   "detail.exportMenu.title": "Export this filament — print a label, write to NFC, or download a slicer preset",
   "detail.exportMenu.slicerSection": "Slicer presets",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -891,6 +891,7 @@
   "detail.slicerExport.orca": "OrcaSlicer filament preset",
   "detail.slicerExport.bambu": "Bambu Studio filament preset",
   "detail.slicerExport.multiColorNotice": "Slicer presets only support one color. The primary will be exported; secondaries are dropped.",
+  "detail.slicerExport.multiNozzleNotice": "This filament has calibrations for more than one nozzle. The single Orca/Bambu preset bakes only the default nozzle's tuning; the others are dropped.",
   "detail.exportMenu": "Export",
   "detail.exportMenu.title": "Export this filament — print a label, write to NFC, or download a slicer preset",
   "detail.exportMenu.slicerSection": "Slicer presets",

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -104,6 +104,50 @@ function mergeSettingsDotKeys(setBody: Record<string, unknown>): Record<string, 
 }
 
 /**
+ * GH #969 (Codex on #950.8b): compute the `settings.<k>` $unset keys that
+ * restore variant self-heal under the dot-key MERGE.
+ *
+ * `splitInheritedImportSet` filters a settings key OUT of `set.settings` when
+ * the incoming value equals the parent's (so the variant keeps inheriting it).
+ * Under the OLD whole-object `$set: { settings: filtered }` that dropped a stale
+ * variant override for free (the replace wiped it). Under the dot-key merge
+ * (`mergeSettingsDotKeys`) no `settings.<k>` key is emitted for a filtered-out
+ * key, so an existing variant override such as `settings.cooling = "0"` SURVIVES
+ * even when the imported INI's `cooling` now matches the parent — inheritance
+ * never resumes. So for every incoming settings key whose value equals the
+ * parent AND that the variant still overrides locally with a DIFFERENT value,
+ * emit a `settings.<k>` $unset. Keys the incoming section OMITS are left
+ * untouched (the omitted-key preservation #950.8b added — e.g. openprinttag_slug).
+ * The keys this returns are disjoint from `mergeSettingsDotKeys`'s emitted
+ * `settings.<k>` $set keys (matches-parent vs differs-from-parent), so $set and
+ * $unset never collide on the same path.
+ */
+function settingsSelfHealUnset(
+  incoming: unknown,
+  variant: LeanFilament,
+  parent: LeanFilament,
+): string[] {
+  if (!incoming || typeof incoming !== "object" || Array.isArray(incoming)) return [];
+  const parentSettings =
+    parent.settings && typeof parent.settings === "object" && !Array.isArray(parent.settings)
+      ? (parent.settings as Record<string, unknown>)
+      : null;
+  const variantSettings =
+    variant.settings && typeof variant.settings === "object" && !Array.isArray(variant.settings)
+      ? (variant.settings as Record<string, unknown>)
+      : null;
+  if (!parentSettings || !variantSettings) return [];
+  const unset: string[] = [];
+  for (const [sk, sv] of Object.entries(incoming as Record<string, unknown>)) {
+    if (parentSettings[sk] !== sv) continue; // differs from parent → written via $set, not healed
+    const local = variantSettings[sk];
+    // Mirror the scalar path's `hasLocalValue`: null/"" is already inheriting.
+    if (local != null && local !== "" && local !== sv) unset.push(`settings.${sk}`);
+  }
+  return unset;
+}
+
+/**
  * Build the atomic Mongo update body ({ $set } + optional { $unset }) for a
  * name-matched INI import target. For a variant it applies the inheritance
  * split; for a root (or a variant whose parent is missing/trashed — nothing to
@@ -127,8 +171,15 @@ async function buildIniUpdate(
   // Dot-flatten AFTER the per-key inheritance diff so its settings branch saw the
   // whole object; the resulting keys then MERGE rather than replace (GH #950.8b).
   const out: Record<string, unknown> = { $set: mergeSettingsDotKeys(split.set) };
-  if (split.unset.length > 0) {
-    out.$unset = Object.fromEntries(split.unset.map((k) => [k, ""]));
+  // GH #969: the dot-key merge preserves omitted keys but no longer wipes a stale
+  // variant settings override that now matches the parent — restore that self-heal
+  // with per-key `settings.<k>` $unsets (disjoint from the $set dot-keys above).
+  const unsetKeys = [
+    ...split.unset,
+    ...settingsSelfHealUnset(flat.settings, existing, parent as LeanFilament),
+  ];
+  if (unsetKeys.length > 0) {
+    out.$unset = Object.fromEntries(unsetKeys.map((k) => [k, ""]));
   }
   return out;
 }

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -38,15 +38,18 @@ import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
  * vendor/type/cost/density/diameter/maxVolumetricSpeed/inherits/spoolWeight/
  * shrinkageXY/shrinkageZ + the four temp subfields). Projected on the variant
  * AND its parent so `splitInheritedImportSet` can compare incoming vs parent and
- * detect a stale variant override to clear. `settings` is deliberately NOT
- * projected: after `stripStructuredSettings` removes the top-level shadows the
- * bag holds only genuine passthrough keys, so `splitInheritedImportSet` writes it
- * through unchanged (its settings branch no-ops when the parent's settings are
- * absent). GH #951 (Codex).
+ * detect a stale variant override to clear. GH #950.8b: `settings` is now projected
+ * too so `splitInheritedImportSet`'s per-key merge runs for a variant — it stores
+ * only settings keys that DIFFER from the parent (parent-equal keys keep
+ * inheriting) instead of pinning the whole resolved bag. `buildIniUpdate` then
+ * dot-flattens the resulting `settings` object into `settings.<k>` `$set` keys, so
+ * the write MERGES into the stored subdocument — preserving both inheritance and
+ * keys the section omitted (e.g. openprinttag_slug/_uuid, the OPT re-sync linkage).
+ * `stripStructuredSettings` still removes the top-level shadows first. GH #951 / #950.8b.
  */
 const INI_INHERITANCE_PROJECTION =
   "_id parentId vendor type cost density diameter maxVolumetricSpeed inherits " +
-  "spoolWeight shrinkageXY shrinkageZ temperatures";
+  "spoolWeight shrinkageXY shrinkageZ temperatures settings";
 
 /** Loosely-typed lean filament — same posture as resolveFilament / importFilaments. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -74,6 +77,33 @@ function toUpdateSet(collapsed: CollapsedFilamentData): Record<string, unknown> 
 }
 
 /**
+ * GH #950.8b: convert a whole `settings` object in an update `$set` body into
+ * `settings.<key>` DOT-keys, so the write MERGES into the stored settings
+ * subdocument instead of REPLACING it. A whole-object `$set: { settings }` dropped
+ * every key the incoming section didn't carry — notably settings.openprinttag_slug
+ * / _uuid (the #607 OPT re-sync linkage) when importing a foreign/hand-crafted INI
+ * by name over an OPT-linked filament. Dot-keys preserve omitted keys, matching the
+ * per-id sync route's mergeSlicerSettings semantics (INI import is additive for
+ * settings; key DELETION is not expressible via bulk import). Runs AFTER
+ * `splitInheritedImportSet` so the variant per-key inheritance diff still operates
+ * on the whole object. An empty incoming bag emits no settings key → the stored bag
+ * is left untouched (an empty `$set:{settings:{}}` would previously have wiped it).
+ */
+function mergeSettingsDotKeys(setBody: Record<string, unknown>): Record<string, unknown> {
+  const settings = setBody.settings;
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+    return setBody;
+  }
+  const { settings: _drop, ...rest } = setBody;
+  void _drop;
+  const out: Record<string, unknown> = { ...rest };
+  for (const [k, v] of Object.entries(settings as Record<string, unknown>)) {
+    out[`settings.${k}`] = v;
+  }
+  return out;
+}
+
+/**
  * Build the atomic Mongo update body ({ $set } + optional { $unset }) for a
  * name-matched INI import target. For a variant it applies the inheritance
  * split; for a root (or a variant whose parent is missing/trashed — nothing to
@@ -84,15 +114,19 @@ async function buildIniUpdate(
   existing: LeanFilament,
 ): Promise<Record<string, unknown>> {
   const flat = toUpdateSet(collapsed);
-  if (!existing.parentId) return { $set: flat };
+  // Root (or a variant with no resolvable parent): merge settings via dot-keys so
+  // the write doesn't replace the whole bag (GH #950.8b).
+  if (!existing.parentId) return { $set: mergeSettingsDotKeys(flat) };
 
   const parent = await Filament.findOne({ _id: existing.parentId, _deletedAt: null })
     .select(INI_INHERITANCE_PROJECTION)
     .lean();
-  if (!parent) return { $set: flat };
+  if (!parent) return { $set: mergeSettingsDotKeys(flat) };
 
   const split = splitInheritedImportSet(flat, existing, parent as LeanFilament);
-  const out: Record<string, unknown> = { $set: split.set };
+  // Dot-flatten AFTER the per-key inheritance diff so its settings branch saw the
+  // whole object; the resulting keys then MERGE rather than replace (GH #950.8b).
+  const out: Record<string, unknown> = { $set: mergeSettingsDotKeys(split.set) };
   if (split.unset.length > 0) {
     out.$unset = Object.fromEntries(split.unset.map((k) => [k, ""]));
   }

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -105,22 +105,38 @@ function mergeSettingsDotKeys(setBody: Record<string, unknown>): Record<string, 
 
 /**
  * GH #969 (Codex on #950.8b): compute the `settings.<k>` $unset keys that
- * restore variant self-heal under the dot-key MERGE.
+ * restore variant settings inheritance under the dot-key MERGE.
  *
  * `splitInheritedImportSet` filters a settings key OUT of `set.settings` when
- * the incoming value equals the parent's (so the variant keeps inheriting it).
- * Under the OLD whole-object `$set: { settings: filtered }` that dropped a stale
- * variant override for free (the replace wiped it). Under the dot-key merge
- * (`mergeSettingsDotKeys`) no `settings.<k>` key is emitted for a filtered-out
- * key, so an existing variant override such as `settings.cooling = "0"` SURVIVES
- * even when the imported INI's `cooling` now matches the parent — inheritance
- * never resumes. So for every incoming settings key whose value equals the
- * parent AND that the variant still overrides locally with a DIFFERENT value,
- * emit a `settings.<k>` $unset. Keys the incoming section OMITS are left
- * untouched (the omitted-key preservation #950.8b added — e.g. openprinttag_slug).
+ * the incoming value equals the parent's — meaning "the variant should inherit
+ * this key". Under the OLD whole-object `$set: { settings: filtered }` that was
+ * self-enforcing: the replace dropped EVERY key not in `filtered`, so any local
+ * override of an inherited key vanished for free. #950.8b switched to a dot-key
+ * merge (`mergeSettingsDotKeys`) to preserve keys the section OMITS (e.g.
+ * `openprinttag_slug` — the #607 OPT linkage), but the merge emits nothing for a
+ * filtered-out key, so a stored variant override SURVIVES. That regresses
+ * inheritance for section-carried keys: an override like `settings.cooling = "0"`
+ * (round 1) — OR one that already equals the parent, e.g. `settings.cooling = "1"`
+ * (round 2, this fix) — stays pinned. The parent-EQUAL pin resolves to the right
+ * value today but is still a stored local override, so a later parent edit would
+ * NOT propagate through `resolveFilament`'s shallow settings merge.
+ *
+ * So for every incoming settings key whose value matches the parent (i.e. the
+ * variant should inherit it) that the variant STILL has as a local override,
+ * emit a `settings.<k>` $unset — restoring the pre-#950.8b drop while keeping
+ * #950.8b's omitted-key preservation (the loop only touches section keys). A
+ * PRESENCE check (`hasOwnProperty`), not a value comparison: settings values are
+ * `string | null` and `resolveFilament` merges them shallowly with no
+ * empty=inherit rule, so any present key is a genuine override worth clearing.
  * The keys this returns are disjoint from `mergeSettingsDotKeys`'s emitted
  * `settings.<k>` $set keys (matches-parent vs differs-from-parent), so $set and
  * $unset never collide on the same path.
+ *
+ * Note the intentional divergence from the SCALAR inheritance path
+ * (`splitInheritedImportSet`), which clears only a DIVERGENT override and leaves
+ * a parent-equal one pinned: scalars were always field-level (never a
+ * whole-object replace), so that's their established semantics; settings had
+ * whole-object semantics, and this restores them.
  */
 function settingsSelfHealUnset(
   incoming: unknown,
@@ -139,10 +155,14 @@ function settingsSelfHealUnset(
   if (!parentSettings || !variantSettings) return [];
   const unset: string[] = [];
   for (const [sk, sv] of Object.entries(incoming as Record<string, unknown>)) {
-    if (parentSettings[sk] !== sv) continue; // differs from parent → written via $set, not healed
-    const local = variantSettings[sk];
-    // Mirror the scalar path's `hasLocalValue`: null/"" is already inheriting.
-    if (local != null && local !== "" && local !== sv) unset.push(`settings.${sk}`);
+    // Only keys the section says should INHERIT (incoming matches parent); a
+    // divergent value is written through mergeSettingsDotKeys' $set instead.
+    if (parentSettings[sk] !== sv) continue;
+    // Clear ANY local override of that key — divergent OR parent-equal — so the
+    // variant truly inherits and future parent edits propagate.
+    if (Object.prototype.hasOwnProperty.call(variantSettings, sk)) {
+      unset.push(`settings.${sk}`);
+    }
   }
   return unset;
 }

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -175,26 +175,43 @@ function settingsSelfHealUnset(
 }
 
 /**
- * GH #969 (Codex round 4): $unset never-bagged shadow keys
- * (`filament_settings_id` / `filamentdb_id` / `filamentdb_nozzle`) still stored
- * on the EXISTING doc. The incoming section already strips them and the dot-key
- * merge (#950.8b) only writes keys it emits, so a LEGACY stored shadow survives
- * — and `filamentToSlicerKeys` seeds from the bag then only sets
- * `filament_settings_id` when absent, so the stale copy would keep overriding
- * the re-derived current name on the next export. The pre-#950.8b whole-object
- * replace dropped these for free (the incoming, stripped, replaced the bag);
- * restore that purge explicitly. Disjoint from every $set path (the incoming
- * never carries these) and from the self-heal/inheritance $unsets (different
- * keys), so no path collision.
+ * Keys that must never persist in the settings bag on an INI import — the exact
+ * set the incoming section is stripped of, so the existing-doc purge mirrors it:
+ *   - NEVER_BAGGED_KEYS: routing/id hints (filament_settings_id / filamentdb_id
+ *     / filamentdb_nozzle) — stripped from incoming by the collapse step.
+ *   - INI_TOP_LEVEL_SETTING_KEYS: settings-bag SHADOWS of top-level fields
+ *     (temperature, filament_cost, filament_type, …) — stripped from incoming by
+ *     `stripStructuredSettings`.
  */
-function neverBaggedUnset(existing: LeanFilament): string[] {
+const STALE_SETTINGS_SHADOW_KEYS = new Set<string>([
+  ...NEVER_BAGGED_KEYS,
+  ...INI_TOP_LEVEL_SETTING_KEYS,
+]);
+
+/**
+ * GH #969 (Codex rounds 4 & 5): $unset stale shadow keys still stored on the
+ * EXISTING doc's settings. The incoming section is already stripped of both key
+ * classes (routing/id hints AND top-level-field shadows), and the dot-key merge
+ * (#950.8b) only writes keys it emits — so a LEGACY stored shadow (from older
+ * import code) SURVIVES. That's harmful because `filamentToSlicerKeys` seeds the
+ * export from the settings bag and only overrides a key when the resolved
+ * top-level value is truthy: a stale `settings.filament_settings_id` keeps
+ * overriding the re-derived current name, and a stale `settings.temperature`
+ * resurfaces once the canonical top-level field goes null/inherited. The
+ * pre-#950.8b whole-object replace dropped these for free (the stripped incoming
+ * replaced the bag); restore that purge explicitly. OPT keys
+ * (openprinttag_slug/_uuid) are NOT in either set, so they're preserved. Disjoint
+ * from every $set path (the incoming never carries these keys) and from the
+ * self-heal/inheritance $unsets (different keys), so no path collision.
+ */
+function staleSettingsShadowUnset(existing: LeanFilament): string[] {
   const settings =
     existing.settings && typeof existing.settings === "object" && !Array.isArray(existing.settings)
       ? (existing.settings as Record<string, unknown>)
       : null;
   if (!settings) return [];
   const unset: string[] = [];
-  for (const k of NEVER_BAGGED_KEYS) {
+  for (const k of STALE_SETTINGS_SHADOW_KEYS) {
     if (Object.prototype.hasOwnProperty.call(settings, k)) unset.push(`settings.${k}`);
   }
   return unset;
@@ -205,15 +222,15 @@ function neverBaggedUnset(existing: LeanFilament): string[] {
  * name-matched INI import target. For a variant it applies the inheritance
  * split; for a root (or a variant whose parent is missing/trashed — nothing to
  * inherit) it writes the flattened doc verbatim. Every UPDATE path also purges
- * legacy never-bagged settings shadows (GH #969 r4, neverBaggedUnset).
+ * legacy stale settings shadows (GH #969 r4/r5, staleSettingsShadowUnset).
  */
 async function buildIniUpdate(
   collapsed: CollapsedFilamentData,
   existing: LeanFilament,
 ): Promise<Record<string, unknown>> {
   const flat = toUpdateSet(collapsed);
-  const purge = neverBaggedUnset(existing);
-  // Attach the never-bagged purge (+ any caller unsets) to a `$set`-only body.
+  const purge = staleSettingsShadowUnset(existing);
+  // Attach the stale-shadow purge (+ any caller unsets) to a `$set`-only body.
   const withUnset = (
     out: Record<string, unknown>,
     extra: string[] = [],

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -104,39 +104,45 @@ function mergeSettingsDotKeys(setBody: Record<string, unknown>): Record<string, 
 }
 
 /**
- * GH #969 (Codex on #950.8b): compute the `settings.<k>` $unset keys that
- * restore variant settings inheritance under the dot-key MERGE.
+ * GH #969 (Codex on #950.8b): compute the `settings.<k>` $unset keys that keep a
+ * variant tracking its parent for section-carried settings keys under the
+ * dot-key MERGE.
  *
- * `splitInheritedImportSet` filters a settings key OUT of `set.settings` when
- * the incoming value equals the parent's — meaning "the variant should inherit
- * this key". Under the OLD whole-object `$set: { settings: filtered }` that was
- * self-enforcing: the replace dropped EVERY key not in `filtered`, so any local
- * override of an inherited key vanished for free. #950.8b switched to a dot-key
- * merge (`mergeSettingsDotKeys`) to preserve keys the section OMITS (e.g.
- * `openprinttag_slug` — the #607 OPT linkage), but the merge emits nothing for a
- * filtered-out key, so a stored variant override SURVIVES. That regresses
- * inheritance for section-carried keys: an override like `settings.cooling = "0"`
- * (round 1) — OR one that already equals the parent, e.g. `settings.cooling = "1"`
- * (round 2, this fix) — stays pinned. The parent-EQUAL pin resolves to the right
- * value today but is still a stored local override, so a later parent edit would
- * NOT propagate through `resolveFilament`'s shallow settings merge.
+ * Why clearing is correct: a bundle export resolves a variant through
+ * `resolveFilament`, so a *pinned* key (`variant.settings.cooling = "1"`) and an
+ * *inherited* one (variant blank, parent `"1"`) BOTH flatten to the same
+ * `cooling = 1` in the exported section. The INI format can't express pin-vs-
+ * inherit intent, so on re-import the only safe default for a key the section
+ * reports equal to the parent is to drop the local override and let the variant
+ * track the parent live (GH #106).
  *
- * So for every incoming settings key whose value matches the parent (i.e. the
- * variant should inherit it) that the variant STILL has as a local override,
- * emit a `settings.<k>` $unset — restoring the pre-#950.8b drop while keeping
- * #950.8b's omitted-key preservation (the loop only touches section keys). A
- * PRESENCE check (`hasOwnProperty`), not a value comparison: settings values are
- * `string | null` and `resolveFilament` merges them shallowly with no
- * empty=inherit rule, so any present key is a genuine override worth clearing.
- * The keys this returns are disjoint from `mergeSettingsDotKeys`'s emitted
- * `settings.<k>` $set keys (matches-parent vs differs-from-parent), so $set and
- * $unset never collide on the same path.
+ * Why a dedicated $unset is needed: `splitInheritedImportSet` already filters a
+ * parent-equal key OUT of `set.settings` (so `mergeSettingsDotKeys` never writes
+ * it). But #950.8b switched the settings write from a whole-object `$set` to a
+ * per-key dot-key merge so keys the section OMITS survive (e.g.
+ * `openprinttag_slug` — the #607 OPT linkage). The merge only touches keys it
+ * emits, so a *stored* variant override of a now-inherited key SURVIVES — whether
+ * it diverges (`cooling = "0"`, round 1) or already equals the parent
+ * (`cooling = "1"`, round 2, this fix; resolves right today but wouldn't track a
+ * later parent edit through resolveFilament's shallow settings merge). So for
+ * every incoming settings key the section reports equal to the parent that the
+ * variant STILL has locally, emit a `settings.<k>` $unset. A PRESENCE check
+ * (`hasOwnProperty`), not a value comparison: settings values are `string | null`
+ * and resolveFilament merges them shallowly with NO empty=inherit rule, so any
+ * present key is a genuine override worth clearing.
  *
- * Note the intentional divergence from the SCALAR inheritance path
- * (`splitInheritedImportSet`), which clears only a DIVERGENT override and leaves
- * a parent-equal one pinned: scalars were always field-level (never a
- * whole-object replace), so that's their established semantics; settings had
- * whole-object semantics, and this restores them.
+ * Disjointness: the loop only ever touches keys the section carries (so OMITTED
+ * keys stay put), and it emits ONLY parent-equal keys while `mergeSettingsDotKeys`
+ * emits ONLY differs-from-parent keys — disjoint, so $set and $unset never
+ * collide on one path. That invariant holds because BOTH sides key off the same
+ * strict parent-equality predicate (`splitInheritedImportSet`'s `!==`); a future
+ * change to one must keep the other in lockstep.
+ *
+ * Known scope gap (GH #971): the SCALAR path (`splitInheritedImportSet`) clears
+ * only a DIVERGENT parent-equal override and leaves a parent-*equal* scalar pin
+ * in place — the same latent gap this fixes for settings. It's shared by three
+ * call sites (CSV import, per-id sync, INI import), so aligning it is tracked
+ * separately rather than widened into this PR.
  */
 function settingsSelfHealUnset(
   incoming: unknown,
@@ -191,9 +197,11 @@ async function buildIniUpdate(
   // Dot-flatten AFTER the per-key inheritance diff so its settings branch saw the
   // whole object; the resulting keys then MERGE rather than replace (GH #950.8b).
   const out: Record<string, unknown> = { $set: mergeSettingsDotKeys(split.set) };
-  // GH #969: the dot-key merge preserves omitted keys but no longer wipes a stale
-  // variant settings override that now matches the parent — restore that self-heal
-  // with per-key `settings.<k>` $unsets (disjoint from the $set dot-keys above).
+  // GH #969: the dot-key merge only writes the keys it emits, so a stored variant
+  // settings override the section now reports equal to the parent would stay
+  // pinned. Clear those via per-key `settings.<k>` $unsets so the variant keeps
+  // tracking the parent (disjoint from the $set dot-keys above — see the
+  // settingsSelfHealUnset docblock).
   const unsetKeys = [
     ...split.unset,
     ...settingsSelfHealUnset(flat.settings, existing, parent as LeanFilament),

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -30,6 +30,7 @@ import Filament from "@/models/Filament";
 import { splitInheritedImportSet } from "@/lib/importFilaments";
 import { isDuplicateKeyError } from "@/lib/apiErrorHandler";
 import { INI_TOP_LEVEL_SETTING_KEYS } from "@/lib/parseIni";
+import { NEVER_BAGGED_KEYS } from "@/lib/slicerSettings";
 import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
 
 /**
@@ -174,42 +175,75 @@ function settingsSelfHealUnset(
 }
 
 /**
+ * GH #969 (Codex round 4): $unset never-bagged shadow keys
+ * (`filament_settings_id` / `filamentdb_id` / `filamentdb_nozzle`) still stored
+ * on the EXISTING doc. The incoming section already strips them and the dot-key
+ * merge (#950.8b) only writes keys it emits, so a LEGACY stored shadow survives
+ * — and `filamentToSlicerKeys` seeds from the bag then only sets
+ * `filament_settings_id` when absent, so the stale copy would keep overriding
+ * the re-derived current name on the next export. The pre-#950.8b whole-object
+ * replace dropped these for free (the incoming, stripped, replaced the bag);
+ * restore that purge explicitly. Disjoint from every $set path (the incoming
+ * never carries these) and from the self-heal/inheritance $unsets (different
+ * keys), so no path collision.
+ */
+function neverBaggedUnset(existing: LeanFilament): string[] {
+  const settings =
+    existing.settings && typeof existing.settings === "object" && !Array.isArray(existing.settings)
+      ? (existing.settings as Record<string, unknown>)
+      : null;
+  if (!settings) return [];
+  const unset: string[] = [];
+  for (const k of NEVER_BAGGED_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(settings, k)) unset.push(`settings.${k}`);
+  }
+  return unset;
+}
+
+/**
  * Build the atomic Mongo update body ({ $set } + optional { $unset }) for a
  * name-matched INI import target. For a variant it applies the inheritance
  * split; for a root (or a variant whose parent is missing/trashed — nothing to
- * inherit) it writes the flattened doc verbatim.
+ * inherit) it writes the flattened doc verbatim. Every UPDATE path also purges
+ * legacy never-bagged settings shadows (GH #969 r4, neverBaggedUnset).
  */
 async function buildIniUpdate(
   collapsed: CollapsedFilamentData,
   existing: LeanFilament,
 ): Promise<Record<string, unknown>> {
   const flat = toUpdateSet(collapsed);
+  const purge = neverBaggedUnset(existing);
+  // Attach the never-bagged purge (+ any caller unsets) to a `$set`-only body.
+  const withUnset = (
+    out: Record<string, unknown>,
+    extra: string[] = [],
+  ): Record<string, unknown> => {
+    const keys = [...extra, ...purge];
+    if (keys.length > 0) out.$unset = Object.fromEntries(keys.map((k) => [k, ""]));
+    return out;
+  };
+
   // Root (or a variant with no resolvable parent): merge settings via dot-keys so
   // the write doesn't replace the whole bag (GH #950.8b).
-  if (!existing.parentId) return { $set: mergeSettingsDotKeys(flat) };
+  if (!existing.parentId) return withUnset({ $set: mergeSettingsDotKeys(flat) });
 
   const parent = await Filament.findOne({ _id: existing.parentId, _deletedAt: null })
     .select(INI_INHERITANCE_PROJECTION)
     .lean();
-  if (!parent) return { $set: mergeSettingsDotKeys(flat) };
+  if (!parent) return withUnset({ $set: mergeSettingsDotKeys(flat) });
 
   const split = splitInheritedImportSet(flat, existing, parent as LeanFilament);
   // Dot-flatten AFTER the per-key inheritance diff so its settings branch saw the
   // whole object; the resulting keys then MERGE rather than replace (GH #950.8b).
-  const out: Record<string, unknown> = { $set: mergeSettingsDotKeys(split.set) };
   // GH #969: the dot-key merge only writes the keys it emits, so a stored variant
   // settings override the section now reports equal to the parent would stay
   // pinned. Clear those via per-key `settings.<k>` $unsets so the variant keeps
   // tracking the parent (disjoint from the $set dot-keys above — see the
   // settingsSelfHealUnset docblock).
-  const unsetKeys = [
+  return withUnset({ $set: mergeSettingsDotKeys(split.set) }, [
     ...split.unset,
     ...settingsSelfHealUnset(flat.settings, existing, parent as LeanFilament),
-  ];
-  if (unsetKeys.length > 0) {
-    out.$unset = Object.fromEntries(unsetKeys.map((k) => [k, ""]));
-  }
-  return out;
+  ]);
 }
 
 export type IniUpsertOutcome = "created" | "updated";

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -229,11 +229,28 @@ export function droppedCalibrationCount(filament: FilamentDoc): number {
  * Generate an array of OrcaSlicer-format filament profile objects
  * from resolved Filament DB documents.
  */
-export function generateOrcaSlicerProfiles(filaments: FilamentDoc[]): Record<string, string[] | string>[] {
+/**
+ * GH #950.4 / #969 (Codex round 5): `bakeCalibration` is OPT-IN and defaults to
+ * false. Baking is only correct for the SINGLE-preset download paths
+ * (`GET /api/filaments/{id}/{orcaslicer,bambustudio}`), which are manual imports
+ * with no dynamic calibration module. The BULK bundle (`GET /api/filaments/orcaslicer`)
+ * feeds the OrcaSlicer FilamentDB module, which fetches `/calibration?format=orcaslicer`
+ * for the ACTIVE nozzle/bed at print time — baking the any-printer/any-bed
+ * representative there would seed every profile with wrong-context tuning until
+ * (or unless) the dynamic fetch overwrites it. So the bulk route leaves this off.
+ */
+export function generateOrcaSlicerProfiles(
+  filaments: FilamentDoc[],
+  { bakeCalibration = false }: { bakeCalibration?: boolean } = {},
+): Record<string, string[] | string>[] {
   return filaments.map((filament) => {
-    // GH #950.4: bake the representative calibration so tuned flow/PA/retraction/
-    // fan values reach the exported preset (stock Bambu has no dynamic fallback).
-    const orcaKeys = filamentToOrcaSlicerKeys(filament, pickRepresentativeCalibration(filament));
+    // Bake the representative calibration only on the opt-in single-preset path
+    // so tuned flow/PA/retraction/fan values reach a standalone preset (stock
+    // Bambu / a manually-imported Orca .json has no dynamic fallback).
+    const orcaKeys = filamentToOrcaSlicerKeys(
+      filament,
+      bakeCalibration ? pickRepresentativeCalibration(filament) : null,
+    );
 
     return {
       // Metadata fields (plain strings, not arrays)

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -201,9 +201,9 @@ export function calibrationToOrcaSlicerKeys(
  * GH #950.4: pick the ONE calibration to bake into a filament's single exported
  * preset — the any-printer / any-bed "default" entry (printer == null && bedType
  * == null) preferred, else the first calibration. Orca/Bambu presets are a single
- * .json, so a multi-nozzle filament collapses to this representative (the detail
- * page shows a notice when >1 distinct nozzle calibration exists — see
- * distinctNozzleCalibrationCount).
+ * .json, so a filament with more than one calibration collapses to this
+ * representative (the detail page shows a notice whenever any calibration is
+ * dropped — see droppedCalibrationCount).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function pickRepresentativeCalibration(filament: FilamentDoc): Record<string, any> | null {
@@ -213,20 +213,16 @@ export function pickRepresentativeCalibration(filament: FilamentDoc): Record<str
 }
 
 /**
- * GH #950.4: count DISTINCT nozzle calibrations (diameter + type + high-flow),
- * mirroring the #872 grouping in prusaSlicerBundle. The detail page warns when
- * this is >1 because the single Orca/Bambu .json export bakes only ONE
- * (see pickRepresentativeCalibration) — the other nozzles' tuning is dropped.
+ * GH #950.4 / #969 (Codex round 3): how many calibrations the single Orca/Bambu
+ * .json export will DROP. `pickRepresentativeCalibration` bakes exactly one, so
+ * every other calibration is lost — regardless of whether it's on a different
+ * nozzle OR the SAME nozzle with a different bed type / printer. The detail page
+ * warns when this is > 0. (The original counted DISTINCT nozzles, which silently
+ * collapsed same-nozzle tuning contexts and under-warned — the bug this fixes.)
  */
-export function distinctNozzleCalibrationCount(filament: FilamentDoc): number {
+export function droppedCalibrationCount(filament: FilamentDoc): number {
   const cals = Array.isArray(filament.calibrations) ? filament.calibrations : [];
-  const keys = new Set<string>();
-  for (const cal of cals) {
-    const nz = cal?.nozzle;
-    if (!nz || typeof nz !== "object" || nz.diameter == null) continue;
-    keys.add(`${nz.diameter}|${(nz.type ?? "").trim().toLowerCase()}|${nz.highFlow ? "HF" : ""}`);
-  }
-  return keys.size;
+  return Math.max(0, cals.length - 1);
 }
 
 /**

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -53,9 +53,20 @@ const BED_TYPE_KEY_MAP: Record<string, { temp: string; initial: string }> = {
  * Map a resolved Filament DB document to OrcaSlicer JSON key-value pairs.
  * All values are wrapped in single-element arrays per OrcaSlicer convention.
  * Structured DB fields take precedence over the settings bag.
+ *
+ * GH #950.4: when a representative `calibration` is supplied, its tuned values
+ * (flow ratio, pressure advance, retraction, fan speeds, per-calibration temps)
+ * are BAKED on top of the base keys via calibrationToOrcaSlicerKeys. Unlike the
+ * PrusaSlicer fork (which applies calibration dynamically via GET .../calibration),
+ * stock Bambu Studio has no such module, so without baking those values never
+ * reach an exported preset and prints revert to defaults. Pressure advance IS
+ * baked here (calibrationToOrcaSlicerKeys emits it) — the opposite of PrusaSlicer's
+ * deliberate omission — precisely because there is no dynamic fallback for Bambu.
  */
 export function filamentToOrcaSlicerKeys(
   filament: FilamentDoc,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  calibration?: Record<string, any> | null,
 ): Record<string, string[]> {
   const keys: Record<string, string[]> = {};
 
@@ -130,6 +141,15 @@ export function filamentToOrcaSlicerKeys(
   if (filament.shrinkageXY != null) set("filament_shrink", String(filament.shrinkageXY) + "%");
   if (filament.shrinkageZ != null) set("filament_shrinkage_compensation_z", filament.shrinkageZ);
 
+  // GH #950.4: bake the representative calibration on top (flow/PA/retraction/fans/
+  // per-calibration temps). Calibration values WIN over the structured/settings
+  // defaults above — they're the tuned per-nozzle numbers the user dialed in.
+  if (calibration) {
+    for (const [k, v] of Object.entries(calibrationToOrcaSlicerKeys(calibration))) {
+      keys[k] = v;
+    }
+  }
+
   return keys;
 }
 
@@ -178,12 +198,46 @@ export function calibrationToOrcaSlicerKeys(
 }
 
 /**
+ * GH #950.4: pick the ONE calibration to bake into a filament's single exported
+ * preset — the any-printer / any-bed "default" entry (printer == null && bedType
+ * == null) preferred, else the first calibration. Orca/Bambu presets are a single
+ * .json, so a multi-nozzle filament collapses to this representative (the detail
+ * page shows a notice when >1 distinct nozzle calibration exists — see
+ * distinctNozzleCalibrationCount).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function pickRepresentativeCalibration(filament: FilamentDoc): Record<string, any> | null {
+  const cals = Array.isArray(filament.calibrations) ? filament.calibrations : [];
+  if (cals.length === 0) return null;
+  return cals.find((c) => c && c.printer == null && c.bedType == null) ?? cals[0];
+}
+
+/**
+ * GH #950.4: count DISTINCT nozzle calibrations (diameter + type + high-flow),
+ * mirroring the #872 grouping in prusaSlicerBundle. The detail page warns when
+ * this is >1 because the single Orca/Bambu .json export bakes only ONE
+ * (see pickRepresentativeCalibration) — the other nozzles' tuning is dropped.
+ */
+export function distinctNozzleCalibrationCount(filament: FilamentDoc): number {
+  const cals = Array.isArray(filament.calibrations) ? filament.calibrations : [];
+  const keys = new Set<string>();
+  for (const cal of cals) {
+    const nz = cal?.nozzle;
+    if (!nz || typeof nz !== "object" || nz.diameter == null) continue;
+    keys.add(`${nz.diameter}|${(nz.type ?? "").trim().toLowerCase()}|${nz.highFlow ? "HF" : ""}`);
+  }
+  return keys.size;
+}
+
+/**
  * Generate an array of OrcaSlicer-format filament profile objects
  * from resolved Filament DB documents.
  */
 export function generateOrcaSlicerProfiles(filaments: FilamentDoc[]): Record<string, string[] | string>[] {
   return filaments.map((filament) => {
-    const orcaKeys = filamentToOrcaSlicerKeys(filament);
+    // GH #950.4: bake the representative calibration so tuned flow/PA/retraction/
+    // fan values reach the exported preset (stock Bambu has no dynamic fallback).
+    const orcaKeys = filamentToOrcaSlicerKeys(filament, pickRepresentativeCalibration(filament));
 
     return {
       // Metadata fields (plain strings, not arrays)

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -293,6 +293,87 @@ filamentdb_nozzle = 0.6 Brass
       expect(fresh.temperatures.nozzle).toBe(240); // not clobbered by 235/245
     });
 
+    it("#950.8b: a non-hinted import by name MERGES settings — omitted keys (openprinttag_slug/_uuid) survive", async () => {
+      const existing = await Filament.create({
+        name: "Prusament PLA",
+        vendor: "Prusa",
+        type: "PLA",
+        temperatures: { nozzle: 215 },
+        settings: { openprinttag_slug: "prusa-pla", openprinttag_uuid: "abc-123", some_fork_key: "keep" },
+      });
+      // A foreign/hand-crafted section (e.g. from stock PrusaSlicer) that OMITS the OPT keys.
+      const ini = `[filament:Prusament PLA]\nfilament_type = PLA\nfilament_vendor = Prusa\ntemperature = 220\ncooling = 1\n`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(existing._id);
+      // The OPT re-sync linkage the section didn't carry is PRESERVED (merge, not whole-replace).
+      expect(fresh.settings.openprinttag_slug).toBe("prusa-pla");
+      expect(fresh.settings.openprinttag_uuid).toBe("abc-123");
+      expect(fresh.settings.some_fork_key).toBe("keep");
+      expect(fresh.settings.cooling).toBe("1"); // the section's own passthrough key applied
+      // item5 guard: structured shadows still NOT persisted in the bag.
+      expect(fresh.settings.filament_type).toBeUndefined();
+      expect(fresh.settings.temperature).toBeUndefined();
+      expect(fresh.temperatures.nozzle).toBe(220); // incoming temp landed on the structured field
+    });
+
+    it("#950.8b: a variant re-import MERGES settings — the variant's own openprinttag_slug survives", async () => {
+      const parent = await Filament.create({
+        name: "Base PLA",
+        vendor: "Prusa",
+        type: "PLA",
+        temperatures: { nozzle: 215 },
+      });
+      const variant = await Filament.create({
+        name: "Base PLA Red",
+        vendor: "Prusa",
+        type: "PLA",
+        color: "#cc0000",
+        parentId: parent._id,
+        settings: { openprinttag_slug: "opt-red", some_key: "v" },
+      });
+      const ini = `[filament:Base PLA Red]\nfilament_type = PLA\nfilament_vendor = Prusa\nfilament_colour = #cc0000\ntemperature = 218\n`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(variant._id);
+      expect(fresh.settings.openprinttag_slug).toBe("opt-red"); // variant's own linkage preserved
+      expect(fresh.settings.some_key).toBe("v");
+    });
+
+    it("#950.8b: merge still does NOT persist a never-bagged key (filament_settings_id) into the bag", async () => {
+      const existing = await Filament.create({
+        name: "Guard PLA",
+        vendor: "X",
+        type: "PLA",
+        settings: { openprinttag_slug: "keep-me" },
+      });
+      const ini = `[filament:Guard PLA]\nfilament_type = PLA\nfilament_vendor = X\nfilament_settings_id = Guard PLA\ncooling = 1\n`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(existing._id);
+      expect(fresh.settings.filament_settings_id).toBeUndefined(); // stripped (item5/950.5)
+      expect(fresh.settings.openprinttag_slug).toBe("keep-me"); // preserved (950.8b merge)
+      expect(fresh.settings.cooling).toBe("1");
+    });
+
     it("#872: a hint-only collapsed section does NOT clobber the base's vendor/type/cost/density/color", async () => {
       const base = await Filament.create({
         name: "ABS",

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -414,12 +414,14 @@ filamentdb_nozzle = 0.6 Brass
       expect(fresh.settings.cooling).toBe("1");
     });
 
-    it("#969 (r4): purges a LEGACY never-bagged shadow already stored on the doc, keeping OPT keys", async () => {
-      // A pre-existing doc carrying stale never-bagged shadows (from an old
-      // import before they were stripped). The incoming section doesn't carry
-      // them, and the dot-key merge only writes present keys — so without an
-      // explicit purge they'd survive and keep overriding the re-derived name on
-      // the next export. They must be $unset; the OPT linkage must survive.
+    it("#969 (r4/r5): purges LEGACY never-bagged AND top-level-field shadows on the doc, keeping OPT keys", async () => {
+      // A pre-existing doc carrying stale shadows (from old import code): both
+      // never-bagged hints (filament_settings_id / filamentdb_nozzle) and
+      // top-level-field shadows (temperature / filament_cost). The incoming
+      // section doesn't carry them and the dot-key merge only writes present
+      // keys — so without an explicit purge they'd survive and keep overriding
+      // the re-derived / inherited values on the next export. All must be $unset;
+      // the OPT linkage must survive.
       const existing = await Filament.create({
         name: "Legacy PLA",
         vendor: "X",
@@ -427,6 +429,8 @@ filamentdb_nozzle = 0.6 Brass
         settings: {
           filament_settings_id: "Old Stale Name",
           filamentdb_nozzle: "0.4 Brass",
+          temperature: "999", // stale top-level-field shadow (r5)
+          filament_cost: "5", // stale top-level-field shadow (r5)
           openprinttag_slug: "opt-keep",
           cooling: "0",
         },
@@ -441,8 +445,10 @@ filamentdb_nozzle = 0.6 Brass
       );
       expect(res.status).toBe(200);
       const fresh = await Filament.findById(existing._id).lean();
-      expect(fresh.settings.filament_settings_id).toBeUndefined(); // stale shadow purged
-      expect(fresh.settings.filamentdb_nozzle).toBeUndefined(); // stale hint purged
+      expect(fresh.settings.filament_settings_id).toBeUndefined(); // never-bagged shadow purged
+      expect(fresh.settings.filamentdb_nozzle).toBeUndefined(); // never-bagged hint purged
+      expect(fresh.settings.temperature).toBeUndefined(); // top-level shadow purged (r5)
+      expect(fresh.settings.filament_cost).toBeUndefined(); // top-level shadow purged (r5)
       expect(fresh.settings.openprinttag_slug).toBe("opt-keep"); // OPT linkage preserved
       expect(fresh.settings.cooling).toBe("1"); // section value applied
     });

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -352,6 +352,46 @@ filamentdb_nozzle = 0.6 Brass
       expect(fresh.settings.some_key).toBe("v");
     });
 
+    it("#969: a variant's stale settings override that now matches the parent SELF-HEALS (merge-safe $unset)", async () => {
+      const parent = await Filament.create({
+        name: "Heal PLA",
+        vendor: "Prusa",
+        type: "PLA",
+        temperatures: { nozzle: 215 },
+        settings: { cooling: "1" },
+      });
+      const variant = await Filament.create({
+        name: "Heal PLA Red",
+        vendor: "Prusa",
+        type: "PLA",
+        color: "#cc0000",
+        parentId: parent._id,
+        // A stale local override that DIVERGES from the parent, plus an OPT
+        // linkage the imported section will NOT carry.
+        settings: { cooling: "0", openprinttag_slug: "opt-red" },
+      });
+      // The imported section carries cooling = 1, matching the parent — so the
+      // variant should stop overriding it and resume inheriting the parent's "1".
+      const ini = `[filament:Heal PLA Red]\nfilament_type = PLA\nfilament_vendor = Prusa\nfilament_colour = #cc0000\ncooling = 1\n`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(variant._id).lean();
+      // Self-heal: the stale local override is cleared so inheritance resumes.
+      expect(fresh?.settings?.cooling).toBeUndefined();
+      // Omitted-key preservation still holds — the OPT linkage survives.
+      expect(fresh?.settings?.openprinttag_slug).toBe("opt-red");
+      // And the effective (resolved) value now tracks the parent's "1".
+      const { resolveFilament } = await import("@/lib/resolveFilament");
+      const resolved = resolveFilament(fresh, parent.toObject());
+      expect(resolved.settings?.cooling).toBe("1");
+    });
+
     it("#950.8b: merge still does NOT persist a never-bagged key (filament_settings_id) into the bag", async () => {
       const existing = await Filament.create({
         name: "Guard PLA",

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -414,6 +414,39 @@ filamentdb_nozzle = 0.6 Brass
       expect(fresh.settings.cooling).toBe("1");
     });
 
+    it("#969 (r4): purges a LEGACY never-bagged shadow already stored on the doc, keeping OPT keys", async () => {
+      // A pre-existing doc carrying stale never-bagged shadows (from an old
+      // import before they were stripped). The incoming section doesn't carry
+      // them, and the dot-key merge only writes present keys — so without an
+      // explicit purge they'd survive and keep overriding the re-derived name on
+      // the next export. They must be $unset; the OPT linkage must survive.
+      const existing = await Filament.create({
+        name: "Legacy PLA",
+        vendor: "X",
+        type: "PLA",
+        settings: {
+          filament_settings_id: "Old Stale Name",
+          filamentdb_nozzle: "0.4 Brass",
+          openprinttag_slug: "opt-keep",
+          cooling: "0",
+        },
+      });
+      const ini = `[filament:Legacy PLA]\nfilament_type = PLA\nfilament_vendor = X\ncooling = 1\n`;
+      const res = await prusaImport(
+        new NextRequest("http://localhost/api/filaments/prusaslicer", {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: ini,
+        }),
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(existing._id).lean();
+      expect(fresh.settings.filament_settings_id).toBeUndefined(); // stale shadow purged
+      expect(fresh.settings.filamentdb_nozzle).toBeUndefined(); // stale hint purged
+      expect(fresh.settings.openprinttag_slug).toBe("opt-keep"); // OPT linkage preserved
+      expect(fresh.settings.cooling).toBe("1"); // section value applied
+    });
+
     it("#872: a hint-only collapsed section does NOT clobber the base's vendor/type/cost/density/color", async () => {
       const base = await Filament.create({
         name: "ABS",

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -213,4 +213,85 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
       expect(await Filament.findOne({ name: "Live Name", _deletedAt: null })).not.toBeNull();
     });
   });
+
+  // ── GH #969: the dot-key settings merge (#950.8b) preserves omitted keys but
+  //    no longer wipes a stale variant override that now matches the parent.
+  //    `buildIniUpdate` restores that self-heal with per-key `settings.<k>`
+  //    $unsets, disjoint from the merge's $set dot-keys. ──────────────────────
+  describe("variant settings self-heal (GH #969)", () => {
+    const variantSection = (
+      name: string,
+      settings: Record<string, string>,
+    ): CollapsedFilamentData => ({ name, settings, inherits: null });
+
+    it("unsets a stale override that now matches the parent, preserves an omitted key", async () => {
+      const parent = await Filament.create({
+        name: "SH Parent",
+        vendor: "Acme",
+        type: "PLA",
+        settings: { cooling: "1" },
+      });
+      const variant = await Filament.create({
+        name: "SH Variant",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#cc0000",
+        parentId: parent._id,
+        settings: { cooling: "0", keep_me: "v" },
+      });
+      const outcome = await upsertIniFilament(variantSection("SH Variant", { cooling: "1" }));
+      expect(outcome).toBe("updated");
+      const fresh = await Filament.findById(variant._id).lean();
+      expect(fresh.settings.cooling).toBeUndefined(); // self-healed → inherits parent "1"
+      expect(fresh.settings.keep_me).toBe("v"); // omitted key preserved (merge, not replace)
+    });
+
+    it("writes a differing key while leaving a matching-but-unowned key to inherit", async () => {
+      const parent = await Filament.create({
+        name: "Diff Parent",
+        vendor: "Acme",
+        type: "PLA",
+        settings: { fan: "50", theme: "dark" },
+      });
+      const variant = await Filament.create({
+        name: "Diff Variant",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#00cc00",
+        parentId: parent._id,
+        settings: {}, // no local overrides
+      });
+      // fan differs from parent → written; theme matches parent AND the variant
+      // has no local override → neither set nor unset (keeps inheriting).
+      const outcome = await upsertIniFilament(
+        variantSection("Diff Variant", { fan: "80", theme: "dark" }),
+      );
+      expect(outcome).toBe("updated");
+      const fresh = await Filament.findById(variant._id).lean();
+      expect(fresh.settings.fan).toBe("80"); // divergent value written through
+      expect(fresh.settings.theme).toBeUndefined(); // matches parent, unowned → inherits
+    });
+
+    it("does not throw when the variant carries no settings at all", async () => {
+      const parent = await Filament.create({
+        name: "NoSet Parent",
+        vendor: "Acme",
+        type: "PLA",
+        settings: { cooling: "1" },
+      });
+      const variant = await Filament.create({
+        name: "NoSet Variant",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#0000cc",
+        parentId: parent._id,
+        // no settings field
+      });
+      const outcome = await upsertIniFilament(variantSection("NoSet Variant", { cooling: "1" }));
+      expect(outcome).toBe("updated");
+      const fresh = await Filament.findById(variant._id).lean();
+      // Nothing to heal; the matching key keeps inheriting (no phantom local write).
+      expect(fresh.settings?.cooling).toBeUndefined();
+    });
+  });
 });

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -259,17 +259,19 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
         type: "PLA",
         color: "#00cc00",
         parentId: parent._id,
-        settings: {}, // no local overrides
+        settings: { extra: "old" }, // a variant-only key absent from the parent
       });
       // fan differs from parent → written; theme matches parent AND the variant
-      // has no local override → neither set nor unset (keeps inheriting).
+      // has no local override → neither set nor unset (keeps inheriting); extra is
+      // absent from the parent → a genuine override, written through (not unset).
       const outcome = await upsertIniFilament(
-        variantSection("Diff Variant", { fan: "80", theme: "dark" }),
+        variantSection("Diff Variant", { fan: "80", theme: "dark", extra: "new" }),
       );
       expect(outcome).toBe("updated");
       const fresh = await Filament.findById(variant._id).lean();
       expect(fresh.settings.fan).toBe("80"); // divergent value written through
       expect(fresh.settings.theme).toBeUndefined(); // matches parent, unowned → inherits
+      expect(fresh.settings.extra).toBe("new"); // absent from parent → override written, not healed
     });
 
     it("clears a parent-EQUAL local override so a future parent edit propagates (GH #969 round 2)", async () => {
@@ -300,6 +302,30 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
       const freshParent = await Filament.findById(parent._id).lean();
       const freshVariant = await Filament.findById(variant._id).lean();
       expect(resolveFilament(freshVariant, freshParent).settings.cooling).toBe("2");
+    });
+
+    it("self-heals on the RESURRECT path — a trashed variant's pin is cleared alongside the tombstone (phase 2)", async () => {
+      const parent = await Filament.create({
+        name: "Res Parent",
+        vendor: "Acme",
+        type: "PLA",
+        settings: { cooling: "1" },
+      });
+      // A TRASHED variant with a parent-equal pin — resurrected by the import.
+      const variant = await Filament.create({
+        name: "Res Variant",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#cccc00",
+        parentId: parent._id,
+        settings: { cooling: "1" },
+        _deletedAt: new Date(),
+      });
+      const outcome = await upsertIniFilament(variantSection("Res Variant", { cooling: "1" }));
+      expect(outcome).toBe("updated");
+      const fresh = await Filament.findById(variant._id).lean();
+      expect(fresh._deletedAt).toBeNull(); // resurrected
+      expect(fresh.settings.cooling).toBeUndefined(); // pin cleared on resurrect ($unset rode along)
     });
 
     it("does not throw when the variant carries no settings at all", async () => {

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -272,6 +272,36 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
       expect(fresh.settings.theme).toBeUndefined(); // matches parent, unowned → inherits
     });
 
+    it("clears a parent-EQUAL local override so a future parent edit propagates (GH #969 round 2)", async () => {
+      const parent = await Filament.create({
+        name: "Eq Parent",
+        vendor: "Acme",
+        type: "PLA",
+        settings: { cooling: "1" },
+      });
+      const variant = await Filament.create({
+        name: "Eq Variant",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#cc00cc",
+        parentId: parent._id,
+        // Local override that ALREADY equals the parent — functionally
+        // inheriting now, but pinned: a future parent edit wouldn't propagate.
+        settings: { cooling: "1" },
+      });
+      const outcome = await upsertIniFilament(variantSection("Eq Variant", { cooling: "1" }));
+      expect(outcome).toBe("updated");
+      const fresh = await Filament.findById(variant._id).lean();
+      // Pin cleared → the key is truly inherited now.
+      expect(fresh.settings.cooling).toBeUndefined();
+      // Prove propagation: edit the parent, the variant now tracks it.
+      await Filament.updateOne({ _id: parent._id }, { $set: { "settings.cooling": "2" } });
+      const { resolveFilament } = await import("@/lib/resolveFilament");
+      const freshParent = await Filament.findById(parent._id).lean();
+      const freshVariant = await Filament.findById(variant._id).lean();
+      expect(resolveFilament(freshVariant, freshParent).settings.cooling).toBe("2");
+    });
+
     it("does not throw when the variant carries no settings at all", async () => {
       const parent = await Filament.create({
         name: "NoSet Parent",

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -4,7 +4,7 @@ import {
   calibrationToOrcaSlicerKeys,
   generateOrcaSlicerProfiles,
   pickRepresentativeCalibration,
-  distinctNozzleCalibrationCount,
+  droppedCalibrationCount,
 } from "@/lib/orcaSlicerBundle";
 
 describe("filamentToOrcaSlicerKeys", () => {
@@ -732,16 +732,33 @@ describe("GH #950.4 — bake calibration into the Orca/Bambu export", () => {
     expect(pickRepresentativeCalibration(noDefault)?.extrusionMultiplier).toBe(0.9);
   });
 
-  it("distinctNozzleCalibrationCount groups by diameter+type+highFlow", () => {
-    expect(distinctNozzleCalibrationCount({ calibrations: [] })).toBe(0);
+  it("droppedCalibrationCount is calibrations beyond the one baked representative", () => {
+    // 0 or 1 calibration → nothing dropped.
+    expect(droppedCalibrationCount({ calibrations: [] })).toBe(0);
+    expect(droppedCalibrationCount({})).toBe(0);
+    expect(
+      droppedCalibrationCount({ calibrations: [{ nozzle: { diameter: 0.4, type: "Brass" } }] }),
+    ).toBe(0);
+    // GH #969 (Codex r3): two calibrations on the SAME nozzle but different bed
+    // types must count as a drop — the old distinct-nozzle count collapsed these
+    // to 1 and under-warned. Only one is baked, so one is dropped.
+    expect(
+      droppedCalibrationCount({
+        calibrations: [
+          { nozzle: { diameter: 0.4, type: "Brass" }, printer: null, bedType: null },
+          { nozzle: { diameter: 0.4, type: "Brass" }, printer: null, bedType: { name: "Textured PEI" } },
+        ],
+      }),
+    ).toBe(1);
+    // Multiple across nozzles + contexts → all but the representative dropped.
     const f = {
       calibrations: [
         { nozzle: { diameter: 0.4, type: "Brass" }, printer: null },
-        { nozzle: { diameter: 0.4, type: "brass" }, printer: { name: "MK4" } }, // case-fold → same
-        { nozzle: { diameter: 0.6, type: "Brass" }, printer: null }, // distinct
-        { nozzle: { diameter: 0.4, type: "Brass", highFlow: true }, printer: null }, // distinct (HF)
+        { nozzle: { diameter: 0.4, type: "brass" }, printer: { name: "MK4" } },
+        { nozzle: { diameter: 0.6, type: "Brass" }, printer: null },
+        { nozzle: { diameter: 0.4, type: "Brass", highFlow: true }, printer: null },
       ],
     };
-    expect(distinctNozzleCalibrationCount(f)).toBe(3);
+    expect(droppedCalibrationCount(f)).toBe(3);
   });
 });

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -707,7 +707,7 @@ describe("GH #950.4 — bake calibration into the Orca/Bambu export", () => {
     expect(keys.pressure_advance).toBeUndefined();
   });
 
-  it("generateOrcaSlicerProfiles bakes the representative (default) calibration", () => {
+  it("generateOrcaSlicerProfiles bakes the representative calibration ONLY when opted in (GH #969 r5)", () => {
     const filaments = [{
       name: "PLA", vendor: "X", type: "PLA", diameter: 1.75, temperatures: {}, settings: {},
       calibrations: [
@@ -715,8 +715,14 @@ describe("GH #950.4 — bake calibration into the Orca/Bambu export", () => {
         { nozzle: { diameter: 0.4, type: "Brass" }, printer: null, bedType: null, extrusionMultiplier: 0.978 }, // default
       ],
     }];
-    const profile = generateOrcaSlicerProfiles(filaments)[0];
-    expect(profile.filament_flow_ratio).toEqual(["0.978"]); // the printer==null/bedType==null default
+    // Bulk bundle (default): must NOT bake — the OrcaSlicer module fetches
+    // /calibration dynamically for the active nozzle/bed, so a baked static
+    // representative would seed wrong-context tuning.
+    const bulk = generateOrcaSlicerProfiles(filaments)[0];
+    expect(bulk.filament_flow_ratio).toBeUndefined();
+    // Single-preset download (opt-in): bakes the any-printer/any-bed default.
+    const single = generateOrcaSlicerProfiles(filaments, { bakeCalibration: true })[0];
+    expect(single.filament_flow_ratio).toEqual(["0.978"]);
   });
 
   it("pickRepresentativeCalibration prefers the any-printer/any-bed default, else the first", () => {

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -3,6 +3,8 @@ import {
   filamentToOrcaSlicerKeys,
   calibrationToOrcaSlicerKeys,
   generateOrcaSlicerProfiles,
+  pickRepresentativeCalibration,
+  distinctNozzleCalibrationCount,
 } from "@/lib/orcaSlicerBundle";
 
 describe("filamentToOrcaSlicerKeys", () => {
@@ -668,5 +670,78 @@ describe("generateOrcaSlicerProfiles", () => {
     expect(profile.cool_plate_temp).toEqual(["0"]);
     expect(profile.hot_plate_temp).toEqual(["100"]);
     expect(profile.hot_plate_temp_initial_layer).toEqual(["110"]);
+  });
+});
+
+describe("GH #950.4 — bake calibration into the Orca/Bambu export", () => {
+  it("filamentToOrcaSlicerKeys bakes a supplied calibration (flow / PA / retraction / fans) over the base keys", () => {
+    const filament = { name: "PLA", vendor: "X", type: "PLA", diameter: 1.75, temperatures: {}, settings: {} };
+    const keys = filamentToOrcaSlicerKeys(filament, {
+      extrusionMultiplier: 0.978,
+      pressureAdvance: 0.028,
+      retractLength: 0.8,
+      fanMinSpeed: 60,
+      fanMaxSpeed: 100,
+    });
+    expect(keys.filament_flow_ratio).toEqual(["0.978"]);
+    expect(keys.pressure_advance).toEqual(["0.028"]); // baked for Bambu (no dynamic fallback)
+    expect(keys.filament_retraction_length).toEqual(["0.8"]);
+    expect(keys.overhang_fan_speed).toEqual(["60"]);
+    expect(keys.additional_cooling_fan_speed).toEqual(["100"]);
+  });
+
+  it("calibration values WIN over structured/settings defaults", () => {
+    const filament = {
+      name: "PLA", vendor: "X", type: "PLA", diameter: 1.75, maxVolumetricSpeed: 12,
+      temperatures: { nozzle: 210 }, settings: {},
+    };
+    const keys = filamentToOrcaSlicerKeys(filament, { maxVolumetricSpeed: 20, nozzleTemp: 225 });
+    expect(keys.filament_max_volumetric_speed).toEqual(["20"]); // calibration, not the 12 default
+    expect(keys.nozzle_temperature).toEqual(["225"]);
+  });
+
+  it("no calibration → base keys unchanged (backward compatible)", () => {
+    const filament = { name: "PLA", vendor: "X", type: "PLA", diameter: 1.75, temperatures: {}, settings: {} };
+    const keys = filamentToOrcaSlicerKeys(filament);
+    expect(keys.filament_flow_ratio).toBeUndefined();
+    expect(keys.pressure_advance).toBeUndefined();
+  });
+
+  it("generateOrcaSlicerProfiles bakes the representative (default) calibration", () => {
+    const filaments = [{
+      name: "PLA", vendor: "X", type: "PLA", diameter: 1.75, temperatures: {}, settings: {},
+      calibrations: [
+        { nozzle: { diameter: 0.4, type: "Brass" }, printer: { name: "MK4" }, extrusionMultiplier: 0.9 },
+        { nozzle: { diameter: 0.4, type: "Brass" }, printer: null, bedType: null, extrusionMultiplier: 0.978 }, // default
+      ],
+    }];
+    const profile = generateOrcaSlicerProfiles(filaments)[0];
+    expect(profile.filament_flow_ratio).toEqual(["0.978"]); // the printer==null/bedType==null default
+  });
+
+  it("pickRepresentativeCalibration prefers the any-printer/any-bed default, else the first", () => {
+    expect(pickRepresentativeCalibration({ calibrations: [] })).toBeNull();
+    const withDefault = {
+      calibrations: [
+        { printer: { name: "MK4" }, extrusionMultiplier: 0.9 },
+        { printer: null, bedType: null, extrusionMultiplier: 0.978 },
+      ],
+    };
+    expect(pickRepresentativeCalibration(withDefault)?.extrusionMultiplier).toBe(0.978);
+    const noDefault = { calibrations: [{ printer: { name: "MK4" }, extrusionMultiplier: 0.9 }] };
+    expect(pickRepresentativeCalibration(noDefault)?.extrusionMultiplier).toBe(0.9);
+  });
+
+  it("distinctNozzleCalibrationCount groups by diameter+type+highFlow", () => {
+    expect(distinctNozzleCalibrationCount({ calibrations: [] })).toBe(0);
+    const f = {
+      calibrations: [
+        { nozzle: { diameter: 0.4, type: "Brass" }, printer: null },
+        { nozzle: { diameter: 0.4, type: "brass" }, printer: { name: "MK4" } }, // case-fold → same
+        { nozzle: { diameter: 0.6, type: "Brass" }, printer: null }, // distinct
+        { nozzle: { diameter: 0.4, type: "Brass", highFlow: true }, printer: null }, // distinct (HF)
+      ],
+    };
+    expect(distinctNozzleCalibrationCount(f)).toBe(3);
   });
 });

--- a/tests/single-filament-slicer-export.test.ts
+++ b/tests/single-filament-slicer-export.test.ts
@@ -148,6 +148,35 @@ describe("single-filament slicer export routes", () => {
       expect(body.from).toBe("User");
       expect(body.filament_type).toEqual(["ASA"]);
     });
+
+    it("GH #950.4 — bakes the representative calibration's tuned values into the exported preset", async () => {
+      const nozzle = await mongoose.models.Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
+      const f = await Filament.create({
+        name: "Tuned PLA",
+        vendor: "TestCo",
+        type: "PLA",
+        temperatures: { nozzle: 210, bed: 60 },
+        calibrations: [
+          {
+            nozzle: nozzle._id,
+            printer: null,
+            bedType: null,
+            extrusionMultiplier: 0.978,
+            pressureAdvance: 0.028,
+            retractLength: 0.8,
+          },
+        ],
+      });
+      const res = await exportBambu(req(String(f._id)), {
+        params: Promise.resolve({ id: String(f._id) }),
+      });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(await res.text());
+      // Without baking these would be absent → stock Bambu prints revert to defaults.
+      expect(body.filament_flow_ratio).toEqual(["0.978"]);
+      expect(body.pressure_advance).toEqual(["0.028"]);
+      expect(body.filament_retraction_length).toEqual(["0.8"]);
+    });
   });
 
   // ── Lookup by name with special characters ────────────────────────


### PR DESCRIPTION
Fixes #950 — the two remaining sub-findings (950.1/.2/.3/.5/.6/.7/.8a/.9 shipped in #968; a re-triage confirmed those still hold and only these two remained). Product/UX calls confirmed with the maintainer.

## 950.4 — bake calibration into the Orca/Bambu single-preset export
`generateOrcaSlicerProfiles → filamentToOrcaSlicerKeys(filament)` never emitted `calibrations[]` (tuned flow ratio / pressure advance / retraction / fan) — `calibrationToOrcaSlicerKeys`'s only caller was the dynamic `/calibration` endpoint, which stock Bambu Studio never hits. So a "Sync from Bambu Studio" → later export lost all tuning → prints reverted to defaults. #872 already solved this for PrusaSlicer.

- `filamentToOrcaSlicerKeys(filament, calibration?)` gains an optional calibration param; when present it bakes `calibrationToOrcaSlicerKeys(cal)` **on top** (calibration wins). Unlike PrusaSlicer, **pressure_advance IS baked** for Bambu — there's no dynamic fallback.
- `generateOrcaSlicerProfiles` bakes the representative calibration per filament via `pickRepresentativeCalibration` (the `printer==null && bedType==null` default, else the first). Single Bambu/Orca .json → one representative; a multi-nozzle filament collapses to the default nozzle's tuning.
- Detail page shows a notice (`detail.slicerExport.multiNozzleNotice`, EN+DE) when `>1` distinct nozzle calibration exists, so the collapse is visible (mirrors the multi-color drop notice). `distinctNozzleCalibrationCount` exported for that.

## 950.8b — bulk INI import merges settings instead of whole-replacing
`upsertIniFilament` `$set`-ed `settings` as a whole object, so a name-matched import from a section that **omitted** keys (e.g. `openprinttag_slug`/`_uuid` — the OPT re-sync linkage, when importing a foreign/stock-slicer INI) **replaced** the subdocument and severed re-sync.

- `buildIniUpdate` now dot-flattens the `settings` object into `settings.<k>` `$set` keys (`mergeSettingsDotKeys`) so the write MERGES — omitted keys survive. Matches the per-id sync route's `mergeSlicerSettings` semantics (INI import is additive for settings; key deletion isn't expressible via bulk import).
- `settings` added to `INI_INHERITANCE_PROJECTION` so `splitInheritedImportSet`'s per-key diff runs for a variant (store only settings keys that differ from the parent) — dot-flatten happens AFTER, so both inheritance and omitted keys are preserved. `stripStructuredSettings` still removes structured shadows (item5).

## Tests
`orcaSlicerBundle` (bake / representative pick / distinct-nozzle count), `single-filament-slicer-export` (Bambu export bakes flow/PA/retraction), `filaments-import-export-route` (import preserves openprinttag_slug/_uuid on root + variant; still doesn't persist filament_settings_id). Full tsc / lint / coverage / i18n-parity gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
