### PR TITLE
fix(nfc): NTAG size = user choice when GET_VERSION is unavailable (ACR1552U) (#973)

### DIFF
--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -27,6 +27,7 @@ import { decodeFromNdefRecords, OPENPRINTTAG_MIME } from "../src/lib/tagCodecs";
 import { OPENTAG3D_MIME } from "../src/lib/opentag3d";
 import {
   parseNtagNdefBytesFromGetVersion,
+  resolveNtagWriteSize,
   NTAG_NAME_TO_NDEF_BYTES,
   type NtagSizeName,
 } from "../src/lib/ntagVersion";
@@ -93,16 +94,9 @@ const DEFAULT_BLOCK_COUNT = 80;
 const NTAG_CC_OFFSET = 12;
 const NTAG_TLV_OFFSET = 16;
 const NTAG_MAX_NDEF_BYTES = 1024;
-// Write/erase extent caps (Codex #927 — bound a corrupt/foreign CC size so a
-// write never runs off the chip / into config-lock pages). NTAG216 (the largest
-// real NTAG) holds 872 NDEF bytes → last user page 221 (< 256, no APDU wrap).
-const NTAG_MAX_NDEF_WRITE_BYTES = 872;
-// When the true chip size is UNKNOWN (GET_VERSION unsupported), bound the
-// hygiene zero-fill to NTAG213's user area (144 bytes) — safe on ANY chip, since
-// even the smallest NTAG's lock/config pages sit above its user area. The fresh
-// CC + empty-NDEF TLV already make the tag blank; the deeper wipe is just hygiene
-// and stale bytes past the TLV terminator are unreachable by NDEF readers.
-const NTAG_CONSERVATIVE_WIPE_BYTES = 144;
+// Write-side extent caps (Codex #927) now live in the pure, unit-tested
+// resolveNtagWriteSize (src/lib/ntagVersion.ts): NTAG216_MAX_NDEF_BYTES (872,
+// the largest real NTAG) and NTAG213_NDEF_BYTES (144, safe on ANY chip).
 // NTAG213's last user page (144 B ÷ 4 = pages 4–39). A write whose top page stays
 // ≤ this fits ANY NTAG (213/215/216); a write that goes BEYOND it needs a 215/216
 // and would run into a 213's lock/config pages — see the #973 brick-guard probe.
@@ -919,27 +913,6 @@ export class NfcService extends EventEmitter {
   }
 
   /**
-   * Resolve the SAFE NDEF byte capacity of a FORMATTED NTAG for write/size
-   * decisions (Codex P1, #927). GET_VERSION (`verSize`) is authoritative when
-   * available — take the smaller of it and the CC-claimed size. When GET_VERSION
-   * is UNAVAILABLE we must NOT trust a possibly-inflated CC: a corrupt CC claiming
-   * 215/216 on a real NTAG213 would let an Extended write run past the 213's user
-   * area into its lock/config pages — a brick the writeNtagPage [3,255] guard
-   * can't catch, since those pages sit INSIDE that range on a small chip. So fall
-   * back to the conservative NTAG213 extent (144 B), safe on ANY NTAG. Real
-   * 215/216 tags then degrade to Core-only writes when GET_VERSION is unsupported
-   * (the renderer surfaces the opentag3dCoreOnly notice) rather than risking a
-   * brick. In practice GET_VERSION works on the ACR1552U (a blank-NTAG write
-   * requires it), so this conservative branch is the rare edge case.
-   */
-  private safeNtagNdefBytes(ccByte2: number, verSize: number | null): number {
-    const ccBytes = Math.min(Math.max(0, ccByte2 * 8), NTAG_MAX_NDEF_WRITE_BYTES);
-    return verSize != null
-      ? Math.min(ccBytes, verSize)
-      : Math.min(ccBytes, NTAG_CONSERVATIVE_WIPE_BYTES);
-  }
-
-  /**
    * Read an NFC-Forum Type 2 (NTAG213/215/216) tag carrying an OpenTag3D (or any
    * registered) NDEF record. Returns:
    *   - the decoded tag on success,
@@ -1226,10 +1199,21 @@ export class NfcService extends EventEmitter {
       // family check rests on the byte-0 NXP guard (detectType2Head) + the CC 0xE1/
       // 0x00 guard above + the writeNtagPage [3,255] bound — exactly the guards the
       // hardware-proven dev CLI relies on (it never issued GET_VERSION at all).
+      // The size decision lives in the pure, unit-tested resolveNtagWriteSize
+      // (src/lib/ntagVersion.ts) — the electron path isn't CI-covered and this is
+      // the safety-critical branch. Key case (#973): formatted tag + GET_VERSION
+      // unavailable + a user-declared size ⇒ the user's size is authoritative and
+      // the CC is rewritten to it (needsFormat), so a tag an earlier write
+      // mis-sized gets corrected. The brick-guard probe below validates it.
       const verSize = await this.getNtagNdefBytesViaGetVersion(protocol);
       const hintBytes = ntagSize != null ? NTAG_NAME_TO_NDEF_BYTES[ntagSize] : null;
-      const resolvedSize = verSize ?? hintBytes;
-      if (resolvedSize == null) {
+      const sizing = resolveNtagWriteSize({
+        ccMagic,
+        ccSizeByte: head[NTAG_CC_OFFSET + 2],
+        verSize,
+        hintBytes,
+      });
+      if (!sizing.ok) {
         throw new Error(
           "NTAG_SIZE_UNKNOWN: Couldn't determine the NTAG's size — the reader didn't return a " +
             "recognized GET_VERSION response. Choose the tag type (NTAG213/215/216) and try again.",
@@ -1242,22 +1226,8 @@ export class NfcService extends EventEmitter {
       // permanently lock a tag out of our own write path. A GENUINELY locked NTAG
       // (its static lock bytes set, which WE never set) just fails the page write
       // below with an SW error. NTAG "set read-only" is unsupported for this reason.
-      let ndefBytes: number;
-      let needsFormat = false;
-      if (ccMagic === 0xe1) {
-        // Formatted: bound the payload by min(CC, resolvedSize) via safeNtagNdefBytes
-        // so a corrupt/inflated CC (a real 213 claiming 215/216) can't drive an
-        // Extended TLV past the chip's user area into its lock/config pages (the
-        // [3,255] page guard can't catch that, since config sits in that range on a
-        // small chip).
-        ndefBytes = this.safeNtagNdefBytes(head[NTAG_CC_OFFSET + 2], resolvedSize);
-      } else {
-        // Blank NTAG (CC magic 0x00 — the guard above ruled out every other
-        // non-0xE1 value): size from the resolved (GET_VERSION or user-declared)
-        // value; the fresh CC is written below, AFTER the capacity check.
-        ndefBytes = resolvedSize;
-        needsFormat = true; // CC written below — AFTER the capacity check (Codex #927)
-      }
+      const ndefBytes = sizing.ndefBytes;
+      const needsFormat = sizing.needsFormat;
 
       // Build the NDEF-message TLV (0x03 … one media record … 0xFE terminator)
       // and capacity-check it BEFORE writing anything, so a too-large payload
@@ -1653,12 +1623,16 @@ export class NfcService extends EventEmitter {
         // as existing OpenTag3D. Mirrors readNtagTag: 0 records ⇒ blank, an
         // opentag3d record ⇒ opentag3d, any other record(s) ⇒ foreign NDEF
         // (formatted but standard null). One connection so size + read-back agree.
-        // Capacity reporting stays via safeNtagNdefBytes (Codex P1): GET_VERSION
-        // when available (smaller of it and the CC) else the conservative NTAG213
-        // extent, so the renderer's Core/Extended choice matches the write's bound.
         return await this.withConnection(async (protocol) => {
           const verSize = await this.getNtagNdefBytesViaGetVersion(protocol);
-          const ndefCapacity = this.safeNtagNdefBytes(head[NTAG_CC_OFFSET + 2], verSize);
+          // GH #973 follow-up: report the chip's TRUE size when GET_VERSION knows
+          // it, else null = UNKNOWN. Do NOT fall back to a conservative 144 here:
+          // that number reads as a genuine NTAG213 to the renderer, suppressing the
+          // size picker and firing the misleading "small NTAG213" notice on a real
+          // 215/216 whose reader (e.g. the ACR1552U) just can't answer GET_VERSION.
+          // A null lets the renderer prompt for the size instead. The write path
+          // keeps its own conservative bound for the no-hint case.
+          const ndefCapacity = verSize;
           let standard: TagDetection["standard"] = null;
           let formatted = false;
           try {

--- a/src/app/filaments/[id]/page.tsx
+++ b/src/app/filaments/[id]/page.tsx
@@ -668,12 +668,16 @@ function FilamentDetail() {
           typeof detected?.ndefCapacity === "number" && detected.ndefCapacity > 0
             ? detected.ndefCapacity
             : null;
-        // GH #973: a BLANK NTAG whose size GET_VERSION couldn't auto-detect
-        // reports a null capacity. Rather than silently downgrade to a 144-byte
-        // NTAG213 (dropping the spool id + weight and mislabelling the chip), ask
-        // the user which NTAG it is — the same posture as the dev CLI's --ntag.
+        // GH #973: an NTAG whose size GET_VERSION couldn't auto-detect reports a
+        // null capacity (some readers — e.g. the ACR1552U — reject GET_VERSION
+        // outright, so this is the NORMAL case there, for blank AND formatted
+        // tags). Rather than silently downgrade to a 144-byte NTAG213 (dropping
+        // the spool id + weight and mislabelling the chip), ask the user which
+        // NTAG it is — the same posture as the dev CLI's --ntag. The chosen size
+        // is authoritative on the write side (it rewrites the CC), so this also
+        // corrects a tag an earlier failed write mis-formatted.
         let ntagSize: NtagSizeName | undefined;
-        if (effectiveCapacity == null && detected?.formatted === false) {
+        if (effectiveCapacity == null) {
           const picked = await promptNtagSize();
           if (!picked) return null; // user cancelled the write
           ntagSize = picked;

--- a/src/lib/ntagVersion.ts
+++ b/src/lib/ntagVersion.ts
@@ -48,6 +48,63 @@ export function isNtagSizeName(v: unknown): v is NtagSizeName {
   return v === "NTAG213" || v === "NTAG215" || v === "NTAG216";
 }
 
+/** Largest real NTAG (NTAG216) NDEF capacity — the hard write ceiling. */
+export const NTAG216_MAX_NDEF_BYTES = 872;
+/** NTAG213 extent — the conservative capacity safe to write on ANY NTAG (its
+ *  lock/config pages sit above its 144-byte user area). */
+export const NTAG213_NDEF_BYTES = 144;
+
+/** Outcome of {@link resolveNtagWriteSize}. */
+export type NtagWriteSizeDecision =
+  | { ok: true; ndefBytes: number; needsFormat: boolean }
+  | { ok: false; error: "size_unknown" };
+
+/**
+ * Decide the NDEF byte capacity to write + whether to (re)write the tag's
+ * Capability Container, from the page-3 CC state, the GET_VERSION result (null
+ * when the reader can't answer it — e.g. the ACR1552U rejects GET_VERSION with
+ * SW 0x6900, GH #973), and an optional user-declared size.
+ *
+ * Pure + unit-tested on purpose: the electron write path isn't exercised by CI,
+ * and this is the safety-critical decision — a size larger than the physical
+ * chip would drive a write into a smaller NTAG's lock/config pages (a permanent
+ * brick the page-address bound can't catch). The caller pairs this with a
+ * page-read probe of the resulting top page to prove the chip is physically big
+ * enough before any write.
+ *
+ * Rules:
+ *  - Formatted (CC 0xE1) + GET_VERSION confirmed → min(CC, chip): a corrupt or
+ *    inflated CC can't outrun the real chip size.
+ *  - Formatted + GET_VERSION unavailable + user size → the USER SIZE is
+ *    authoritative and the CC is REWRITTEN to it (needsFormat=true) — this
+ *    corrects a tag an earlier failed write mis-sized (e.g. a real 215 stamped
+ *    with a 144-byte CC that would otherwise stay stuck at NTAG213).
+ *  - Formatted + neither → conservative min(CC, 144), no reformat (legacy).
+ *  - Blank (CC 0x00) + a size (GET_VERSION or user) → that size, reformat.
+ *  - Blank + neither → { ok:false, size_unknown } — never guess.
+ */
+export function resolveNtagWriteSize(opts: {
+  ccMagic: number;
+  ccSizeByte: number;
+  verSize: number | null;
+  hintBytes: number | null;
+}): NtagWriteSizeDecision {
+  const { ccMagic, ccSizeByte, verSize, hintBytes } = opts;
+  // Clamp the CC size byte to [0, 872] and treat a non-finite value as 0 — in
+  // production it's always a Uint8Array byte (0–255), but this keeps the bound
+  // total (no NaN can leak into ndefBytes).
+  const safeCcByte = Number.isFinite(ccSizeByte) ? Math.trunc(ccSizeByte) : 0;
+  const ccBytes = Math.min(Math.max(0, safeCcByte * 8), NTAG216_MAX_NDEF_BYTES);
+  if (ccMagic === 0xe1) {
+    if (verSize != null) return { ok: true, ndefBytes: Math.min(ccBytes, verSize), needsFormat: false };
+    if (hintBytes != null) return { ok: true, ndefBytes: hintBytes, needsFormat: true };
+    return { ok: true, ndefBytes: Math.min(ccBytes, NTAG213_NDEF_BYTES), needsFormat: false };
+  }
+  const resolved = verSize ?? hintBytes;
+  if (resolved == null) return { ok: false, error: "size_unknown" };
+  return { ok: true, ndefBytes: resolved, needsFormat: true };
+}
+
 /**
  * The full 8-byte NXP NTAG21x GET_VERSION version block:
  *   [0]=0x00 header  [1]=0x04 vendor(NXP)  [2]=0x04 product(NTAG)

--- a/src/lib/ntagVersion.ts
+++ b/src/lib/ntagVersion.ts
@@ -73,12 +73,17 @@ export type NtagWriteSizeDecision =
  * enough before any write.
  *
  * Rules:
- *  - Formatted (CC 0xE1) + GET_VERSION confirmed → min(CC, chip): a corrupt or
- *    inflated CC can't outrun the real chip size.
+ *  - Formatted (CC 0xE1) + GET_VERSION confirmed → GET_VERSION is authoritative
+ *    for the chip's TRUE size, so use it directly (not min(CC, verSize)) and
+ *    REWRITE the CC when it disagrees. This corrects a wrong CC in BOTH
+ *    directions: an inflated CC (a real 213 claiming 215) shrinks to the real
+ *    size, and an under-sized CC (a real 215 stamped 144 by a prior bad write)
+ *    grows back so its Extended image isn't wrongly rejected as TAG_TOO_SMALL.
+ *    The caller's page-read probe guards against a mis-reported (too-large) size.
  *  - Formatted + GET_VERSION unavailable + user size → the USER SIZE is
  *    authoritative and the CC is REWRITTEN to it (needsFormat=true) — this
- *    corrects a tag an earlier failed write mis-sized (e.g. a real 215 stamped
- *    with a 144-byte CC that would otherwise stay stuck at NTAG213).
+ *    corrects a tag an earlier failed write mis-sized on a GET_VERSION-dead
+ *    reader (e.g. a real 215 stamped with a 144-byte CC stuck at NTAG213).
  *  - Formatted + neither → conservative min(CC, 144), no reformat (legacy).
  *  - Blank (CC 0x00) + a size (GET_VERSION or user) → that size, reformat.
  *  - Blank + neither → { ok:false, size_unknown } — never guess.
@@ -96,7 +101,9 @@ export function resolveNtagWriteSize(opts: {
   const safeCcByte = Number.isFinite(ccSizeByte) ? Math.trunc(ccSizeByte) : 0;
   const ccBytes = Math.min(Math.max(0, safeCcByte * 8), NTAG216_MAX_NDEF_BYTES);
   if (ccMagic === 0xe1) {
-    if (verSize != null) return { ok: true, ndefBytes: Math.min(ccBytes, verSize), needsFormat: false };
+    // GET_VERSION is authoritative for the true chip size: use it directly and
+    // rewrite the CC when it disagrees (fixes an under-sized OR inflated CC).
+    if (verSize != null) return { ok: true, ndefBytes: verSize, needsFormat: ccBytes !== verSize };
     if (hintBytes != null) return { ok: true, ndefBytes: hintBytes, needsFormat: true };
     return { ok: true, ndefBytes: Math.min(ccBytes, NTAG213_NDEF_BYTES), needsFormat: false };
   }

--- a/tests/ntagVersion.test.ts
+++ b/tests/ntagVersion.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseNtagNdefBytesFromGetVersion,
   isNtagSizeName,
+  resolveNtagWriteSize,
   NTAG_STORAGE_SIZE_TO_NDEF_BYTES,
   NTAG_NAME_TO_NDEF_BYTES,
 } from "@/lib/ntagVersion";
@@ -102,5 +103,74 @@ describe("parseNtagNdefBytesFromGetVersion", () => {
     expect(NTAG_NAME_TO_NDEF_BYTES.NTAG215).toBe(496);
     expect(NTAG_NAME_TO_NDEF_BYTES.NTAG213).toBe(144);
     expect(NTAG_NAME_TO_NDEF_BYTES.NTAG216).toBe(872);
+  });
+});
+
+describe("resolveNtagWriteSize (GH #973 follow-up)", () => {
+  const E1 = 0xe1; // formatted CC magic
+  const BLANK = 0x00; // blank CC magic
+  // CC size byte = NDEF bytes / 8: 144→18, 496→62, 872→109.
+
+  it("formatted + GET_VERSION confirmed → min(CC, chip), no reformat", () => {
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 62, verSize: 496, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: false });
+    // A CC that over-claims (872) on a chip GET_VERSION says is 496 → capped to 496.
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 109, verSize: 496, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: false });
+  });
+
+  it("formatted + GET_VERSION DEAD + user size → user size is authoritative, REWRITE the CC (#973 core)", () => {
+    // A real 215 an earlier write mis-formatted with a 144-byte CC (ccSizeByte 18):
+    // the user picks NTAG215 → we rewrite the CC to 496, not stay stuck at 144.
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 18, verSize: null, hintBytes: 496 }))
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: true });
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 18, verSize: null, hintBytes: 872 }))
+      .toEqual({ ok: true, ndefBytes: 872, needsFormat: true });
+  });
+
+  it("formatted + neither GET_VERSION nor hint → conservative min(CC, 144), no reformat (legacy)", () => {
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 62, verSize: null, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 144, needsFormat: false });
+  });
+
+  it("blank + a size (GET_VERSION or user) → that size, reformat", () => {
+    expect(resolveNtagWriteSize({ ccMagic: BLANK, ccSizeByte: 0, verSize: 496, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: true });
+    expect(resolveNtagWriteSize({ ccMagic: BLANK, ccSizeByte: 0, verSize: null, hintBytes: 496 }))
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: true });
+    // GET_VERSION wins over a hint when both present.
+    expect(resolveNtagWriteSize({ ccMagic: BLANK, ccSizeByte: 0, verSize: 872, hintBytes: 496 }))
+      .toEqual({ ok: true, ndefBytes: 872, needsFormat: true });
+  });
+
+  it("blank + neither → size_unknown (never guess)", () => {
+    expect(resolveNtagWriteSize({ ccMagic: BLANK, ccSizeByte: 0, verSize: null, hintBytes: null }))
+      .toEqual({ ok: false, error: "size_unknown" });
+  });
+
+  it("formatted + GET_VERSION AND a user hint → GET_VERSION wins (chip size is authoritative)", () => {
+    // A good reader (GET_VERSION works) where the user ALSO over-picked to 872:
+    // the real chip size (496) must win so an over-declared size can't slip
+    // through. CC byte 62 (=496) doesn't under-cap, isolating the verSize-vs-hint
+    // precedence.
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 62, verSize: 496, hintBytes: 872 }))
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: false });
+  });
+
+  it("treats a non-finite / negative CC size byte as 0 (total clamp)", () => {
+    // Can't occur from a real Uint8Array byte, but the bound must never yield NaN.
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: NaN, verSize: null, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 0, needsFormat: false });
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: -5, verSize: null, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 0, needsFormat: false });
+  });
+
+  it("clamps a wildly over-claiming CC to the NTAG216 ceiling (872)", () => {
+    // ccSizeByte 255 → 2040 bytes; formatted + confirmed verSize 872 → min = 872.
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 255, verSize: 872, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 872, needsFormat: false });
+    // formatted + neither, CC 255 → min(872 ceiling, 144) = 144.
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 255, verSize: null, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 144, needsFormat: false });
   });
 });

--- a/tests/ntagVersion.test.ts
+++ b/tests/ntagVersion.test.ts
@@ -111,12 +111,22 @@ describe("resolveNtagWriteSize (GH #973 follow-up)", () => {
   const BLANK = 0x00; // blank CC magic
   // CC size byte = NDEF bytes / 8: 144→18, 496→62, 872→109.
 
-  it("formatted + GET_VERSION confirmed → min(CC, chip), no reformat", () => {
+  it("formatted + GET_VERSION confirmed → chip size, reformat only when CC disagrees", () => {
+    // CC already matches the chip → no reformat.
     expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 62, verSize: 496, hintBytes: null }))
       .toEqual({ ok: true, ndefBytes: 496, needsFormat: false });
-    // A CC that over-claims (872) on a chip GET_VERSION says is 496 → capped to 496.
+    // CC over-claims (872) but GET_VERSION says 496 → use 496 AND rewrite the CC down.
     expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 109, verSize: 496, hintBytes: null }))
-      .toEqual({ ok: true, ndefBytes: 496, needsFormat: false });
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: true });
+  });
+
+  it("formatted + UNDER-sized CC + GET_VERSION works → grows to the real size, rewrites CC (Codex P2)", () => {
+    // A real NTAG215 an earlier bad write stamped with a 144-byte CC (ccSizeByte
+    // 18), now read on a GET_VERSION-CAPABLE reader (verSize 496). Detect reports
+    // 496 (→ Extended); the writer must ALSO use 496 (not min(144,496)=144) and
+    // rewrite the CC, or the Extended image is wrongly rejected as TAG_TOO_SMALL.
+    expect(resolveNtagWriteSize({ ccMagic: E1, ccSizeByte: 18, verSize: 496, hintBytes: null }))
+      .toEqual({ ok: true, ndefBytes: 496, needsFormat: true });
   });
 
   it("formatted + GET_VERSION DEAD + user size → user size is authoritative, REWRITE the CC (#973 core)", () => {


### PR DESCRIPTION
Follow-up to #973 (v1.64.0), driven by an on-hardware log.

## Root cause (confirmed on hardware)
The user's **ACR1552U returns SW `0x6900`** ("command not allowed") to the app's `GET_VERSION` APDU — the reader **rejects the command**, so blank-NTAG auto-sizing can never work there. v1.64.0 then failed two ways:
- **Blank NTAG215** → `NTAG_SIZE_UNKNOWN` write error (the size picker only gated on a *null* capacity, and a detect/write mismatch on the dual-interface reader slipped past).
- **Formatted-empty tag** → conservative-144 fallback → the misleading *"small NTAG213"* notice + core-only write.

## Fix — stop depending on GET_VERSION
- **Detect** reports `ndefCapacity` = the true GET_VERSION size when known, else **null** (unknown) — no conservative-144 masquerading as a real NTAG213.
- **Size picker** now fires whenever capacity is unknown (blank *or* formatted), so the user declares 213/215/216 up front.
- **The pick is authoritative**: the write-size decision is extracted into the pure, unit-tested `resolveNtagWriteSize` (`src/lib/ntagVersion.ts`). A formatted tag + GET_VERSION-unavailable + a user size **rewrites the capability container** to that size — which also **self-corrects a tag an earlier failed write mis-sized** (a real 215 stuck at a 144-byte CC). GET_VERSION still wins over a user hint when it answers.
- **Brick-safety unchanged**: the existing `FF B0` page-read probe (which the #973 log proves works on the ACR1552U) validates the chip is physically big enough before any write, so an over-declared size is **refused, never bricked**. The electron-only `safeNtagNdefBytes` is removed; its logic now lives in the tested pure helper.

## Tests / verification
`resolveNtagWriteSize` has 9 unit cases (formatted±GET_VERSION±hint, blank±size, precedence, clamps). Root `tsc`, `electron:typecheck`, full lint, and full coverage (3144 tests) pass.

## Scope / owed
- **Erase** (`formatNtagImpl`) still needs GET_VERSION and is tracked in #978 — not a blocker, since the Write path's CC-rewrite already un-sticks a mis-sized tag.
- **Hardware-owed**: on-device confirmation on the ACR1552U — the pure size logic is CI-verified; the electron read/write path isn't. The `FF B0` probe is proven on this reader per the log.

## Pre-review hardening
An adversarial pass returned **clean on write/brick-safety** and caught (fixed here): a stale comment referencing the removed `safeNtagNdefBytes`, a missing NaN-guard, and an unpinned verSize-vs-hint precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)