### PR TITLE
fix(security): reject __proto__-dotted keys in the filament PUT body (#1026)

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -6,7 +6,7 @@ import Printer from "@/models/Printer";
 import BedType from "@/models/BedType";
 import { resolveFilament, hasVariants } from "@/lib/resolveFilament";
 import { errorResponse, errorResponseFromCaught, handleDuplicateKeyError, isDuplicateKeyError, assertActiveRefs } from "@/lib/apiErrorHandler";
-import { assertSameOriginRequest } from "@/lib/requestGuard";
+import { assertSameOriginRequest, assertSafeUpdateBody } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
 import { stripLegacyMachineCondition } from "@/lib/stripLegacyNozzleCondition";
 import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
@@ -235,6 +235,18 @@ export async function PUT(
         400,
       );
     }
+
+    // GH #1026: the SECOND injection class the operator check above does not
+    // cover. `body` is forwarded verbatim to findOneAndUpdate below, and a
+    // `__proto__`-prefixed DOTTED key (e.g. `{"__proto__.x": 1}`) is neither a
+    // `$`-operator nor an exact key the strip block matches — it reaches
+    // Mongoose's update casting and pollutes `Object.prototype`
+    // (GHSA-664h-wqgq-64gw; confirmed reproducible on mongoose 9.5.0 through
+    // this exact call, which also 500s). Patched upstream in >= 9.7.2, which
+    // package.json now pins as its floor; this guard keeps a downgraded
+    // lockfile or an upstream regression from silently reopening it.
+    const unsafePath = assertSafeUpdateBody(body);
+    if (unsafePath) return unsafePath;
 
     // Validate parentId if provided
     if (body.parentId) {

--- a/src/lib/requestGuard.ts
+++ b/src/lib/requestGuard.ts
@@ -111,3 +111,65 @@ export function assertSameOriginRequest(request: NextRequest): NextResponse | nu
 
   return null;
 }
+
+/**
+ * Path segments that must never appear in a client-supplied update document.
+ *
+ * Anchored on a segment boundary (`^` or `.`) at both ends so it matches the
+ * dotted-path grammar Mongo/Mongoose use — `__proto__`, `__proto__.x`,
+ * `a.__proto__`, `a.constructor.b` — while leaving legitimate field names that
+ * merely CONTAIN one of the words alone (e.g. a hypothetical
+ * `prototypeNotes`).
+ */
+const UNSAFE_UPDATE_PATH_RE = /(^|\.)(__proto__|constructor|prototype)(\.|$)/;
+
+/**
+ * GH #1026: reject a client update body carrying a prototype-polluting key.
+ *
+ * GHSA-664h-wqgq-64gw — a `__proto__`-prefixed DOTTED key (e.g.
+ * `{"__proto__.x": 1}`) reaching Mongoose's update casting pollutes
+ * `Object.prototype`. `Schema.prototype.path()` does an unguarded
+ * `this.paths[path]` lookup on a plain object, so `"__proto__"` resolves up the
+ * prototype chain and returns `Object.prototype` itself; `_getSchema` then
+ * treats that as a schematype and writes `$fullPath` onto it — ENUMERABLE, so
+ * it leaks into every `for...in` in the process. Confirmed reproducible on
+ * mongoose 9.5.0 through `PUT /api/filaments/{id}`, which also 500s.
+ *
+ * Fixed upstream in mongoose >= 9.7.2 (this repo pins the patched floor). This
+ * guard is the belt-and-braces layer so a future regression, a downgraded
+ * lockfile, or a newly-added raw-body route cannot silently reopen it.
+ *
+ * WHERE TO USE IT: any handler that forwards a client-shaped object into an
+ * update. Today that is exactly ONE route — `PUT /api/filaments/{id}`, which
+ * passes the parsed body straight to `findOneAndUpdate`. Every other mutating
+ * route builds its update from string-LITERAL keys (`update.name = body.name`,
+ * `update["spools.$.totalWeight"] = …`), so no client-controlled key can reach
+ * the update document and the guard would be dead code there. Add the call
+ * alongside the existing `$`-operator check if you ever introduce another
+ * raw-body passthrough.
+ *
+ * Sibling of the `$`-operator guard in that route: that one blocks Mongo
+ * UPDATE OPERATORS, this one blocks PROTOTYPE PATHS. Neither subsumes the
+ * other — `"__proto__.x".startsWith("$")` is false.
+ *
+ * Only own enumerable keys are inspected, which is what `findOneAndUpdate`
+ * casts. Returns a 400 `NextResponse` to short-circuit the handler, or `null`
+ * when the body may proceed.
+ */
+export function assertSafeUpdateBody(body: unknown): NextResponse | null {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    // Not an object update document — the caller's own shape checks own this;
+    // nothing here can pollute, so let it through rather than changing an
+    // existing route's error contract.
+    return null;
+  }
+  for (const key of Object.keys(body)) {
+    if (UNSAFE_UPDATE_PATH_RE.test(key)) {
+      return errorResponse(
+        "Unsafe field path in request body — keys may not reference __proto__, constructor, or prototype.",
+        400,
+      );
+    }
+  }
+  return null;
+}

