### PR TITLE
perf(intl): cache Intl.DateTimeFormat/NumberFormat instances across render sites (#1005 F3)

### DIFF
--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -15,6 +15,7 @@ import {
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { formatWithSeparators } from "@/lib/numberFormatPref";
+import { getNumberFormat } from "@/lib/intlCache";
 
 /**
  * Built-in currencies. v1.12 expanded the list from 4 to 13 to cover the
@@ -282,7 +283,7 @@ export function useCurrency() {
       const isBuiltin = CURRENCIES.some((c) => c.code === currency);
       if (isBuiltin) {
         try {
-          const fmt = new Intl.NumberFormat(baseLocale, {
+          const fmt = getNumberFormat(baseLocale, {
             style: "currency",
             currency,
           });
@@ -319,7 +320,7 @@ export function useCurrency() {
         // System mode (post-hydration): group the number per the device locale
         // so custom-code amounts match weights/counts, not raw toFixed.
         try {
-          return `${symbol}${new Intl.NumberFormat(systemLocale, {
+          return `${symbol}${getNumberFormat(systemLocale, {
             minimumFractionDigits: 2,
             maximumFractionDigits: 2,
           }).format(value)}`;

--- a/src/hooks/useNumberFormat.ts
+++ b/src/hooks/useNumberFormat.ts
@@ -12,6 +12,7 @@ import {
   type FormatOptions,
 } from "@/lib/numberFormatPref";
 import { formatGrams as pureFormatGrams } from "@/lib/formatWeight";
+import { getNumberFormat } from "@/lib/intlCache";
 
 /**
  * useNumberFormat — the global number-format preference (sibling of
@@ -159,7 +160,7 @@ export function useNumberFormat() {
       }
       // system mode: device-locale grouping via Intl (trims trailing zeros).
       try {
-        return new Intl.NumberFormat(deviceLocale, {
+        return getNumberFormat(deviceLocale, {
           maximumFractionDigits: decimals,
         }).format(value);
       } catch {
@@ -194,7 +195,7 @@ export function useNumberFormat() {
         });
       }
       try {
-        return new Intl.NumberFormat(deviceLocale, {
+        return getNumberFormat(deviceLocale, {
           minimumFractionDigits: minDecimals,
           maximumFractionDigits: maxDecimals,
           useGrouping,

--- a/src/lib/dateFormat.ts
+++ b/src/lib/dateFormat.ts
@@ -19,6 +19,7 @@
  */
 
 import { formatWithPattern } from "./dateFormatPref";
+import { getDateTimeFormat } from "./intlCache";
 
 type DateInput = Date | string | number | null | undefined;
 
@@ -56,7 +57,7 @@ export function formatDate(
     return formatWithPattern(d, options.pattern, options.timeZone);
   }
   try {
-    return new Intl.DateTimeFormat(locale, {
+    return getDateTimeFormat(locale, {
       dateStyle: "short",
       ...(options?.timeZone ? { timeZone: options.timeZone } : {}),
     }).format(d);
@@ -80,7 +81,7 @@ export function formatTime(input: DateInput, locale: string): string {
   const d = normalise(input);
   if (!d) return "";
   try {
-    return new Intl.DateTimeFormat(locale, { timeStyle: "short" }).format(d);
+    return getDateTimeFormat(locale, { timeStyle: "short" }).format(d);
   } catch {
     return d.toLocaleTimeString();
   }
@@ -107,7 +108,7 @@ export function formatDateTime(
     return `${formatWithPattern(d, options.pattern)}, ${formatTime(d, locale)}`;
   }
   try {
-    return new Intl.DateTimeFormat(locale, {
+    return getDateTimeFormat(locale, {
       dateStyle: "short",
       timeStyle: "short",
     }).format(d);

--- a/src/lib/dateFormatPref.ts
+++ b/src/lib/dateFormatPref.ts
@@ -15,6 +15,8 @@
  * `src/components/DateFormatSection.tsx`.
  */
 
+import { getDateTimeFormat } from "./intlCache";
+
 /**
  * `system` follows the device's regional setting (the GH #983 request — a UK
  * PC renders `31/12/2026`); the three named presets are locale-INDEPENDENT
@@ -113,7 +115,7 @@ export function formatWithPattern(
   pattern: string,
   timeZone?: string,
 ): string {
-  const parts = new Intl.DateTimeFormat("en-US", {
+  const parts = getDateTimeFormat("en-US", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",

--- a/src/lib/intlCache.ts
+++ b/src/lib/intlCache.ts
@@ -1,0 +1,64 @@
+/**
+ * GH #1005 F3: module-level Intl formatter cache.
+ *
+ * `new Intl.DateTimeFormat(...)` / `new Intl.NumberFormat(...)` is expensive
+ * (~50–200 µs each). The home list and /inventory render a fresh formatter per
+ * cell per render — on a ~2,000-row table that's thousands of constructions on
+ * every keystroke. Cache the constructed formatters keyed by (locale | options)
+ * so repeated (locale, options) pairs reuse one instance. (The analytics page
+ * already memoises its formatter for exactly this reason since v1.60.1; this
+ * generalises it to every date/number render site.)
+ *
+ * A formatter is pure — a (locale, options) pair maps to a deterministic
+ * formatter — so a module-level cache is safe to share across React renders AND
+ * across SSR requests (no request-specific state). The real key space is small
+ * and bounded: a handful of app/device locales × a handful of fixed option
+ * shapes (user-chosen custom date patterns bypass Intl via formatWithPattern;
+ * custom separators are applied manually). A MAX_ENTRIES cap clears the map if
+ * some future caller ever explodes the key space, so it can't grow unbounded.
+ *
+ * Keys use JSON.stringify(options): Intl option bags are small, flat, and
+ * JSON-serializable. A different key ORDER would just miss (a harmless
+ * duplicate entry, never a wrong formatter); callers use literal option objects
+ * with stable key order. A construction that throws (an unknown locale/option)
+ * is NOT cached — it propagates to the caller's existing try/catch fallback.
+ */
+
+const MAX_ENTRIES = 500;
+
+const dateTimeCache = new Map<string, Intl.DateTimeFormat>();
+const numberCache = new Map<string, Intl.NumberFormat>();
+
+function cacheKey(locale: string | undefined, options: unknown): string {
+  return `${locale ?? ""}|${options ? JSON.stringify(options) : ""}`;
+}
+
+/** Cached `Intl.DateTimeFormat` for a (locale, options) pair. */
+export function getDateTimeFormat(
+  locale: string | undefined,
+  options?: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat {
+  const key = cacheKey(locale, options);
+  let fmt = dateTimeCache.get(key);
+  if (fmt === undefined) {
+    fmt = new Intl.DateTimeFormat(locale, options);
+    if (dateTimeCache.size >= MAX_ENTRIES) dateTimeCache.clear();
+    dateTimeCache.set(key, fmt);
+  }
+  return fmt;
+}
+
+/** Cached `Intl.NumberFormat` for a (locale, options) pair. */
+export function getNumberFormat(
+  locale: string | undefined,
+  options?: Intl.NumberFormatOptions,
+): Intl.NumberFormat {
+  const key = cacheKey(locale, options);
+  let fmt = numberCache.get(key);
+  if (fmt === undefined) {
+    fmt = new Intl.NumberFormat(locale, options);
+    if (numberCache.size >= MAX_ENTRIES) numberCache.clear();
+    numberCache.set(key, fmt);
+  }
+  return fmt;
+}

--- a/tests/intlCache.test.ts
+++ b/tests/intlCache.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { getDateTimeFormat, getNumberFormat } from "@/lib/intlCache";
+
+/**
+ * GH #1005 F3: the Intl formatter cache returns one shared instance per
+ * (locale, options) key so hot render paths (the home list / inventory rows)
+ * don't reconstruct a formatter per cell.
+ */
+describe("intlCache", () => {
+  describe("getDateTimeFormat", () => {
+    it("returns the SAME instance for an identical (locale, options) key", () => {
+      const a = getDateTimeFormat("en-US", { dateStyle: "short" });
+      const b = getDateTimeFormat("en-US", { dateStyle: "short" });
+      expect(a).toBe(b);
+    });
+
+    it("returns DIFFERENT instances for different locales or options", () => {
+      const a = getDateTimeFormat("en-US", { dateStyle: "short" });
+      const b = getDateTimeFormat("de-DE", { dateStyle: "short" });
+      const c = getDateTimeFormat("en-US", { timeStyle: "short" });
+      expect(a).not.toBe(b);
+      expect(a).not.toBe(c);
+    });
+
+    it("still formats correctly through the cache (identical to a fresh formatter)", () => {
+      const d = new Date("2026-05-30T00:00:00Z");
+      const opts = { dateStyle: "short", timeZone: "UTC" } as const;
+      const out = getDateTimeFormat("en-US", opts).format(d);
+      expect(out).toBe(new Intl.DateTimeFormat("en-US", opts).format(d));
+    });
+
+    it("treats an omitted options bag as its own key", () => {
+      const a = getDateTimeFormat("en-US");
+      const b = getDateTimeFormat("en-US");
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("getNumberFormat", () => {
+    it("returns the SAME instance for an identical (locale, options) key", () => {
+      const a = getNumberFormat("en-US", { maximumFractionDigits: 2 });
+      const b = getNumberFormat("en-US", { maximumFractionDigits: 2 });
+      expect(a).toBe(b);
+    });
+
+    it("returns DIFFERENT instances for different options", () => {
+      const a = getNumberFormat("en-US", { maximumFractionDigits: 2 });
+      const b = getNumberFormat("en-US", { maximumFractionDigits: 3 });
+      expect(a).not.toBe(b);
+    });
+
+    it("still formats correctly through the cache", () => {
+      expect(getNumberFormat("en-US", { minimumFractionDigits: 2 }).format(5)).toBe("5.00");
+    });
+
+    it("handles an undefined locale (Intl default locale)", () => {
+      const a = getNumberFormat(undefined, { maximumFractionDigits: 0 });
+      const b = getNumberFormat(undefined, { maximumFractionDigits: 0 });
+      expect(a).toBe(b);
+      expect(typeof a.format(1234)).toBe("string");
+    });
+  });
+
+  it("clears each cache once it exceeds MAX_ENTRIES so it can't grow unbounded", () => {
+    // Distinct BCP-47 private-use subtags produce >500 distinct keys, tripping
+    // the size guard's clear() branch. The functions must keep returning valid
+    // formatters across the wipe.
+    let lastNum: Intl.NumberFormat | null = null;
+    let lastDate: Intl.DateTimeFormat | null = null;
+    for (let i = 0; i < 520; i++) {
+      lastNum = getNumberFormat(`en-US-x-t${i}`, { maximumFractionDigits: 2 });
+      lastDate = getDateTimeFormat(`en-US-x-t${i}`, { dateStyle: "short" });
+    }
+    expect(lastNum!.format(1)).toBeTypeOf("string");
+    expect(lastDate!.format(new Date("2026-01-01T00:00:00Z"))).toBeTypeOf("string");
+    // After a wipe, a fresh lookup for a brand-new key still works and caches.
+    const x = getNumberFormat("fr-FR", { maximumFractionDigits: 1 });
+    const y = getNumberFormat("fr-FR", { maximumFractionDigits: 1 });
+    expect(x).toBe(y);
+  });
+});


### PR DESCRIPTION
Closes #1005 (finding 3 — the last of its four; F1/F2/F4 landed in #1010).

`new Intl.DateTimeFormat(...)` / `new Intl.NumberFormat(...)` costs ~50–200 µs. The home list and `/inventory` render a fresh formatter per cell per render — on a ~2,000-row table that's thousands of constructions on every keystroke (plus full-table reconciliation), the exact hot path the finding measured. The analytics page already memoises its formatter (v1.60.1); this generalises it.

New `src/lib/intlCache.ts` exposes `getDateTimeFormat` / `getNumberFormat`, caching constructed formatters keyed by `(locale | JSON.stringify(options))`. Formatters are pure, so a module-level cache is safe across React renders and SSR requests; a `MAX_ENTRIES` cap clears each map if the key space ever explodes (bounded by design). A throwing construction isn't cached and propagates to the caller's existing try/catch.

Swapped all eight construction sites: `dateFormat.ts` (short date/time/datetime), `dateFormatPref.ts` (the fixed-locale `formatToParts` token path), `useCurrency.ts` (builtin + system-locale custom-code paths), and `useNumberFormat.ts` (formatGrams + formatNumber system-mode paths). Output is byte-identical — the cache only removes the repeated construction.

Tests: `intlCache` pins same-instance-on-hit, distinct-instance-on-different-key, undefined-locale, format-parity with a fresh formatter, and the `MAX_ENTRIES` clear branch. Existing date/number/currency suites exercise the swapped output paths unchanged. Full coverage run passed (all `src/lib` thresholds met).

🤖 Generated with [Claude Code](https://claude.com/claude-code)