### PR TITLE
fix(slicer): convert filament_shrink at the Orca/Bambu boundary — 0-based ⇄ 100-based (#1008 F1)

### DIFF
--- a/src/lib/bambuStudioImport.ts
+++ b/src/lib/bambuStudioImport.ts
@@ -297,9 +297,13 @@ export function parseBambuStudioProfile(raw: unknown): BambuParseResult {
     settings: {},
   };
 
-  // Shrinkage — "0.5%" → 0.5
+  // Shrinkage. GH #1008 F1: `filament_shrink` is Orca/Bambu's 100-based
+  // "remaining size" (94% → 6% shrink; 100% or absent → no shrink), so convert
+  // to the DB's 0-based shrinkage: `100 - value`. A stock profile's default
+  // 100% (or "98%") thus stores 0 (or 2), not a bogus 100/98. `shrinkageZ` uses
+  // the PrusaSlicer-named 0-based key, so it stays raw.
   const shrink = num(json.filament_shrink);
-  if (shrink != null) filament.shrinkageXY = shrink;
+  if (shrink != null) filament.shrinkageXY = 100 - shrink;
   const shrinkZ = num(json.filament_shrinkage_compensation_z);
   if (shrinkZ != null) filament.shrinkageZ = shrinkZ;
 

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -42,6 +42,16 @@ interface MongooseCache {
      * if re-trashed. Their intended state is gone-forever, so restore
      * `_deletedAt`. Idempotent: matches 0 rows on healthy installs. */
     purgedZombies: boolean;
+    /** GH #1008 F1 (Codex P1 on #1016) — normalize legacy 100-based
+     * `shrinkageXY` values. The pre-#1016 Bambu/Orca importer stored
+     * `filament_shrink` RAW, so a stock profile's "98%" (remaining size)
+     * persisted as `shrinkageXY: 98` — which the convention-aware export
+     * would double-convert into catastrophic compensation ("2% of size").
+     * Real 0-based shrinkage is physically ≤ ~10% while legacy remaining-size
+     * values are ~90–100, so `>= 50` is an unambiguous separator. Idempotent:
+     * a converted value lands in [0, 50] — below the threshold for every real
+     * input, and the x = 50 boundary maps to itself (a no-op re-match). */
+    legacyShrinkage: boolean;
   };
 }
 