--- a/tests/mass-assignment-hardening.test.ts
+++ b/tests/mass-assignment-hardening.test.ts
@@ -187,4 +187,70 @@ describe("mass-assignment & data-integrity hardening", () => {
     const fresh = await Filament.findById(body._id);
     expect(fresh.openprinttagSnapshot).toBeNull();
   });
+
+  // ── GH #1026: prototype pollution via a __proto__-dotted body key ────
+  //
+  // GHSA-664h-wqgq-64gw. Pre-fix, this exact request set
+  // `Object.prototype.$fullPath = "__proto__"` (ENUMERABLE, so it leaked into
+  // every `for...in` in the process) and 500d, on mongoose 9.5.0. The
+  // `$`-operator guard did not cover it: `"__proto__.x".startsWith("$")` is
+  // false. Asserting the 400 alone would NOT catch a regression where the
+  // guard runs after the write — so these assert the prototype directly.
+
+  it("#1026 — PUT rejects a __proto__-dotted key and leaves Object.prototype clean", async () => {
+    const f = await Filament.create({
+      name: "Proto Guard PLA",
+      vendor: "T",
+      type: "PLA",
+      color: "#111111",
+      diameter: 1.75,
+    });
+
+    const proto = Object.prototype as unknown as Record<string, unknown>;
+    expect(proto.$fullPath).toBeUndefined(); // sanity: clean to start
+
+    // request.json() parses the body, and JSON.parse creates a genuine OWN
+    // "__proto__.polluted" key — a shape an object literal cannot express.
+    const body = JSON.parse('{"name":"Renamed","__proto__.polluted":"yes"}');
+    expect(Object.keys(body)).toContain("__proto__.polluted");
+
+    const res = await PUT(
+      jsonReq(`http://localhost:3456/api/filaments/${f._id}`, body, "PUT"),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(400);
+
+    // The actual regression assertion — the guard must run BEFORE the
+    // findOneAndUpdate that does the casting.
+    expect(proto.$fullPath).toBeUndefined();
+    const probe: Record<string, number> = { a: 1 };
+    const seen: string[] = [];
+    for (const k in probe) seen.push(k);
+    expect(seen).toEqual(["a"]);
+
+    // Rejection is atomic — the legitimate field in the same body is not applied.
+    const after = await Filament.findById(f._id).lean();
+    expect(after.name).toBe("Proto Guard PLA");
+  });
+
+  it("#1026 — PUT still accepts a legitimate dotted temperatures path", async () => {
+    const f = await Filament.create({
+      name: "Proto Guard OK PLA",
+      vendor: "T",
+      type: "PLA",
+      color: "#222222",
+      diameter: 1.75,
+    });
+    const res = await PUT(
+      jsonReq(
+        `http://localhost:3456/api/filaments/${f._id}`,
+        { "temperatures.nozzle": 215 },
+        "PUT",
+      ),
+      { params: Promise.resolve({ id: String(f._id) }) },
+    );
+    expect(res.status).toBe(200);
+    const after = await Filament.findById(f._id).lean();
+    expect(after.temperatures.nozzle).toBe(215);
+  });
 });

