### PR TITLE
chore(release): bump version to 1.64.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.63.0",
+      "version": "1.64.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.63.0",
+    "version": "1.64.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Version bump to **1.64.0** for the release.

Manual bump (the `release-bump.yml` workflow dispatch returned HTTP 403 for this token — no `workflow` scope). Bumps the same files the workflow does, through the normal PR + CI gate:
- `package.json` (top-level `version`)
- `package-lock.json` (top-level `version` + `packages[""].version`)
- `public/openapi.json` (`info.version`)

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)