### PR TITLE
fix(nfc): bound the NTAG read page so a hostile CC can't splice pages 0-3 into the NDEF image (#1028)

### DIFF
--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -31,6 +31,14 @@ import {
   NTAG_NAME_TO_NDEF_BYTES,
   type NtagSizeName,
 } from "../src/lib/ntagVersion";
+import {
+  NTAG_CC_OFFSET,
+  NTAG_TLV_OFFSET,
+  NTAG_FIRST_DATA_PAGE,
+  NTAG_MAX_PAGE,
+  ndefBytesFromCc,
+  isReadablePage,
+} from "../src/lib/ntagPages";
 import { deriveBambuKeys, parseBambuBlocks, bambuToDecodedTag } from "./bambu-tag";
 import {
   classifyNfcError as classifyNfcErrorImpl,
@@ -88,12 +96,16 @@ const BLOCK_SIZE = 4;
 const DEFAULT_BLOCK_COUNT = 80;
 
 // NTAG (NFC-A / ISO 14443 Type 2) read tuning (#864). FF B0 READ BINARY returns
-// a 4-page (16-byte) burst; the Type-2 CC sits in page 3 (bytes 12–15) with the
-// NDEF TLV area starting at page 4 (byte 16). NTAG216 tops out near 872 user
-// bytes, so 1 KB is a generous ceiling that bounds the read loop.
-const NTAG_CC_OFFSET = 12;
-const NTAG_TLV_OFFSET = 16;
-const NTAG_MAX_NDEF_BYTES = 1024;
+// a 4-page (16-byte) burst; the Type-2 CC sits in page 3 (bytes 12-15) with the
+// NDEF TLV area starting at page 4 (byte 16).
+//
+// GH #1028: the offsets, the extent ceiling and the page bound now live in the
+// pure, unit-tested ../src/lib/ntagPages.ts. The old local ceiling of 1024 was
+// arithmetically unreachable — one Type-2 sector is 256 pages x 4 = 1024 bytes
+// TOTAL and the data area starts at page 4, so the real maximum is
+// (256 - 4) x 4 = 1008. Being off by the 16-byte head is exactly what let the
+// read loop run one burst PAST the addressable end and wrap the single-byte
+// page field back to 0.
 // Write-side extent caps (Codex #927) now live in the pure, unit-tested
 // resolveNtagWriteSize (src/lib/ntagVersion.ts): NTAG216_MAX_NDEF_BYTES (872,
 // the largest real NTAG) and NTAG213_NDEF_BYTES (144, safe on ANY chip).
@@ -776,6 +788,17 @@ export class NfcService extends EventEmitter {
 
   /** Read one 16-byte (4-page) burst via the PC/SC READ BINARY pseudo-APDU. */
   private async readNtagBurst(protocol: number, startPage: number): Promise<Buffer> {
+    // GH #1028: the start page rides in a SINGLE APDU byte, and
+    // `Buffer.from(array)` applies `& 0xff` SILENTLY — so page 256 would emit
+    // `ffb0000010`, a read of pages 0-3 (UID / static lock bytes / CC), and the
+    // caller would splice that head into the tail of the NDEF image. Mirror the
+    // backstop `writeNtagPage` has had since #927. Page 0 is legal here (the
+    // head burst) whereas the write bound starts at 3.
+    if (!isReadablePage(startPage)) {
+      throw new Error(
+        `Refusing unsafe NTAG page read: page ${startPage} is outside the addressable [0,${NTAG_MAX_PAGE}] range`,
+      );
+    }
     const cmd = Buffer.from([0xff, 0xb0, 0x00, startPage, 0x10]);
     const resp = await this.transmit(cmd, 20, protocol);
     if (!this.checkSW(resp)) {
@@ -794,14 +817,24 @@ export class NfcService extends EventEmitter {
     protocol: number,
     head: Buffer,
   ): Promise<{ data: Buffer; written: number }> {
-    const mlen = head[NTAG_CC_OFFSET + 2]; // CC byte 2 = NDEF area size / 8
-    const ndefBytes = Math.min(Math.max(0, mlen * 8), NTAG_MAX_NDEF_BYTES);
+    // GH #1028: `ndefBytesFromCc` (pure, unit-tested in src/lib/ntagPages.ts)
+    // clamps the TAG-CONTROLLED CC byte to what a 1-byte page address can
+    // actually reach, and tolerates a short head — the write-verify caller at
+    // writeNtagImpl does NOT length-check its head first, so a truncated burst
+    // used to produce `Buffer.alloc(16 + NaN)` and a raw RangeError.
+    const ndefBytes = ndefBytesFromCc(head);
     const data = Buffer.alloc(NTAG_TLV_OFFSET + ndefBytes);
     head.copy(data, 0);
 
-    let page = 4;
+    let page = NTAG_FIRST_DATA_PAGE;
     let written = NTAG_TLV_OFFSET;
-    while (written < data.length) {
+    // GH #1028: bound the walk explicitly. `readNtagBurst` now refuses an
+    // out-of-range page too, but relying on that throw (caught below and turned
+    // into a `break`) would be too subtle to survive future edits. Do NOT
+    // "fix" this by clamping (`page = Math.min(page, NTAG_MAX_PAGE)`): clamping
+    // keeps the loop alive and converts the old accidental wrap into a
+    // permanent re-read of the same page — an NFC deadlock.
+    while (written < data.length && page <= NTAG_MAX_PAGE) {
       let burst: Buffer;
       try {
         burst = await this.readNtagBurst(protocol, page);
@@ -813,6 +846,11 @@ export class NfcService extends EventEmitter {
         }
       }
       const copyLen = Math.min(burst.length, data.length - written);
+      // GH #1028: a zero-length burst would leave `written` unchanged and spin
+      // forever. Before the page bound above, the accidental wrap to page 0 was
+      // what kept data flowing and masked this; with the bound in place it must
+      // be handled explicitly.
+      if (copyLen === 0) break;
       burst.copy(data, written, 0, copyLen);
       written += copyLen;
       page += 4;

--- a/src/lib/ntagPages.ts
+++ b/src/lib/ntagPages.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure page arithmetic for the NFC-Forum Type 2 (NTAG21x) read path (GH #1028).
+ *
+ * Extracted from `electron/nfc-service.ts`'s `assembleNtagImage` so the
+ * arithmetic lives in coverage-gated, unit-testable code — mirroring what #973
+ * did for the GET_VERSION parse (`src/lib/ntagVersion.ts`). `electron/` has no
+ * test file at all, and this is the second page-arithmetic safety bug in that
+ * module, so the numbers belong here rather than inline.
+ *
+ * THE BUG THIS ENCODES AGAINST
+ *
+ * A Type-2 READ BINARY pseudo-APDU carries the start page in a SINGLE byte:
+ *
+ *     Buffer.from([0xff, 0xb0, 0x00, startPage, 0x10])
+ *
+ * `Buffer.from(array)` applies `& 0xff` silently, so page 256 emits the wire
+ * bytes `ffb0000010` — a read of pages 0-3 (UID, BCC, internal byte, static
+ * LOCK bytes, CC). The assembler derived its read extent from the tag's own
+ * Capability Container byte and walked `page += 4` with no upper bound, so a
+ * tag whose CC byte 2 was >= 0x7f drove the final burst to page 256 and
+ * spliced the head back into the TAIL of the NDEF image — silent corruption
+ * rather than a clean error.
+ *
+ * The write side already had exactly this guard (`writeNtagPage`'s [3,255]
+ * bound, added in #927); the read side never got its counterpart.
+ *
+ * THE OFF-BY-ONE IN THE OLD CEILING
+ *
+ * `NTAG_MAX_NDEF_BYTES` was 1024, commented as "a generous ceiling that bounds
+ * the read loop". It does not bound it. One Type-2 sector is 256 pages x 4 =
+ * 1024 bytes TOTAL, and the NDEF area starts at page 4, so the largest NDEF
+ * extent addressable with a 1-byte page field is (256 - 4) x 4 = 1008 bytes.
+ * The ceiling was off by exactly the 16-byte head — which is precisely why the
+ * loop could run one burst past the addressable end.
+ */
+
+/** Byte offset of the Type-2 Capability Container within the pages-0-3 head. */
+export const NTAG_CC_OFFSET = 12;
+
+/** Byte offset where the NDEF TLV area begins (page 4). */
+export const NTAG_TLV_OFFSET = 16;
+
+/** First page of the NDEF/user data area. */
+export const NTAG_FIRST_DATA_PAGE = 4;
+
+/** Highest page addressable by the single-byte READ BINARY page field. */
+export const NTAG_MAX_PAGE = 0xff;
+
+/**
+ * Largest NDEF extent reachable with a 1-byte page address:
+ * `(256 - 4) pages x 4 bytes = 1008`.
+ *
+ * Replaces the old, unreachable 1024. Chosen over `NTAG216_MAX_NDEF_BYTES`
+ * (872, the largest REAL chip) so the read path stays exactly as permissive as
+ * it is today — this is a correctness fix, not a narrowing of which tags can be
+ * read. The page bounds below are the structural guarantee; this constant just
+ * stops the ceiling from being arithmetically impossible.
+ */
+export const NTAG_MAX_NDEF_BYTES = 1008;
+
+/**
+ * Read the CC-declared NDEF extent out of a pages-0-3 head, clamped to what is
+ * actually addressable.
+ *
+ * `head` is tag-controlled, so every field is treated as hostile:
+ *   - a head shorter than the CC offset yields 0 rather than `undefined`,
+ *     which used to reach `Buffer.alloc(16 + NaN)` and throw a raw RangeError
+ *     (the write-verify caller does not length-check its head first);
+ *   - a non-integer / negative / NaN mlen yields 0;
+ *   - an over-large mlen clamps to NTAG_MAX_NDEF_BYTES.
+ */
+export function ndefBytesFromCc(head: ArrayLike<number>): number {
+  const idx = NTAG_CC_OFFSET + 2; // CC byte 2 = NDEF area size / 8
+  if (head.length <= idx) return 0;
+  const mlen = head[idx];
+  if (typeof mlen !== "number" || !Number.isFinite(mlen) || mlen <= 0) return 0;
+  return Math.min(Math.floor(mlen) * 8, NTAG_MAX_NDEF_BYTES);
+}
+
+/**
+ * The exact sequence of start pages `assembleNtagImage` should burst-read for a
+ * given NDEF extent — each burst covering 4 pages / 16 bytes from page 4.
+ *
+ * Never yields a page above `NTAG_MAX_PAGE`, which is the property that makes
+ * the single-byte APDU field safe. Exported primarily so the boundary table can
+ * be pinned by tests; the service consumes `page` via the same bound.
+ */
+export function ntagBurstPages(ndefBytes: number): number[] {
+  const total = NTAG_TLV_OFFSET + Math.max(0, ndefBytes);
+  const pages: number[] = [];
+  let page = NTAG_FIRST_DATA_PAGE;
+  let written = NTAG_TLV_OFFSET;
+  while (written < total && page <= NTAG_MAX_PAGE) {
+    pages.push(page);
+    written += 16;
+    page += 4;
+  }
+  return pages;
+}
+
+/**
+ * True when `page` is a legal READ BINARY start page.
+ *
+ * Page 0 IS legal for a read (the head burst), unlike the write bound which
+ * starts at 3 — writes must never touch pages 0-2 (UID / static lock bytes),
+ * but reading them is exactly how detection works.
+ */
+export function isReadablePage(page: number): boolean {
+  return Number.isInteger(page) && page >= 0 && page <= NTAG_MAX_PAGE;
+}

--- a/tests/ntagPages.test.ts
+++ b/tests/ntagPages.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  NTAG_CC_OFFSET,
+  NTAG_TLV_OFFSET,
+  NTAG_FIRST_DATA_PAGE,
+  NTAG_MAX_PAGE,
+  NTAG_MAX_NDEF_BYTES,
+  ndefBytesFromCc,
+  ntagBurstPages,
+  isReadablePage,
+} from "@/lib/ntagPages";
+
+/**
+ * GH #1028 — NTAG read page arithmetic.
+ *
+ * A Type-2 READ BINARY pseudo-APDU carries the start page in ONE byte:
+ *
+ *     Buffer.from([0xff, 0xb0, 0x00, startPage, 0x10])
+ *
+ * `Buffer.from(array)` applies `& 0xff` silently, so page 256 emits
+ * `ffb0000010` — a read of pages 0-3 (UID / BCC / internal / static LOCK bytes
+ * / CC). `assembleNtagImage` derived its extent from the TAG-CONTROLLED CC byte
+ * and walked `page += 4` unbounded, so a CC byte >= 0x7f spliced that head back
+ * into the TAIL of the NDEF image — silent corruption, not an error.
+ *
+ * The write side has had the equivalent bound since #927; the read side never
+ * got its counterpart.
+ */
+describe("ntagPages — burst page bounds (GH #1028)", () => {
+  it("never yields a page above the single-byte APDU maximum, for ANY CC value", () => {
+    // The property that actually matters — exhaustive over every possible byte.
+    for (let mlen = 0; mlen <= 0xff; mlen++) {
+      const head = new Uint8Array(NTAG_TLV_OFFSET);
+      head[NTAG_CC_OFFSET + 2] = mlen;
+      for (const page of ntagBurstPages(ndefBytesFromCc(head))) {
+        expect(Number.isInteger(page)).toBe(true);
+        expect(page).toBeGreaterThanOrEqual(NTAG_FIRST_DATA_PAGE);
+        expect(page).toBeLessThanOrEqual(NTAG_MAX_PAGE);
+      }
+    }
+  });
+
+  it("pins the boundary table for real chips and the former wrap point", () => {
+    const rows = [0x12, 0x3e, 0x6d, 0x7e, 0x7f, 0x80, 0xff].map((mlen) => {
+      const head = new Uint8Array(NTAG_TLV_OFFSET);
+      head[NTAG_CC_OFFSET + 2] = mlen;
+      const nd = ndefBytesFromCc(head);
+      const pages = ntagBurstPages(nd);
+      return {
+        mlen: `0x${mlen.toString(16)}`,
+        ndefBytes: nd,
+        bursts: pages.length,
+        finalPage: pages[pages.length - 1] ?? null,
+      };
+    });
+
+    expect(rows).toEqual([
+      // Real chips — unchanged by this fix.
+      { mlen: "0x12", ndefBytes: 144, bursts: 9, finalPage: 36 },   // NTAG213
+      { mlen: "0x3e", ndefBytes: 496, bursts: 31, finalPage: 124 }, // NTAG215
+      { mlen: "0x6d", ndefBytes: 872, bursts: 55, finalPage: 220 }, // NTAG216
+      // 0x7e was the last SAFE value pre-fix.
+      { mlen: "0x7e", ndefBytes: 1008, bursts: 63, finalPage: 252 },
+      // 0x7f was the FIRST value that wrapped to page 0 pre-fix (NOT 0x80 —
+      // the issue's original table was off by one value).
+      { mlen: "0x7f", ndefBytes: 1008, bursts: 63, finalPage: 252 },
+      { mlen: "0x80", ndefBytes: 1008, bursts: 63, finalPage: 252 },
+      { mlen: "0xff", ndefBytes: 1008, bursts: 63, finalPage: 252 },
+    ]);
+  });
+
+  it("clamps the extent to what a 1-byte page address can actually reach", () => {
+    // The old ceiling (1024) was arithmetically impossible: the data area
+    // starts at page 4, so only (256-4)*4 = 1008 bytes are addressable.
+    expect(NTAG_MAX_NDEF_BYTES).toBe(1008);
+    expect(NTAG_TLV_OFFSET + NTAG_MAX_NDEF_BYTES).toBe(1024); // one full sector
+    const head = new Uint8Array(NTAG_TLV_OFFSET);
+    head[NTAG_CC_OFFSET + 2] = 0xff; // claims 2040 bytes
+    expect(ndefBytesFromCc(head)).toBe(1008);
+  });
+
+  it("covers the whole declared extent for every real chip (no truncation)", () => {
+    for (const [mlen, expected] of [
+      [0x12, 144],
+      [0x3e, 496],
+      [0x6d, 872],
+    ] as const) {
+      const head = new Uint8Array(NTAG_TLV_OFFSET);
+      head[NTAG_CC_OFFSET + 2] = mlen;
+      const pages = ntagBurstPages(ndefBytesFromCc(head));
+      // bursts * 16 bytes must reach or exceed the declared NDEF extent
+      expect(pages.length * 16).toBeGreaterThanOrEqual(expected);
+    }
+  });
+});
+
+describe("ntagPages — ndefBytesFromCc treats the head as hostile", () => {
+  it("returns 0 for a head too short to contain the CC", () => {
+    // The write-verify caller does NOT length-check its head, so a truncated
+    // burst used to yield `Buffer.alloc(16 + NaN)` → a raw RangeError.
+    expect(ndefBytesFromCc(new Uint8Array(0))).toBe(0);
+    expect(ndefBytesFromCc(new Uint8Array(NTAG_CC_OFFSET))).toBe(0);
+    expect(ndefBytesFromCc(new Uint8Array(NTAG_CC_OFFSET + 2))).toBe(0);
+  });
+
+  it("returns 0 for a zero / absent CC size", () => {
+    const head = new Uint8Array(NTAG_TLV_OFFSET); // all zeroes
+    expect(ndefBytesFromCc(head)).toBe(0);
+  });
+
+  it("returns 0 for non-numeric or non-finite CC bytes", () => {
+    expect(ndefBytesFromCc({ length: 16, [NTAG_CC_OFFSET + 2]: NaN } as never)).toBe(0);
+    expect(ndefBytesFromCc({ length: 16, [NTAG_CC_OFFSET + 2]: -3 } as never)).toBe(0);
+    expect(
+      ndefBytesFromCc({ length: 16, [NTAG_CC_OFFSET + 2]: Infinity } as never),
+    ).toBe(0);
+  });
+
+  it("yields no bursts at all when the extent is 0", () => {
+    expect(ntagBurstPages(0)).toEqual([]);
+    expect(ntagBurstPages(-100)).toEqual([]);
+  });
+});
+
+describe("ntagPages — isReadablePage", () => {
+  it("accepts the whole addressable range INCLUDING page 0", () => {
+    // Page 0 is legal for a READ (the head burst) — unlike the write bound,
+    // which starts at 3 because pages 0-2 hold the UID and static lock bytes.
+    expect(isReadablePage(0)).toBe(true);
+    expect(isReadablePage(4)).toBe(true);
+    expect(isReadablePage(NTAG_MAX_PAGE)).toBe(true);
+  });
+
+  it("rejects the wrap point and everything past it", () => {
+    expect(isReadablePage(256)).toBe(false); // the exact value that wrapped to 0
+    expect(isReadablePage(512)).toBe(false);
+    expect(isReadablePage(-1)).toBe(false);
+  });
+
+  it("rejects non-integers", () => {
+    expect(isReadablePage(4.5)).toBe(false);
+    expect(isReadablePage(NaN)).toBe(false);
+    expect(isReadablePage(Infinity)).toBe(false);
+  });
+
+  it("demonstrates WHY the bound exists: Buffer.from silently masks to a byte", () => {
+    // This is the actual defect mechanism, pinned so it can't be argued away.
+    expect(Buffer.from([0xff, 0xb0, 0x00, 256, 0x10]).toString("hex")).toBe(
+      "ffb0000010",
+    );
+    expect(Buffer.from([0xff, 0xb0, 0x00, 256, 0x10])[3]).toBe(0);
+    // ...and that byte-3 of 0 is a read of pages 0-3, i.e. the head.
+    expect(Buffer.from([0xff, 0xb0, 0x00, 0, 0x10]).toString("hex")).toBe(
+      "ffb0000010",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1028

A Type-2 READ BINARY pseudo-APDU carries the start page in a **single byte**:

```ts
Buffer.from([0xff, 0xb0, 0x00, startPage, 0x10])
```

`Buffer.from(array)` applies `& 0xff` **silently**, so page 256 emits `ffb0000010` — a read of pages 0–3 (UID, BCC, internal byte, static **LOCK** bytes, CC). `assembleNtagImage` derived its extent from the **tag-controlled** Capability Container byte and walked `page += 4` unbounded, so a CC byte ≥ `0x7f` drove the final burst to page 256 and copied that head back into the **tail** of the NDEF image — silent corruption, not an error.

`assembleNtagImage` feeds the read path, the OpenTag3D record check **and the post-write verify**, so a corrupted tail can also make a write verify reach the wrong conclusion.

## Threshold correction

The issue's original table said `>= 0x80`. **It's `>= 0x7f`** — `0x7f` → 1016 bytes → 1032-byte buffer → 64 bursts → final page 256. `0x7e` (1008 bytes, final page 252) is the last safe value. Caught by triage, verified independently, and the issue has been corrected.

No real NTAG21x reaches it — the largest legitimate `mlen` is `0x6d` (NTAG216, 872 bytes, final page 220) — so this needs a malformed / foreign / partially-written / hostile tag. Hence P3.

## Provenance

The write side has had exactly this guard since #927. `git log -L 793,821` shows commit `b1179fff` added `writeNtagPage`'s `[3,255]` bound **while extracting this very loop** — and never added the read-side counterpart.

## Four parts

**1. `readNtagBurst` refuses a page outside `[0, 255]`.** Page 0 *is* legal for a read (the head burst), unlike the write bound which starts at 3 because pages 0–2 hold the UID and static lock bytes.

**2. The assembly loop is bounded explicitly** (`page <= NTAG_MAX_PAGE`) rather than relying on that throw being caught and turned into a `break` — too subtle to survive future edits.

It also gains `if (copyLen === 0) break;`, and **this line is load-bearing**: a zero-length burst leaves `written` unchanged and spins forever, and the accidental wrap to page 0 was what kept data flowing and *masked* it. Bounding the page **without** the zero-progress guard converts an accidental save into a permanent NFC deadlock. For the same reason, do not "fix" this by clamping (`page = Math.min(page, 255)`) — clamping keeps the loop alive and is exactly the deadlock case.

**3. The ceiling was mis-derived.** `NTAG_MAX_NDEF_BYTES = 1024` was commented as *"a generous ceiling that bounds the read loop"* — it does not bound it. One Type-2 sector is 256 pages × 4 = 1024 bytes **total**, and the data area starts at page 4, so the largest addressable NDEF extent is (256−4) × 4 = **1008**. Being off by exactly the 16-byte head is precisely what let the loop run one burst past the addressable end.

> **I diverged from triage here.** It recommended `872` (`NTAG216_MAX_NDEF_BYTES`, aligning read with the write path's clamp). I chose **1008**: the page bounds in parts 1–2 are the structural guarantee, so the constant only controls permissiveness — and 1008 is a pure arithmetic correction with **zero behavioural narrowing**, whereas 872 would additionally truncate a hypothetical foreign/emulated Type-2 device claiming 873–1008 bytes. Easy to change to 872 if you'd rather have the alignment; the guards make it correct either way.

**4. `ndefBytesFromCc` tolerates a short head.** Two of the three callers check `head.length >= 16` first; the **write-verify caller does not**, so a truncated burst produced `Buffer.alloc(16 + NaN)` → a raw `RangeError`.

## Behavioural posture

Unchanged apart from the fix: an over-large CC now yields a **short image** (callers already use the returned `written`) instead of a wrapped read. Truncating silently matches the existing NAK-driven `break`; failing loudly could regress tags that work today.

## Extraction

The arithmetic moves to `src/lib/ntagPages.ts` — pure, and inside the **coverage-gated** tree — mirroring what #973 did for the GET_VERSION parse (`src/lib/ntagVersion.ts`). `electron/` has no test file at all and `nfc-service.ts` is its largest module; this is its *second* page-arithmetic safety bug, so the numbers belong somewhere they can be pinned.

## Tests

- **Exhaustive over all 256 CC values** — no burst page may exceed 255, for any byte a tag can present.
- Pins the boundary table, including the corrected `0x7f` threshold and every real chip (`0x12`/`0x3e`/`0x6d` unchanged at 9/31/55 bursts).
- Asserts no truncation for real chips (bursts × 16 ≥ declared extent).
- Hostile-head cases: short head, zero CC, `NaN`/negative/`Infinity`.
- Asserts **the defect mechanism itself**, so it can't be argued away:

```ts
expect(Buffer.from([0xff, 0xb0, 0x00, 256, 0x10]).toString("hex")).toBe("ffb0000010");
expect(Buffer.from([0xff, 0xb0, 0x00, 256, 0x10])[3]).toBe(0);
```

**Verified non-vacuous** — restoring the 1024 ceiling + unbounded walk fails 3 tests, including `expected 256 to be less than or equal to 255`.

| check | result |
|---|---|
| `npm run lint` | clean |
| `npx tsc --noEmit` | clean |
| `npm run electron:typecheck` | clean |
| `npm test` | **3419/3419**, 164 files |
| coverage thresholds | met — 99.55% lines / 99.06% statements / 97.74% functions / 97.57% branches |

## Still owed

**On-hardware confirmation.** No ACR1552U + NTAG in this environment. Mitigating: the change is arithmetic-only and **cannot affect a tag whose CC byte is ≤ 0x7e**, which covers every real NTAG213/215/216 — the burst sequence for those is byte-for-byte identical to before (pinned by the boundary table test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
