### PR TITLE
test(sync): lock per-id sync settings self-heal (#972 is a false positive)

### DIFF
--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1067,6 +1067,53 @@ describe("API route correctness", () => {
     expect(resolved.temperatures?.nozzle).toBe(230);
   });
 
+  it("#972 — per-id sync self-heals a parent-EQUAL SETTINGS pin while keeping variant-only settings", async () => {
+    // #972 was filed as a suspected gap (the per-id route never emits a
+    // settings.<k> $unset like the INI path's settingsSelfHealUnset). It's a
+    // FALSE POSITIVE: this route $sets the WHOLE settings object to
+    // splitInheritedImportSet's parent-filtered bag, so a stored parent-equal pin
+    // — excluded from `filtered` — is dropped by the whole-object replace, and
+    // variant-only keys (which differ from the parent) survive in `filtered`.
+    // (The INI path needs settingsSelfHealUnset only because #950.8b switched it
+    // to a non-replacing dot-key merge.) This test LOCKS that behavior so a future
+    // refactor of the route to a merge-style write can't silently reintroduce #972.
+    const parent = await Filament.create({
+      name: "S972 Parent",
+      vendor: "Acme",
+      type: "PLA",
+      settings: { cooling: "1" },
+    });
+    const variant = await Filament.create({
+      name: "S972 Variant",
+      vendor: "Acme",
+      type: "PLA",
+      color: "#123456",
+      parentId: parent._id,
+      settings: { cooling: "1", opt: "x" }, // cooling = parent-equal pin; opt = variant-only
+    });
+    // Fork echoes the resolved (== parent) config; cooling is a passthrough key.
+    const res = await slicerSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}`, {
+        config: {
+          filamentdb_id: String(variant._id),
+          filament_type: "PLA",
+          filament_vendor: "Acme",
+          cooling: "1",
+        },
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const fresh = await Filament.findById(variant._id).lean();
+    expect(fresh.settings?.cooling ?? null).toBeNull(); // parent-equal pin cleared → inherits
+    expect(fresh.settings?.opt).toBe("x"); // variant-only key preserved
+    // A later parent edit propagates through resolveFilament's shallow merge.
+    await Filament.updateOne({ _id: parent._id }, { $set: { "settings.cooling": "2" } });
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    expect(resolveFilament(fresh, freshParent).settings.cooling).toBe("2");
+  });
+
   it("#951 — a variant sync value that DIFFERS from the parent is written as a genuine override", async () => {
     const parent = await Filament.create({
       name: "Sync PETG",


### PR DESCRIPTION
Closes #972.

## TL;DR
#972 is a **false positive** — the per-id PrusaSlicer sync route already self-heals parent-equal variant **settings** pins. This PR adds a regression test that **locks** that behavior; no production code changes.

## Why it's a false positive
#972 (spawned by a #971-triage note) suspected the per-id route never clears a stored parent-equal `settings.<k>` pin because — unlike the INI path's `settingsSelfHealUnset` — it emits no `settings.<k>` `$unset`. But it doesn't need one:

1. `mergeSlicerSettings` is **additive** → `merge.settings = { ...variant.settings, ...config }`.
2. `splitInheritedImportSet`'s settings branch returns `split.set.settings = filtered` (only keys **differing** from the parent).
3. The route does a **whole-object** `$set: split.set` ([route.ts:969](src/app/api/filaments/[id]/route.ts)), which **replaces** the whole `settings` subdoc with `filtered`.

So a stored parent-equal pin is in the merged bag but **excluded from `filtered`**, and the whole-object replace **drops** it → the variant inherits. Variant-only keys (differ from parent) stay in `filtered` → preserved. (The INI path needs `settingsSelfHealUnset` only because #950.8b switched it to a non-replacing dot-key *merge*.)

Verified empirically against current `main` (throwaway test, no code change): parent-equal `settings.cooling` pin cleared, variant-only `settings.opt` kept, later parent edit propagated.

## This PR
Adds a permanent route-level regression test in `tests/api-route-correctness.test.ts` pinning: parent-equal settings pin cleared → inherits, variant-only key preserved, and a subsequent parent edit propagates. This guards against a future refactor of the route to a merge-style settings write silently reintroducing the gap. Test-only; full route-correctness suite green (76 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)