### PR TITLE
Bump version to 1.68.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.68.0",
+      "version": "1.68.1",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.68.0",
+  "version": "1.68.1",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.68.0",
+    "version": "1.68.1",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Patch release covering the five fixes merged since v1.68.0.

| issue | fix |
|---|---|
| #1025 | CI audit gate unblocked — 4 advisories resolved, brace-expansion allowlisted |
| #1026 | **Security:** prototype pollution via `__proto__`-dotted keys in the filament PUT |
| #1028 | NTAG read page bound — a hostile CC could splice pages 0–3 into the NDEF image |
| #1029 | i18n `interpolate()` single-pass — a param value could inject another token |
| #1030 | usage `grams` upper bound — one oversized entry nulled out analytics totals |

## Why patch and not minor

All five are `fix(...)`. The only added source file is `src/lib/ntagPages.ts` (a pure internal page-arithmetic helper extracted from `electron/nfc-service.ts`); `git diff --stat v1.68.0..HEAD -- src/i18n/locales/` is **empty** (zero new translation keys, which this repo's `i18n-key-coverage` invariant makes a reliable proxy for zero new UI surface), and there are zero added API routes, components or hooks. `package.json` is `private: true`, so there is no published library surface.

Worth disclosing in the notes though: the release does **tighten** the public HTTP API with two new `400`s — `grams > 1_000_000` at both usage-write boundaries, and `__proto__`/`constructor`/`prototype`-dotted keys on the filament PUT. `public/openapi.json` is updated to match. Both reject only input that was already invalid or malicious, but the PrusaSlicer/OrcaSlicer forks and the mobile app post to these endpoints.

## Why this PR exists at all — and why it must land before the tag

`electron-builder` derives `artifactName` and every update feed's `version:` field from `package.json` alone, and **nothing in `release.yml` cross-checks the git tag against it**. Tagging `v1.68.1` without this bump would go *fully green* while producing assets named `FilamentDB-1.68.0-*` and `latest*.yml` declaring `version: 1.68.0` — so electron-updater would offer nothing to existing users. Silent, total auto-update failure.

This is not theoretical: a local packaging rehearsal on the current tree emitted exactly `dist-electron/FilamentDB-1.68.0-mac-arm64.zip`.

## Method

Bumped **by hand**. `release-bump.yml` is not dispatchable with this token (HTTP 403; it last ran 2026-07-02 and was used for neither 1.67.0 nor 1.68.0 — PR #1024 was manual, on branch `bump/1.68.0` with no `v` prefix).

The lockfile was edited **surgically** (2 lines) rather than re-resolved with `npm install --package-lock-only`, to avoid perturbing the #1025 advisory remediation that only just turned the audit gate green.

Diff shape is byte-identical to the previous bump (`git show --stat f3b88dc9`): **3 files changed, 4 insertions(+), 4 deletions(-)**.

## Pre-tag verification already done

- `node scripts/audit-gate.mjs` → exit 0, 3 allowlisted advisories tolerated
- Local **mac-arm64 packaging rehearsal on the new electron-builder 26.15.3 TS backend** (first tag to use it — #1025 swapped out the Go `app-builder` binary): exit 0, signed with the real Developer ID, zip + dmg + blockmaps produced
- **Native-zip integrity** (the 26.15.2 change, #698 blast radius): 14 symlinks preserved — identical to the old backend's output — `Versions/Current` resolves, `codesign --verify --deep --strict` passes after the zip round-trip, and `@pokusew/pcsclite` is correctly unpacked (`asar: false` guard holds)

## Not in this release

The bundled technical-reference snapshot stays at `6c24943` / 2026-06-12. The wiki has moved to `e7ef6ce` (2026-07-12) and `reference-drift` has failed two weeks running, but v1.68.0 shipped the identical snapshot, nothing depends on `src/content/`, and folding a ~34k-char content diff into a security patch isn't worth the delay. Deferred to 1.69.0 by decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)