### PR TITLE
fix(slicer): stop Orca/Bambu syncs pinning variant inheritance + hot-plate bed guard (#1008 F2+F4+F5)

### DIFF
--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -11,6 +11,7 @@ import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
 import { isUpdateNozzleRangeInverted } from "@/lib/temperatureRange";
+import { splitInheritedImportSet } from "@/lib/importFilaments";
 
 /**
  * Top-level body keys that map to structured Filament DB fields.
@@ -185,6 +186,15 @@ export async function POST(
     }
 
     // Temperatures — same finite-number coercion per sub-field (GH #618).
+    // GH #1008 F2: write the temps as DOTTED paths (`temperatures.<sub>`),
+    // never a merged whole-object $set. Two reasons: (a) the inheritance
+    // split below (`splitInheritedImportSet`) only splits dotted temperature
+    // keys — a nested temps object falls through its pass-through branch
+    // whole, pinning every subfield onto a variant; (b) same rationale as
+    // #859 on the PrusaSlicer sync: update-validators check every path in
+    // the $set, so merging the STORED temps into the payload let one legacy
+    // out-of-range stored value 400 an unrelated sync. Dotted paths validate
+    // only the incoming values and leave untouched siblings alone.
     let touchesNozzleRange = false;
     if (body.temperatures && typeof body.temperatures === "object") {
       const src = body.temperatures as Record<string, unknown>;
@@ -199,30 +209,33 @@ export async function POST(
         temps[field] = n;
       }
       touchesNozzleRange = "nozzleRangeMin" in temps || "nozzleRangeMax" in temps;
-      if (Object.keys(temps).length > 0) {
-        update.temperatures = { ...filament.temperatures, ...temps };
+      for (const [key, value] of Object.entries(temps)) {
+        update[`temperatures.${key}`] = value;
       }
     }
 
+    // GH #1008 F2: fetch the FULL active parent once — shared by the
+    // nozzle-range inversion check below AND the variant inheritance split
+    // before the write (replaces the earlier range-only projected fetch).
+    // Null for standalones/roots and for a soft-deleted parent.
+    const parent = filament.parentId
+      ? await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
+      : null;
+
     // #574 / GH #618: reject an inverted nozzle range (min > max) the same
     // way the regular PUT does — the per-field 0–600 validators can't catch
-    // the cross-field relationship. `update.temperatures` is a full replace
-    // built from stored + incoming, so it IS the effective own range; only
-    // validate when the sync actually touches an endpoint, so pre-existing
-    // bad data can't 400 an unrelated sync. A variant inherits any endpoint
-    // it leaves null from its parent (resolveFilament: own ?? parent), so
-    // resolve the parent's endpoints in before checking (#577).
+    // the cross-field relationship. The dotted `temperatures.*` keys merge
+    // into the stored subdoc, so the effective own range is the incoming
+    // endpoint(s) combined with the stored other endpoint (the dotted branch
+    // of effectiveNozzleRangeForUpdate); only validate when the sync actually
+    // touches an endpoint, so pre-existing bad data can't 400 an unrelated
+    // sync. A variant inherits any endpoint it leaves null from its parent
+    // (resolveFilament: own ?? parent), so resolve the parent's endpoints in
+    // before checking (#577).
     if (touchesNozzleRange) {
       // GH #892: shared combinator (same guard the Bambu routes use) — own
       // effective range + parent inheritance + inversion test in one call.
-      let parentTemps = null;
-      if (filament.parentId) {
-        const parent = await Filament.findOne({ _id: filament.parentId, _deletedAt: null })
-          .select("temperatures.nozzleRangeMin temperatures.nozzleRangeMax")
-          .lean();
-        parentTemps = parent?.temperatures ?? null;
-      }
-      if (isUpdateNozzleRangeInverted(update, filament.temperatures, parentTemps)) {
+      if (isUpdateNozzleRangeInverted(update, filament.temperatures, parent?.temperatures ?? null)) {
         return errorResponse(
           "Nozzle range minimum temperature must be less than or equal to the maximum",
           400,
@@ -251,6 +264,35 @@ export async function POST(
       update.settings = merge.settings;
     }
 
+    // GH #1008 F2 (sibling of the GH #951 fix on the PrusaSlicer per-id
+    // sync): the Orca bundle export flattens a variant through
+    // resolveFilament, so the fork echoes the parent's type/density/cost/
+    // temps/settings back on every sync. Blindly $set-ing them onto the
+    // variant pins each value as a local override and severs GH #106 live
+    // inheritance — a later parent edit stops propagating. This was the only
+    // slicer sync path without the split. Reuse the CSV importer's
+    // battle-tested split (GH #628/#649/#971): drop each inheritable field
+    // whose incoming value equals the parent's (keep inheriting), and $unset
+    // a stale local override so inheritance resumes; a divergent value still
+    // writes. Variant-only keys (color, …) pass through untouched. When the
+    // parent is missing/soft-deleted there's nothing to inherit — write
+    // verbatim, matching the PrusaSlicer route.
+    let setBody: Record<string, unknown> = update;
+    let unsetKeys: string[] = [];
+    if (filament.parentId && parent) {
+      const split = splitInheritedImportSet(
+        update,
+        filament.toObject(),
+        parent.toObject(),
+      );
+      setBody = split.set;
+      unsetKeys = split.unset;
+    }
+    const mongoUpdate: Record<string, unknown> = { $set: setBody };
+    if (unsetKeys.length > 0) {
+      mongoUpdate.$unset = Object.fromEntries(unsetKeys.map((k) => [k, ""]));
+    }
+
     // GH #618: `runValidators` so the #337 numeric range validators fire
     // on an OrcaSlicer sync (negative cost/density, out-of-range temps) —
     // `context: "query"` matches the Bambu sync route (Codex P2 on #387).
@@ -262,7 +304,7 @@ export async function POST(
     try {
       updateResult = await Filament.updateOne(
         { _id: filament._id, _deletedAt: null },
-        { $set: update },
+        mongoUpdate,
         { runValidators: true, context: "query" },
       );
     } catch (validationErr) {
@@ -281,7 +323,10 @@ export async function POST(
     return NextResponse.json({
       success: true,
       filament: filament.name,
-      updated: Object.keys(update),
+      // GH #1008 F2: report what was actually $set after the inheritance
+      // split (dotted `temperatures.*` keys included) — parent-equal fields
+      // the split dropped are not "updated".
+      updated: Object.keys(setBody),
       settingsAdded,
     });
   } catch (err) {

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -336,13 +336,78 @@ export function buildStructuredUpdate(
 
   // Temperatures: merge with whatever's already on the doc so we don't
   // clobber e.g. nozzleRangeMin when the import only carries `nozzle`.
+  //
+  // GH #1008 F5 (import-side guard, least-lossy — user decision; the export
+  // stays unchanged): `hot_plate_temp` double-maps on BOTH sides. The export
+  // emits it from `temperatures.bed` and then re-emits it from the
+  // "Hot Plate" bedTypeTemps entry (which wins when both exist); the parser
+  // inverts it into BOTH `temperatures.bed` AND a "Hot Plate" bedTypeTemps
+  // entry. So a filament with bed=60 + bedTypeTemps=[{Hot Plate, 65}] exports
+  // hot_plate_temp=65 only, and syncing that same profile back used to
+  // rewrite the generic bed temp 60→65 — silently replacing the value the
+  // PrusaSlicer export and OpenPrintTag writes read. Guard: when the parsed
+  // profile carries a distinct "Hot Plate" bedTypeTemps entry AND the target
+  // already has a bed temp (its own, or — for a variant — inherited from its
+  // parent, mirroring resolveFilament's own ?? parent), keep the stored value
+  // and do NOT merge the parsed hot-plate value into `temperatures.bed`. The
+  // plate-specific value still lands in bedTypeTemps["Hot Plate"] below, so
+  // nothing is lost and the Bambu round-trip stays stable. A fresh import
+  // (no existing bed temp anywhere) still seeds bed from hot_plate_temp.
+  // Same guard for `bedFirstLayer` / hot_plate_temp_initial_layer — the
+  // identical double-mapping.
   const t = parsed.temperatures;
-  const tempKeys = Object.entries(t).filter(([, v]) => v != null);
+  let tempKeys = Object.entries(t).filter(([, v]) => v != null);
+  const hotPlate = parsed.bedTypeTemps.find((e) => e.bedType === "Hot Plate");
+  if (hotPlate) {
+    const ownTemps =
+      (existing?.temperatures as Record<string, unknown> | undefined) ?? {};
+    const inheritedTemps = isVariantWithParent
+      ? ((parent?.temperatures as Record<string, unknown> | undefined) ?? {})
+      : {};
+    const hasEffectiveBed = (sub: "bed" | "bedFirstLayer") =>
+      (ownTemps[sub] ?? inheritedTemps[sub]) != null;
+    tempKeys = tempKeys.filter(([key]) => {
+      if (key === "bed" && hotPlate.temperature != null && hasEffectiveBed("bed")) {
+        return false;
+      }
+      if (
+        key === "bedFirstLayer" &&
+        hotPlate.firstLayerTemperature != null &&
+        hasEffectiveBed("bedFirstLayer")
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }
   if (tempKeys.length > 0) {
-    u.temperatures = {
+    const mergedTemps: Record<string, unknown> = {
       ...((existing?.temperatures as Record<string, unknown>) || {}),
       ...Object.fromEntries(tempKeys),
     };
+    // GH #1008 F4 (sibling of GH #403's scalar guard — which covers scalars
+    // only): a variant's export flattens its inherited temps through
+    // resolveFilament, so syncing that preset back used to write the
+    // parent's temps into the variant as local pins, severing GH #106 live
+    // inheritance. Reset each merged subfield whose value EQUALS the
+    // parent's to null — the inherit sentinel resolveFilament reads
+    // (own ?? parent) — so inheritance resumes; divergent values stay as
+    // genuine overrides. Null-in-the-object rather than a `$unset` because
+    // `u.temperatures` must STAY a nested full-replace object: the bulk
+    // route's create path spreads this update into `Filament.create`, where
+    // dotted keys would be silently dropped by strict mode (and a $unset
+    // would conflict with the object $set on the same path). This also
+    // self-heals a stale parent-equal pin the profile didn't touch (it rides
+    // in via the merge spread) — the GH #971 posture.
+    if (isVariantWithParent && parent) {
+      const parentTemps =
+        (parent.temperatures as Record<string, unknown> | undefined) ?? {};
+      for (const sub of Object.keys(mergedTemps)) {
+        const v = mergedTemps[sub];
+        if (v != null && v === parentTemps[sub]) mergedTemps[sub] = null;
+      }
+    }
+    u.temperatures = mergedTemps;
   }
 
   if (parsed.bedTypeTemps.length > 0) {
@@ -365,10 +430,72 @@ export function buildStructuredUpdate(
     for (const entry of parsed.bedTypeTemps) {
       byName.set(entry.bedType, { ...byName.get(entry.bedType), ...entry });
     }
-    u.bedTypeTemps = [...byName.values()];
+    const mergedBedTypes = [...byName.values()];
+    // GH #1008 F4: bedTypeTemps inherits as a WHOLE array (empty === inherit,
+    // GH #106/#477 array-fallback in resolveFilament). A variant's export
+    // flattens the parent's plate list into per-plate keys, so syncing it
+    // back used to materialize a full copy on the variant — a non-empty own
+    // array that then shadows every later parent edit. When the merged array
+    // deep-equals the parent's effective array (same entries by bedType,
+    // order-insensitive), write `[]` — the inherit sentinel — instead of the
+    // copy. Writing [] (rather than skipping) also self-heals a stale
+    // materialized copy that now matches the parent (GH #971 posture). A
+    // divergent merged array still writes as a genuine override.
+    if (
+      isVariantWithParent &&
+      parent &&
+      bedTypeTempsEqualParent(mergedBedTypes, parent.bedTypeTemps)
+    ) {
+      u.bedTypeTemps = [];
+    } else {
+      u.bedTypeTemps = mergedBedTypes;
+    }
   }
 
   return { set: u, unset };
+}
+
+/**
+ * GH #1008 F4: order-insensitive deep equality between the merged
+ * bedTypeTemps array and the parent's effective array (a parent is never
+ * itself a variant, so its own array IS its effective array). Entries match
+ * when bedType, temperature, and firstLayerTemperature agree —
+ * null/undefined are collapsed (the model stores null defaults where the
+ * parser emits undefined). Conservative on malformed parent data (duplicate
+ * bedTypes, non-array): returns false so the merged array writes through.
+ */
+function bedTypeTempsEqualParent(
+  merged: Array<{
+    bedType: string;
+    temperature?: number | null;
+    firstLayerTemperature?: number | null;
+  }>,
+  parentArr: unknown,
+): boolean {
+  if (!Array.isArray(parentArr) || parentArr.length !== merged.length) {
+    return false;
+  }
+  const byType = new Map<
+    string,
+    { temperature?: number | null; firstLayerTemperature?: number | null }
+  >();
+  for (const raw of parentArr) {
+    const e = raw as {
+      bedType?: unknown;
+      temperature?: number | null;
+      firstLayerTemperature?: number | null;
+    };
+    if (typeof e.bedType !== "string" || byType.has(e.bedType)) return false;
+    byType.set(e.bedType, e);
+  }
+  return merged.every((m) => {
+    const p = byType.get(m.bedType);
+    return (
+      p != null &&
+      (m.temperature ?? null) === (p.temperature ?? null) &&
+      (m.firstLayerTemperature ?? null) === (p.firstLayerTemperature ?? null)
+    );
+  });
 }
 
 export interface CalibrationOutcome {

--- a/src/lib/bambuStudioApply.ts
+++ b/src/lib/bambuStudioApply.ts
@@ -366,18 +366,20 @@ export function buildStructuredUpdate(
       : {};
     const hasEffectiveBed = (sub: "bed" | "bedFirstLayer") =>
       (ownTemps[sub] ?? inheritedTemps[sub]) != null;
-    tempKeys = tempKeys.filter(([key]) => {
-      if (key === "bed" && hotPlate.temperature != null && hasEffectiveBed("bed")) {
-        return false;
-      }
-      if (
-        key === "bedFirstLayer" &&
-        hotPlate.firstLayerTemperature != null &&
-        hasEffectiveBed("bedFirstLayer")
-      ) {
-        return false;
-      }
-      return true;
+    tempKeys = tempKeys.filter(([key, value]) => {
+      const guarded =
+        (key === "bed" && hotPlate.temperature != null) ||
+        (key === "bedFirstLayer" && hotPlate.firstLayerTemperature != null);
+      if (!guarded || !hasEffectiveBed(key as "bed" | "bedFirstLayer")) return true;
+      // Codex P2 on #1018: a PARENT-EQUAL incoming value must still reach the
+      // F4 nulling branch below — the hot-plate key is the only Bambu field
+      // that can express "set my bed back to the parent's", and filtering it
+      // here left a stale divergent variant pin un-healable forever (F4 nulls
+      // a parent-equal merged value, resuming GH #106 inheritance). Only a
+      // parent-DIVERGENT hot-plate value is suppressed, which is the F5
+      // data-loss case this guard exists for. `inheritedTemps` is {} for a
+      // standalone filament, so this passes nothing extra through there.
+      return value != null && value === inheritedTemps[key];
     });
   }
   if (tempKeys.length > 0) {

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -1225,6 +1225,174 @@ describe("API route correctness", () => {
     expect(resolved.settings.some_passthrough_key).toBe("changed");
   });
 
+  // ── #1008 F2: the ORCA per-id sync gets the same inheritance split ──
+  // The Orca bundle export flattens a variant through resolveFilament, so the
+  // Orca fork echoes the parent's cost/density/temps back on every sync. This
+  // was the ONLY slicer sync path with no parent-equality split — one sync
+  // pinned every echoed value onto the variant and severed GH #106 live
+  // inheritance.
+
+  it("#1008 F2 — orca sync does NOT pin parent-equal inherited values on a variant (inheritance survives)", async () => {
+    const parent = await Filament.create({
+      name: "Orca Sync PLA",
+      vendor: "Acme",
+      type: "PLA",
+      cost: 25,
+      density: 1.24,
+      temperatures: { nozzle: 215, bed: 60 },
+    });
+    const variant = await Filament.create({
+      name: "Orca Sync PLA — Red",
+      vendor: "Acme",
+      type: "PLA",
+      color: "#FF0000",
+      parentId: parent._id,
+      // fully inheriting
+    });
+
+    // The Orca fork echoes the full (resolved) preset — every value == parent.
+    const res = await orcaSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}/orcaslicer`, {
+        type: "PLA",
+        vendor: "Acme",
+        cost: 25,
+        density: 1.24,
+        temperatures: { nozzle: 215, bed: 60 },
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const fresh = await Filament.findById(variant._id).lean();
+    // None of the parent-equal inherited fields were pinned as local overrides.
+    expect(fresh.cost).toBeNull();
+    expect(fresh.density).toBeNull();
+    expect(fresh.temperatures?.nozzle ?? null).toBeNull();
+    expect(fresh.temperatures?.bed ?? null).toBeNull();
+
+    // A later parent edit still propagates to the variant (GH #106 intact).
+    await Filament.updateOne(
+      { _id: parent._id },
+      { $set: { cost: 30, "temperatures.nozzle": 230 } },
+    );
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    const resolved = resolveFilament(fresh, freshParent);
+    expect(resolved.cost).toBe(30);
+    expect(resolved.temperatures?.nozzle).toBe(230);
+  });
+
+  it("#1008 F2 — orca sync $unsets a stale parent-equal local override and still writes divergent values", async () => {
+    const parent = await Filament.create({
+      name: "Orca Sync PETG",
+      vendor: "Acme",
+      type: "PETG",
+      cost: 20,
+      temperatures: { nozzle: 240 },
+    });
+    const variant = await Filament.create({
+      name: "Orca Sync PETG — Black",
+      vendor: "Acme",
+      type: "PETG",
+      color: "#000000",
+      parentId: parent._id,
+      cost: 22, // stale local override — diverges from parent
+      temperatures: { nozzle: 245 }, // stale local temp override
+    });
+
+    const res = await orcaSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}/orcaslicer`, {
+        cost: 20, // == parent → stale 22 must be $unset
+        temperatures: {
+          nozzle: 240, // == parent → stale 245 must be $unset
+          bed: 85, // parent has no bed → genuine override, still writes
+        },
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // The response reports what was actually $set post-split: the divergent
+    // dotted temp key, not the dropped parent-equal fields.
+    expect(body.updated).toContain("temperatures.bed");
+    expect(body.updated).not.toContain("cost");
+    expect(body.updated).not.toContain("temperatures.nozzle");
+
+    const fresh = await Filament.findById(variant._id).lean();
+    expect(fresh.cost ?? null).toBeNull(); // stale pin cleared → inherits
+    expect(fresh.temperatures?.nozzle ?? null).toBeNull(); // stale pin cleared
+    expect(fresh.temperatures?.bed).toBe(85); // divergent value written
+
+    // The cleared pins now track the parent live.
+    await Filament.updateOne(
+      { _id: parent._id },
+      { $set: { cost: 21, "temperatures.nozzle": 242 } },
+    );
+    const { resolveFilament } = await import("@/lib/resolveFilament");
+    const freshParent = await Filament.findById(parent._id).lean();
+    const resolved = resolveFilament(fresh, freshParent);
+    expect(resolved.cost).toBe(21);
+    expect(resolved.temperatures?.nozzle).toBe(242);
+    expect(resolved.temperatures?.bed).toBe(85); // own override still wins
+  });
+
+  it("#1008 F2 — a sync where EVERY field is parent-equal (empty $set) still clears a stale pin", async () => {
+    // The split can drop every $set key while still emitting $unset — the
+    // write must survive Mongoose's empty-$set stripping and apply the unset.
+    const parent = await Filament.create({
+      name: "Orca Sync ASA",
+      vendor: "Acme",
+      type: "ASA",
+      cost: 35,
+    });
+    const variant = await Filament.create({
+      name: "Orca Sync ASA — White",
+      vendor: "Acme",
+      type: "ASA",
+      color: "#FFFFFF",
+      parentId: parent._id,
+      cost: 40, // stale divergence
+    });
+
+    const res = await orcaSync(
+      jsonReq(`http://localhost/api/filaments/${variant._id}/orcaslicer`, {
+        cost: 35, // == parent → dropped from $set, stale 40 → $unset
+      }),
+      { params: Promise.resolve({ id: String(variant._id) }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).updated).toEqual([]);
+
+    const fresh = await Filament.findById(variant._id).lean();
+    expect(fresh.cost == null).toBe(true); // $unset applied → inherits again
+  });
+
+  it("#1008 F2 — orca sync on a standalone filament writes everything unchanged (no regression)", async () => {
+    const f = await Filament.create({
+      name: "Orca Standalone PLA",
+      vendor: "Acme",
+      type: "PLA",
+      temperatures: { bed: 55 },
+    });
+
+    const res = await orcaSync(
+      jsonReq(`http://localhost/api/filaments/${f._id}/orcaslicer`, {
+        cost: 25,
+        density: 1.24,
+        temperatures: { nozzle: 215 },
+      }),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+
+    const fresh = await Filament.findById(f._id).lean();
+    expect(fresh.cost).toBe(25);
+    expect(fresh.density).toBe(1.24);
+    expect(fresh.temperatures?.nozzle).toBe(215);
+    // Dotted temp writes leave stored siblings the sync didn't touch alone.
+    expect(fresh.temperatures?.bed).toBe(55);
+  });
+
   it("#872 — a per-nozzle sync with an out-of-range baked calibration value is rejected with 400 (nothing persisted)", async () => {
     const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
     const f = await Filament.create({

--- a/tests/bambuStudioApply.test.ts
+++ b/tests/bambuStudioApply.test.ts
@@ -430,6 +430,398 @@ describe("buildStructuredUpdate", () => {
       expect(unset).toEqual(["density"]);
     });
   });
+
+  describe("variant temperature inheritance (GH #1008 F4)", () => {
+    // GH #403's setIfNotInherited guards scalars only; the temps merge used
+    // to write the parent's (export-flattened) temps into the variant as
+    // local pins. Parent-equal subfields are now reset to null — the inherit
+    // sentinel resolveFilament reads (own ?? parent) — INSIDE the nested
+    // object, because the bulk route's create path spreads the update into
+    // Filament.create where dotted keys would be dropped by strict mode.
+
+    it("nulls parent-equal temperature subfields on a variant (inherit sentinel)", () => {
+      const parent = { temperatures: { nozzle: 215, bed: 60 } };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+      };
+      const { set: update, unset } = buildStructuredUpdate(
+        makeParsed({ temperatures: { nozzle: 215, bed: 60 } }),
+        existing,
+      );
+      // Parent-equal values become null sentinels — not pinned copies.
+      expect(update.temperatures).toEqual({ nozzle: null, bed: null });
+      // No $unset — null-in-object IS the clear (a $unset on
+      // temperatures.nozzle would conflict with the object $set).
+      expect(unset).toEqual([]);
+    });
+
+    it("keeps a divergent temperature value as a genuine variant override", () => {
+      const parent = { temperatures: { nozzle: 215, bed: 60 } };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ temperatures: { nozzle: 230, bed: 60 } }),
+        existing,
+      );
+      // nozzle diverges → stays; bed equals parent → null sentinel.
+      expect(update.temperatures).toEqual({ nozzle: 230, bed: null });
+    });
+
+    it("self-heals a stale parent-equal pin that rides in via the merge spread (GH #971 posture)", () => {
+      const parent = {
+        temperatures: { nozzle: 215, nozzleRangeMin: 180 },
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        temperatures: {
+          nozzle: 215, // stale parent-equal pin — profile also carries it
+          nozzleRangeMin: 190, // genuine divergent override — must survive
+        },
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ temperatures: { nozzle: 215 } }),
+        existing,
+      );
+      expect(update.temperatures).toEqual({
+        nozzle: null, // parent-equal → inherit resumes
+        nozzleRangeMin: 190, // divergent local override survives the merge
+      });
+    });
+
+    it("does not touch temps on a root filament (no parent) — old behavior intact", () => {
+      const existing: ExistingFilamentForApply = {
+        parentId: null,
+        parent: null,
+        temperatures: { bed: 60 },
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ temperatures: { nozzle: 215 } }),
+        existing,
+      );
+      expect(update.temperatures).toEqual({ bed: 60, nozzle: 215 });
+    });
+  });
+
+  describe("variant bedTypeTemps inheritance (GH #1008 F4)", () => {
+    // bedTypeTemps inherits as a WHOLE array (empty === inherit, GH
+    // #106/#477). A variant's export flattens the parent's plate list, so a
+    // sync-back used to materialize a full copy — a non-empty own array that
+    // shadows every later parent edit.
+
+    it("collapses the merged array to [] when it deep-equals the parent's effective array (order-insensitive)", () => {
+      const parent = {
+        bedTypeTemps: [
+          // Parent order differs from the parsed order; lean docs also carry
+          // extra keys (e.g. _id) the comparison must ignore.
+          { bedType: "Cool Plate", temperature: 35, _id: "x1" },
+          { bedType: "Hot Plate", temperature: 65, firstLayerTemperature: 70, _id: "x2" },
+        ],
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        bedTypeTemps: [], // inheriting
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({
+          bedTypeTemps: [
+            { bedType: "Hot Plate", temperature: 65, firstLayerTemperature: 70 },
+            { bedType: "Cool Plate", temperature: 35 },
+          ],
+        }),
+        existing,
+      );
+      // [] = the array-fallback inherit sentinel, not a materialized copy.
+      expect(update.bedTypeTemps).toEqual([]);
+    });
+
+    it("self-heals a stale materialized copy that now matches the parent", () => {
+      const parent = {
+        bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }],
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        // Stale full copy pinned by a pre-#1008 sync.
+        bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }] }),
+        existing,
+      );
+      expect(update.bedTypeTemps).toEqual([]); // pin cleared → inherits live
+    });
+
+    it("keeps the merged array when it differs from the parent's (genuine override)", () => {
+      const parent = {
+        bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }],
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        bedTypeTemps: [],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ bedTypeTemps: [{ bedType: "Hot Plate", temperature: 70 }] }),
+        existing,
+      );
+      expect(update.bedTypeTemps).toEqual([
+        { bedType: "Hot Plate", temperature: 70 },
+      ]);
+    });
+
+    it("keeps the merged array when the parent has more plate entries (length mismatch)", () => {
+      const parent = {
+        bedTypeTemps: [
+          { bedType: "Hot Plate", temperature: 65 },
+          { bedType: "Cool Plate", temperature: 35 },
+        ],
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        bedTypeTemps: [],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }] }),
+        existing,
+      );
+      // One entry ≠ the parent's two-entry list → written as-is (the
+      // deep-equal skip covers only the full-echo round-trip case).
+      expect(update.bedTypeTemps).toEqual([
+        { bedType: "Hot Plate", temperature: 65 },
+      ]);
+    });
+
+    it("writes the merged array unchanged on a root filament (no parent)", () => {
+      const existing: ExistingFilamentForApply = {
+        parentId: null,
+        parent: null,
+        bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }] }),
+        existing,
+      );
+      expect(update.bedTypeTemps).toEqual([
+        { bedType: "Hot Plate", temperature: 65 },
+      ]);
+    });
+  });
+
+  describe("hot_plate_temp vs temperatures.bed (GH #1008 F5 — import-side guard)", () => {
+    // hot_plate_temp double-maps: the parser inverts it into BOTH
+    // temperatures.bed and a "Hot Plate" bedTypeTemps entry. When the target
+    // already has a generic bed temp, the plate-specific value must not
+    // overwrite it — it still lands in bedTypeTemps["Hot Plate"], so nothing
+    // is lost (least-lossy, per the user decision on #1008: export unchanged).
+
+    // What the real parser produces for hot_plate_temp=65 +
+    // hot_plate_temp_initial_layer=70 (both homes populated).
+    const hotPlateParsed = () =>
+      makeParsed({
+        temperatures: { bed: 65, bedFirstLayer: 70 },
+        bedTypeTemps: [
+          { bedType: "Hot Plate", temperature: 65, firstLayerTemperature: 70 },
+        ],
+      });
+
+    it("keeps a stored generic bed temp; the parsed hot-plate value lands in bedTypeTemps only", () => {
+      const existing: ExistingFilamentForApply = {
+        temperatures: { bed: 60, bedFirstLayer: 65 },
+      };
+      const { set: update } = buildStructuredUpdate(hotPlateParsed(), existing);
+      // Both bed subfields were guarded and nothing else was parsed → no
+      // temperatures write at all (stored 60/65 untouched).
+      expect("temperatures" in update).toBe(false);
+      // The plate-specific value has its own home.
+      expect(update.bedTypeTemps).toEqual([
+        { bedType: "Hot Plate", temperature: 65, firstLayerTemperature: 70 },
+      ]);
+    });
+
+    it("guards per-subfield: a missing stored bedFirstLayer still seeds while bed is kept", () => {
+      const existing: ExistingFilamentForApply = {
+        temperatures: { bed: 60 }, // no stored bedFirstLayer
+      };
+      const { set: update } = buildStructuredUpdate(hotPlateParsed(), existing);
+      expect(update.temperatures).toEqual({
+        bed: 60, // stored value rides the merge unchanged
+        bedFirstLayer: 70, // no stored value → seeded from the profile
+      });
+    });
+
+    it("a fresh import (create branch) still seeds bed from hot_plate_temp", () => {
+      const { set: update } = buildStructuredUpdate(hotPlateParsed(), null);
+      expect(update.temperatures).toEqual({ bed: 65, bedFirstLayer: 70 });
+    });
+
+    it("an existing filament with NO bed temp still seeds bed from hot_plate_temp", () => {
+      const existing: ExistingFilamentForApply = {
+        temperatures: { nozzle: 215 },
+      };
+      const { set: update } = buildStructuredUpdate(hotPlateParsed(), existing);
+      expect(update.temperatures).toEqual({
+        nozzle: 215,
+        bed: 65,
+        bedFirstLayer: 70,
+      });
+    });
+
+    it("a variant INHERITING its bed temp keeps inheriting (parent's effective value counts as 'has a bed temp')", () => {
+      const parent = { temperatures: { bed: 60 } };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        // own bed null → effective bed = parent's 60
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({
+          temperatures: { bed: 65 },
+          bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }],
+        }),
+        existing,
+      );
+      // bed guarded (effective value exists) and nothing else parsed → no
+      // temps write; the variant keeps resolving bed=60 from the parent.
+      expect("temperatures" in update).toBe(false);
+    });
+
+    it("without a 'Hot Plate' bedTypeTemps entry the bed merge is unchanged (guard keyed on the double-map)", () => {
+      // Hand-built parsed payloads (and any future parser shape that maps a
+      // dedicated bed key) bypass the guard — it exists only for the
+      // hot_plate_temp double-mapping.
+      const existing: ExistingFilamentForApply = {
+        temperatures: { bed: 60 },
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ temperatures: { bed: 65 } }),
+        existing,
+      );
+      expect(update.temperatures).toEqual({ bed: 65 });
+    });
+
+    it("guards only the subfields the Hot Plate entry actually carries", () => {
+      // A Hot Plate entry without the matching field is not the double-map
+      // for that subfield — the merge behaves as before (defensive; the real
+      // parser always populates both homes from the same key).
+      const existing: ExistingFilamentForApply = {
+        temperatures: { bed: 60, bedFirstLayer: 65 },
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({
+          temperatures: { bed: 66, bedFirstLayer: 71 },
+          bedTypeTemps: [{ bedType: "Hot Plate" }], // neither field present
+        }),
+        existing,
+      );
+      expect(update.temperatures).toEqual({ bed: 66, bedFirstLayer: 71 });
+    });
+
+    it("a variant whose parent has no temperatures at all still seeds bed", () => {
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent: {}, // parent doc without a temperatures object
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({
+          temperatures: { bed: 65 },
+          bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }],
+        }),
+        existing,
+      );
+      // No own value, no inherited value → fresh seed.
+      expect(update.temperatures).toEqual({ bed: 65 });
+    });
+  });
+
+  describe("bedTypeTempsEqualParent edge shapes (GH #1008 F4)", () => {
+    it("same length but a different bedType name is NOT equal (merged array writes)", () => {
+      const parent = {
+        bedTypeTemps: [{ bedType: "Cool Plate", temperature: 65 }],
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        bedTypeTemps: [],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }] }),
+        existing,
+      );
+      expect(update.bedTypeTemps).toEqual([
+        { bedType: "Hot Plate", temperature: 65 },
+      ]);
+    });
+
+    it("same bedType + temperature but a different firstLayerTemperature is NOT equal", () => {
+      const parent = {
+        bedTypeTemps: [
+          { bedType: "Hot Plate", temperature: 65, firstLayerTemperature: 70 },
+        ],
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        bedTypeTemps: [],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({
+          bedTypeTemps: [
+            { bedType: "Hot Plate", temperature: 65, firstLayerTemperature: 75 },
+          ],
+        }),
+        existing,
+      );
+      expect(update.bedTypeTemps).toEqual([
+        { bedType: "Hot Plate", temperature: 65, firstLayerTemperature: 75 },
+      ]);
+    });
+
+    it("is conservative on malformed parent entries (non-string bedType → merged array writes)", () => {
+      const parent = {
+        bedTypeTemps: [{ bedType: 42, temperature: 65 }], // malformed
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        bedTypeTemps: [],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }] }),
+        existing,
+      );
+      expect(update.bedTypeTemps).toEqual([
+        { bedType: "Hot Plate", temperature: 65 },
+      ]);
+    });
+
+    it("is conservative on duplicate parent bedTypes (ambiguous → merged array writes)", () => {
+      const parent = {
+        bedTypeTemps: [
+          { bedType: "Hot Plate", temperature: 65 },
+          { bedType: "Hot Plate", temperature: 70 }, // duplicate name
+        ],
+      };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        bedTypeTemps: [{ bedType: "Cool Plate", temperature: 35 }],
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({ bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }] }),
+        existing,
+      );
+      // merged = [Cool 35 (existing), Hot 65 (parsed)] — length matches the
+      // parent's 2, but the duplicate bails the comparison conservatively.
+      const list = update.bedTypeTemps as Array<Record<string, unknown>>;
+      expect(list).toHaveLength(2);
+    });
+  });
 });
 
 /**

--- a/tests/bambuStudioApply.test.ts
+++ b/tests/bambuStudioApply.test.ts
@@ -691,6 +691,49 @@ describe("buildStructuredUpdate", () => {
       expect("temperatures" in update).toBe(false);
     });
 
+    it("a PARENT-EQUAL hot-plate value un-pins a stale divergent variant bed override (Codex P2 on #1018)", () => {
+      // The variant carries a divergent own bed pin (70 ≠ parent's 60). The
+      // user sets the Bambu profile's bed back to the parent's value —
+      // hot_plate_temp is the ONLY Bambu field that can express this. The F5
+      // guard must let the parent-equal value through to the F4 nulling
+      // branch (pre-fix it filtered it, leaving the pin un-healable forever).
+      const parent = { temperatures: { bed: 60 } };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        temperatures: { bed: 70 }, // stale divergent pin
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({
+          temperatures: { bed: 60 }, // == parent
+          bedTypeTemps: [{ bedType: "Hot Plate", temperature: 60 }],
+        }),
+        existing,
+      );
+      // The value flowed through and F4 nulled it — inheritance resumes.
+      expect((update.temperatures as Record<string, unknown>).bed).toBeNull();
+    });
+
+    it("a PARENT-DIVERGENT hot-plate value is still suppressed on a pinned variant (the F5 case)", () => {
+      const parent = { temperatures: { bed: 60 } };
+      const existing: ExistingFilamentForApply = {
+        parentId: "parent-id",
+        parent,
+        temperatures: { bed: 70 },
+      };
+      const { set: update } = buildStructuredUpdate(
+        makeParsed({
+          temperatures: { bed: 65 }, // ≠ parent AND ≠ own — the plate-specific value
+          bedTypeTemps: [{ bedType: "Hot Plate", temperature: 65 }],
+        }),
+        existing,
+      );
+      // Suppressed → nothing else parsed → no temperatures write at all;
+      // the stored own pin (70) stays and 65 lives only in the Hot Plate entry.
+      expect("temperatures" in update).toBe(false);
+      expect(update.bedTypeTemps).toEqual([{ bedType: "Hot Plate", temperature: 65 }]);
+    });
+
     it("without a 'Hot Plate' bedTypeTemps entry the bed merge is unchanged (guard keyed on the double-map)", () => {
       // Hand-built parsed payloads (and any future parser shape that maps a
       // dedicated bed key) bypass the guard — it exists only for the

--- a/tests/bambustudio-route.test.ts
+++ b/tests/bambustudio-route.test.ts
@@ -124,7 +124,17 @@ describe("Bambu Studio importer routes", () => {
 
       const stored = await Filament.findOne({ name: "QA Bambu PLA" });
       expect(stored.temperatures.nozzle).toBe(225);
-      expect(stored.temperatures.bed).toBe(65);
+      // GH #1008 F5 (import-side guard): hot_plate_temp double-maps into both
+      // temperatures.bed and the "Hot Plate" bedTypeTemps entry. The target
+      // already has a generic bed temp (50), so the parsed hot-plate value must
+      // NOT overwrite it — it lands in bedTypeTemps["Hot Plate"] instead
+      // (nothing lost; the next export emits hot_plate_temp=65 from that entry).
+      // Pre-#1008 this expected bed to become 65.
+      expect(stored.temperatures.bed).toBe(50);
+      const hotPlate = stored.bedTypeTemps.find(
+        (e: { bedType: string }) => e.bedType === "Hot Plate",
+      );
+      expect(hotPlate?.temperature).toBe(65);
     });
 
     it("preserves filament_notes in the settings bag through import (GH #620)", async () => {


### PR DESCRIPTION
Part of #1008 (findings 2, 4, 5). With #1016 (F1) and #1017 (F3+F6), this completes the issue.

## F2 (P2) — `POST /api/filaments/{id}/orcaslicer` wrote flattened variant values verbatim
The only slicer sync path with no inheritance split: the Orca export flattens a variant through `resolveFilament`, and the sync-back `$set` the parent's density/cost/temps/settings onto the variant as local overrides — silently severing GH #106 live inheritance (parent edits stopped propagating). Temps are now written as **dotted** `temperatures.<sub>` paths (the split helper only splits dotted keys — a nested object passed through whole; dotted paths also stop update-validators dragging every *stored* temp into validation, the #859 class), the full active parent is fetched once (feeding both the existing nozzle-range inversion check and the split), and the update runs through `splitInheritedImportSet` with `$set`/`$unset` composition — exactly the PrusaSlicer per-id route's pattern (#951). The response `updated` reports the post-split keys.

## F4 (P3) — Bambu sync pinned inherited `temperatures` and `bedTypeTemps`
`setIfNotInherited` guarded scalars only. The temps merge now resets each parent-equal merged subfield to **null in the nested object** (the create-path-safe inherit sentinel — the bulk route spreads the update into `Filament.create`, where dotted keys would be silently dropped by strict mode, so no `$unset`); a merged `bedTypeTemps` array that deep-equals the parent's effective array (order-insensitive) collapses to `[]` (array-fallback inheritance per GH #106/#477) instead of materializing a copy.

## F5 (P3) — `hot_plate_temp` doubles as `temperatures.bed` (import-side guard, per product decision)
Export unchanged (the plate value correctly wins in the preset — Bambu's default plate IS the hot plate). On import/sync, when the parsed profile carries a "Hot Plate" `bedTypeTemps` entry and the target already has an **effective** bed temp (own ?? parent — an inheriting variant counts), the hot-plate value no longer overwrites `temperatures.bed`/`bedFirstLayer`; it lands only in the Hot Plate entry. Both DB values now survive a re-sync; fresh imports still seed bed from `hot_plate_temp`. One pre-existing route test pinned the old overwrite (the exact data loss the finding reports) and was updated with the rationale in-test.

## Tests
4 new F2 route tests (no-pin + parent-edit propagation, stale-pin `$unset` + divergent write, empty-`$set`+`$unset` edge, standalone no-regression), 21 new `bambuStudioApply` unit tests (F4 temps/bedTypeTemps + all F5 cases). Full suite green (3282 tests) pre-rebase; 319 targeted tests green post-rebase onto the #1016 merge. `tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)