### PR TITLE
Bump version to 1.67.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.66.1",
+      "version": "1.67.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.66.1",
+  "version": "1.67.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.66.1",
+    "version": "1.67.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Manual equivalent of `release-bump.yml` (workflow dispatch returns 403 for this token). Bumps `package.json`, `package-lock.json` (×2), and `public/openapi.json` to **1.67.0** — the audit-remediation release (#1004–#1008, 26 findings across 10 PRs, incl. the purged-zombie and legacy-shrinkage data migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)