--- a/tests/requestGuard.test.ts
+++ b/tests/requestGuard.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
-import { assertSameOriginRequest } from "@/lib/requestGuard";
+import { assertSameOriginRequest, assertSafeUpdateBody } from "@/lib/requestGuard";
 
 /**
  * Coverage-focused companion to tests/destructive-route-guard.test.ts.
@@ -109,5 +109,100 @@ describe("assertSameOriginRequest — IPv6 authority + edge branches", () => {
     );
     expect(guard).not.toBeNull();
     expect(guard!.status).toBe(403);
+  });
+});
+
+/**
+ * GH #1026 — assertSafeUpdateBody.
+ *
+ * GHSA-664h-wqgq-64gw: a `__proto__`-prefixed DOTTED key forwarded into
+ * Mongoose update casting writes `$fullPath` onto `Object.prototype`
+ * (enumerable, so it leaks into every `for...in` in the process). The
+ * `$`-operator guard in the filament PUT does NOT cover it —
+ * `"__proto__.x".startsWith("$")` is false — so this is a second, independent
+ * injection class with its own guard.
+ */
+describe("assertSafeUpdateBody — prototype-path rejection (GH #1026)", () => {
+  const REJECTED = [
+    "__proto__",
+    "__proto__.polluted",
+    "__proto__.a.b",
+    "constructor",
+    "constructor.prototype",
+    "constructor.prototype.polluted",
+    "prototype",
+    "a.__proto__",
+    "a.__proto__.b",
+    "temperatures.__proto__",
+    "a.constructor.b",
+    "a.prototype",
+  ];
+
+  for (const key of REJECTED) {
+    it(`rejects a body key "${key}" with 400`, () => {
+      const guard = assertSafeUpdateBody({ name: "PLA", [key]: "x" });
+      expect(guard).not.toBeNull();
+      expect(guard!.status).toBe(400);
+    });
+  }
+
+  const ALLOWED = [
+    "name",
+    "temperatures.nozzle",
+    "temperatures.bedFirstLayer",
+    "spools.$.totalWeight",
+    "settings",
+    // Words that merely CONTAIN a banned token are legitimate field names —
+    // the regex is anchored on segment boundaries, so these must pass.
+    "prototypeNotes",
+    "myconstructor",
+    "a.prototypeNotes",
+    "reconstructor",
+  ];
+
+  for (const key of ALLOWED) {
+    it(`allows the legitimate field path "${key}"`, () => {
+      expect(assertSafeUpdateBody({ [key]: 1 })).toBeNull();
+    });
+  }
+
+  it("allows an ordinary filament edit body", () => {
+    expect(
+      assertSafeUpdateBody({
+        name: "PLA Basic",
+        vendor: "Prusa",
+        type: "PLA",
+        "temperatures.nozzle": 215,
+        settings: { compatible_printers: "" },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores non-object bodies rather than changing an existing error contract", () => {
+    expect(assertSafeUpdateBody(null)).toBeNull();
+    expect(assertSafeUpdateBody(undefined)).toBeNull();
+    expect(assertSafeUpdateBody("string")).toBeNull();
+    expect(assertSafeUpdateBody(42)).toBeNull();
+    expect(assertSafeUpdateBody([{ "__proto__.x": 1 }])).toBeNull();
+  });
+
+  it("does not treat an inherited key as an own key", () => {
+    // A literal `{"__proto__": ...}` in JS source sets the PROTOTYPE, not an
+    // own key — so Object.keys is empty and there is nothing to reject. The
+    // dangerous shape is the DOTTED string key, covered above. This pins that
+    // we inspect own enumerable keys (what findOneAndUpdate casts).
+    const viaLiteral = { __proto__: { polluted: true } };
+    expect(Object.keys(viaLiteral)).toHaveLength(0);
+    expect(assertSafeUpdateBody(viaLiteral)).toBeNull();
+  });
+
+  it("rejects the exact payload that pollutes Object.prototype via JSON.parse", () => {
+    // JSON.parse DOES create an own "__proto__" key (unlike an object literal),
+    // which is precisely how a request body carries it.
+    const body = JSON.parse('{"name":"ok","__proto__.polluted":"yes"}');
+    expect(Object.keys(body)).toContain("__proto__.polluted");
+    const guard = assertSafeUpdateBody(body);
+    expect(guard).not.toBeNull();
+    expect(guard!.status).toBe(400);
   });
 });


### PR DESCRIPTION
Fixes #1026

`PUT /api/filaments/{id}` forwards the raw parsed body to `findOneAndUpdate`, and its only injection guard rejects `$`-prefixed keys. But `"__proto__.x".startsWith("$")` is `false`, and the mass-assignment strip block above it is an exact-key denylist that matches nothing — so a `__proto__`-dotted key reached Mongoose's update casting ([GHSA-664h-wqgq-64gw](https://github.com/advisories/GHSA-664h-wqgq-64gw)).

> **Note on the original issue:** I first filed this saying "I tried to reproduce and could not." **That was a bad probe** — I used `Query#cast()`, which is not the exec path. Triage caught it; I then reproduced it against a real DB. The issue has been corrected and re-labelled **P1**.

## Confirmed reproduction

The exact call at `route.ts:370`, against `mongodb-memory-server`, on mongoose 9.5.0:

```js
const body = JSON.parse('{"name":"PLA edited","__proto__.polluted":"yes"}');
await M.findOneAndUpdate({ _id }, body, { returnDocument: "after", runValidators: true }).lean();
```

```
request error: TypeError: Cannot read properties of undefined (reading 'strict')
Object.prototype.$fullPath AFTER: "__proto__"
  descriptor: {"value":"__proto__","writable":true,"enumerable":true,"configurable":true}
  for..in over {a:1} -> [ 'a', '$fullPath' ]
```

One unauthenticated request both **500s the handler** and **permanently pollutes `Object.prototype`** for the process lifetime — `enumerable: true`, so it leaks into every `for...in`.

**Upstream cause:** `Schema.prototype.path()` (`lib/schema.js:1269`) does an unguarded `this.paths[path]` lookup on a plain object, so `"__proto__"` resolves up the prototype chain and returns `Object.prototype` itself; `_getSchema` then treats that as a schematype and writes `$fullPath` onto it (`lib/schema.js:2958`).

## The fix

**1. `assertSafeUpdateBody` in `src/lib/requestGuard.ts`** — rejects keys matching `/(^|\.)(__proto__|constructor|prototype)(\.|$)/` with 400. Anchored on segment boundaries so legitimate names that merely *contain* a banned word (`prototypeNotes`, `reconstructor`) still pass.

**2. Applied in the filament PUT**, next to the existing `$`-operator check. The two are siblings, and neither subsumes the other: that one blocks Mongo **operators**, this one blocks **prototype paths**.

The upstream fix in mongoose >= 9.7.2 (pinned as the floor by #1031) is the real remedy; this is the belt-and-braces layer so a downgraded lockfile, an upstream regression, or a newly-added raw-body route can't silently reopen it.

## Scope was measured, not assumed

The issue suggested applying the guard to "the nozzle/printer/bed-type/location PUTs too." I checked, and **that would be dead code**. `PUT /api/filaments/{id}` is the **only** route that forwards a client-shaped object into an update:

```
$ # update calls whose update ARG is the raw parsed body
src/app/api/filaments/[id]/route.ts:370  -> update arg = body
src/app/api/printers/[id]/route.ts:141   -> update arg = update   (built)
src/app/api/locations/[id]/route.ts:54   -> update arg = update   (built)
src/app/api/bed-types/[id]/route.ts:50   -> update arg = update   (built)
src/app/api/nozzles/[id]/route.ts:120    -> update arg = update   (built)
```

Those four build their updates from **string-literal keys only** (`if ("name" in body) update.name = body.name;` …) — verified no `update[<var>]` dynamic assignment anywhere in them, so no client-controlled key can reach the update document. The one dynamic key in the whole codebase is `` update[`temperatures.${key}`] `` (route.ts:679), and `temps` is populated by four literal assignments (`temps.nozzle`, `temps.nozzleFirstLayer`, `temps.bed`, `temps.bedFirstLayer`).

So the guard is exported as a **shared helper with a docstring saying when to reach for it**, and called at the one real sink.

## Behaviour change worth a look

On **patched** mongoose, a `__proto__`-dotted key is silently **dropped** and the request returns **200**. This guard makes it an explicit **400**.

I went with 400 for consistency with the adjacent `$`-operator guard, and because it surfaces a malformed/malicious client instead of quietly ignoring part of a request. Silently ignoring unknown fields is a defensible alternative — say the word and I'll flip it.

## Tests

**They assert the prototype directly, not just the status code.** A test that only checked for 400 would not catch a regression where the guard runs *after* the write:

```ts
expect(proto.$fullPath).toBeUndefined();
const seen: string[] = []; for (const k in { a: 1 }) seen.push(k);
expect(seen).toEqual(["a"]);
```

**Verified non-vacuous** — with the guard neutered, the route-level test fails (`expected 200 to be 400`).

- `tests/requestGuard.test.ts` — 12 rejected shapes, 9 legitimate paths that must pass, non-object bodies, and the own-key-vs-inherited-key distinction (a `{__proto__: …}` *literal* sets the prototype and has no own keys; `JSON.parse` creates a real own key — which is what a request body carries).
- `tests/mass-assignment-hardening.test.ts` — route-level: rejects with 400, leaves `Object.prototype` clean, rejects atomically (the legitimate `name` in the same body is not applied), and still accepts a legitimate `temperatures.nozzle` dotted path.

| check | result |
|---|---|
| `npm run lint` | clean |
| `npx tsc --noEmit` | clean |
| `npm test` | **3399/3399**, 163 files |
| coverage thresholds | met — 99.55% lines / 99.05% statements / 97.73% functions / 97.56% branches |

## Relationship to #1031

Deliberately separate, per the triage recommendation. #1031 carries the mongoose floor bump (its job is to unblock the release tag); this PR is code-only and touches no lockfile, so the two **cannot conflict in either merge order**.

One honest caveat: because `node_modules` now has the patched 9.7.4, the route-level test proves *the guard produces the 400*, but the prototype assertions pass on 9.7.4 with or without the guard — upstream already prevents the pollution there. The pollution itself was reproduced separately on 9.5.0 (output above). That's the correct end state: defence in depth, with upstream as the primary fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
