### PR TITLE
chore(release): bump version to 1.66.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.66.0",
+      "version": "1.66.1",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.66.0",
+    "version": "1.66.1",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Patch release **1.66.1**. Bumps the version in `package.json`, `package-lock.json` (×2), and `public/openapi.json`.

Contents since v1.66.0:
- `fix(api)`: cap `POST /api/spools/import` body size before buffering (#991)
- `fix(lint)`: ignore local Codex/Claude worktrees in root ESLint (#990)
- `test(api)`: cover the 8 previously-untested API routes
- `docs`: catch docs up to v1.66 (#989)

No new user-facing features → patch bump.

> Manual bump PR because `release-bump.yml` dispatch isn't available to this token (`workflow` scope). Goes through the same PR + CI gate as the workflow would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)