### PR TITLE
Bump version to 1.68.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.67.0",
+      "version": "1.68.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.67.0",
+    "version": "1.68.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Version bump for the v1.68.0 release (the release-bump workflow dispatch returns 403 for this token, so this is the manual equivalent — same three files: `package.json`, `package-lock.json` ×2, `public/openapi.json`).

Ships since v1.67.0:
- #1022 — the #1021 hidden-presets fix (derivation removal + provenance-matched cleanup migration + ingestion guards + snapshot v5 + hybrid transit clears)
- #1023 — npm audit remediation + the allowlisted audit gate
- #1020 — post-v1.67.0 docs audit fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)