### PR TITLE
chore(release): bump version to 1.64.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.64.0",
+      "version": "1.64.1",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.64.0",
+    "version": "1.64.1",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Patch release **1.64.1** — ships the #973 follow-up (PR #979): NTAG size becomes a user choice when the reader can't answer `GET_VERSION` (ACR1552U), fixing the "NTAG215 mis-detected as NTAG213 / write fails" report.

Manual bump (the `release-bump.yml` dispatch returns HTTP 403 for this token). Bumps `package.json`, `package-lock.json` (×2), `public/openapi.json`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)