### PR TITLE
fix(import,nfc): INI import stops nulling temps+inherits; create-from-tag uses recommended temp (#1008 F3+F6)

### DIFF
--- a/src/lib/decodedTagToFilament.ts
+++ b/src/lib/decodedTagToFilament.ts
@@ -1,6 +1,19 @@
 import type { DecodedOpenPrintTag } from "./openprinttag-decode";
 
 /**
+ * GH #1008 F6: coerce an `aux` value to a finite number. Aux values ride
+ * unvalidated client JSON (`Record<string, unknown>`), so they may arrive as
+ * strings or junk — only numbers and non-empty numeric strings pass; anything
+ * else (booleans, objects, arrays, "", NaN, Infinity) returns null.
+ */
+function auxTemp(v: unknown): number | null {
+  if (typeof v !== "number" && typeof v !== "string") return null;
+  if (typeof v === "string" && v.trim() === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
  * Map a tag decoded by `POST /api/nfc/decode` (a `DecodedOpenPrintTag`) into a
  * Filament DB creation payload — the server-side mapper behind create-from-scan
  * (mobile Phase 2, plan §4.4). The phone never reproduces this mapping: it
@@ -58,6 +71,22 @@ export function decodedTagToFilamentPayload(
 
   const secondaryColors = Array.isArray(decoded.secondaryColors) ? decoded.secondaryColors : [];
 
+  // GH #1008 F6: for an OpenTag3D tag with a RANGED print temp,
+  // `decoded.nozzleTemp` is the Extended range MAX (`maxPrintTemp ??
+  // recPrintTemp` — see opentag3d-decode.ts), while the Core RECOMMENDED
+  // print_temp survives only in `aux.opentag3d_recommended_print_temp_c`
+  // (stashed exactly when a distinct max exists). Mapping the max into the
+  // everyday `temperatures.nozzle` made write→scan→create asymmetric: a
+  // filament written with nozzle=215 / rangeMax=230 scanned back and created
+  // with nozzle=230 — the same everyday-vs-max drift #970 fixed on the OPT
+  // encode side. Prefer the preserved recommended value for the everyday temp;
+  // the max stays on `nozzleRangeMax`. Same for bed — the schema has no
+  // bed-range fields, so the recommended value simply wins the single `bed`
+  // slot. Only OpenTag3D decodes populate these aux keys, so OpenPrintTag /
+  // Bambu payloads are unchanged.
+  const recommendedNozzle = auxTemp(decoded.aux?.opentag3d_recommended_print_temp_c);
+  const recommendedBed = auxTemp(decoded.aux?.opentag3d_recommended_bed_temp_c);
+
   return {
     name,
     vendor: brand || null,
@@ -76,11 +105,14 @@ export function decodedTagToFilamentPayload(
     // and fall back to the 1.75 the OPT importer assumes when the tag omits it.
     diameter: decoded.diameter ?? 1.75,
     temperatures: {
-      nozzle: decoded.nozzleTemp ?? null,
+      // GH #1008 F6: everyday temp = the Core recommended value when the tag
+      // preserved one (ranged OpenTag3D); otherwise decoded.nozzleTemp (OPT /
+      // Bambu / Core-only OpenTag3D, where it IS the recommended value).
+      nozzle: recommendedNozzle ?? decoded.nozzleTemp ?? null,
       nozzleFirstLayer: null,
       nozzleRangeMin: decoded.nozzleTempMin ?? null,
       nozzleRangeMax: decoded.nozzleTemp ?? null,
-      bed: decoded.bedTemp ?? null,
+      bed: recommendedBed ?? decoded.bedTemp ?? null,
       bedFirstLayer: null,
       standby: decoded.preheatTemp ?? null,
     },

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -156,9 +156,21 @@ const SETTINGS_STRIP_KEYS = [...IMPORT_ROUTING_HINT_KEYS, "filament_settings_id"
  */
 export type CollapsedFilamentData = Omit<
   import("./parseIni").FilamentData,
-  "temperatures" | "maxVolumetricSpeed" | "cost" | "density" | "diameter" | "color" | "vendor" | "type"
+  | "temperatures"
+  | "maxVolumetricSpeed"
+  | "cost"
+  | "density"
+  | "diameter"
+  | "color"
+  | "vendor"
+  | "type"
+  | "inherits"
 > & {
-  temperatures?: import("./parseIni").FilamentData["temperatures"];
+  /** GH #1008 F3: subfields individually optional — the non-hinted collapse
+   *  deletes each temp the section didn't supply so the importer's dot-key
+   *  `$set` can't null a stored value (leave-when-omitted, same as the
+   *  scalars); the whole object is dropped when no subfield remains. */
+  temperatures?: Partial<import("./parseIni").FilamentData["temperatures"]>;
   maxVolumetricSpeed?: number | null;
   cost?: number | null;
   density?: number | null;
@@ -166,6 +178,10 @@ export type CollapsedFilamentData = Omit<
   color?: string;
   vendor?: string;
   type?: string;
+  /** GH #1008 F3: optional/deletable — omitted when the section carries no
+   *  `inherits` key (parseIni materialises `inherits: null` either way). An
+   *  EXPLICIT `inherits = nil` keeps the key (null value) and writes through. */
+  inherits?: string | null;
   /** GH #950: the section's round-tripped `filamentdb_id` routing hint (the
    *  filament _id). Carried for id-first resolution in `upsertIniFilament`;
    *  NEVER persisted (stripped from the settings bag above). */
@@ -195,7 +211,14 @@ export function collapsePerNozzleImportSections(
       // Pass through, but never persist routing hints / re-derived keys.
       const settings = { ...f.settings };
       for (const k of SETTINGS_STRIP_KEYS) delete settings[k];
-      const collapsed: CollapsedFilamentData = { ...f, settings };
+      // GH #1008 F3: CLONE `temperatures` — the `...f` spread below would share
+      // the source object's reference, and the per-subfield deletes further down
+      // must not corrupt the caller's parsed FilamentData.
+      const collapsed: CollapsedFilamentData = {
+        ...f,
+        settings,
+        temperatures: { ...f.temperatures },
+      };
       // GH #950: leave-when-omitted. parseIni fills absent fields with defaults
       // (null / "#808080" / 1.75 / "Unknown"); $set-ing those over a name-matched
       // existing filament CLOBBERS its real values on a partial/hand-crafted
@@ -209,6 +232,23 @@ export function collapsePerNozzleImportSections(
       if (!("filament_vendor" in f.settings)) delete collapsed.vendor;
       if (!("filament_type" in f.settings)) delete collapsed.type;
       if (!("filament_max_volumetric_speed" in f.settings)) delete collapsed.maxVolumetricSpeed;
+      // GH #1008 F3: extend the same rule to the four temp SUBFIELDS and
+      // `inherits`, which the #950 guard above skipped. parseIni ALWAYS
+      // materialises `temperatures` as {nozzle: null, …} and `inherits: null`
+      // when the keys are absent — riding those through gets dot-flattened by
+      // the importer and `$set`s every stored temp (and inherits) to null on a
+      // name-matched filament. Real PrusaSlicer user presets are
+      // `inherits = <system preset>` + only the diverged keys, so the partial
+      // section is the NORMAL shape, not an edge case. An EXPLICIT
+      // `temperature = nil` / `inherits = nil` keeps its key present in
+      // f.settings and still writes null through (a deliberate reset).
+      const temps = collapsed.temperatures!;
+      if (!("temperature" in f.settings)) delete temps.nozzle;
+      if (!("first_layer_temperature" in f.settings)) delete temps.nozzleFirstLayer;
+      if (!("bed_temperature" in f.settings)) delete temps.bed;
+      if (!("first_layer_bed_temperature" in f.settings)) delete temps.bedFirstLayer;
+      if (Object.keys(temps).length === 0) delete collapsed.temperatures;
+      if (!("inherits" in f.settings)) delete collapsed.inherits;
       const fid = (f.settings.filamentdb_id ?? "").trim();
       if (fid) collapsed.filamentdbId = fid; // GH #950: id-first resolution hint
       out.push(collapsed);
@@ -260,6 +300,11 @@ export function collapsePerNozzleImportSections(
     void maxVolumetricSpeed;
     const collapsed: CollapsedFilamentData = { ...sharedFields, name: baseName, settings };
     if (id) collapsed.filamentdbId = id; // GH #950: id-first resolution hint
+    // GH #1008 F3: same `inherits` leave-when-omitted as the non-hinted branch —
+    // a suffixed section without an `inherits` key must not `$set` null over the
+    // base's stored value. (Temps / max-vol are already omitted wholesale above;
+    // an explicit `inherits = nil` keeps the key and writes null through.)
+    if (!("inherits" in f.settings)) delete collapsed.inherits;
     // Carry a shared field ONLY when the suffixed section actually SUPPLIED it (the
     // source INI key is present) — otherwise parseIni's defaults (null / "#808080" /
     // 1.75 / "Unknown") would $set over the base filament's real cost/density/color/

--- a/tests/decodedTagToFilament.test.ts
+++ b/tests/decodedTagToFilament.test.ts
@@ -152,4 +152,91 @@ describe("decodedTagToFilamentPayload", () => {
       standby: null,
     });
   });
+
+  // ── GH #1008 F6: for a RANGED OpenTag3D tag, decoded.nozzleTemp is the
+  //    Extended range MAX; the Core RECOMMENDED print_temp survives only in
+  //    aux.opentag3d_recommended_print_temp_c (stashed exactly when a distinct
+  //    max exists). The create payload must map the recommended value to the
+  //    everyday temp, keeping the max on nozzleRangeMax — otherwise a filament
+  //    written with nozzle=215/rangeMax=230 scans back and creates with 230. ──
+
+  it("#1008 F6: OpenTag3D ranged tag — everyday nozzle/bed = the Core RECOMMENDED, max stays on nozzleRangeMax", () => {
+    const p = decodedTagToFilamentPayload(
+      tag({
+        tagSource: "opentag3d",
+        brandName: "Polar Filament",
+        materialName: "PETG",
+        materialType: "PETG",
+        nozzleTemp: 230, // = Extended max_print_temp
+        nozzleTempMin: 190,
+        bedTemp: 70, // = Extended max_bed_temp
+        aux: {
+          opentag3d_recommended_print_temp_c: 215,
+          opentag3d_recommended_bed_temp_c: 60,
+        },
+      }),
+    );
+    expect(p.temperatures).toEqual({
+      nozzle: 215, // everyday = recommended, NOT the range max
+      nozzleFirstLayer: null,
+      nozzleRangeMin: 190,
+      nozzleRangeMax: 230, // the max survives on the range field
+      bed: 60, // bed likewise prefers the recommended value
+      bedFirstLayer: null,
+      standby: null,
+    });
+  });
+
+  it("#1008 F6: falls back to decoded.nozzleTemp/bedTemp when no recommended aux key exists", () => {
+    // A Core-only OpenTag3D image (no Extended max): nozzleTemp IS the
+    // recommended value and no aux key is stashed. Unrelated aux keys must not
+    // interfere; OpenPrintTag / Bambu decodes (no opentag3d_* aux) take this
+    // same path — pinned by the OPT test at the top of this file too.
+    const p = decodedTagToFilamentPayload(
+      tag({
+        tagSource: "opentag3d",
+        nozzleTemp: 215,
+        bedTemp: 60,
+        aux: { opentag3d_serial: "abc123" },
+      }),
+    );
+    const temps = p.temperatures as Record<string, number | null>;
+    expect(temps.nozzle).toBe(215);
+    expect(temps.nozzleRangeMax).toBe(215);
+    expect(temps.bed).toBe(60);
+  });
+
+  it("#1008 F6: coerces numeric-string aux temps; an empty string falls back", () => {
+    const p = decodedTagToFilamentPayload(
+      tag({
+        tagSource: "opentag3d",
+        nozzleTemp: 230,
+        bedTemp: 70,
+        aux: {
+          opentag3d_recommended_print_temp_c: "215", // string → coerced
+          opentag3d_recommended_bed_temp_c: "  ", // blank → ignored
+        },
+      }),
+    );
+    const temps = p.temperatures as Record<string, number | null>;
+    expect(temps.nozzle).toBe(215);
+    expect(temps.bed).toBe(70); // fell back to the decoded bed temp
+  });
+
+  it("#1008 F6: ignores non-finite / non-numeric aux junk and falls back to the decoded temps", () => {
+    const p = decodedTagToFilamentPayload(
+      tag({
+        tagSource: "opentag3d",
+        nozzleTemp: 230,
+        bedTemp: 70,
+        aux: {
+          opentag3d_recommended_print_temp_c: "not-a-number", // NaN → ignored
+          opentag3d_recommended_bed_temp_c: { nested: true }, // object → ignored
+        },
+      }),
+    );
+    const temps = p.temperatures as Record<string, number | null>;
+    expect(temps.nozzle).toBe(230);
+    expect(temps.bed).toBe(70);
+  });
 });

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { upsertIniFilament } from "@/lib/iniImportApply";
+import { parseIniFilaments } from "@/lib/parseIni";
+import { collapsePerNozzleImportSections } from "@/lib/prusaSlicerBundle";
 import type { CollapsedFilamentData } from "@/lib/prusaSlicerBundle";
 
 /**
@@ -348,6 +350,67 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
       const fresh = await Filament.findById(variant._id).lean();
       // Nothing to heal; the matching key keeps inheriting (no phantom local write).
       expect(fresh.settings?.cooling).toBeUndefined();
+    });
+  });
+
+  // ── GH #1008 F3: end-to-end leave-when-omitted for temps + inherits through
+  //    the REAL pipeline (parseIni → collapse → upsert). Pre-fix, a section
+  //    omitting the temp keys rode parseIni's all-null `temperatures` (and
+  //    `inherits: null`) into the importer's dot-key $set and wiped all four
+  //    stored temps + inherits on a name-matched filament. ────────────────────
+  describe("leave-when-omitted temps + inherits (GH #1008 F3)", () => {
+    /** Parse a raw INI through the actual import pipeline (parse → collapse). */
+    const collapse = (ini: string) => collapsePerNozzleImportSections(parseIniFilaments(ini));
+
+    it("a section with NO temp keys and NO inherits preserves all four stored temps + inherits", async () => {
+      const existing = await Filament.create({
+        name: "Prusament PLA",
+        vendor: "Prusa",
+        type: "PLA",
+        temperatures: { nozzle: 215, nozzleFirstLayer: 220, bed: 60, bedFirstLayer: 65 },
+        inherits: "Prusament PLA @MK4S",
+      });
+      // The realistic PrusaSlicer user-preset shape: only the diverged key(s).
+      const [section] = collapse(
+        `[filament:Prusament PLA]\nfilament_retract_length = 1.2\n`,
+      );
+      expect(await upsertIniFilament(section)).toBe("updated");
+      const fresh = await Filament.findById(existing._id).lean();
+      expect(fresh.temperatures.nozzle).toBe(215);
+      expect(fresh.temperatures.nozzleFirstLayer).toBe(220);
+      expect(fresh.temperatures.bed).toBe(60);
+      expect(fresh.temperatures.bedFirstLayer).toBe(65);
+      expect(fresh.inherits).toBe("Prusament PLA @MK4S");
+      expect(fresh.settings.filament_retract_length).toBe("1.2"); // the diverged key landed
+    });
+
+    it("a PARTIAL temp section updates only the supplied subfield; siblings + inherits survive", async () => {
+      const existing = await Filament.create({
+        name: "Partial PLA",
+        vendor: "Prusa",
+        type: "PLA",
+        temperatures: { nozzle: 215, bed: 60 },
+        inherits: "*PLA*",
+      });
+      const [section] = collapse(`[filament:Partial PLA]\ntemperature = 230\n`);
+      expect(await upsertIniFilament(section)).toBe("updated");
+      const fresh = await Filament.findById(existing._id).lean();
+      expect(fresh.temperatures.nozzle).toBe(230); // supplied → updated
+      expect(fresh.temperatures.bed).toBe(60); // omitted → survives
+      expect(fresh.inherits).toBe("*PLA*"); // omitted → survives
+    });
+
+    it("an explicit `inherits = nil` still clears the stored inherits (deliberate reset writes through)", async () => {
+      const existing = await Filament.create({
+        name: "NilInherits PLA",
+        vendor: "Prusa",
+        type: "PLA",
+        inherits: "*PLA*",
+      });
+      const [section] = collapse(`[filament:NilInherits PLA]\ninherits = nil\n`);
+      expect(await upsertIniFilament(section)).toBe("updated");
+      const fresh = await Filament.findById(existing._id).lean();
+      expect(fresh.inherits ?? null).toBeNull();
     });
   });
 });

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -1372,6 +1372,106 @@ describe("collapsePerNozzleImportSections (#872)", () => {
     const base = collapsePerNozzleImportSections(parseIniFilaments(bundle))[0];
     expect(base.settings.compatible_printers_condition).toBe("printer_model==MK4"); // survived
   });
+
+  // ── GH #1008 F3: leave-when-omitted for the four temp SUBFIELDS + `inherits`.
+  //    parseIni materialises `temperatures` as {nozzle: null, …} and
+  //    `inherits: null` even when the source keys are absent; riding those
+  //    through the collapse gets dot-flattened by the importer and $sets every
+  //    stored temp (and inherits) to null on a name-matched filament. Real
+  //    PrusaSlicer user presets are `inherits = <system>` + only diverged keys,
+  //    so the partial section is the NORMAL shape. ─────────────────────────────
+
+  it("#1008 F3: a non-hinted section omitting ALL temp keys + inherits drops both (no null clobber)", () => {
+    // The canonical failure shape: a user preset carrying only one diverged key.
+    const parsed = parseIniFilaments(
+      `[filament:Prusament PLA]\nfilament_retract_length = 1.2\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect("temperatures" in f).toBe(false);
+    expect("inherits" in f).toBe(false);
+    expect(f.settings.filament_retract_length).toBe("1.2"); // passthrough kept
+  });
+
+  it("#1008 F3: an explicit `temperature = 215` keeps ONLY the supplied temp subfield", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Plain PLA]\nfilament_type = PLA\ntemperature = 215\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    // The other three subfields are ABSENT (not null) so the importer's
+    // dot-key $set can't touch a stored bed/first-layer value.
+    expect(f.temperatures).toEqual({ nozzle: 215 });
+    expect("inherits" in f).toBe(false);
+  });
+
+  it("#1008 F3: all four temp keys supplied → the full temperatures object survives", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Full PLA]\nfilament_type = PLA\ntemperature = 215\nfirst_layer_temperature = 220\nbed_temperature = 60\nfirst_layer_bed_temperature = 65\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect(f.temperatures).toEqual({
+      nozzle: 215,
+      nozzleFirstLayer: 220,
+      bed: 60,
+      bedFirstLayer: 65,
+    });
+  });
+
+  it("#1008 F3: an explicit `temperature = nil` keeps the subfield as null (a deliberate reset writes through)", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Nil PLA]\nfilament_type = PLA\ntemperature = nil\nbed_temperature = 60\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect(f.temperatures).toEqual({ nozzle: null, bed: 60 });
+  });
+
+  it("#1008 F3: an explicit `inherits = nil` still carries inherits (null) through", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Plain PLA]\nfilament_type = PLA\ninherits = nil\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect("inherits" in f).toBe(true);
+    expect(f.inherits).toBeNull();
+  });
+
+  it("#1008 F3: an explicit inherits VALUE is kept", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Plain PLA]\nfilament_type = PLA\ninherits = Prusament PLA @MK4S\n`,
+    );
+    const f = collapsePerNozzleImportSections(parsed)[0];
+    expect(f.inherits).toBe("Prusament PLA @MK4S");
+  });
+
+  it("#1008 F3: the collapse does NOT mutate the source section's temperatures (by-reference clone)", () => {
+    const parsed = parseIniFilaments(
+      `[filament:Plain PLA]\nfilament_type = PLA\ntemperature = 215\n`,
+    );
+    const source = parsed[0];
+    collapsePerNozzleImportSections(parsed);
+    // The caller's parsed FilamentData keeps its full all-subfield shape — the
+    // collapse pruned a CLONE, not the shared object.
+    expect(source.temperatures).toEqual({
+      nozzle: 215,
+      nozzleFirstLayer: null,
+      bed: null,
+      bedFirstLayer: null,
+    });
+  });
+
+  it("#1008 F3: a HINTED section without inherits drops it too (no clobber of the base's stored inherits)", () => {
+    const parsed = parseIniFilaments(
+      `[filament:PLA 0.4 Brass]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass\n`,
+    );
+    const base = collapsePerNozzleImportSections(parsed)[0];
+    expect("inherits" in base).toBe(false);
+  });
+
+  it("#1008 F3: a HINTED section WITH inherits keeps it", () => {
+    const parsed = parseIniFilaments(
+      `[filament:PLA 0.4 Brass]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass\ninherits = *PLA*\n`,
+    );
+    const base = collapsePerNozzleImportSections(parsed)[0];
+    expect(base.inherits).toBe("*PLA*");
+  });
 });
 
 describe("resolveSyncBackColor (#883)", () => {


### PR DESCRIPTION
Part of #1008 (findings 3 and 6; F2/F4/F5 follow in a sibling PR).

## F3 (P2) — bulk INI import nulls all four temps (and `inherits`) on a name-matched filament
`parseIni` always materialises `temperatures` as `{nozzle: null, …}` and `inherits: null` when the keys are absent, and the non-hinted collapse branch in `prusaSlicerBundle.ts` only applied the #950 leave-when-omitted guard to the scalar fields — so the all-null temps rode through, got flattened to dot-keys, and `$set` every stored temp to null. Real PrusaSlicer user presets are `inherits = <system preset>` + only diverged keys, so importing such a bundle over an existing filament wiped its temps while reporting "updated".

The collapse now **clones** `temperatures` (the spread shared it by reference — deleting in place would corrupt the caller's parsed source) and deletes each subfield whose source INI key is absent (`temperature`→nozzle, `first_layer_temperature`→nozzleFirstLayer, `bed_temperature`→bed, `first_layer_bed_temperature`→bedFirstLayer), dropping the whole key when empty; `inherits` is dropped when absent. An **explicit** `temperature = nil` / `inherits = nil` still writes null through (parseIni stores nil as present-with-null, so the `in` check distinguishes omitted from nil). Same `inherits` guard on the hinted branch.

## F6 (P3) — OpenTag3D scan → create stores the range MAX as the everyday nozzle temp
For OpenTag3D, `decoded.nozzleTemp = maxPrintTemp ?? recPrintTemp` (the Extended max when present) while the Core recommended value survives only in `aux.opentag3d_recommended_print_temp_c`. Create-from-tag mapped `nozzle` AND `nozzleRangeMax` from `decoded.nozzleTemp` — so a filament written with nozzle=215/rangeMax=230 scanned back and created with `temperatures.nozzle = 230` (every downstream consumer then uses the ceiling). `decodedTagToFilamentPayload` now prefers the preserved recommended values (`opentag3d_recommended_print_temp_c` / `_bed_temp_c`, coerced via a finite-number guard) for the everyday nozzle/bed temps, keeping `nozzleRangeMax = decoded.nozzleTemp`. OpenPrintTag/Bambu tags carry no such aux keys — unchanged.

Note: when a recommended **bed** value exists, the Extended max bed temp has no schema home (`bedRangeMin/Max` don't exist) and is not stored — matching the issue's prescribed fix; documented in a code comment.

## Tests
- 9 collapse unit cases in `prusaSlicerBundle.test.ts` (incl. the by-reference-clone pin and explicit-nil semantics), 3 end-to-end DB-backed cases in `iniImportApply.test.ts` through the real parse→collapse→upsert pipeline (stored temps + `inherits` survive a diverged-key-only user preset), 4 cases in `decodedTagToFilament.test.ts` (recommended-wins, fallback, string coercion, junk rejection).
- Full suite green (3280 tests) pre-rebase; 253 targeted tests green post-rebase onto the #1016 merge. `tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)