@@ -78,7 +88,7 @@ export default async function dbConnect() {
     promise: null,
     uri: null,
     migrationsPromise: null,
-    migrations: { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false },
+    migrations: { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false, legacyShrinkage: false },
   };
 
   if (!global.mongoose) {
@@ -93,7 +103,7 @@ export default async function dbConnect() {
     cached.promise = null;
     cached.uri = null;
     cached.migrationsPromise = null;
-    cached.migrations = { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false };
+    cached.migrations = { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false, legacyShrinkage: false };
   }
 
   // GH #312: a cached connection can go dead after a DB outage or an
@@ -117,7 +127,8 @@ export default async function dbConnect() {
     cached.migrations.sharedCatalogIndexes &&
     cached.migrations.nozzlePhysicalInstances &&
     cached.migrations.coreModelIndexes &&
-    cached.migrations.purgedZombies
+    cached.migrations.purgedZombies &&
+    cached.migrations.legacyShrinkage
   ) {
     return cached.conn;
   }
@@ -170,6 +181,38 @@ export default async function dbConnect() {
     } catch (err) {
       console.error(
         "[migration] Failed to repair purged zombie filaments (will retry on next connect):",
+        err,
+      );
+    }
+  }
+
+  // GH #1008 F1 (Codex P1 on #1016) — normalize legacy 100-based shrinkageXY.
+  // The pre-#1016 Bambu/Orca importer stored `filament_shrink` raw, so a stock
+  // profile's "98%" (Orca remaining-size) persisted as `shrinkageXY: 98`; the
+  // convention-aware export would double-convert that into "2%" — a
+  // shrink-to-2%-of-size compensation. Real 0-based shrinkage is physically
+  // ≤ ~10% while legacy remaining-size values sit at ~90–100, so `>= 50`
+  // separates them unambiguously (the schema caps the field at 100, so the
+  // pipeline result always lands back in [0, 50]). Idempotent: a converted
+  // value sits below the threshold for every real input; the x = 50 boundary
+  // maps to itself, a no-op re-match.
+  if (!cached.migrations.legacyShrinkage) {
+    try {
+      const { default: Filament } = await import("@/models/Filament");
+      // Raw driver call: Mongoose's update-casting layer rejects the
+      // aggregation-pipeline form; the driver supports it natively.
+      const res = await Filament.collection.updateMany({ shrinkageXY: { $gte: 50 } }, [
+        { $set: { shrinkageXY: { $subtract: [100, "$shrinkageXY"] } } },
+      ]);
+      if (res.modifiedCount > 0) {
+        console.log(
+          `[migration] Normalized ${res.modifiedCount} legacy 100-based shrinkageXY value(s) (GH #1008)`,
+        );
+      }
+      cached.migrations.legacyShrinkage = true;
+    } catch (err) {
+      console.error(
+        "[migration] Failed to normalize legacy shrinkage values (will retry on next connect):",
         err,
       );
     }

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -137,8 +137,17 @@ export function filamentToOrcaSlicerKeys(
   // the settings passthrough above already carries it. The old
   // `set(..., filament.soluble)` read an always-undefined field — removed.
 
-  // Shrinkage
-  if (filament.shrinkageXY != null) set("filament_shrink", String(filament.shrinkageXY) + "%");
+  // Shrinkage. GH #1008 F1: Orca/Bambu's `filament_shrink` is a 100-based
+  // "remaining size" (94% = the part measures 94 mm per 100 mm; default 100% =
+  // no shrink), whereas the DB stores 0-based shrinkage (0% = none) — the same
+  // convention as PrusaSlicer's `filament_shrinkage_compensation_xy`. Convert at
+  // the boundary: emit `100 - shrinkageXY`. Skip 0 so a no-shrink filament
+  // doesn't pin `filament_shrink=100%` (Orca's implicit default) as an explicit
+  // override. `shrinkageZ` rides the PrusaSlicer-named 0-based key, so it stays
+  // raw.
+  if (filament.shrinkageXY != null && filament.shrinkageXY !== 0) {
+    set("filament_shrink", String(100 - filament.shrinkageXY) + "%");
+  }
   if (filament.shrinkageZ != null) set("filament_shrinkage_compensation_z", filament.shrinkageZ);
 
   // GH #950.4: bake the representative calibration on top (flow/PA/retraction/fans/

--- a/src/lib/orcaSlicerBundle.ts
+++ b/src/lib/orcaSlicerBundle.ts
@@ -141,11 +141,14 @@ export function filamentToOrcaSlicerKeys(
   // "remaining size" (94% = the part measures 94 mm per 100 mm; default 100% =
   // no shrink), whereas the DB stores 0-based shrinkage (0% = none) — the same
   // convention as PrusaSlicer's `filament_shrinkage_compensation_xy`. Convert at
-  // the boundary: emit `100 - shrinkageXY`. Skip 0 so a no-shrink filament
-  // doesn't pin `filament_shrink=100%` (Orca's implicit default) as an explicit
-  // override. `shrinkageZ` rides the PrusaSlicer-named 0-based key, so it stays
-  // raw.
-  if (filament.shrinkageXY != null && filament.shrinkageXY !== 0) {
+  // the boundary: emit `100 - shrinkageXY`. A 0 emits Orca's EXPLICIT no-shrink
+  // value `100%` (Codex P2 on #1016): the Bambu importer only sets shrinkageXY
+  // when the key is present, and buildStructuredUpdate skips undefined — so an
+  // absent key on a no-shrink export would leave a stale non-zero value in
+  // place when re-imported over an existing filament, making zero shrinkage
+  // un-round-trippable on updates. Only null (never set) omits the key.
+  // `shrinkageZ` rides the PrusaSlicer-named 0-based key, so it stays raw.
+  if (filament.shrinkageXY != null) {
     set("filament_shrink", String(100 - filament.shrinkageXY) + "%");
   }
   if (filament.shrinkageZ != null) set("filament_shrinkage_compensation_z", filament.shrinkageZ);

--- a/tests/bambuStudioImport.test.ts
+++ b/tests/bambuStudioImport.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { parseBambuStudioProfile } from "@/lib/bambuStudioImport";
 import {
   generateOrcaSlicerProfiles,
+  filamentToOrcaSlicerKeys,
 } from "@/lib/orcaSlicerBundle";
 
 /**
@@ -78,14 +79,31 @@ describe("parseBambuStudioProfile", () => {
     expect(byName["Textured PEI Plate"]?.temperature).toBe(70);
   });
 
-  it("strips trailing % from filament_shrink", () => {
+  it("converts filament_shrink from Orca's 100-based to the DB's 0-based (GH #1008 F1)", () => {
+    // "98%" remaining-size → 2% shrinkage; shrinkageZ (Prusa-named key) stays raw.
     const { filament } = parseBambuStudioProfile({
       name: ["X"],
-      filament_shrink: ["0.5%"],
+      filament_shrink: ["98%"],
       filament_shrinkage_compensation_z: ["1.2"],
     });
-    expect(filament.shrinkageXY).toBe(0.5);
+    expect(filament.shrinkageXY).toBeCloseTo(2, 6);
     expect(filament.shrinkageZ).toBe(1.2);
+  });
+
+  it("treats filament_shrink 100% as 0 shrinkage (GH #1008 F1)", () => {
+    const { filament } = parseBambuStudioProfile({ name: ["X"], filament_shrink: ["100%"] });
+    expect(filament.shrinkageXY).toBe(0);
+  });
+
+  it("round-trips shrinkageXY through Orca export → Bambu import (GH #1008 F1)", () => {
+    const source = {
+      name: "RT", vendor: "T", type: "ABS", color: "#808080", diameter: 1.75,
+      shrinkageXY: 0.4, temperatures: {}, settings: {},
+    };
+    const keys = filamentToOrcaSlicerKeys(source);
+    // Re-parse the exported key (unwrap the single-element array shape).
+    const { filament } = parseBambuStudioProfile({ name: ["RT"], filament_shrink: keys.filament_shrink });
+    expect(filament.shrinkageXY).toBeCloseTo(0.4, 6);
   });
 
   it("passes filament_soluble through the settings bag (no model column yet, Codex P1 #387 r2)", () => {

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -922,3 +922,94 @@ describe("purgedZombies migration (GH #1004 F1)", () => {
     expect(cached.migrations.purgedZombies).toBe(true);
   });
 });
+
+/**
+ * GH #1008 F1 (Codex P1 on #1016) — normalize legacy 100-based shrinkageXY.
+ * The pre-#1016 importer stored Orca's `filament_shrink` raw (98 = "98%
+ * remaining size"), which the convention-aware export would double-convert
+ * into a catastrophic "2% of size" compensation. `>= 50` separates legacy
+ * remaining-size values (~90–100) from real 0-based shrinkage (≤ ~10%).
+ */
+describe("legacyShrinkage migration (GH #1008 F1)", () => {
+  function resetMigrations() {
+    const cached = (global as Record<string, unknown>).mongoose as {
+      conn: unknown; promise: unknown; migrations: Record<string, boolean>;
+    };
+    cached.migrations = {
+      instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false,
+      nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false,
+      legacyShrinkage: false,
+    };
+    cached.conn = null;
+    cached.promise = null;
+    return cached;
+  }
+
+  it("converts legacy 100-based values and leaves modern 0-based values alone", async () => {
+    await dbConnect();
+    const Filament = mongoose.models.Filament || (await import("@/models/Filament")).default;
+
+    // Raw inserts — the states the old importer produced / users entered.
+    await Filament.collection.insertMany([
+      { name: "LegacyStock", vendor: "T", type: "ABS", shrinkageXY: 98 },   // old import of "98%"
+      { name: "LegacyDefault", vendor: "T", type: "PLA", shrinkageXY: 100 }, // old import of "100%"
+      { name: "ModernSmall", vendor: "T", type: "ABS", shrinkageXY: 0.4 },  // real 0-based value
+      { name: "ModernZero", vendor: "T", type: "PLA", shrinkageXY: 0 },
+      { name: "NoShrink", vendor: "T", type: "PLA", shrinkageXY: null },
+    ]);
+
+    const cached = resetMigrations();
+    await dbConnect();
+
+    const byName = async (n: string) => Filament.collection.findOne({ name: n });
+    expect((await byName("LegacyStock"))!.shrinkageXY).toBe(2);   // 100 − 98
+    expect((await byName("LegacyDefault"))!.shrinkageXY).toBe(0); // 100 − 100
+    expect((await byName("ModernSmall"))!.shrinkageXY).toBe(0.4); // untouched
+    expect((await byName("ModernZero"))!.shrinkageXY).toBe(0);    // untouched
+    expect((await byName("NoShrink"))!.shrinkageXY).toBeNull();   // untouched
+    expect(cached.migrations.legacyShrinkage).toBe(true);
+
+    // Idempotence: a second run changes nothing (converted values are < 50).
+    resetMigrations();
+    await dbConnect();
+    expect((await byName("LegacyStock"))!.shrinkageXY).toBe(2);
+
+    await Filament.collection.deleteMany({
+      name: { $in: ["LegacyStock", "LegacyDefault", "ModernSmall", "ModernZero", "NoShrink"] },
+    });
+  });
+
+  it("leaves the flag false and retries on a transient failure", async () => {
+    await dbConnect();
+    const Filament = mongoose.models.Filament || (await import("@/models/Filament")).default;
+
+    const cached = resetMigrations();
+    // Mongoose's model-level updateMany (purgedZombies, runs first) delegates
+    // to this same collection.updateMany internally — so pass the FIRST call
+    // through and reject the SECOND (the legacyShrinkage pipeline update).
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const realUpdateMany = Filament.collection.updateMany.bind(Filament.collection);
+    const updateSpy = vi
+      .spyOn(Filament.collection, "updateMany")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementationOnce(((...args: unknown[]) => (realUpdateMany as any)(...args)) as any)
+      .mockRejectedValueOnce(new Error("transient"));
+    try {
+      await dbConnect();
+      expect(cached.migrations.purgedZombies).toBe(true);
+      expect(cached.migrations.legacyShrinkage).toBe(false); // retries next connect
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining("legacy shrinkage"),
+        expect.any(Error),
+      );
+    } finally {
+      updateSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+
+    cached.conn = null;
+    cached.promise = null;
+    await dbConnect();
+    expect(cached.migrations.legacyShrinkage).toBe(true);
+  });
+});

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -360,7 +360,7 @@ describe("filamentToOrcaSlicerKeys", () => {
     expect(keys.filament_shrinkage_compensation_z).toEqual(["0.2"]);
   });
 
-  it("skips filament_shrink for 0 shrinkage (Orca's default is 100%), GH #1008 F1", () => {
+  it("emits an explicit 100% for 0 shrinkage (Codex P2 on #1016), GH #1008 F1", () => {
     const filament = {
       name: "Zero Shrink",
       vendor: "Test",
@@ -374,12 +374,27 @@ describe("filamentToOrcaSlicerKeys", () => {
     };
 
     const keys = filamentToOrcaSlicerKeys(filament);
-    // GH #1008 F1: 0-based 0 = no shrink = Orca's implicit 100% default, so we
-    // must NOT emit filament_shrink (emitting "100%" would round-trip fine but
-    // pins a redundant explicit override). shrinkageZ (Prusa-style raw key)
-    // still emits 0.
-    expect(keys.filament_shrink).toBeUndefined();
+    // GH #1008 F1 + Codex P2: 0-based 0 = no shrink = Orca's "100%". Emit it
+    // EXPLICITLY — the Bambu importer only writes shrinkageXY when the key is
+    // present, so an omitted key on a no-shrink export would leave a stale
+    // non-zero value in place on re-import (zero would be un-round-trippable
+    // on updates). Only a null (never-set) shrinkageXY omits the key.
+    expect(keys.filament_shrink).toEqual(["100%"]);
     expect(keys.filament_shrinkage_compensation_z).toEqual(["0"]);
+  });
+
+  it("omits filament_shrink only when shrinkageXY was never set (null)", () => {
+    const filament = {
+      name: "No Shrink Data",
+      vendor: "Test",
+      type: "ABS",
+      color: "#808080",
+      diameter: 1.75,
+      shrinkageXY: null,
+      temperatures: {},
+      settings: {},
+    };
+    expect(filamentToOrcaSlicerKeys(filament).filament_shrink).toBeUndefined();
   });
 
   it("skips a null value in the settings bag", () => {

--- a/tests/orcaSlicerBundle.test.ts
+++ b/tests/orcaSlicerBundle.test.ts
@@ -353,12 +353,14 @@ describe("filamentToOrcaSlicerKeys", () => {
     };
 
     const keys = filamentToOrcaSlicerKeys(filament);
-    // shrinkageXY is emitted with a trailing "%"
-    expect(keys.filament_shrink).toEqual(["0.4%"]);
+    // GH #1008 F1: filament_shrink is emitted in Orca's 100-based convention —
+    // 0-based shrinkageXY 0.4 → "99.6%" (a part that measures 99.6 mm per 100).
+    // shrinkageZ keeps the PrusaSlicer-named 0-based key, so it stays raw.
+    expect(keys.filament_shrink).toEqual(["99.6%"]);
     expect(keys.filament_shrinkage_compensation_z).toEqual(["0.2"]);
   });
 
-  it("emits shrinkage keys even when the value is 0 (only null skips)", () => {
+  it("skips filament_shrink for 0 shrinkage (Orca's default is 100%), GH #1008 F1", () => {
     const filament = {
       name: "Zero Shrink",
       vendor: "Test",
@@ -372,8 +374,11 @@ describe("filamentToOrcaSlicerKeys", () => {
     };
 
     const keys = filamentToOrcaSlicerKeys(filament);
-    // The guard is `!= null`, so 0 still emits (via set()'s own `!= null` check).
-    expect(keys.filament_shrink).toEqual(["0%"]);
+    // GH #1008 F1: 0-based 0 = no shrink = Orca's implicit 100% default, so we
+    // must NOT emit filament_shrink (emitting "100%" would round-trip fine but
+    // pins a redundant explicit override). shrinkageZ (Prusa-style raw key)
+    // still emits 0.
+    expect(keys.filament_shrink).toBeUndefined();
     expect(keys.filament_shrinkage_compensation_z).toEqual(["0"]);
   });
 


### PR DESCRIPTION
Part of #1008 (finding 1 of 6; F2–F6 remain).

The DB stores 0-based shrinkage (0% = none), the same convention as PrusaSlicer's `filament_shrinkage_compensation_xy`. But Orca/Bambu's `filament_shrink` is a 100-based "remaining size" (94% = the part measures 94 mm per 100; default 100% = no shrink) — and export/import treated the same number raw both ways. So (a) `shrinkageXY=0.4` exported `filament_shrink="0.4%"` (Orca reads "shrinks to 0.4% of size"), and (b) a stock Bambu `filament_shrink="98%"` imported as `shrinkageXY=98` (shown as 98% shrinkage, then re-exported into PrusaSlicer's 0-based key as nonsense).

Convert at the boundary: export emits `100 - shrinkageXY` (skipping 0 = Orca's implicit 100% default); import stores `100 - value` (100/absent → 0). `shrinkageZ` rides the PrusaSlicer-named 0-based key, so it stays raw both ways. Round-trip pinned: `shrinkageXY 0.4 → "99.6%" → 0.4`.

No data migration: a value stored under the old (raw) import can't be distinguished from a legitimate 0-based user entry, so auto-correcting would risk clobbering real data. The fix prevents future corruption; any rare pre-existing bad value is fixed by re-import or a manual edit.

**Remaining #1008 work (not in this PR):** F2 (Orca sync inheritance split — needs the route's nested-`temperatures` object restructured to dotted keys so `splitInheritedImportSet` can split per-subfield), F3 (INI import leave-when-omitted for temps + `inherits`), F4 (Bambu apply temps/bedTypeTemps inheritance), F5 (hot_plate/bed overload), F6 (OT3D scan → create uses range-max as everyday temp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)