### PR TITLE
chore(release): bump version to 1.64.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.64.1",
+  "version": "1.64.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.64.1",
+      "version": "1.64.2",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.64.1",
+  "version": "1.64.2",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.64.1",
+    "version": "1.64.2",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Patch release **1.64.2** — ships the configurable default NTAG type (PR #981): a "Remember this" checkbox in the size picker + a Settings → Devices → NFC Tools selector, so batch writes on `GET_VERSION`-less readers skip the prompt.

Manual bump (the `release-bump.yml` dispatch returns HTTP 403 for this token). Bumps `package.json`, `package-lock.json` (×2), `public/openapi.json`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)