### PR TITLE
fix(lint): ignore local Codex/Claude worktrees in root ESLint (#990)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,15 @@ const eslintConfig = defineConfig([
     // Expo mobile app) — linted from within packages/mobile, not by the
     // web/Electron root config.
     "packages/**",
+    // Local Codex/Claude tooling + metadata (skills, launch.json,
+    // settings.local.json, and generated worktree checkouts under
+    // .claude/worktrees/). None of it is root-app source; a nested worktree
+    // ships its own packages/mobile with CommonJS require() files that trip
+    // the root rules (GH #990). ESLint flat config doesn't auto-ignore
+    // dot-dirs (only node_modules/.git) and the `packages/**` entry above is
+    // root-anchored, so it wouldn't catch `.claude/worktrees/*/packages/**`.
+    // Mirrors vitest.config.ts's tests/-only scoping against the same class.
+    ".claude/**",
   ]),
 ]);
 


### PR DESCRIPTION
## Problem

`npm run lint` (bare `eslint`) fails from a normal checkout when a local `.claude/worktrees/<name>/…` checkout is present: ESLint walks the hidden `.claude/` tree and lint-runs files from that nested generated checkout (`packages/mobile/eslint.config.js`, `scripts/reset-project.js`), reporting `@typescript-eslint/no-require-imports` errors unrelated to the root app source.

## Root cause

Two facts combine:
1. **ESLint flat config doesn't auto-ignore dot-directories** the way legacy `.eslintrc` did — by default it only skips `**/node_modules/` and `.git/`, so the hidden `.claude/` dir is traversed. `globalIgnores()` had no `.claude` entry.
2. The existing `"packages/**"` ignore is **root-anchored** — it matches root `packages/mobile/…` but *not* the nested `.claude/worktrees/…/packages/mobile/…` (no leading `**/`), so the worktree's own CommonJS files get linted under root rules.

## Fix

Add `".claude/**"` to `globalIgnores()` in `eslint.config.mjs`. The whole `.claude/` tree is local tooling/metadata (skills, `launch.json`, `settings.local.json`, generated worktrees) with no root-app source to lint. Broad `.claude/**` over `.claude/worktrees/**` so it's robust to anything else dropped there. Mirrors `vitest.config.ts`'s `tests/`-only scoping, which already fences off the same nested-worktree class.

**Note:** the issue's secondary suggestion to add `.claude/` to `.gitignore` would *not* fix lint on its own — ESLint flat config doesn't read `.gitignore` automatically (needs an explicit `includeIgnoreFile()`, which this repo doesn't use). The load-bearing change is the eslint config. Left `.gitignore` untouched per the triage decision.

## Verification

- With the `.claude/worktrees/…` checkout present: `npm run lint` → **exit 0** (pre-fix: exit 1, 5 errors).
- **Negative control:** a temporary `no-var` + unused-var probe under `src/` is still flagged — the ignore is scoped to `.claude/**` only, so root coverage (`src/`, `electron/`, `scripts/`, `tests/`) is unchanged.

Config-only change; no runtime surface, no tests needed.

Fixes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)