### PR TITLE
fix(electron/nfc): all 4 audit findings — SLIX2 mid-write, get-status contract, conn-recover, stop-mongod (#1006)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1192,6 +1192,12 @@ ipcMain.handle("nfc-get-status", (event) => {
     readerName: null,
     tagPresent: false,
     tagUid: null,
+    // GH #1006 F4: NfcService.getStatus() always includes `lastError`, and
+    // src/types/electron.d.ts types it as required (`lastError: {...} | null`,
+    // GH #450). This null-service fallback (SCardSvr stopped / pcsclite threw —
+    // the exact degraded-host path #450 surfaces errors for) must match the
+    // contract, or the renderer receives `undefined` where it's typed `null`.
+    lastError: null,
   };
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -766,6 +766,12 @@ async function resolveMongoUri(): Promise<string | null> {
       await client.close();
 
       store.set("mongodbUri", atlasUri);
+      // GH #1006 F3: pure Atlas doesn't use the embedded mongod — stop one a
+      // prior offline/hybrid session started, or it idles for the rest of the
+      // session (~200–300 MB RSS + a dbPath lock) serving nothing. No-op when
+      // none is running; the atlas-fallback path below restarts it on demand
+      // when Atlas is unreachable. Mirrors the syncService teardown above (#672).
+      await stopLocalMongo();
       return atlasUri;
     } catch {
       console.log("Atlas unreachable, falling back to local MongoDB...");
@@ -993,14 +999,39 @@ ipcMain.handle("save-config", async (event, config: {
         serverRestarted = true;
       } catch (err) {
         console.error("Failed to start server after config save:", err);
+        // GH #1006 F2: stopServer() already killed the healthy server, so the
+        // app now has NO embedded server. The usual cause is a transient port
+        // race (EADDRINUSE from the not-yet-dead old process still holding 3456
+        // during the gap). Clear any half-spawned process and retry once on the
+        // SAME resolved uri — resolveMongoUri already stood up THIS mode's
+        // mongod/sync (and tore down the previous mode's, so the old uri would
+        // now point at a stopped mongod), making the new uri the only coherent
+        // recovery target. Mirrors the LAN-toggle branch's recover-or-fail shape.
+        await stopServer();
+        try {
+          await startProductionServer(uri || undefined);
+          serverRestarted = true;
+        } catch (recoveryErr) {
+          console.error("Failed to restore server after config-change failure:", recoveryErr);
+        }
       } finally {
         intentionalServerRestart = false;
       }
       // Refresh LAN auto-discovery so a stale advert doesn't point at a server
       // that just restarted (or failed to). syncMdnsAdvertisement() no-ops when
       // exposeToLan is off; stop outright if the restart failed.
-      if (serverRestarted) syncMdnsAdvertisement();
-      else stopMdnsAdvertisement();
+      if (serverRestarted) {
+        syncMdnsAdvertisement();
+      } else {
+        // GH #1006 F2: recovery failed too — the app has no embedded server.
+        // Don't advertise a dead one, don't reload the window into a Chromium
+        // error page (the #176 white-window class), and return failure so the
+        // renderer surfaces its error path instead of showing "Switched to
+        // <mode>" over a dead server. Pre-fix this fell through to loadURL +
+        // { success: true } unconditionally.
+        stopMdnsAdvertisement();
+        return { success: false };
+      }
     }
 
     // Reload the window on a connection change so the renderer picks up

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1025,6 +1025,14 @@ ipcMain.handle("save-config", async (event, config: {
           serverRestarted = true;
         } catch (recoveryErr) {
           console.error("Failed to restore server after config-change failure:", recoveryErr);
+          // Codex P2 on #1015: the failed recovery can leave a stray child —
+          // startProductionServer rejects with the utility process still alive
+          // (waitForServer timeout) or with `serverProcess` pointing at a dead
+          // handle. We're about to report "no embedded server", so make that
+          // true: kill/clear the half-spawned process before returning failure,
+          // or a late child squats the port and the next retry waits on
+          // stopServer()'s 5s safety net for an already-exited handle.
+          await stopServer();
         }
       } finally {
         intentionalServerRestart = false;
@@ -1096,6 +1104,10 @@ ipcMain.handle("save-config", async (event, config: {
           await startProductionServer((store.get("mongodbUri") as string) || undefined);
         } catch (recoveryErr) {
           console.error("Failed to restore server after LAN-share toggle failure:", recoveryErr);
+          // Codex P2 on #1015 (same hazard as the connection-change branch):
+          // the failed recovery can leave a half-spawned/stale child — clear
+          // it so "no embedded server" is actually true before we report it.
+          await stopServer();
         }
         // Reflect the reverted bind state in the mDNS advertisement too.
         syncMdnsAdvertisement();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -771,7 +771,19 @@ async function resolveMongoUri(): Promise<string | null> {
       // session (~200–300 MB RSS + a dbPath lock) serving nothing. No-op when
       // none is running; the atlas-fallback path below restarts it on demand
       // when Atlas is unreachable. Mirrors the syncService teardown above (#672).
-      await stopLocalMongo();
+      //
+      // Codex P2 on #1015: guard with its OWN try/catch. The enclosing catch
+      // means "Atlas unreachable → fall back to local" — a mongod.stop()
+      // rejection AFTER a successful Atlas ping must not jump the user onto
+      // local-fallback (which would silently ignore their reachable Atlas
+      // selection and, since a failed stop doesn't clear the cached local URI,
+      // startLocalMongo() would hand back the stale mongod). A failed stop just
+      // leaves the mongod idling — the exact pre-F3 behavior, logged, no worse.
+      try {
+        await stopLocalMongo();
+      } catch (stopErr) {
+        console.warn("Failed to stop embedded MongoDB after Atlas switch (leaving it running):", stopErr);
+      }
       return atlasUri;
     } catch {
       console.log("Atlas unreachable, falling back to local MongoDB...");

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -1120,9 +1120,18 @@ export class NfcService extends EventEmitter {
 
         try {
           await this.writeBlock(protocol, i, blockData);
-        } catch {
-          // Last block(s) may be write-protected on SLIX2 (config area) — stop
-          break;
+        } catch (err) {
+          // GH #1006 F1: ONLY the last block (the SLIX2 config/lock area, e.g.
+          // block 79) is legitimately write-protected — that's the expected,
+          // ignorable failure this catch was written for. A failure at any
+          // EARLIER block means live CC/NDEF data didn't land (the tag was
+          // lifted, an RF NAK), leaving the payload truncated mid-CBOR. The
+          // old code broke on ANY failure and still resolved { success: true },
+          // so the user pocketed a corrupt tag that fails on the next scan with
+          // no indication the write failed. Rethrow early failures so the write
+          // reports failure; only swallow the protected-tail case.
+          if (i >= numBlocks - 1) break;
+          throw err;
         }
 
         // Small delay for EEPROM programming time

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -19,6 +19,13 @@ interface NfcStatus {
   readerName: string | null;
   tagPresent: boolean;
   tagUid: string | null;
+  // GH #1006 F4: mirror the canonical contract in src/types/electron.d.ts
+  // (GH #450) — NfcService.getStatus() always includes this, and the drift
+  // was invisible to typecheck because this local interface omitted it.
+  lastError: {
+    code: "permission" | "busy" | "no-daemon" | "generic";
+    message: string;
+  } | null;
 }
 
 interface UpdateInstallStrings {

--- a/src/app/settings/network/page.tsx
+++ b/src/app/settings/network/page.tsx
@@ -154,7 +154,16 @@ export default function NetworkSettingsPage() {
                             return;
                           }
                           setModeSwitching(true);
-                          await window.electronAPI!.saveConfig({ connectionMode: pendingMode, atlasUri: atlasUri.trim() });
+                          // GH #1006 F2 (Codex P2 on #1015): a failed server respawn
+                          // RESOLVES with { success: false } — it doesn't reject — so
+                          // the catch below never fires for it. Check the result (the
+                          // exposeToLan toggle's pattern) or the toast shows
+                          // "Switched to…" over a dead server.
+                          const saveRes = await window.electronAPI!.saveConfig({ connectionMode: pendingMode, atlasUri: atlasUri.trim() });
+                          if (!saveRes?.success) {
+                            setModeResult({ ok: false, message: t("settings.switchFailed") });
+                            return;
+                          }
                           setCurrentMode(pendingMode);
                           setHasStoredUri(true);
                           setPendingMode("");
@@ -190,7 +199,13 @@ export default function NetworkSettingsPage() {
                       setModeSwitching(true);
                       setModeResult(null);
                       try {
-                        await window.electronAPI!.saveConfig({ connectionMode: pendingMode });
+                        // GH #1006 F2 (Codex P2 on #1015): same result check as the
+                        // connect-and-switch path above — {success:false} resolves.
+                        const saveRes = await window.electronAPI!.saveConfig({ connectionMode: pendingMode });
+                        if (!saveRes?.success) {
+                          setModeResult({ ok: false, message: t("settings.switchFailed") });
+                          return;
+                        }
                         setCurrentMode(pendingMode);
                         setPendingMode("");
                         setModeResult({ ok: true, message: t("settings.switchedTo", { mode: CONNECTION_MODES.find((m) => m.id === pendingMode)?.label || "" }) });

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -36,10 +36,19 @@ export default function SetupPage() {
           return;
         }
 
-        await window.electronAPI.saveConfig({
+        // GH #1006 F2 (Codex P2 on #1015): a failed server respawn RESOLVES
+        // with { success: false } (no rejection) and skips the redirect — check
+        // the result or setup just clears the spinner with no error while the
+        // app has no embedded server.
+        const saveRes = await window.electronAPI.saveConfig({
           connectionMode: mode === "hybrid" ? "hybrid" : "atlas",
           atlasUri: mongoUri,
         });
+        if (!saveRes?.success) {
+          setError(t("setup.setupFailed"));
+          setTesting(false);
+          return;
+        }
         // Electron will redirect to home
       } else {
         // Web app: test via API route
@@ -92,9 +101,14 @@ export default function SetupPage() {
     setError("");
 
     try {
-      await window.electronAPI.saveConfig({
+      // GH #1006 F2 (Codex P2 on #1015): same result check as the Atlas path.
+      const saveRes = await window.electronAPI.saveConfig({
         connectionMode: "offline",
       });
+      if (!saveRes?.success) {
+        setError(t("setup.setupFailed"));
+        return;
+      }
       // Electron will redirect to home
     } catch (err) {
       setError(err instanceof Error ? err.message : t("setup.setupFailed"));


### PR DESCRIPTION
Closes #1006 (all 4 findings).

**F1 (P2)** — `writeSlix2Impl` caught a `writeBlock` failure at ANY block, broke the loop, and still resolved `{ success: true }`. But `wrapNdefForTag` lays live CC/NDEF data across blocks 0–78; only the last block (79, the config/lock area) is legitimately write-protected. So a tag lifted (or RF NAK) at block 20 reported success — the user pocketed a tag truncated mid-CBOR. Now only the last block (`i >= numBlocks - 1`) is the expected protected-tail case; any earlier failure rethrows.

**F4 (P3)** — the `nfc-get-status` null-service fallback returned no `lastError`, though `src/types/electron.d.ts` types it required and `NfcService.getStatus()` always includes it. Added `lastError: null` to the fallback and to preload's local `NfcStatus` interface (whose omission hid the drift from typecheck).

**F2 (P3)** — a connection-mode change caught a `startProductionServer` failure, only logged it, then unconditionally reached `loadURL` + returned `{ success: true }` — so a failed respawn (EADDRINUSE port race) left NO embedded server yet reported success and reloaded into a dead page. Now retries once on the resolved uri (resolveMongoUri already stood up this mode's mongod/sync, so the new uri is the coherent recovery target); if recovery fails too, it stops mDNS, skips the loadURL, and returns `{ success: false }`.

**F3 (P3)** — `resolveMongoUri`'s Atlas branch destroyed a leftover syncService (#672) but never stopped an embedded mongod from a prior offline/hybrid session, so pure Atlas idled a ~200–300 MB process for the session. Added `await stopLocalMongo()` to the Atlas success path (no-op when none running).

`electron:typecheck` + root `tsc` + ESLint clean. `electron/` is typecheck-gated, not part of the vitest suite; the NFC + connection-mode lifecycle is validated manually on the desktop build. The SLIX2 error-propagation change and the connection-recover path should be reconfirmed on hardware (a real block-79 protection still succeeds; earlier NAKs now fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)