### PR TITLE
fix(nfc): OpenPrintTag encode keeps the everyday temp in MAX (closes #952)

### DIFF
--- a/src/lib/openprinttag.ts
+++ b/src/lib/openprinttag.ts
@@ -716,14 +716,22 @@ function buildMainMap(input: OpenPrintTagInput): number[] {
   // before it reaches the encoder so a bad input can't crash the whole
   // NFC-write path.
   if (input.nozzleTemp != null) {
-    // Use nozzle temp as max, derive min as temp - 20.
-    // GH #634: a first-layer temp ≥ nozzle+20 made the derived min exceed
-    // the max — order the pair with Math.min/Math.max exactly like the
-    // bed temps below, and derive preheat from the effective min.
+    // GH #952.4: the EVERYDAY nozzle temp must ALWAYS land in MAX_PRINT — the
+    // decoder reads it back from MAX as the primary nozzleTemp (openprinttag-
+    // decode.ts). GH #634 derived MIN from the first-layer temp and Math.max-ordered
+    // the pair, which SWAPPED them when firstLayer > nozzle+20: the everyday temp
+    // fell into MIN and the decoder read the inflated first-layer value as everyday.
+    // Fix: pin MAX to the everyday temp and clamp MIN so it never exceeds it (min ≤
+    // max still holds — the #634 invariant). A first-layer temp above the everyday
+    // temp can't extend a pinned MAX, so its excess isn't stored — but the everyday
+    // temp (the primary) now round-trips correctly, and first-layer was already
+    // dropped on decode (OPT has no first-layer field). Tags written BEFORE this
+    // fix keep the old swapped reading; there is no OPT version field to tell them
+    // apart, so this only corrects newly-written tags.
     const nozzleMax = clampTemp(input.nozzleTemp);
     const derivedMin = clampTemp((input.nozzleTempFirstLayer ?? nozzleMax) - 20);
     const minTemp = Math.min(derivedMin, nozzleMax);
-    const maxTemp = Math.max(derivedMin, nozzleMax);
+    const maxTemp = nozzleMax;
     const preheatTemp = clampTemp(minTemp - 20);
 
     encodeCBORKey(buf, OPT_KEY.MIN_PRINT_TEMPERATURE);
@@ -735,13 +743,19 @@ function buildMainMap(input: OpenPrintTagInput): number[] {
   }
 
   if (input.bedTemp != null) {
-    const maxBed = clampTemp(input.bedTemp);
-    const minBed = clampTemp(input.bedTempFirstLayer ?? maxBed - 10);
+    // GH #952.4: same fix as the nozzle above — the EVERYDAY bed temp must always
+    // land in MAX_BED (the decoder reads bedTemp from MAX). The prior Math.max
+    // ordering swapped everyday↔first-layer on the COMMON first-layer-hotter bed
+    // profile (e.g. bed 85 / first-layer 90), decoding the everyday bed as 90.
+    // Pin MAX to the everyday temp; MIN is the range floor (min of everyday and the
+    // first-layer temp, or everyday-10 when no first-layer is given).
+    const everydayBed = clampTemp(input.bedTemp);
+    const firstLayerBed = clampTemp(input.bedTempFirstLayer ?? everydayBed - 10);
 
     encodeCBORKey(buf, OPT_KEY.MIN_BED_TEMPERATURE);
-    encodeCBORUint(buf, Math.min(minBed, maxBed));
+    encodeCBORUint(buf, Math.min(firstLayerBed, everydayBed));
     encodeCBORKey(buf, OPT_KEY.MAX_BED_TEMPERATURE);
-    encodeCBORUint(buf, Math.max(minBed, maxBed));
+    encodeCBORUint(buf, everydayBed);
   }
 
   if (input.chamberTemp != null && input.chamberTemp > 0) {

--- a/tests/nfc-roundtrip.test.ts
+++ b/tests/nfc-roundtrip.test.ts
@@ -57,7 +57,8 @@ describe("NFC round-trip: encode → NDEF wrap → NDEF parse → decode", () =>
     expect(decoded.density).toBeCloseTo(1.24, 1);
     expect(decoded.diameter).toBe(1.75);
     expect(decoded.nozzleTemp).toBe(215);
-    expect(decoded.bedTemp).toBe(65);
+    // GH #952.4: the everyday bed temp (60) round-trips, not the first-layer (65).
+    expect(decoded.bedTemp).toBe(60);
     expect(decoded.chamberTemp).toBe(20);
     expect(decoded.weightGrams).toBe(1000);
     expect(decoded.countryOfOrigin).toBe("CZ");

--- a/tests/openprinttag-decode.test.ts
+++ b/tests/openprinttag-decode.test.ts
@@ -201,8 +201,10 @@ describe("decodeOpenPrintTagBinary", () => {
     expect(decoded.density).toBeCloseTo(1.24, 1);
     expect(decoded.diameter).toBe(1.75);
     expect(decoded.nozzleTemp).toBe(215);
-    // Encoder uses max(bedTempFirstLayer, bedTemp) = max(65, 60) = 65 as MAX_BED_TEMPERATURE
-    expect(decoded.bedTemp).toBe(65);
+    // GH #952.4: the EVERYDAY bed temp (60) now round-trips, not the first-layer
+    // temp (65). Pre-fix the encoder put max(65,60)=65 in MAX_BED and the decoder
+    // read bedTemp from MAX, inflating the everyday bed by the first-layer delta.
+    expect(decoded.bedTemp).toBe(60);
     expect(decoded.chamberTemp).toBe(20);
     expect(decoded.weightGrams).toBe(1000);
     expect(decoded.countryOfOrigin).toBe("CZ");
@@ -888,5 +890,41 @@ describe("decodeOpenPrintTagBinary", () => {
     ]);
     const decoded = decodeOpenPrintTagBinary(payload);
     expect(decoded.color).toBeUndefined();
+  });
+});
+
+describe("GH #952.4 — everyday temp round-trips as the primary (no first-layer inflation)", () => {
+  const base = { materialName: "Test PLA", brandName: "TestBrand", materialType: "PLA" };
+  const rt = (over: Partial<OpenPrintTagInput>) =>
+    decodeOpenPrintTagBinary(generateOpenPrintTagBinary({ ...base, ...over } as OpenPrintTagInput));
+
+  it("bed: first-layer HOTTER (the common convention) no longer inflates the everyday bed", () => {
+    const d = rt({ bedTemp: 85, bedTempFirstLayer: 90 });
+    expect(d.bedTemp).toBe(85); // everyday, not the 90 first-layer (pre-fix bug)
+    expect(d.bedTempMin).toBe(85); // MIN clamped to everyday (first-layer excess not stored)
+  });
+
+  it("bed: first-layer COOLER keeps the everyday temp in MAX and the floor in MIN", () => {
+    const d = rt({ bedTemp: 85, bedTempFirstLayer: 80 });
+    expect(d.bedTemp).toBe(85);
+    expect(d.bedTempMin).toBe(80);
+  });
+
+  it("bed: NO first-layer value still round-trips the everyday temp (no regression)", () => {
+    const d = rt({ bedTemp: 85 });
+    expect(d.bedTemp).toBe(85);
+    expect(d.bedTempMin).toBe(75); // synthesized everyday-10 floor
+  });
+
+  it("nozzle: first-layer > everyday + 20 no longer inflates the everyday nozzle temp", () => {
+    const d = rt({ nozzleTemp: 200, nozzleTempFirstLayer: 230 });
+    expect(d.nozzleTemp).toBe(200); // everyday, not firstLayer-20 = 210 (pre-fix bug)
+    expect(d.nozzleTempMin).toBe(200); // MIN clamped to everyday
+  });
+
+  it("nozzle: NO first-layer value still round-trips the everyday temp (no regression)", () => {
+    const d = rt({ nozzleTemp: 215 });
+    expect(d.nozzleTemp).toBe(215);
+    expect(d.nozzleTempMin).toBe(195); // synthesized everyday-20 floor
   });
 });

--- a/tests/openprinttag.test.ts
+++ b/tests/openprinttag.test.ts
@@ -1179,11 +1179,11 @@ describe("generateOpenPrintTagBinary", () => {
     expect(bytes[dIdx + 3]).toBe(100); // capped to the Shore scale
   });
 
-  it("orders min <= max print temps when first-layer >= nozzle+20 (GH #634)", () => {
+  it("keeps the everyday nozzle temp in MAX even when first-layer >= nozzle+20 (GH #634 / #952.4)", () => {
     const input: OpenPrintTagInput = {
       ...minimalInput,
       nozzleTemp: 230,
-      nozzleTempFirstLayer: 260, // derived min would be 240 > max 230
+      nozzleTempFirstLayer: 260, // derived min would be 240 > everyday 230
     };
     const result = generateOpenPrintTagBinary(input);
     const bytes = Array.from(result);
@@ -1192,11 +1192,13 @@ describe("generateOpenPrintTagBinary", () => {
     const maxIdx = findCBORKey(bytes, OPT_KEY.MAX_PRINT_TEMPERATURE);
     expect(minIdx).not.toBe(-1);
     expect(maxIdx).not.toBe(-1);
-    // Mirrors the bed-temp Math.min/Math.max guard: min 230, max 240
+    // GH #952.4: MAX is pinned to the EVERYDAY temp (230) so the decoder reads it
+    // back correctly; MIN is clamped to it (min ≤ max holds — the #634 invariant).
+    // The first-layer excess (260) can't extend a pinned MAX, so it isn't stored.
     expect(bytes[minIdx + 2]).toBe(0x18);
     expect(bytes[minIdx + 3]).toBe(230);
     expect(bytes[maxIdx + 2]).toBe(0x18);
-    expect(bytes[maxIdx + 3]).toBe(240);
+    expect(bytes[maxIdx + 3]).toBe(230);
 
     // Preheat derives from the effective min: 230 - 20 = 210
     const preheatIdx = findCBORKey(bytes, OPT_KEY.PREHEAT_TEMPERATURE);


### PR DESCRIPTION
Fixes #952 — the last remaining sub-finding (952.4; items 1/2/3/5 shipped in #967, and a re-triage confirmed those still hold).

## 952.4 — first-layer temperature round-trip inflation
The OpenPrintTag encoder anchored the everyday temp to one range bound and derived the other from the first-layer temp, then `Math.min/max`-ordered the pair (GH #634, to keep `MIN ≤ MAX`). When the first-layer temp was the **hotter** one — the *normal* slicer convention for the bed — the ordering **swapped** everyday↔first-layer, and since the decoder reads the primary temp from `MAX`, the app's own NFC write→scan path decoded the everyday bed **inflated** by the first-layer delta (`bed 85 / first-layer 90` → decoded `bed 90`), with the first-layer value lost. Same drift on the nozzle when `firstLayer > nozzle + 20`.

**Fix (encode-only, per the maintainer's call):** always write the **everyday** temp into `MAX_BED` / `MAX_PRINT`; derive `MIN` downward only (`min(everyday, first-layer-derived)`), so `MIN ≤ MAX` still holds. The decoder is unchanged — it reads the everyday temp from `MAX` and now gets the right value on newly-written tags.

Trade-offs (accepted, documented in the code):
- A first-layer temp *above* the everyday temp can't extend a pinned `MAX`, so its excess isn't stored — but first-layer was **already** dropped on decode (OpenPrintTag has no first-layer field), so this loses nothing new; it just makes the *everyday* (primary) temp correct.
- OpenPrintTag has **no version field** in the codec, so tags written before this fix can't be distinguished and keep the old (swapped) reading. This corrects newly-written tags only. (Confirmed: no version gate exists to support dual-scheme reads.)
- The no-first-layer case is unchanged: the encoder still synthesizes `MIN = everyday-10` (bed) / `everyday-20` (nozzle), and `MAX` already held the everyday temp there — a decode-only "read from MIN" fix would have regressed exactly this case, which is why the fix is on the encode side.

## Tests
New `openprinttag-decode` round-trip block covering bed first-layer-hotter / cooler / none and nozzle first-layer>+20 / none (everyday round-trips, no-first-layer preserved). Updated the mechanism-note tests in `openprinttag-decode`, `openprinttag` (#634), and `nfc-roundtrip` that pinned the old inflated read. Full tsc / lint / coverage gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
