### PR TITLE
fix(import): clear parent-equal variant pins on round-trip (scalar/temp/array) (#971)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -948,11 +948,17 @@ export async function POST(
     // this, only `color` had echo suppression (resolveSyncBackColor). Reuse the
     // CSV importer's battle-tested split (GH #628 / #649): drop each inheritable
     // field whose incoming value equals the parent's (keep inheriting), and
-    // $unset a stale diverging local override so inheritance resumes. Variant-
+    // $unset a stale local override so inheritance resumes. Variant-
     // only + non-inheritable keys (color, colorName, name, settings, soluble,
     // …) pass through untouched. `calParent` is the already-fetched parent doc;
     // when it's null (standalone/parent, or a soft-deleted/missing parent —
     // nothing to inherit) the update is written verbatim.
+    // GH #971: because the fork ALWAYS sends resolveFilament-flattened values
+    // (per the docblock above), a parent-EQUAL incoming value is indistinguishable
+    // from a true inherit on this path exactly as on the CSV/INI bundle paths — so
+    // splitInheritedImportSet's presence-based clear (which now also drops a
+    // parent-equal pin, not just a divergent one) is the correct shared default
+    // here too, not a bundle-only concern.
     const mongoUpdate: Record<string, unknown> = { $set: update };
     if (filament.parentId && calParent) {
       const split = splitInheritedImportSet(

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -327,24 +327,38 @@ type LeanFilament = Record<string, any>;
  *
  *   - incoming value equals the parent's value → SKIP the $set so the
  *     variant keeps inheriting dynamically at read time;
- *   - …and if the variant currently carries a local override that DIFFERS
- *     from the incoming value, emit an `$unset` so inheritance resumes
- *     (a stale divergence the import just reconciled) — except for
- *     schema-required fields, which are left in place;
+ *   - …and if the variant currently carries ANY local override of that field
+ *     (divergent OR parent-equal — see the GH #971 note below), emit an
+ *     `$unset` so inheritance resumes — except for schema-required fields,
+ *     which are left in place;
  *   - incoming value differs from the parent → $set normally (a genuine
  *     variant override).
  *
+ * GH #971: when the incoming section reports a field EQUAL to the parent, the
+ * export (which flattens through resolveFilament) can't tell a deliberate pin
+ * from a true inherit — both serialize to the same value — so the safe re-import
+ * default is to CLEAR any variant-local override so it tracks the parent live
+ * (GH #106). The `$unset` therefore fires on PRESENCE of a local override, not
+ * on divergence: a variant value equal to the parent is still a stored pin that
+ * would block a future parent edit, so it's cleared too (this matches the
+ * settings self-heal added in #969). Divergent pins were already cleared; #971
+ * extends it to parent-equal pins across the scalar, temperature, AND
+ * secondaryColors branches.
+ *
  * Array + nested handling:
  *   - `temperatures.*` dot-keys compare against the parent's same subfield
- *     (resolveFilament inherits each temp independently via `??`).
+ *     (resolveFilament inherits each temp independently via `??`); a local temp
+ *     override of a parent-equal subfield is cleared.
  *   - `secondaryColors` inherits as a WHOLE array (resolveFilament treats
- *     an empty array as "inherit"), so it's skipped only when the incoming
- *     array matches the parent's array exactly (order-sensitive — order is
- *     meaningful for multi-color rendering).
+ *     an empty array as "inherit"); when the incoming array matches the parent's
+ *     array exactly (order-sensitive — order is meaningful for multi-color
+ *     rendering), any non-empty variant-local array is cleared so it inherits.
  *   - `settings` inherits by SHALLOW PER-KEY merge, so it's rebuilt to hold
  *     only keys that differ from the parent's `settings` (parent-equal keys
  *     keep inheriting). This runs only when the caller supplies the parent's
- *     settings; without them it writes through (GH #951, Codex).
+ *     settings; without them it writes through (GH #951, Codex). (Note: the
+ *     bulk INI path's `settingsSelfHealUnset` clears stored parent-equal
+ *     settings pins on top of this; the per-id sync path does not yet — GH #972.)
  *   - The variant-local empty-string rule mirrors resolveFilament:67-72 —
  *     a variant value of `""` counts as "missing" (already inheriting), so
  *     it never triggers an $unset.
@@ -367,7 +381,9 @@ export function splitInheritedImportSet(
       const parentVal = parent.temperatures?.[sub] ?? null;
       const variantVal = variant.temperatures?.[sub] ?? null;
       if (incoming != null && parentVal === incoming) {
-        if (variantVal != null && variantVal !== incoming) unset.push(key);
+        // GH #971: clear ANY local override of a parent-equal subfield
+        // (divergent OR parent-equal pin) so it inherits live.
+        if (variantVal != null) unset.push(key);
         continue;
       }
       set[key] = incoming;
@@ -384,7 +400,10 @@ export function splitInheritedImportSet(
       const equalsArr = (a: unknown[], b: unknown[]) =>
         a.length === b.length && a.every((v, i) => v === b[i]);
       if (incoming.length > 0 && equalsArr(incoming, parentArr)) {
-        if (variantArr.length > 0 && !equalsArr(variantArr, incoming)) {
+        // GH #971: the section reports the array equal to the parent's, so any
+        // non-empty variant-local array is a pin (divergent OR parent-equal) —
+        // clear it so the whole array inherits live.
+        if (variantArr.length > 0) {
           unset.push(key);
         }
         continue;
@@ -436,7 +455,10 @@ export function splitInheritedImportSet(
           if (variantVal !== incoming) set[key] = incoming;
           continue;
         }
-        if (hasLocalValue(variantVal) && variantVal !== incoming) {
+        // GH #971: clear ANY local override of a parent-equal scalar (divergent
+        // OR parent-equal pin) so a later parent edit propagates. Required
+        // fields returned above; they never inherit and are never unset.
+        if (hasLocalValue(variantVal)) {
           unset.push(key);
         }
         continue;

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -139,11 +139,13 @@ function mergeSettingsDotKeys(setBody: Record<string, unknown>): Record<string, 
  * strict parent-equality predicate (`splitInheritedImportSet`'s `!==`); a future
  * change to one must keep the other in lockstep.
  *
- * Known scope gap (GH #971): the SCALAR path (`splitInheritedImportSet`) clears
- * only a DIVERGENT parent-equal override and leaves a parent-*equal* scalar pin
- * in place — the same latent gap this fixes for settings. It's shared by three
- * call sites (CSV import, per-id sync, INI import), so aligning it is tracked
- * separately rather than widened into this PR.
+ * Sibling paths (GH #971, now fixed): the SCALAR / temperature / secondaryColors
+ * branches of `splitInheritedImportSet` now also clear a parent-*equal* pin
+ * (presence-based `$unset`), matching this settings self-heal across all three
+ * shared call sites (CSV import, per-id sync, INI import). The one remaining
+ * asymmetry is that THIS settings self-heal is still wired only into the INI
+ * path; the per-id PrusaSlicer sync route doesn't yet clear stored parent-equal
+ * settings pins — tracked in GH #972.
  */
 function settingsSelfHealUnset(
   incoming: unknown,

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1015,6 +1015,58 @@ describe("API route correctness", () => {
     expect(resolveFilament(fresh, freshParent).cost).toBe(30);
   });
 
+  it("#971 — syncing a variant CLEARS a parent-EQUAL local pin so future parent edits propagate", async () => {
+    const parent = await Filament.create({
+      name: "PEq Sync PLA",
+      vendor: "Acme",
+      type: "PLA",
+      cost: 25,
+      temperatures: { nozzle: 215 },
+    });
+    // The variant carries LOCAL pins that already EQUAL the parent's values.
+    const variant = await Filament.create({
+      name: "PEq Sync PLA — Green",
+      vendor: "Acme",
+      type: "PLA",
+      color: "#00FF00",
+      parentId: parent._id,
+      cost: 25, // parent-equal pin
+      temperatures: { nozzle: 215 }, // parent-equal pin
+    });
+
+    // The fork echoes the resolved (== parent) config; a parent-equal incoming
+    // value is indistinguishable from a true inherit, so the pin must be cleared.
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}`, {
+        config: {
+          filamentdb_id: String(variant._id),
+          filament_type: "PLA",
+          filament_vendor: "Acme",
+          filament_cost: "25",
+          temperature: "215",
+        },
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const fresh = await Filament.findById(variant._id).lean();
+    // Parent-equal pins cleared ($unset removes the field) → truly inheriting.
+    expect(fresh.cost ?? null).toBeNull();
+    expect(fresh.temperatures?.nozzle ?? null).toBeNull();
+
+    // A later parent edit now propagates (GH #106 restored).
+    await Filament.updateOne(
+      { _id: parent._id },
+      { $set: { cost: 40, "temperatures.nozzle": 230 } },
+    );
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    const resolved = resolveFilament(fresh, freshParent);
+    expect(resolved.cost).toBe(40);
+    expect(resolved.temperatures?.nozzle).toBe(230);
+  });
+
   it("#951 — a variant sync value that DIFFERS from the parent is written as a genuine override", async () => {
     const parent = await Filament.create({
       name: "Sync PETG",

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -252,6 +252,52 @@ bed_temperature = 60
       const freshParent = await Filament.findById(parent._id).lean();
       expect(resolveFilament(fresh, freshParent).cost).toBe(30);
     });
+
+    it("#971: re-importing clears a variant's parent-EQUAL scalar/temp pin so future parent edits propagate", async () => {
+      const parent = await Filament.create({
+        name: "PEq Base",
+        vendor: "Acme",
+        type: "PLA",
+        cost: 25,
+        temperatures: { nozzle: 215, bed: 60 },
+      });
+      // The variant PINS cost + nozzle to values that already EQUAL the parent.
+      const variant = await Filament.create({
+        name: "PEq Base — Blue",
+        vendor: "Acme",
+        type: "PLA",
+        color: "#0000FF",
+        parentId: parent._id,
+        cost: 25, // parent-equal pin
+        temperatures: { nozzle: 215 }, // parent-equal pin
+      });
+      // The flattened export section carries the resolved (== parent) values.
+      const ini = `[filament:PEq Base — Blue]
+filament_type = PLA
+filament_vendor = Acme
+filament_cost = 25
+temperature = 215
+`;
+      const file = new File([ini], "peq.ini", { type: "text/plain" });
+      const res = await importFilaments(
+        multipartReq("http://localhost/api/filaments/import", file),
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(variant._id).lean();
+      // Pins cleared ($unset removes the field entirely) → now truly inheriting.
+      expect(fresh.cost ?? null).toBeNull();
+      expect(fresh.temperatures?.nozzle ?? null).toBeNull();
+      // Prove propagation: a later parent edit now reaches the variant.
+      await Filament.updateOne(
+        { _id: parent._id },
+        { $set: { cost: 40, "temperatures.nozzle": 230 } },
+      );
+      const { resolveFilament } = await import("@/lib/resolveFilament");
+      const freshParent = await Filament.findById(parent._id).lean();
+      const resolved = resolveFilament(fresh, freshParent);
+      expect(resolved.cost).toBe(40);
+      expect(resolved.temperatures?.nozzle).toBe(230);
+    });
   });
 
   describe("POST /api/filaments/prusaslicer (bundle import)", () => {

--- a/tests/importFilaments.test.ts
+++ b/tests/importFilaments.test.ts
@@ -996,6 +996,32 @@ describe("splitInheritedImportSet (GH #628)", () => {
     expect(unset).toEqual(["cost"]);
   });
 
+  it("$unsets a scalar override that already EQUALS the parent (GH #971 parent-equal pin)", () => {
+    // variant pinned cost=25, parent=25, import=25 → the pin is redundant now
+    // but would block a future parent cost edit; a flattened export can't
+    // distinguish it from a true inherit, so it's cleared so inheritance resumes.
+    const variant = { cost: 25 };
+    const { set, unset } = splitInheritedImportSet(
+      { name: "V", cost: 25 },
+      variant,
+      parent,
+    );
+    expect(set).toEqual({ name: "V" });
+    expect(unset).toEqual(["cost"]);
+  });
+
+  it("$unsets a temperature subfield override that already EQUALS the parent (GH #971)", () => {
+    // variant nozzle=215 == parent 215 == incoming → cleared so it inherits.
+    const variant = { temperatures: { nozzle: 215 } };
+    const { set, unset } = splitInheritedImportSet(
+      { name: "V", "temperatures.nozzle": 215 },
+      variant,
+      parent,
+    );
+    expect(set).toEqual({ name: "V" });
+    expect(unset).toEqual(["temperatures.nozzle"]);
+  });
+
   it("never $unsets schema-required fields (vendor/type), and writes them through when stale (GH #649)", () => {
     // Required fields can't be unset (validation) and never inherit at read
     // time — resolveFilament always uses the variant's own value. So when
@@ -1111,8 +1137,10 @@ describe("splitInheritedImportSet (GH #628)", () => {
     expect(unset).toEqual(["secondaryColors"]);
   });
 
-  it("does NOT $unset secondaryColors when the variant's local array already equals the incoming/parent array", () => {
-    // variantArr equals incoming → nothing stale to reconcile → skip $set, no $unset.
+  it("$unsets secondaryColors when the variant's local array equals the incoming/parent array (GH #971)", () => {
+    // GH #971: a variant-local array equal to the parent's is still a stored pin
+    // — a flattened export can't distinguish it from a true inherit, so on
+    // re-import it's cleared so the whole array inherits live.
     const variant = { secondaryColors: ["#FF0000", "#00FF00"] };
     const { set, unset } = splitInheritedImportSet(
       { name: "V", secondaryColors: ["#FF0000", "#00FF00"] },
@@ -1120,7 +1148,7 @@ describe("splitInheritedImportSet (GH #628)", () => {
       parent,
     );
     expect(set).toEqual({ name: "V" });
-    expect(unset).toEqual([]);
+    expect(unset).toEqual(["secondaryColors"]);
   });
 
   it("treats a non-array parent.secondaryColors as [] so a non-empty incoming array is a genuine override (branch 344)", () => {


### PR DESCRIPTION
Fixes #971.

## Problem

`splitInheritedImportSet` (shared by the CSV/XLSX importer, the per-id PrusaSlicer sync route, and the bulk INI importer) cleared a variant's parent-equal override **only when it diverged** from the incoming value. A bundle/CSV export — and the PrusaSlicer fork's per-id sync — flatten a variant through `resolveFilament`, so a deliberate *pin* and a true *inherit* serialize to the identical value. When the variant's stored value already **equalled** the parent, the divergence gate (`variantVal !== incoming`) was false, so no `$unset` fired and the pin survived — silently blocking future parent edits from propagating (GH #106). #969 fixed this for the settings bag; this extends the same presence-based clear to the three scalar/array branches.

## Fix

Presence-based `$unset` (clear any local override of a field the section reports equal to the parent), in `splitInheritedImportSet`:
- **scalar** (`IMPORT_INHERITABLE_SCALARS`): drop the `variantVal !== incoming` gate — the `IMPORT_REQUIRED_FIELDS` (vendor/type) guard above it is unchanged, so those are still never `$unset`.
- **temperatures.***: `$unset` on `variantVal != null`.
- **secondaryColors**: `$unset` any non-empty variant-local array when the incoming array equals the parent's.

One shared helper → all three call sites pick it up.

## Why this is correct on ALL three paths (incl. per-id sync)

The per-id PrusaSlicer sync route (`POST /api/filaments/[id]`) receives config the fork produces by flattening the variant through `resolveFilament` (see the route docblock), so a parent-equal incoming value is **indistinguishable from an inherit** there exactly as on the CSV/INI bundle paths. Presence-based clearing is therefore the correct *shared* default, not a bundle-only concern. Added a code comment stating this invariant at the call site.

## Tests
- Unit (`importFilaments.test.ts`): parent-equal `$unset` for scalar + temperature; flipped the secondaryColors parent-equal test to expect `$unset` (both arms of the `variantArr.length > 0` gate covered).
- Route round-trip: bulk INI (`filaments-import-export-route.test.ts`) and per-id sync (`api-route-correctness.test.ts`) each seed a parent-equal pin, sync/import, and assert it clears + a later parent edit propagates.
- Full coverage gate green (98.99 / 97.44 / 97.49 / 99.51).

## Out of scope (tracked)
The per-id sync route does not yet clear parent-equal **settings**-bag pins (`settingsSelfHealUnset` is INI-only) — a separate pre-existing gap tracked in #972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)