### PR TITLE
chore(release): bump version to 1.65.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.64.2",
+  "version": "1.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.64.2",
+      "version": "1.65.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.64.2",
+  "version": "1.65.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.64.2",
+    "version": "1.65.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Version bump to **1.65.0** for the date-format release (#983 / #984).

Manual bump because `release-bump.yml` couldn't be dispatched (this token lacks Actions write). Bumps the three version files:
- `package.json`
- `package-lock.json` (top-level + `packages[""]`)
- `public/openapi.json` (`info.version`)

No code changes — mechanical version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)