### PR TITLE
feat(labels): TSPL transport for a second label printer + dry-box label template

### DIFF
--- a/electron/label-printer.ts
+++ b/electron/label-printer.ts
@@ -30,10 +30,17 @@ import { join, win32 } from "node:path";
 
 const execFileP = promisify(execFile);
 
-/** Heuristic match for "this device is a label printer we know about" —
- *  the PT-series (Brother raster) or the Y813BT (KNAON, TSPL). Drives a
- *  badge in the picker only; it never gates printing. */
-const PRINTER_PATTERN = /pt-?p710bt|p-?touch|brother|knaon|y-?813/i;
+/**
+ * Heuristic match for "this device is a Brother PT-series label printer".
+ *
+ * Deliberately NOT widened to cover the KNAON. The only consumer today is the
+ * Brother picker in LabelPrinterSettings, which renders this flag as a
+ * "PT-Touch" badge and saves the selection for labelPrinterPrint — whose test
+ * job is Brother raster. Badging a Y813BT there would actively invite the user
+ * to select it and print raster bytes to a TSPL printer. Per-kind badging
+ * belongs with the TSPL picker, alongside a pattern of its own.
+ */
+const PRINTER_PATTERN = /pt-?p710bt|p-?touch|brother/i;
 
 /**
  * Which label printer a job is bound for.

--- a/electron/label-printer.ts
+++ b/electron/label-printer.ts
@@ -30,13 +30,61 @@ import { join, win32 } from "node:path";
 
 const execFileP = promisify(execFile);
 
-/** Heuristic match for "this printer/device is a PT-series label printer". */
-const PRINTER_PATTERN = /pt-?p710bt|p-?touch|brother/i;
+/** Heuristic match for "this device is a label printer we know about" —
+ *  the PT-series (Brother raster) or the Y813BT (KNAON, TSPL). Drives a
+ *  badge in the picker only; it never gates printing. */
+const PRINTER_PATTERN = /pt-?p710bt|p-?touch|brother|knaon|y-?813/i;
+
+/**
+ * Which label printer a job is bound for.
+ *
+ * The app drives two physically different printers that never overlap:
+ * "brother" is the PT-P710BT on 24mm tape (spool labels, raster bytes) and
+ * "tspl" is the KNAON Y813BT on 4x6 stock (dry-box labels, TSPL bytes).
+ * The transport itself is byte-agnostic — this only selects which managed
+ * queue and description a raw `usb://` device gets bound to.
+ */
+export type LabelPrinterKind = "brother" | "tspl";
 
 /** Name of the hidden raw CUPS queue we manage for raw `usb://` devices
  *  that aren't already installed as a queue. CUPS queue names allow only
  *  letters, digits and underscores. */
 const MANAGED_QUEUE = "FilamentDB_Label";
+
+/**
+ * The TSPL printer gets its OWN managed queue, and that is load-bearing
+ * rather than tidiness.
+ *
+ * `ensureManagedQueue` REBINDS its queue to whichever device is currently
+ * printing. With both printers sharing one queue name, a Brother print and
+ * a dry-box print overlapping in time would rebind the queue away from each
+ * other — and because CUPS delivery is asynchronous (the `lp` job is spooled
+ * after the rebind but drains later) a job could be delivered to the WRONG
+ * PHYSICAL PRINTER. Per-kind queues make that impossible.
+ *
+ * The Brother queue keeps its original name so existing installs, which
+ * already have `FilamentDB_Label` bound, are untouched by the upgrade.
+ */
+const MANAGED_QUEUE_TSPL = `${MANAGED_QUEUE}_TSPL`;
+
+/** Every queue this app creates and owns. */
+const MANAGED_QUEUES: readonly string[] = [MANAGED_QUEUE, MANAGED_QUEUE_TSPL];
+
+/** True when `name` is one of OUR managed queues — an implementation detail
+ *  the picker surfaces as the underlying USB device rather than as a queue. */
+function isManagedQueueName(name: string): boolean {
+  return MANAGED_QUEUES.includes(name);
+}
+
+function managedQueueFor(kind: LabelPrinterKind): string {
+  return kind === "tspl" ? MANAGED_QUEUE_TSPL : MANAGED_QUEUE;
+}
+
+/** `lpadmin -D` description, so the two queues are distinguishable in the
+ *  user's system printer list rather than appearing as duplicates. */
+function queueDescriptionFor(kind: LabelPrinterKind): string {
+  return kind === "tspl" ? "Filament DB Dry-Box Label Printer" : "Filament DB Label Printer";
+}
 
 /** Per-subprocess timeout for listing + the CUPS `lp` print. Listing and a
  *  single 24mm label both complete well under this; the IPC handler wraps the
@@ -156,7 +204,7 @@ async function listCupsPrinters(probeUsb: boolean): Promise<LabelPrinterDevice[]
       const name = m[1].trim();
       const uri = m[2].trim();
       seenUris.add(uri);
-      if (name === MANAGED_QUEUE) {
+      if (isManagedQueueName(name)) {
         // Our own managed queue is an implementation detail — surface it as
         // the underlying USB *device* (path = the uri), so selecting it and
         // printing both route through ensureManagedQueue idempotently. Without
@@ -437,19 +485,33 @@ function isLegacySerialTarget(target: string): boolean {
  * Send the raster byte stream to the selected print target. Rejects with a
  * descriptive Error on failure; the IPC handler surfaces it to the renderer.
  */
-export async function printLabel(target: string, bytes: Uint8Array): Promise<void> {
+export async function printLabel(
+  target: string,
+  bytes: Uint8Array,
+  kind: LabelPrinterKind = "brother",
+): Promise<void> {
   if (isLegacySerialTarget(target)) {
+    // Only the Brother setting can hold a legacy serial value — the TSPL
+    // setting postdates the Bluetooth transport entirely — so the Brother
+    // copy stays, and the TSPL case gets wording that isn't a lie.
     throw new Error(
-      `"${target}" is a serial-port setting from an older version that printed over Bluetooth. ` +
-        `The PT-P710BT now prints over USB — open Settings → Label Printer and select your printer again.`,
+      kind === "tspl"
+        ? `"${target}" is a serial-port setting, which is not a valid print target. ` +
+            `Open Settings → Devices and select your label printer again.`
+        : `"${target}" is a serial-port setting from an older version that printed over Bluetooth. ` +
+            `The PT-P710BT now prints over USB — open Settings → Label Printer and select your printer again.`,
     );
   }
   if (process.platform === "win32") return printWindows(target, bytes);
-  if (isCups()) return printCups(target, bytes);
+  if (isCups()) return printCups(target, bytes, kind);
   throw new Error(`Label printing is not supported on platform "${process.platform}".`);
 }
 
-async function printCups(target: string, bytes: Uint8Array): Promise<void> {
+async function printCups(
+  target: string,
+  bytes: Uint8Array,
+  kind: LabelPrinterKind,
+): Promise<void> {
   // A `usb://…` target is a raw device → route it through our managed raw
   // queue. Otherwise it's an installed queue name. Only the usb scheme is
   // accepted — it's the only scheme listLabelPrinters ever surfaces — so a
@@ -457,8 +519,8 @@ async function printCups(target: string, bytes: Uint8Array): Promise<void> {
   // instead of being forwarded verbatim to `lpadmin -v` (GH #623).
   let queue = target;
   if (/^usb:\/\//i.test(target)) {
-    await ensureManagedQueue(target);
-    queue = MANAGED_QUEUE;
+    queue = managedQueueFor(kind);
+    await ensureManagedQueue(target, kind);
   } else if (/^[a-z][a-z0-9+.-]*:\/\//i.test(target)) {
     throw new Error(
       `Unsupported print target "${target}" — only usb:// devices and installed ` +
@@ -504,10 +566,11 @@ async function printCups(target: string, bytes: Uint8Array): Promise<void> {
  * Ensure the hidden raw queue exists and points at `uri`. Idempotent —
  * a no-op when it's already bound correctly.
  */
-async function ensureManagedQueue(uri: string): Promise<void> {
+async function ensureManagedQueue(uri: string, kind: LabelPrinterKind): Promise<void> {
+  const queueName = managedQueueFor(kind);
   let current: string | null = null;
   try {
-    const stdout = await runCupsTool("lpstat", ["-v", MANAGED_QUEUE]);
+    const stdout = await runCupsTool("lpstat", ["-v", queueName]);
     const m = stdout.match(/^device for .+?:\s*(.+)$/m);
     current = m ? m[1].trim() : null;
   } catch {
@@ -516,12 +579,13 @@ async function ensureManagedQueue(uri: string): Promise<void> {
   if (current === uri) return;
 
   // No `-m <model>` → CUPS creates a *raw* queue (no PPD), which is exactly
-  // what we want: the raster bytes pass straight through.
+  // what we want: the bytes pass straight through. That is what lets one
+  // transport carry both Brother raster and TSPL — neither is interpreted.
   const args = [
-    "-p", MANAGED_QUEUE,
+    "-p", queueName,
     "-v", uri,
     "-E",
-    "-D", "Filament DB Label Printer",
+    "-D", queueDescriptionFor(kind),
     "-o", "printer-is-shared=false",
   ];
   try {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,7 +5,12 @@ import { execFile } from "child_process";
 import Store from "electron-store";
 import http from "http";
 import { NfcService } from "./nfc-service";
-import { listLabelPrinters, printLabel as printLabelToDevice, disableBidi } from "./label-printer";
+import {
+  listLabelPrinters,
+  printLabel as printLabelToDevice,
+  disableBidi,
+  type LabelPrinterKind,
+} from "./label-printer";
 import { isLoopbackHostname } from "../src/lib/loopbackHost";
 import { listLanIpv4 } from "../src/lib/getLanIp";
 import { isNtagSizeName, type NtagSizeName } from "../src/lib/ntagVersion";
@@ -1376,41 +1381,143 @@ ipcMain.handle("label-printer-list-devices", async (event, probeUsb) => {
   );
 });
 
-ipcMain.handle("label-printer-get-device-path", (event) => {
-  assertTrustedSender(event, "label-printer-get-device-path");
-  // The picker's chosen device path lives in the same electron-store
-  // the rest of the app uses — see the get-config handler above. Kept
-  // as a separate handler so the renderer doesn't have to read the
-  // whole config object just to render the Print Label dialog.
-  return (store as unknown as Store<Record<string, unknown>>).get("labelPrinterDevicePath", null);
-});
+/**
+ * The two label printers the app drives, and the electron-store key backing
+ * each one's device selection.
+ *
+ * Registering both from ONE table is deliberate. These handlers are mirrored
+ * by hand in electron/preload.ts and src/types/electron.d.ts with no
+ * compile-time link between the three files, and that hand-mirroring has
+ * already drifted in production once (GH #1006 F4, where preload's local
+ * NfcStatus silently omitted a field). Two hand-copied ~50-line print
+ * handlers would be the same trap: a validation guard tightened on one and
+ * missed on the other is a security fix that only half-lands. Sharing the
+ * body makes divergence impossible.
+ *
+ * "brother" is the PT-P710BT (24mm tape, spool labels, raster bytes).
+ * "tspl" is the KNAON Y813BT (4x6 stock, dry-box labels, TSPL bytes).
+ */
+const LABEL_PRINTER_CHANNELS: readonly {
+  kind: LabelPrinterKind;
+  storeKey: string;
+  channels: { get: string; set: string; print: string };
+  noPrinterMessage: string;
+}[] = [
+  {
+    kind: "brother",
+    storeKey: "labelPrinterDevicePath",
+    channels: {
+      get: "label-printer-get-device-path",
+      set: "label-printer-set-device-path",
+      print: "label-printer-print",
+    },
+    noPrinterMessage: "No label printer selected. Open Settings → Label Printer.",
+  },
+  {
+    kind: "tspl",
+    storeKey: "tsplPrinterDevicePath",
+    channels: {
+      get: "tspl-printer-get-device-path",
+      set: "tspl-printer-set-device-path",
+      print: "tspl-printer-print",
+    },
+    noPrinterMessage: "No dry-box label printer selected. Open Settings → Devices.",
+  },
+];
 
-ipcMain.handle("label-printer-set-device-path", (event, devicePath: string | null) => {
-  assertTrustedSender(event, "label-printer-set-device-path");
-  if (devicePath != null && typeof devicePath !== "string") {
-    throw new Error("devicePath must be a string or null");
-  }
-  if (devicePath == null) {
-    (store as unknown as Store<Record<string, unknown>>).delete("labelPrinterDevicePath");
-  } else {
-    // GH #623: only accept the shapes listLabelPrinters ever surfaces —
-    // a `usb://…` device URI (the one scheme the CUPS lister emits) or an
-    // installed queue / Windows printer name. Anything else (ipp://,
-    // file://, a path with slashes) could otherwise be persisted by a
-    // compromised renderer and later handed to `lpadmin -v` by printCups,
-    // binding the managed queue to an attacker-chosen device URI.
-    const isUsbUri = /^usb:\/\//i.test(devicePath);
-    const isQueueName =
-      !devicePath.includes("/") && !/^[a-z][a-z0-9+.-]*:\/\//i.test(devicePath);
-    if (!isUsbUri && !isQueueName) {
-      throw new Error(
-        "devicePath must be a usb:// device URI or an installed printer/queue name",
-      );
+/**
+ * Safety cap on a single print job.
+ *
+ * A maxed-out 24mm × 200mm Brother label is ~270 KB and a 4x6 TSPL job is
+ * ~600 bytes (or ~124 KB if it ever carries a full-page raster), so 5 MB is
+ * well past any legitimate single label and ensures a misbehaving renderer
+ * can't lock a printer indefinitely.
+ */
+const MAX_PRINT_BYTES = 5_000_000;
+
+for (const spec of LABEL_PRINTER_CHANNELS) {
+  ipcMain.handle(spec.channels.get, (event) => {
+    assertTrustedSender(event, spec.channels.get);
+    // The picker's chosen device path lives in the same electron-store
+    // the rest of the app uses — see the get-config handler above. Kept
+    // as a separate handler so the renderer doesn't have to read the
+    // whole config object just to render a print dialog.
+    return (store as unknown as Store<Record<string, unknown>>).get(spec.storeKey, null);
+  });
+
+  ipcMain.handle(spec.channels.set, (event, devicePath: string | null) => {
+    assertTrustedSender(event, spec.channels.set);
+    if (devicePath != null && typeof devicePath !== "string") {
+      throw new Error("devicePath must be a string or null");
     }
-    (store as unknown as Store<Record<string, unknown>>).set("labelPrinterDevicePath", devicePath);
-  }
-  return { ok: true };
-});
+    if (devicePath == null) {
+      (store as unknown as Store<Record<string, unknown>>).delete(spec.storeKey);
+    } else {
+      // GH #623: only accept the shapes listLabelPrinters ever surfaces —
+      // a `usb://…` device URI (the one scheme the CUPS lister emits) or an
+      // installed queue / Windows printer name. Anything else (ipp://,
+      // file://, a path with slashes) could otherwise be persisted by a
+      // compromised renderer and later handed to `lpadmin -v` by printCups,
+      // binding the managed queue to an attacker-chosen device URI.
+      const isUsbUri = /^usb:\/\//i.test(devicePath);
+      const isQueueName =
+        !devicePath.includes("/") && !/^[a-z][a-z0-9+.-]*:\/\//i.test(devicePath);
+      if (!isUsbUri && !isQueueName) {
+        throw new Error(
+          "devicePath must be a usb:// device URI or an installed printer/queue name",
+        );
+      }
+      (store as unknown as Store<Record<string, unknown>>).set(spec.storeKey, devicePath);
+    }
+    return { ok: true };
+  });
+
+  ipcMain.handle(spec.channels.print, async (event, bytes: number[]) => {
+    assertTrustedSender(event, spec.channels.print);
+    // Validate the payload from the renderer up front — bad inputs here
+    // would otherwise be handed straight to the OS print transport.
+    if (!Array.isArray(bytes) || bytes.length === 0) {
+      throw new Error("bytes must be a non-empty array");
+    }
+    if (bytes.length > MAX_PRINT_BYTES) {
+      throw new Error(`bytes array too large (${bytes.length} bytes)`);
+    }
+    // GH #523: per-byte validation mirroring nfc-write-tag (#278). Without
+    // this, `new Uint8Array(bytes)` silently coerces floats to truncated
+    // ints, NaN/Infinity/strings/objects/null to 0, and out-of-range
+    // values mod-256 wrap. Both wire formats are positional — Brother's
+    // `ESC i z` media width / `ESC i M`/`K` mode bits / `0x1A` trailer, and
+    // TSPL's CRLF framing, where a stray 0x0A splices a command boundary —
+    // so a byte in the wrong slot leaves the printer in a wrong-mode or
+    // chain-stuck state for the next print.
+    //
+    // Codex P2 round 1: use an index loop, not Array.prototype.every —
+    // `every` skips sparse-array holes (`new Array(100)` or
+    // `delete arr[5]`), so a hostile renderer could send a 5MB array
+    // with NO actual bytes and the guard would pass. `new Uint8Array`
+    // would then convert every hole to 0x00, reintroducing the silent
+    // coercion this hardening is meant to block.
+    for (let i = 0; i < bytes.length; i++) {
+      const b = bytes[i];
+      if (!Number.isInteger(b) || b < 0 || b > 255) {
+        throw new Error("bytes must contain only integers in [0, 255]");
+      }
+    }
+    const target = (store as unknown as Store<Record<string, unknown>>).get(
+      spec.storeKey,
+      null,
+    ) as string | null;
+    if (!target) {
+      throw new Error(spec.noPrinterMessage);
+    }
+    await withIpcTimeout(
+      () => printLabelToDevice(target, new Uint8Array(bytes), spec.kind),
+      spec.channels.print,
+      30_000, // give long labels + a slow spooler a generous window
+    );
+    return { ok: true };
+  });
+}
 
 // Public base URL used for URL-mode label QR payloads (e.g.
 // "https://filament-db.lan" or "https://my-instance.example.com").
@@ -1475,55 +1582,6 @@ ipcMain.handle("label-printer-set-public-url", (event, url: string | null) => {
   return { ok: true };
 });
 
-ipcMain.handle("label-printer-print", async (event, bytes: number[]) => {
-  assertTrustedSender(event, "label-printer-print");
-  // Validate the payload from the renderer up front — bad inputs here
-  // would otherwise be handed straight to the OS print transport.
-  if (!Array.isArray(bytes) || bytes.length === 0) {
-    throw new Error("bytes must be a non-empty array");
-  }
-  if (bytes.length > 5_000_000) {
-    // Safety cap. A maxed-out 24mm × 200mm label is ~270 KB, so 5 MB
-    // is well past any legitimate single-label print and ensures a
-    // misbehaving renderer can't lock the printer indefinitely.
-    throw new Error(`bytes array too large (${bytes.length} bytes)`);
-  }
-  // GH #523: per-byte validation mirroring nfc-write-tag (#278). Without
-  // this, `new Uint8Array(bytes)` silently coerces floats to truncated
-  // ints, NaN/Infinity/strings/objects/null to 0, and out-of-range
-  // values mod-256 wrap. Brother's raster protocol is positional —
-  // `ESC i z` media width, `ESC i M`/`K` mode bits, `0x1A`/`0x0C`
-  // trailer — and a stray byte in the wrong slot leaves the printer
-  // in a wrong-mode / chain-stuck state for the next print.
-  //
-  // Codex P2 round 1: use an index loop, not Array.prototype.every —
-  // `every` skips sparse-array holes (`new Array(100)` or
-  // `delete arr[5]`), so a hostile renderer could send a 5MB array
-  // with NO actual bytes and the guard would pass. `new Uint8Array`
-  // would then convert every hole to 0x00, reintroducing the silent
-  // coercion this hardening is meant to block.
-  for (let i = 0; i < bytes.length; i++) {
-    const b = bytes[i];
-    if (!Number.isInteger(b) || b < 0 || b > 255) {
-      throw new Error("bytes must contain only integers in [0, 255]");
-    }
-  }
-  const target = (store as unknown as Store<Record<string, unknown>>).get(
-    "labelPrinterDevicePath",
-    null,
-  ) as string | null;
-  if (!target) {
-    throw new Error(
-      "No label printer selected. Open Settings → Label Printer.",
-    );
-  }
-  await withIpcTimeout(
-    () => printLabelToDevice(target, new Uint8Array(bytes)),
-    "label-printer-print",
-    30_000, // give long labels + a slow spooler a generous window
-  );
-  return { ok: true };
-});
 
 // Disable bidirectional support on a Windows printer queue via an elevated
 // helper (UAC). Some drivers (Brother PT-P710BT) crash the Print Spooler with

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -138,6 +138,17 @@ contextBridge.exposeInMainWorld("electronAPI", {
   labelPrinterDisableBidi: (printerName: string) =>
     ipcRenderer.invoke("label-printer-disable-bidi", printerName),
 
+  // KNAON Y813BT dry-box label printer (TSPL). A SECOND, independent device
+  // selection — the two printers never print the same thing, so they get
+  // separate settings rather than a shared "which kind" toggle. Device
+  // listing is deliberately NOT duplicated: labelPrinterListDevices is
+  // printer-agnostic (it lists every CUPS queue / usb:// device) and both
+  // pickers share it.
+  tsplPrinterGetDevicePath: () => ipcRenderer.invoke("tspl-printer-get-device-path"),
+  tsplPrinterSetDevicePath: (devicePath: string | null) =>
+    ipcRenderer.invoke("tspl-printer-set-device-path", devicePath),
+  tsplPrinterPrint: (bytes: number[]) => ipcRenderer.invoke("tspl-printer-print", bytes),
+
   // Runtime mode (packaged vs dev). Used by the DevModeBanner to warn
   // when the renderer's data source (next dev's .env.local) doesn't
   // match the connection-mode wizard the user clicked through (#489).

--- a/src/app/api/locations/[id]/route.ts
+++ b/src/app/api/locations/[id]/route.ts
@@ -4,6 +4,7 @@ import Location from "@/models/Location";
 import Filament from "@/models/Filament";
 import { errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
+import { isValidIsoDateString } from "@/lib/validateSpoolBody";
 
 export async function GET(
   _request: NextRequest,
@@ -50,6 +51,16 @@ export async function PUT(
     if ("name" in body) update.name = body.name;
     if ("kind" in body) update.kind = body.kind;
     if ("humidity" in body) update.humidity = body.humidity;
+    if ("desiccantChangedAt" in body) {
+      // Mongoose casts an ISO-shaped-but-impossible date (Feb 30, month 13)
+      // by rolling it over rather than rejecting it, so validate the string
+      // explicitly first — same posture as the spool date fields (GH #372).
+      const raw = body.desiccantChangedAt;
+      if (raw !== null && !(typeof raw === "string" && isValidIsoDateString(raw))) {
+        return errorResponse("desiccantChangedAt must be an ISO date string or null", 400);
+      }
+      update.desiccantChangedAt = raw;
+    }
     if ("notes" in body) update.notes = body.notes;
     const location = await Location.findOneAndUpdate(
       { _id: id, _deletedAt: null },

--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -4,6 +4,7 @@ import Location from "@/models/Location";
 import Filament from "@/models/Filament";
 import { getErrorMessage, errorResponse, errorResponseFromCaught, handleDuplicateKeyError } from "@/lib/apiErrorHandler";
 import { assertSameOriginRequest } from "@/lib/requestGuard";
+import { isValidIsoDateString } from "@/lib/validateSpoolBody";
 
 export async function GET(request: NextRequest) {
   try {
@@ -120,6 +121,13 @@ export async function POST(request: NextRequest) {
     delete body.updatedAt;
     delete body.__v;
     delete body.syncId;
+    // Same explicit ISO check as the PUT path: Mongoose rolls an
+    // impossible-but-ISO-shaped date over instead of rejecting it (GH #372).
+    if (body.desiccantChangedAt != null &&
+        !(typeof body.desiccantChangedAt === "string" &&
+          isValidIsoDateString(body.desiccantChangedAt))) {
+      return errorResponse("desiccantChangedAt must be an ISO date string or null", 400);
+    }
     const location = await Location.create(body);
     return NextResponse.json(location, { status: 201 });
   } catch (err) {

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -29,7 +29,7 @@ let restoreInProgress = false;
  * post-upgrade migration would then re-judge (and could erase) a
  * byte-identical post-cleanup user pin; the #953 version guard in those
  * builds rejects v5 instead. */
-const CURRENT_SNAPSHOT_VERSION = 5;
+const CURRENT_SNAPSHOT_VERSION = 6;
 
 /** The collection keys a v≤4 snapshot carries. Restore requires at least one to
  * be present so a wrong-shape / newer file 400s instead of silently wiping the
@@ -192,6 +192,13 @@ export async function GET(request: NextRequest) {
   //        (GH #1021: restore must know whether the data predates the
   //        one-shot nozzle-condition cleanup; bumped so pre-#1022 builds —
   //        which would drop the flag — reject the file via the #953 guard)
+  //   v6 — adds Location.desiccantChangedAt. Bumped for the same reason as
+  //        v5 and v4: a build without the field would accept the file and
+  //        its stricter Location schema would silently DROP the date, so the
+  //        user gets a "restored successfully" that quietly lost data. v4
+  //        exists because exactly that happened to share links. Failing
+  //        closed via the #953 guard is the established trade-off here —
+  //        a refused restore is recoverable, a silent partial one isn't.
   // Older snapshots still restore cleanly because POST destructures
   // missing collections to `[]`.
   // GH #1021 r12: cleanup provenance. Restore uses this to decide whether the

--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -72,6 +72,7 @@ const DATE_FIELDS = new Set([
   "_deletedAt",
   "purchaseDate",
   "openedDate",
+  "desiccantChangedAt",
   "startedAt",
   "date",
   "expiresAt",

--- a/src/app/api/spools/by-location/route.ts
+++ b/src/app/api/spools/by-location/route.ts
@@ -409,7 +409,7 @@ export async function GET(request: NextRequest) {
           foreignField: "_id",
           pipeline: [
             { $match: { _deletedAt: null } },
-            { $project: { _id: 1, name: 1, kind: 1, humidity: 1, notes: 1 } },
+            { $project: { _id: 1, name: 1, kind: 1, humidity: 1, desiccantChangedAt: 1, notes: 1 } },
           ],
           as: "_location",
         },

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -76,7 +76,16 @@ interface SpoolRow {
 
 interface Group {
   locationId: string | null;
-  location: { _id: string; name: string; kind: string; humidity: number | null; notes: string } | null;
+  location: {
+    _id: string;
+    name: string;
+    kind: string;
+    humidity: number | null;
+    /** ISO string over the wire; drives the dry-box label's
+     *  "DESICCANT CHANGED" line. */
+    desiccantChangedAt: string | null;
+    notes: string;
+  } | null;
   spools: SpoolRow[];
   count: number;
   totalGrams: number;

--- a/src/app/locations/LocationForm.tsx
+++ b/src/app/locations/LocationForm.tsx
@@ -7,6 +7,8 @@ interface LocationFormData {
   name: string;
   kind: string;
   humidity: string;
+  /** `<input type="date">` value — "YYYY-MM-DD" or "" for unset. */
+  desiccantChangedAt: string;
   notes: string;
 }
 
@@ -14,6 +16,7 @@ interface LocationInitialData {
   name?: string;
   kind?: string;
   humidity?: number | null;
+  desiccantChangedAt?: string | null;
   notes?: string;
 }
 
@@ -39,6 +42,12 @@ export default function LocationForm({ initialData, onSubmit, onDirtyChange }: P
     name: initialData?.name || "",
     kind: initialData?.kind || "shelf",
     humidity: initialData?.humidity != null ? String(initialData.humidity) : "",
+    // `<input type="date">` wants bare YYYY-MM-DD; the API returns a full
+    // ISO timestamp. Slice rather than going through Date, which would
+    // shift the calendar day for anyone west of UTC.
+    desiccantChangedAt: initialData?.desiccantChangedAt
+      ? initialData.desiccantChangedAt.slice(0, 10)
+      : "",
     notes: initialData?.notes || "",
   });
   const [saving, setSaving] = useState(false);
@@ -72,6 +81,9 @@ export default function LocationForm({ initialData, onSubmit, onDirtyChange }: P
         kind: form.kind,
         humidity:
           humidityNum != null && Number.isFinite(humidityNum) ? humidityNum : null,
+        desiccantChangedAt: form.desiccantChangedAt.trim() === ""
+          ? null
+          : form.desiccantChangedAt,
         notes: form.notes,
       });
       savedRef.current = true;
@@ -132,6 +144,22 @@ export default function LocationForm({ initialData, onSubmit, onDirtyChange }: P
           placeholder={t("locations.form.humidityPlaceholder")}
         />
         <p className="text-xs text-gray-400 mt-1">{t("locations.form.humidityHint")}</p>
+      </div>
+
+      <div>
+        <label htmlFor="location-desiccant" className={labelClass}>
+          {t("locations.form.desiccantChangedAt")}
+        </label>
+        <input
+          id="location-desiccant"
+          type="date"
+          className={inputClass}
+          value={form.desiccantChangedAt}
+          onChange={(e) => updateForm({ desiccantChangedAt: e.target.value })}
+        />
+        <p className="text-xs text-gray-400 mt-1">
+          {t("locations.form.desiccantChangedAtHint")}
+        </p>
       </div>
 
       <div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -500,6 +500,8 @@
   "locations.form.humidity": "Luftfeuchtigkeit (%rF)",
   "locations.form.humidityPlaceholder": "z.B. 18",
   "locations.form.humidityHint": "Optional. Typisch für Trockenboxen — nach Hygrometer-Ablesung manuell aktualisieren.",
+  "locations.form.desiccantChangedAt": "Trockenmittel gewechselt",
+  "locations.form.desiccantChangedAtHint": "Optional. Üblicherweise für Trockenboxen — setzen Sie es, wenn Sie das Granulat wechseln oder regenerieren.",
   "locations.form.notes": "Notizen",
   "locations.form.notesPlaceholder": "Optionale Notizen zu diesem Standort...",
   "locations.form.saving": "Wird gespeichert...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -500,6 +500,8 @@
   "locations.form.humidity": "Humidity (%RH)",
   "locations.form.humidityPlaceholder": "e.g. 18",
   "locations.form.humidityHint": "Optional. Typically used for dryboxes — update manually after checking the hygrometer.",
+  "locations.form.desiccantChangedAt": "Desiccant changed",
+  "locations.form.desiccantChangedAtHint": "Optional. Typically used for dryboxes — set it when you swap or regenerate the beads.",
   "locations.form.notes": "Notes",
   "locations.form.notesPlaceholder": "Optional notes about this location...",
   "locations.form.saving": "Saving...",

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -309,6 +309,7 @@ function toCalendarDate(value: string | Date): Date {
   return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
 }
 
+
 /** Case-folded, separator-normalised and space-padded, so a containment test
  *  matches only WHOLE tokens. Padding is what supplies the word boundaries:
  *  " prusa space gray " does not contain " pa ", where a raw substring test
@@ -343,7 +344,16 @@ export function describeItem(item: DryBoxLabelItem): string {
   const vendor = item.filamentVendor?.trim() || "";
   const type = item.filamentType?.trim() || "";
   const parts: string[] = [];
-  if (vendor && !name.toLowerCase().startsWith(vendor.toLowerCase())) parts.push(vendor);
+  // Match the vendor as WHOLE LEADING TOKENS, not a raw prefix. `startsWith`
+  // suppressed any vendor that merely began the name — "Sun" vanished from
+  // "Sunset Orange", "Pol" from "Polar White" — losing the brand from the
+  // manifest. Same prefix-collision flaw the type dedup below already had.
+  //
+  // The trade-off: "Prusa" + "Prusament PLA" now renders "Prusa Prusament
+  // PLA" rather than suppressing. A redundant word costs nothing; a dropped
+  // vendor loses information. The case this guard was actually written for —
+  // "Prusament" + "Prusament PLA" — still collapses correctly.
+  if (vendor && !tokenized(name).startsWith(tokenized(vendor))) parts.push(vendor);
   if (name) parts.push(name);
   if (type && !tokenized(`${vendor} ${name}`).includes(tokenized(type))) parts.push(type);
   return parts.join(" ").trim();

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -21,29 +21,105 @@
 import {
   DPI_203,
   mmToDots,
+  qrModuleCount,
   type LabelDocument,
   type LabelSpec,
   type TsplCommand,
+  type TsplEcc,
 } from "./tsplEncoder";
+
+/** Largest module size we will use. Bigger scans easier but wastes sheet. */
+const QR_MAX_CELL = 8;
+/** Below this, a 203 dpi thermal print is unreliable to scan in a garage. */
+const QR_MIN_CELL = 4;
+/** Right-hand margin kept clear of the printable edge. */
+const EDGE_MARGIN = 8;
+/** Advance width in dots of TSPL internal font "3" (16x24). */
+const FONT3_WIDTH = 16;
+
+export interface FittedQr {
+  ecc: TsplEcc;
+  cell: number;
+  sizeDots: number;
+}
+
+/**
+ * Choose the ECC level and module size for a QR that must fit `maxDots`.
+ *
+ * A `QRCODE` command's printed size is NOT implied by its arguments — the
+ * firmware picks the symbol version from the payload at print time. Hardcoding
+ * a cell size therefore prints a symbol whose dimensions depend on the data:
+ * the 16-byte payload in the original fixture is 29 modules, but a real deep
+ * link is 67 bytes and 49 modules, which at the fixture's cell 7 runs 104 dots
+ * past the edge of 100mm stock and simply isn't printed.
+ *
+ * Prefers the STRONGEST error correction that still prints at a scannable
+ * module size — a dry-box label gets handled, smudged and scanned in a
+ * workshop, so ECC earns its space — and steps down only when geometry
+ * forces it. That is the trade-off the handoff spec calls for ("beyond ~60
+ * characters, drop to ECC M and document the tradeoff").
+ */
+export function fitQr(payload: string, maxDots: number): FittedQr {
+  let best: FittedQr | null = null;
+  for (const ecc of ["H", "Q", "M", "L"] as const) {
+    const modules = qrModuleCount(payload, ecc);
+    if (modules == null) continue;
+    const cell = Math.min(QR_MAX_CELL, Math.floor(maxDots / modules));
+    if (cell < 1) continue;
+    const candidate: FittedQr = { ecc, cell, sizeDots: modules * cell };
+    // First (strongest) ECC that reaches a readable module size wins.
+    if (cell >= QR_MIN_CELL) return candidate;
+    if (!best || candidate.cell > best.cell) best = candidate;
+  }
+  if (!best) {
+    throw new Error(
+      `QR payload is too long to print in ${maxDots} dots (${payload.length} chars). ` +
+        `Shorten the deep link or use a larger label.`,
+    );
+  }
+  return best;
+}
+
+/**
+ * Truncate a manifest row to what actually fits the sheet.
+ *
+ * TSPL `TEXT` does not wrap and does not clip — it just runs off the edge, so
+ * an over-long spool label silently loses its tail with no indication. An
+ * explicit "..." at least shows the row was cut.
+ */
+export function fitRowText(text: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
+  if (text.length <= maxChars) return text;
+  if (maxChars <= 3) return text.slice(0, maxChars);
+  return `${text.slice(0, maxChars - 3)}...`;
+}
+
+/** How many font-3 characters fit on a manifest row for this stock. */
+export function maxRowChars(spec: LabelSpec): number {
+  const usable = mmToDots(spec.widthMm, spec.dpi) - DRY_BOX_LAYOUT.rows.x - EDGE_MARGIN;
+  return Math.max(0, Math.floor(usable / FONT3_WIDTH));
+}
 
 /**
  * Layout geometry, in dots at 203 dpi, kept in one object so the label can be
  * tuned without hunting through the builder.
  *
- * Values below y=640 are derived rather than fixed: the footer is pinned to
- * the bottom of whatever stock is configured so the contents list gets every
- * remaining row.
+ * Only the header block is fixed. Everything below it is DERIVED, because the
+ * QR's printed size depends on the payload (see fitQr) — a fixed contents
+ * position would either collide with a large QR or waste a band of sheet
+ * under a small one.
  */
 export const DRY_BOX_LAYOUT = {
-  /** Header box enclosing the location name + QR. */
-  headerBox: { x0: 16, y0: 16, x1: 796, y1: 180, thickness: 5 },
+  headerBox: { x0: 16, y0: 16, x1: 796, thickness: 5, minBottom: 180 },
   name: { x: 40, y: 50, font: "5" as const },
   subtitle: { x: 40, y: 130, font: "3" as const },
-  qr: { x: 560, y: 40, cell: 7, ecc: "H" as const },
-  contentsHeading: { x: 40, y: 230, font: "3" as const },
-  contentsRule: { x: 40, y: 268, width: 740, height: 3 },
-  /** First contents row, and the vertical pitch between rows. */
-  rows: { x: 56, firstY: 290, pitch: 40, font: "3" as const },
+  /** QR origin, and the tallest square region it may occupy. */
+  qr: { x: 560, y: 40, maxRegion: 300 },
+  /** Offsets below the header box for the contents block. */
+  headingOffset: 50,
+  ruleOffset: 88,
+  rowsOffset: 110,
+  rows: { x: 56, pitch: 40, font: "3" as const },
   /** Height reserved at the bottom for the footer block (rule, desiccant
    *  line, replace hint, barcode). Contents stop above this. */
   footerHeight: 240,
@@ -163,11 +239,51 @@ export function describeItem(item: DryBoxLabelItem): string {
   return parts.join(" ").trim();
 }
 
-/** How many manifest rows fit between the contents rule and the footer. */
-export function maxContentRows(spec: LabelSpec): number {
+/** Everything about the label's geometry that depends on the stock and the
+ *  QR payload. Exported so the preview and the tests can assert placement
+ *  without re-deriving it. */
+export interface DryBoxGeometry {
+  widthDots: number;
+  heightDots: number;
+  qr: FittedQr;
+  headerBottom: number;
+  headingY: number;
+  ruleY: number;
+  firstRowY: number;
+  footerTop: number;
+  /** Manifest rows that fit between the rule and the footer. */
+  capacity: number;
+  /** Characters that fit on one manifest row. */
+  rowChars: number;
+}
+
+export function dryBoxGeometry(spec: LabelSpec, qrPayload: string): DryBoxGeometry {
+  const L = DRY_BOX_LAYOUT;
+  const widthDots = mmToDots(spec.widthMm, spec.dpi);
   const heightDots = mmToDots(spec.heightMm, spec.dpi);
-  const available = heightDots - DRY_BOX_LAYOUT.footerHeight - DRY_BOX_LAYOUT.rows.firstY;
-  return Math.max(0, Math.floor(available / DRY_BOX_LAYOUT.rows.pitch));
+
+  // The QR gets whatever square fits between its origin and the right edge,
+  // capped so a short payload doesn't swallow the sheet.
+  const qrRegion = Math.min(L.qr.maxRegion, widthDots - L.qr.x - EDGE_MARGIN);
+  const qr = fitQr(qrPayload, qrRegion);
+
+  // Grow the header box to contain the QR rather than letting it spill.
+  const headerBottom = Math.max(L.headerBox.minBottom, L.qr.y + qr.sizeDots + EDGE_MARGIN);
+  const firstRowY = headerBottom + L.rowsOffset;
+  const footerTop = heightDots - L.footerHeight;
+
+  return {
+    widthDots,
+    heightDots,
+    qr,
+    headerBottom,
+    headingY: headerBottom + L.headingOffset,
+    ruleY: headerBottom + L.ruleOffset,
+    firstRowY,
+    footerTop,
+    capacity: Math.max(0, Math.floor((footerTop - firstRowY) / L.rows.pitch)),
+    rowChars: maxRowChars(spec),
+  };
 }
 
 /**
@@ -184,116 +300,102 @@ export function dryBoxLabel(
   const spec: LabelSpec = { ...DRY_BOX_SPEC, ...input.spec };
   const fmt = input.formatDate ?? isoDate;
   const L = DRY_BOX_LAYOUT;
-  const heightDots = mmToDots(spec.heightMm, spec.dpi);
+  const g = dryBoxGeometry(spec, input.qrPayload);
+
+  const text = (
+    x: number,
+    y: number,
+    font: "2" | "3" | "5",
+    content: string,
+  ): TsplCommand => ({ kind: "text", x, y, font, rotation: 0, xScale: 1, yScale: 1, content });
 
   const commands: TsplCommand[] = [
-    { kind: "box", ...L.headerBox },
     {
-      kind: "text",
-      x: L.name.x,
-      y: L.name.y,
-      font: L.name.font,
-      rotation: 0,
-      xScale: 1,
-      yScale: 1,
-      content: input.location.name,
+      kind: "box",
+      x0: L.headerBox.x0,
+      y0: L.headerBox.y0,
+      x1: L.headerBox.x1,
+      y1: g.headerBottom,
+      thickness: L.headerBox.thickness,
     },
-    {
-      kind: "text",
-      x: L.subtitle.x,
-      y: L.subtitle.y,
-      font: L.subtitle.font,
-      rotation: 0,
-      xScale: 1,
-      yScale: 1,
-      content:
-        input.location.humidity != null
-          ? `${strings.subtitle}  ${input.location.humidity}% RH`
-          : strings.subtitle,
-    },
+    text(L.name.x, L.name.y, L.name.font, input.location.name),
+    text(
+      L.subtitle.x,
+      L.subtitle.y,
+      L.subtitle.font,
+      input.location.humidity != null
+        ? `${strings.subtitle}  ${input.location.humidity}% RH`
+        : strings.subtitle,
+    ),
     {
       kind: "qrcode",
       x: L.qr.x,
       y: L.qr.y,
-      ecc: L.qr.ecc,
-      cell: L.qr.cell,
+      ecc: g.qr.ecc,
+      cell: g.qr.cell,
       mode: "A",
       rotation: 0,
       content: input.qrPayload,
     },
+    text(
+      L.headerBox.x0 + 24,
+      g.headingY,
+      L.subtitle.font,
+      `${strings.contents}  (${strings.asOf} ${fmt(input.asOf)})`,
+    ),
     {
-      kind: "text",
-      x: L.contentsHeading.x,
-      y: L.contentsHeading.y,
-      font: L.contentsHeading.font,
-      rotation: 0,
-      xScale: 1,
-      yScale: 1,
-      content: `${strings.contents}  (${strings.asOf} ${fmt(input.asOf)})`,
+      kind: "bar",
+      x: L.footer.x,
+      y: g.ruleY,
+      width: L.footer.ruleWidth,
+      height: L.footer.ruleHeight,
     },
-    { kind: "bar", x: L.contentsRule.x, y: L.contentsRule.y, width: L.contentsRule.width, height: L.contentsRule.height },
   ];
 
   // --- contents manifest -------------------------------------------------
-  const capacity = maxContentRows(spec);
   const labels = input.items.map(describeItem).filter((s) => s.length > 0);
   const rowText: string[] = [];
   if (labels.length === 0) {
     rowText.push(strings.empty);
-  } else if (labels.length <= capacity) {
+  } else if (labels.length <= g.capacity) {
     rowText.push(...labels.map((s) => `- ${s}`));
   } else {
     // Reserve the final row for the overflow count so the label never
     // implies it is showing everything.
-    const shown = Math.max(0, capacity - 1);
+    const shown = Math.max(0, g.capacity - 1);
     rowText.push(...labels.slice(0, shown).map((s) => `- ${s}`));
     rowText.push(strings.more.replace("{count}", String(labels.length - shown)));
   }
   rowText.forEach((content, i) => {
-    commands.push({
-      kind: "text",
-      x: L.rows.x,
-      y: L.rows.firstY + i * L.rows.pitch,
-      font: L.rows.font,
-      rotation: 0,
-      xScale: 1,
-      yScale: 1,
-      content,
-    });
+    commands.push(
+      text(L.rows.x, g.firstRowY + i * L.rows.pitch, L.rows.font, fitRowText(content, g.rowChars)),
+    );
   });
 
   // --- footer, pinned to the bottom of the stock -------------------------
-  const footerTop = heightDots - L.footerHeight;
   const desiccant = input.location.desiccantChangedAt
     ? fmt(new Date(input.location.desiccantChangedAt))
     : strings.desiccantNever;
 
   commands.push(
-    { kind: "bar", x: L.footer.x, y: footerTop, width: L.footer.ruleWidth, height: L.footer.ruleHeight },
     {
-      kind: "text",
+      kind: "bar",
       x: L.footer.x,
-      y: footerTop + 20,
-      font: L.footer.font,
-      rotation: 0,
-      xScale: 1,
-      yScale: 1,
-      content: `${strings.desiccantChanged}  ${desiccant}`,
+      y: g.footerTop,
+      width: L.footer.ruleWidth,
+      height: L.footer.ruleHeight,
     },
-    {
-      kind: "text",
-      x: L.footer.x,
-      y: footerTop + 64,
-      font: L.footer.hintFont,
-      rotation: 0,
-      xScale: 1,
-      yScale: 1,
-      content: strings.replaceHint,
-    },
+    text(
+      L.footer.x,
+      g.footerTop + 20,
+      L.footer.font,
+      fitRowText(`${strings.desiccantChanged}  ${desiccant}`, g.rowChars),
+    ),
+    text(L.footer.x, g.footerTop + 64, L.footer.hintFont, strings.replaceHint),
     {
       kind: "barcode",
       x: L.footer.x,
-      y: footerTop + 120,
+      y: g.footerTop + 120,
       symbology: "128",
       height: L.footer.barcode.height,
       humanReadable: 1,

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -63,24 +63,23 @@ export interface FittedQr {
  * characters, drop to ECC M and document the tradeoff").
  */
 export function fitQr(payload: string, maxDots: number): FittedQr {
-  let best: FittedQr | null = null;
   for (const ecc of ["H", "Q", "M", "L"] as const) {
     const modules = qrModuleCount(payload, ecc);
     if (modules == null) continue;
-    const cell = Math.min(QR_MAX_CELL, Math.floor(maxDots / modules));
-    if (cell < 1) continue;
-    const candidate: FittedQr = { ecc, cell, sizeDots: modules * cell };
     // First (strongest) ECC that reaches a readable module size wins.
-    if (cell >= QR_MIN_CELL) return candidate;
-    if (!best || candidate.cell > best.cell) best = candidate;
+    const cell = Math.min(QR_MAX_CELL, Math.floor(maxDots / modules));
+    if (cell >= QR_MIN_CELL) return { ecc, cell, sizeDots: modules * cell };
   }
-  if (!best) {
-    throw new Error(
-      `QR payload is too long to print in ${maxDots} dots (${payload.length} chars). ` +
-        `Shorten the deep link or use a larger label.`,
-    );
-  }
-  return best;
+  // QR_MIN_CELL is a floor, not a preference. Returning a 2- or 3-dot symbol
+  // "so something prints" hands the user a label whose QR does not scan at
+  // 203 dpi — indistinguishable from a working one until they try it. A
+  // payload that cannot reach the floor at ANY ECC level is too long for this
+  // label, and saying so is more useful than printing decoration.
+  throw new Error(
+    `QR payload is too long to print legibly in ${maxDots} dots ` +
+      `(${payload.length} chars needs modules under ${QR_MIN_CELL} dots at every ECC level). ` +
+      `Shorten the deep link or use a larger label.`,
+  );
 }
 
 /**
@@ -253,8 +252,26 @@ export const DEFAULT_DRY_BOX_STRINGS: DryBoxLabelStrings = {
   asOf: "as of",
 };
 
+/** Default formatter: ISO `YYYY-MM-DD` from LOCAL components, so it agrees
+ *  with an injected locale-aware formatter rather than disagreeing by a day. */
 function isoDate(date: Date): string {
-  return date.toISOString().slice(0, 10);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/**
+ * Re-anchor a stored calendar date to local midnight.
+ *
+ * `desiccantChangedAt` comes from a `<input type="date">` and is stored as
+ * midnight UTC, so handing that instant to any local-time formatter renders
+ * the PREVIOUS day for every user west of UTC. This repo has already been
+ * bitten by exactly that (v1.60.1 added a `timeZone` option to formatDate for
+ * the analytics day labels). Re-anchoring keeps the calendar day intact no
+ * matter which formatter the caller injects.
+ */
+function toCalendarDate(value: string | Date): Date {
+  const d = new Date(value);
+  return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
 }
 
 /** Case-folded, separator-normalised and space-padded, so a containment test
@@ -317,6 +334,10 @@ export interface DryBoxGeometry {
   nameChars: number;
   /** Characters of the subtitle that fit before the QR column. */
   subtitleChars: number;
+  /** Right edge of the header box, derived from the stock width. */
+  headerRight: number;
+  /** Width of the contents and footer rules, derived from the stock width. */
+  ruleWidth: number;
 }
 
 export function dryBoxGeometry(spec: LabelSpec, qrPayload: string): DryBoxGeometry {
@@ -326,18 +347,45 @@ export function dryBoxGeometry(spec: LabelSpec, qrPayload: string): DryBoxGeomet
 
   // The QR gets whatever square fits between its origin and the right edge,
   // capped so a short payload doesn't swallow the sheet.
-  const qrRegion = Math.min(L.qr.maxRegion, widthDots - L.qr.x - EDGE_MARGIN);
+  // Bound the QR by BOTH axes. Sizing off width alone let wide-but-short
+  // stock (120x70mm) grow a 287-dot symbol that pushed the header past the
+  // footer and turned a printable label into an error; shrinking the symbol
+  // to the available height is the more useful outcome.
+  const qrRegion = Math.min(
+    L.qr.maxRegion,
+    widthDots - L.qr.x - EDGE_MARGIN,
+    heightDots - L.footerHeight - L.qr.y - EDGE_MARGIN,
+  );
+  if (qrRegion < 1) {
+    throw new Error(
+      `Stock is too small for a dry-box label ` +
+        `(${spec.widthMm}x${spec.heightMm}mm leaves no room for the QR).`,
+    );
+  }
   const qr = fitQr(qrPayload, qrRegion);
 
   // Grow the header box to contain the QR rather than letting it spill.
   const headerBottom = Math.max(L.headerBox.minBottom, L.qr.y + qr.sizeDots + EDGE_MARGIN);
   const firstRowY = headerBottom + L.rowsOffset;
   const footerTop = heightDots - L.footerHeight;
+  // Without this the footer lands at a NEGATIVE y on very short stock (20mm
+  // gives 160 - 240 = -80) and the label is emitted with off-sheet
+  // coordinates instead of a diagnosable error.
+  if (footerTop <= headerBottom) {
+    throw new Error(
+      `Stock is too short for a dry-box label (${spec.heightMm}mm leaves no room ` +
+        `between the header and the footer).`,
+    );
+  }
 
   return {
     widthDots,
     heightDots,
     qr,
+    // Decorations are DERIVED from the stock, not fixed: the fixture's
+    // x1=796 header box and 740-dot rules overflow 90mm stock (719 dots).
+    headerRight: widthDots - EDGE_MARGIN,
+    ruleWidth: widthDots - 2 * L.footer.x,
     headerBottom,
     headingY: headerBottom + L.headingOffset,
     ruleY: headerBottom + L.ruleOffset,
@@ -391,7 +439,7 @@ export function dryBoxLabel(
       kind: "box",
       x0: L.headerBox.x0,
       y0: L.headerBox.y0,
-      x1: L.headerBox.x1,
+      x1: g.headerRight,
       y1: g.headerBottom,
       thickness: L.headerBox.thickness,
     },
@@ -435,7 +483,7 @@ export function dryBoxLabel(
         kind: "bar",
         x: L.footer.x,
         y: g.ruleY,
-        width: L.footer.ruleWidth,
+        width: g.ruleWidth,
         height: L.footer.ruleHeight,
       },
     );
@@ -465,7 +513,7 @@ export function dryBoxLabel(
 
   // --- footer, pinned to the bottom of the stock -------------------------
   const desiccant = input.location.desiccantChangedAt
-    ? fmt(new Date(input.location.desiccantChangedAt))
+    ? fmt(toCalendarDate(input.location.desiccantChangedAt))
     : strings.desiccantNever;
 
   commands.push(
@@ -473,7 +521,7 @@ export function dryBoxLabel(
       kind: "bar",
       x: L.footer.x,
       y: g.footerTop,
-      width: L.footer.ruleWidth,
+      width: g.ruleWidth,
       height: L.footer.ruleHeight,
     },
     text(

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -133,6 +133,10 @@ export function fitRowText(text: string, maxChars: number): string {
 const CODE128_FIXED_MODULES = 35;
 /** Each encoded character is 11 modules wide. */
 const CODE128_MODULES_PER_CHAR = 11;
+/** Clear modules required on EACH side of a Code 128 symbol. The QR fix one
+ *  commit ago reserved the 2D quiet zone and left this one unreserved — same
+ *  defect, sibling symbology. */
+const CODE128_QUIET_ZONE_MODULES = 10;
 
 /**
  * Pick a bar width for a Code 128 payload, or null when it cannot fit.
@@ -145,7 +149,14 @@ const CODE128_MODULES_PER_CHAR = 11;
  * something that only appears to work. The QR still carries the identity.
  */
 export function fitBarcode(payload: string, maxDots: number): { narrow: number } | null {
-  const modules = CODE128_MODULES_PER_CHAR * payload.length + CODE128_FIXED_MODULES;
+  // Fit the FOOTPRINT — bars plus both quiet zones — not the bars alone. A
+  // scanner needs the clear space to find the symbol's edges, so a barcode
+  // whose quiet zone is clipped by the sheet edge reads as nothing while
+  // still looking printed. Exactly the QR mistake, one symbology over.
+  const modules =
+    CODE128_MODULES_PER_CHAR * payload.length +
+    CODE128_FIXED_MODULES +
+    2 * CODE128_QUIET_ZONE_MODULES;
   for (const narrow of [2, 1]) {
     if (modules * narrow <= maxDots) return { narrow };
   }
@@ -567,7 +578,8 @@ export function dryBoxLabel(
   if (bars) {
     commands.push({
       kind: "barcode",
-      x: L.footer.x,
+      // Inset by the quiet zone so the clear space is ON the sheet.
+      x: L.footer.x + CODE128_QUIET_ZONE_MODULES * bars.narrow,
       y: g.footerTop + 120,
       symbology: "128",
       height: L.footer.barcode.height,

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -1,0 +1,308 @@
+/**
+ * Dry-box label template — a Location rendered as a 4x6 TSPL label.
+ *
+ * Pure and DB-free: takes plain data, returns a `LabelDocument` for
+ * `render()` in src/lib/tsplEncoder.ts. That keeps it unit-testable and lets
+ * the renderer build an on-screen preview from the same document it prints.
+ *
+ * The layout is the hardware-verified `04_drybox_label.prn` fixture,
+ * generalized: the header block, contents rule, desiccant line and Code 128
+ * keep their proven geometry, while the contents list reflows to fill the
+ * sheet instead of being three hardcoded rows.
+ *
+ * WHY THE MANIFEST CARRIES AN "AS OF" STAMP
+ *   A printed contents list is a point-in-time snapshot and spools move. The
+ *   app already made this call for Brother spool labels — no remaining-grams
+ *   field, because a printed amount goes stale — and the same reasoning
+ *   applies here, except that for a dry box the manifest IS the point of the
+ *   label. So it prints, dated, and the QR resolves the live view.
+ */
+
+import {
+  DPI_203,
+  mmToDots,
+  type LabelDocument,
+  type LabelSpec,
+  type TsplCommand,
+} from "./tsplEncoder";
+
+/**
+ * Layout geometry, in dots at 203 dpi, kept in one object so the label can be
+ * tuned without hunting through the builder.
+ *
+ * Values below y=640 are derived rather than fixed: the footer is pinned to
+ * the bottom of whatever stock is configured so the contents list gets every
+ * remaining row.
+ */
+export const DRY_BOX_LAYOUT = {
+  /** Header box enclosing the location name + QR. */
+  headerBox: { x0: 16, y0: 16, x1: 796, y1: 180, thickness: 5 },
+  name: { x: 40, y: 50, font: "5" as const },
+  subtitle: { x: 40, y: 130, font: "3" as const },
+  qr: { x: 560, y: 40, cell: 7, ecc: "H" as const },
+  contentsHeading: { x: 40, y: 230, font: "3" as const },
+  contentsRule: { x: 40, y: 268, width: 740, height: 3 },
+  /** First contents row, and the vertical pitch between rows. */
+  rows: { x: 56, firstY: 290, pitch: 40, font: "3" as const },
+  /** Height reserved at the bottom for the footer block (rule, desiccant
+   *  line, replace hint, barcode). Contents stop above this. */
+  footerHeight: 240,
+  footer: {
+    ruleWidth: 740,
+    ruleHeight: 3,
+    x: 40,
+    font: "3" as const,
+    hintFont: "2" as const,
+    barcode: { height: 60, narrow: 2, wide: 2 },
+  },
+} as const;
+
+/** The 4x6 stock the Y813BT ships with, declared as the fixtures do. The
+ *  fixtures use 100x150mm rather than a true 4x6 (101.6x152.4mm) and print
+ *  correctly, so that is what ships as the default. */
+export const DRY_BOX_SPEC: LabelSpec = {
+  widthMm: 100,
+  heightMm: 150,
+  gapMm: 3,
+  gapOffsetMm: 0,
+  density: 8,
+  speed: 4,
+  reference: { x: 0, y: 0 },
+  direction: 1,
+  dpi: DPI_203,
+};
+
+export interface DryBoxLabelLocation {
+  name: string;
+  humidity?: number | null;
+  /** ISO string (from the API) or a Date (server-side). */
+  desiccantChangedAt?: string | Date | null;
+}
+
+/** One spool on the shelf. Field names mirror the rows
+ *  `GET /api/spools/by-location` already returns, so the caller can pass
+ *  them through without remapping. */
+export interface DryBoxLabelItem {
+  filamentName: string;
+  filamentVendor?: string | null;
+  filamentType?: string | null;
+  /** The user's own label for this spool, preferred over the filament name
+   *  when set — it is what's written on the physical roll. */
+  label?: string | null;
+}
+
+export interface DryBoxLabelInput {
+  location: DryBoxLabelLocation;
+  items: DryBoxLabelItem[];
+  /** QR payload — a deep link to the live location view. */
+  qrPayload: string;
+  /** Code 128 payload. Defaults to the location name. */
+  barcodePayload?: string;
+  /**
+   * Timestamp for the "as of" stamp.
+   *
+   * Passed in rather than read from the clock so `dryBoxLabel` stays pure and
+   * deterministic — the same input always produces the same document, which
+   * is what makes it snapshot-testable and lets the preview match the print.
+   */
+  asOf: Date;
+  /** Overrides for the label stock. */
+  spec?: Partial<LabelSpec>;
+  /**
+   * Locale-aware date formatter. Defaults to ISO `YYYY-MM-DD`.
+   *
+   * Deliberately injected: calling `toLocaleDateString` in here would make
+   * output depend on the host's locale and time zone, so the same document
+   * would render differently on the preview canvas and the print head.
+   */
+  formatDate?: (date: Date) => string;
+}
+
+/** Strings the caller supplies so the template carries no English. */
+export interface DryBoxLabelStrings {
+  subtitle: string;
+  contents: string;
+  desiccantChanged: string;
+  desiccantNever: string;
+  replaceHint: string;
+  empty: string;
+  /** Rendered with a `{count}` token when the list overflows the sheet. */
+  more: string;
+  asOf: string;
+}
+
+export const DEFAULT_DRY_BOX_STRINGS: DryBoxLabelStrings = {
+  subtitle: "FILAMENT DRY BOX",
+  contents: "CONTENTS",
+  desiccantChanged: "DESICCANT CHANGED",
+  desiccantNever: "not recorded",
+  replaceHint: "Replace every 90 days or when indicator turns pink",
+  empty: "(empty)",
+  more: "+{count} more",
+  asOf: "as of",
+};
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** One manifest line: the spool's own label when it has one, else the
+ *  filament identity. Vendor is prefixed only when it isn't already the
+ *  first word of the name, so "Prusament PLA" doesn't become
+ *  "Prusament Prusament PLA". */
+export function describeItem(item: DryBoxLabelItem): string {
+  const own = item.label?.trim();
+  if (own) return own;
+  const name = item.filamentName?.trim() || "";
+  const vendor = item.filamentVendor?.trim() || "";
+  const type = item.filamentType?.trim() || "";
+  const parts: string[] = [];
+  if (vendor && !name.toLowerCase().startsWith(vendor.toLowerCase())) parts.push(vendor);
+  if (name) parts.push(name);
+  if (type && !`${vendor} ${name}`.toLowerCase().includes(type.toLowerCase())) parts.push(type);
+  return parts.join(" ").trim();
+}
+
+/** How many manifest rows fit between the contents rule and the footer. */
+export function maxContentRows(spec: LabelSpec): number {
+  const heightDots = mmToDots(spec.heightMm, spec.dpi);
+  const available = heightDots - DRY_BOX_LAYOUT.footerHeight - DRY_BOX_LAYOUT.rows.firstY;
+  return Math.max(0, Math.floor(available / DRY_BOX_LAYOUT.rows.pitch));
+}
+
+/**
+ * Build the label document for a dry box.
+ *
+ * Overflow is reported, never silently dropped: when the shelf holds more
+ * spools than fit on the sheet, the last row reads "+N more" so the label
+ * cannot be mistaken for a complete inventory.
+ */
+export function dryBoxLabel(
+  input: DryBoxLabelInput,
+  strings: DryBoxLabelStrings = DEFAULT_DRY_BOX_STRINGS,
+): LabelDocument {
+  const spec: LabelSpec = { ...DRY_BOX_SPEC, ...input.spec };
+  const fmt = input.formatDate ?? isoDate;
+  const L = DRY_BOX_LAYOUT;
+  const heightDots = mmToDots(spec.heightMm, spec.dpi);
+
+  const commands: TsplCommand[] = [
+    { kind: "box", ...L.headerBox },
+    {
+      kind: "text",
+      x: L.name.x,
+      y: L.name.y,
+      font: L.name.font,
+      rotation: 0,
+      xScale: 1,
+      yScale: 1,
+      content: input.location.name,
+    },
+    {
+      kind: "text",
+      x: L.subtitle.x,
+      y: L.subtitle.y,
+      font: L.subtitle.font,
+      rotation: 0,
+      xScale: 1,
+      yScale: 1,
+      content:
+        input.location.humidity != null
+          ? `${strings.subtitle}  ${input.location.humidity}% RH`
+          : strings.subtitle,
+    },
+    {
+      kind: "qrcode",
+      x: L.qr.x,
+      y: L.qr.y,
+      ecc: L.qr.ecc,
+      cell: L.qr.cell,
+      mode: "A",
+      rotation: 0,
+      content: input.qrPayload,
+    },
+    {
+      kind: "text",
+      x: L.contentsHeading.x,
+      y: L.contentsHeading.y,
+      font: L.contentsHeading.font,
+      rotation: 0,
+      xScale: 1,
+      yScale: 1,
+      content: `${strings.contents}  (${strings.asOf} ${fmt(input.asOf)})`,
+    },
+    { kind: "bar", x: L.contentsRule.x, y: L.contentsRule.y, width: L.contentsRule.width, height: L.contentsRule.height },
+  ];
+
+  // --- contents manifest -------------------------------------------------
+  const capacity = maxContentRows(spec);
+  const labels = input.items.map(describeItem).filter((s) => s.length > 0);
+  const rowText: string[] = [];
+  if (labels.length === 0) {
+    rowText.push(strings.empty);
+  } else if (labels.length <= capacity) {
+    rowText.push(...labels.map((s) => `- ${s}`));
+  } else {
+    // Reserve the final row for the overflow count so the label never
+    // implies it is showing everything.
+    const shown = Math.max(0, capacity - 1);
+    rowText.push(...labels.slice(0, shown).map((s) => `- ${s}`));
+    rowText.push(strings.more.replace("{count}", String(labels.length - shown)));
+  }
+  rowText.forEach((content, i) => {
+    commands.push({
+      kind: "text",
+      x: L.rows.x,
+      y: L.rows.firstY + i * L.rows.pitch,
+      font: L.rows.font,
+      rotation: 0,
+      xScale: 1,
+      yScale: 1,
+      content,
+    });
+  });
+
+  // --- footer, pinned to the bottom of the stock -------------------------
+  const footerTop = heightDots - L.footerHeight;
+  const desiccant = input.location.desiccantChangedAt
+    ? fmt(new Date(input.location.desiccantChangedAt))
+    : strings.desiccantNever;
+
+  commands.push(
+    { kind: "bar", x: L.footer.x, y: footerTop, width: L.footer.ruleWidth, height: L.footer.ruleHeight },
+    {
+      kind: "text",
+      x: L.footer.x,
+      y: footerTop + 20,
+      font: L.footer.font,
+      rotation: 0,
+      xScale: 1,
+      yScale: 1,
+      content: `${strings.desiccantChanged}  ${desiccant}`,
+    },
+    {
+      kind: "text",
+      x: L.footer.x,
+      y: footerTop + 64,
+      font: L.footer.hintFont,
+      rotation: 0,
+      xScale: 1,
+      yScale: 1,
+      content: strings.replaceHint,
+    },
+    {
+      kind: "barcode",
+      x: L.footer.x,
+      y: footerTop + 120,
+      symbology: "128",
+      height: L.footer.barcode.height,
+      humanReadable: 1,
+      rotation: 0,
+      narrow: L.footer.barcode.narrow,
+      wide: L.footer.barcode.wide,
+      content: input.barcodePayload ?? input.location.name,
+    },
+  );
+
+  return { spec, commands };
+}

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -36,6 +36,8 @@ const QR_MIN_CELL = 4;
 const EDGE_MARGIN = 8;
 /** Advance width in dots of TSPL internal font "3" (16x24). */
 const FONT3_WIDTH = 16;
+/** Advance width in dots of TSPL internal font "5" (32x48). */
+const FONT5_WIDTH = 32;
 
 export interface FittedQr {
   ecc: TsplEcc;
@@ -222,10 +224,27 @@ function isoDate(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+/** Case-folded, separator-normalised and space-padded, so a containment test
+ *  matches only WHOLE tokens. Padding is what supplies the word boundaries:
+ *  " prusa space gray " does not contain " pa ", where a raw substring test
+ *  would find the "pa" inside "space". */
+function tokenized(value: string): string {
+  return ` ${value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim()} `;
+}
+
 /** One manifest line: the spool's own label when it has one, else the
  *  filament identity. Vendor is prefixed only when it isn't already the
  *  first word of the name, so "Prusament PLA" doesn't become
- *  "Prusament Prusament PLA". */
+ *  "Prusament Prusament PLA".
+ *
+ *  The type dedup matches WHOLE TOKENS, not substrings. A bare
+ *  `includes(type)` silently swallowed short material codes that happen to
+ *  occur inside a colour or vendor word — "Prusa Space Gray" + "PA" printed
+ *  without its material, as did "Papaya"/PA, "Sapphire"/PP and
+ *  "Petrol Blue"/PET. On a dry-box manifest the material is the one thing a
+ *  glance needs, so dropping it is the worst available failure. Normalising
+ *  separators also keeps hyphenated types like "PC-ABS" matching a
+ *  "PC ABS" name. */
 export function describeItem(item: DryBoxLabelItem): string {
   const own = item.label?.trim();
   if (own) return own;
@@ -235,7 +254,7 @@ export function describeItem(item: DryBoxLabelItem): string {
   const parts: string[] = [];
   if (vendor && !name.toLowerCase().startsWith(vendor.toLowerCase())) parts.push(vendor);
   if (name) parts.push(name);
-  if (type && !`${vendor} ${name}`.toLowerCase().includes(type.toLowerCase())) parts.push(type);
+  if (type && !tokenized(`${vendor} ${name}`).includes(tokenized(type))) parts.push(type);
   return parts.join(" ").trim();
 }
 
@@ -255,6 +274,10 @@ export interface DryBoxGeometry {
   capacity: number;
   /** Characters that fit on one manifest row. */
   rowChars: number;
+  /** Characters of the location name that fit before the QR column. */
+  nameChars: number;
+  /** Characters of the subtitle that fit before the QR column. */
+  subtitleChars: number;
 }
 
 export function dryBoxGeometry(spec: LabelSpec, qrPayload: string): DryBoxGeometry {
@@ -283,6 +306,11 @@ export function dryBoxGeometry(spec: LabelSpec, qrPayload: string): DryBoxGeomet
     footerTop,
     capacity: Math.max(0, Math.floor((footerTop - firstRowY) / L.rows.pitch)),
     rowChars: maxRowChars(spec),
+    // The header's two text fields share their row with the QR, so they get
+    // their own budget ending at the QR column — the manifest's full-width
+    // budget would let a normal location name overprint the symbol.
+    nameChars: Math.max(0, Math.floor((L.qr.x - L.name.x - EDGE_MARGIN) / FONT5_WIDTH)),
+    subtitleChars: Math.max(0, Math.floor((L.qr.x - L.subtitle.x - EDGE_MARGIN) / FONT3_WIDTH)),
   };
 }
 
@@ -318,14 +346,17 @@ export function dryBoxLabel(
       y1: g.headerBottom,
       thickness: L.headerBox.thickness,
     },
-    text(L.name.x, L.name.y, L.name.font, input.location.name),
+    text(L.name.x, L.name.y, L.name.font, fitRowText(input.location.name, g.nameChars)),
     text(
       L.subtitle.x,
       L.subtitle.y,
       L.subtitle.font,
-      input.location.humidity != null
-        ? `${strings.subtitle}  ${input.location.humidity}% RH`
-        : strings.subtitle,
+      fitRowText(
+        input.location.humidity != null
+          ? `${strings.subtitle}  ${input.location.humidity}% RH`
+          : strings.subtitle,
+        g.subtitleChars,
+      ),
     ),
     {
       kind: "qrcode",
@@ -355,7 +386,11 @@ export function dryBoxLabel(
   // --- contents manifest -------------------------------------------------
   const labels = input.items.map(describeItem).filter((s) => s.length > 0);
   const rowText: string[] = [];
-  if (labels.length === 0) {
+  if (g.capacity === 0) {
+    // Stock too short for even one row. Emitting one anyway would print it
+    // over the footer rule and barcode; better to show no manifest than a
+    // corrupted one.
+  } else if (labels.length === 0) {
     rowText.push(strings.empty);
   } else if (labels.length <= g.capacity) {
     rowText.push(...labels.map((s) => `- ${s}`));

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -106,6 +106,29 @@ export function fitRowText(text: string, maxChars: number): string {
   return `${printed.slice(0, maxChars - 3)}...`;
 }
 
+/** Code 128 overhead in modules: start (11) + checksum (11) + stop (13). */
+const CODE128_FIXED_MODULES = 35;
+/** Each encoded character is 11 modules wide. */
+const CODE128_MODULES_PER_CHAR = 11;
+
+/**
+ * Pick a bar width for a Code 128 payload, or null when it cannot fit.
+ *
+ * Like the QR, a barcode's printed width is driven by its payload, and
+ * location names have no schema or form length limit — a 40-character name at
+ * the fixture's 2-dot bars is 950 dots against 751 available. A clipped
+ * Code 128 has no stop pattern, so it scans as nothing while still looking
+ * like a barcode; returning null lets the caller OMIT it rather than print
+ * something that only appears to work. The QR still carries the identity.
+ */
+export function fitBarcode(payload: string, maxDots: number): { narrow: number } | null {
+  const modules = CODE128_MODULES_PER_CHAR * payload.length + CODE128_FIXED_MODULES;
+  for (const narrow of [2, 1]) {
+    if (modules * narrow <= maxDots) return { narrow };
+  }
+  return null;
+}
+
 /** How many font-3 characters fit on a manifest row for this stock. */
 export function maxRowChars(spec: LabelSpec): number {
   const usable = mmToDots(spec.widthMm, spec.dpi) - DRY_BOX_LAYOUT.rows.x - EDGE_MARGIN;
@@ -344,7 +367,17 @@ export function dryBoxLabel(
   const spec: LabelSpec = { ...DRY_BOX_SPEC, ...input.spec };
   const fmt = input.formatDate ?? isoDate;
   const L = DRY_BOX_LAYOUT;
-  const g = dryBoxGeometry(spec, input.qrPayload);
+
+  // Sanitize EVERY payload once, here, and use the sanitized string for both
+  // sizing and emission. renderCommand sanitizes on the way out anyway, and
+  // several of those substitutions GROW the string ("GBP" for "£"), so any
+  // measurement taken against the raw input under-counts what the printer
+  // receives — twelve "£" size a 203-dot symbol and print a 259-dot one.
+  // Measuring the raw string bit the manifest rows first and then the QR; the
+  // fix is structural so a third call site cannot repeat it.
+  const qrPayload = sanitizeTsplLiteral(input.qrPayload);
+  const barcodePayload = sanitizeTsplLiteral(input.barcodePayload ?? input.location.name);
+  const g = dryBoxGeometry(spec, qrPayload);
 
   const text = (
     x: number,
@@ -382,7 +415,7 @@ export function dryBoxLabel(
       cell: g.qr.cell,
       mode: "A",
       rotation: 0,
-      content: input.qrPayload,
+      content: qrPayload,
     },
   ];
 
@@ -449,8 +482,15 @@ export function dryBoxLabel(
       L.footer.font,
       fitRowText(`${strings.desiccantChanged}  ${desiccant}`, g.rowChars),
     ),
-    text(L.footer.x, g.footerTop + 64, L.footer.hintFont, strings.replaceHint),
-    {
+    text(L.footer.x, g.footerTop + 64, L.footer.hintFont, fitRowText(strings.replaceHint, g.rowChars)),
+  );
+
+  // Omit the barcode entirely rather than print a clipped one — a Code 128
+  // without its stop pattern scans as nothing while still looking like a
+  // barcode. The QR carries the identity regardless.
+  const bars = fitBarcode(barcodePayload, g.widthDots - L.footer.x - EDGE_MARGIN);
+  if (bars) {
+    commands.push({
       kind: "barcode",
       x: L.footer.x,
       y: g.footerTop + 120,
@@ -458,11 +498,11 @@ export function dryBoxLabel(
       height: L.footer.barcode.height,
       humanReadable: 1,
       rotation: 0,
-      narrow: L.footer.barcode.narrow,
-      wide: L.footer.barcode.wide,
-      content: input.barcodePayload ?? input.location.name,
-    },
-  );
+      narrow: bars.narrow,
+      wide: bars.narrow,
+      content: barcodePayload,
+    });
+  }
 
   return { spec, commands };
 }

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -22,6 +22,7 @@ import {
   DPI_203,
   mmToDots,
   qrModuleCount,
+  sanitizeTsplLiteral,
   type LabelDocument,
   type LabelSpec,
   type TsplCommand,
@@ -88,12 +89,21 @@ export function fitQr(payload: string, maxDots: number): FittedQr {
  * TSPL `TEXT` does not wrap and does not clip — it just runs off the edge, so
  * an over-long spool label silently loses its tail with no indication. An
  * explicit "..." at least shows the row was cut.
+ *
+ * Measures the SANITIZED string, not the input. The encoder folds text to
+ * 7-bit ASCII on the way out and several of those substitutions are
+ * length-INCREASING — "ß" becomes "ss", "°" becomes "deg", "€" becomes "EUR"
+ * — so budgeting against the raw string under-counts the printed width and
+ * lets a fitted row overflow anyway. Sixteen "ß" characters print as
+ * thirty-two. Sanitisation is idempotent, so re-folding at encode time is a
+ * no-op.
  */
 export function fitRowText(text: string, maxChars: number): string {
+  const printed = sanitizeTsplLiteral(text);
   if (maxChars <= 0) return "";
-  if (text.length <= maxChars) return text;
-  if (maxChars <= 3) return text.slice(0, maxChars);
-  return `${text.slice(0, maxChars - 3)}...`;
+  if (printed.length <= maxChars) return printed;
+  if (maxChars <= 3) return printed.slice(0, maxChars);
+  return `${printed.slice(0, maxChars - 3)}...`;
 }
 
 /** How many font-3 characters fit on a manifest row for this stock. */
@@ -227,9 +237,15 @@ function isoDate(date: Date): string {
 /** Case-folded, separator-normalised and space-padded, so a containment test
  *  matches only WHOLE tokens. Padding is what supplies the word boundaries:
  *  " prusa space gray " does not contain " pa ", where a raw substring test
- *  would find the "pa" inside "space". */
+ *  would find the "pa" inside "space".
+ *
+ *  "+" survives normalisation because it is a MATERIAL DISTINCTION, not
+ *  punctuation: collapsing it made tokenized("PLA+") equal tokenized("PLA"),
+ *  so a PLA+ spool whose name mentions PLA printed as plain "PLA" and the
+ *  label understated the material. Hyphens and slashes still collapse, which
+ *  is what lets a "PC-ABS" type match a "PC ABS" name. */
 function tokenized(value: string): string {
-  return ` ${value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim()} `;
+  return ` ${value.toLowerCase().replace(/[^a-z0-9+]+/g, " ").trim()} `;
 }
 
 /** One manifest line: the spool's own label when it has one, else the
@@ -368,28 +384,35 @@ export function dryBoxLabel(
       rotation: 0,
       content: input.qrPayload,
     },
-    text(
-      L.headerBox.x0 + 24,
-      g.headingY,
-      L.subtitle.font,
-      `${strings.contents}  (${strings.asOf} ${fmt(input.asOf)})`,
-    ),
-    {
-      kind: "bar",
-      x: L.footer.x,
-      y: g.ruleY,
-      width: L.footer.ruleWidth,
-      height: L.footer.ruleHeight,
-    },
   ];
+
+  // The contents block is emitted as a UNIT — heading, rule and rows — or not
+  // at all. Suppressing only the rows still printed a "CONTENTS" heading and
+  // its rule on top of the footer on short stock (at 65mm the heading lands
+  // at y=303 against a footer starting at 279).
+  if (g.capacity > 0) {
+    commands.push(
+      text(
+        L.headerBox.x0 + 24,
+        g.headingY,
+        L.subtitle.font,
+        fitRowText(`${strings.contents}  (${strings.asOf} ${fmt(input.asOf)})`, g.rowChars),
+      ),
+      {
+        kind: "bar",
+        x: L.footer.x,
+        y: g.ruleY,
+        width: L.footer.ruleWidth,
+        height: L.footer.ruleHeight,
+      },
+    );
+  }
 
   // --- contents manifest -------------------------------------------------
   const labels = input.items.map(describeItem).filter((s) => s.length > 0);
   const rowText: string[] = [];
   if (g.capacity === 0) {
-    // Stock too short for even one row. Emitting one anyway would print it
-    // over the footer rule and barcode; better to show no manifest than a
-    // corrupted one.
+    // Stock too short for even one row — see the contents-block guard above.
   } else if (labels.length === 0) {
     rowText.push(strings.empty);
   } else if (labels.length <= g.capacity) {

--- a/src/lib/dryBoxLabel.ts
+++ b/src/lib/dryBoxLabel.ts
@@ -33,6 +33,10 @@ import {
 const QR_MAX_CELL = 8;
 /** Below this, a 203 dpi thermal print is unreliable to scan in a garage. */
 const QR_MIN_CELL = 4;
+/** Clear modules required on every side of a QR by the spec. Matches
+ *  QR_QUIET_ZONE_MODULES in src/lib/labelBitmap.ts, which passes it to the
+ *  qrcode renderer as `margin: 4` for the same reason. */
+const QR_QUIET_ZONE_MODULES = 4;
 /** Right-hand margin kept clear of the printable edge. */
 const EDGE_MARGIN = 8;
 /** Advance width in dots of TSPL internal font "3" (16x24). */
@@ -43,7 +47,12 @@ const FONT5_WIDTH = 32;
 export interface FittedQr {
   ecc: TsplEcc;
   cell: number;
+  /** The data symbol itself, excluding its quiet zone. */
   sizeDots: number;
+  /** Clear space required on EACH side. */
+  quietDots: number;
+  /** sizeDots + 2 * quietDots — the space the symbol actually needs. */
+  footprintDots: number;
 }
 
 /**
@@ -66,9 +75,24 @@ export function fitQr(payload: string, maxDots: number): FittedQr {
   for (const ecc of ["H", "Q", "M", "L"] as const) {
     const modules = qrModuleCount(payload, ecc);
     if (modules == null) continue;
+    // Fit the FOOTPRINT, not the symbol. A QR needs four clear modules on
+    // every side; sizing the data area alone lets a neighbouring border sit
+    // inside the quiet zone, which is another "prints fine, never scans"
+    // failure. Counting the quiet zone as part of what must fit makes it
+    // impossible to squeeze out.
+    const perSide = QR_QUIET_ZONE_MODULES;
+    const cell = Math.min(QR_MAX_CELL, Math.floor(maxDots / (modules + 2 * perSide)));
     // First (strongest) ECC that reaches a readable module size wins.
-    const cell = Math.min(QR_MAX_CELL, Math.floor(maxDots / modules));
-    if (cell >= QR_MIN_CELL) return { ecc, cell, sizeDots: modules * cell };
+    if (cell >= QR_MIN_CELL) {
+      const quietDots = perSide * cell;
+      return {
+        ecc,
+        cell,
+        sizeDots: modules * cell,
+        quietDots,
+        footprintDots: modules * cell + 2 * quietDots,
+      };
+    }
   }
   // QR_MIN_CELL is a floor, not a preference. Returning a 2- or 3-dot symbol
   // "so something prints" hands the user a label whose QR does not scan at
@@ -364,8 +388,9 @@ export function dryBoxGeometry(spec: LabelSpec, qrPayload: string): DryBoxGeomet
   }
   const qr = fitQr(qrPayload, qrRegion);
 
-  // Grow the header box to contain the QR rather than letting it spill.
-  const headerBottom = Math.max(L.headerBox.minBottom, L.qr.y + qr.sizeDots + EDGE_MARGIN);
+  // Grow the header box to clear the QR's FOOTPRINT, so the border never
+  // lands inside its quiet zone.
+  const headerBottom = Math.max(L.headerBox.minBottom, L.qr.y + qr.footprintDots);
   const firstRowY = headerBottom + L.rowsOffset;
   const footerTop = heightDots - L.footerHeight;
   // Without this the footer lands at a NEGATIVE y on very short stock (20mm
@@ -457,8 +482,10 @@ export function dryBoxLabel(
     ),
     {
       kind: "qrcode",
-      x: L.qr.x,
-      y: L.qr.y,
+      // L.qr.{x,y} is the FOOTPRINT origin; inset the symbol by its quiet
+      // zone so the clear space is reserved on the leading edges too.
+      x: L.qr.x + g.qr.quietDots,
+      y: L.qr.y + g.qr.quietDots,
       ecc: g.qr.ecc,
       cell: g.qr.cell,
       mode: "A",

--- a/src/lib/inventorySort.ts
+++ b/src/lib/inventorySort.ts
@@ -41,6 +41,9 @@ export interface InventoryLocation {
   name: string;
   kind: string;
   humidity: number | null;
+  /** Arrives JSON-serialized as a string on the client, as a Date in
+   *  server-side tests. */
+  desiccantChangedAt: Date | string | null;
   notes: string;
 }
 

--- a/src/lib/tsplEncoder.ts
+++ b/src/lib/tsplEncoder.ts
@@ -166,6 +166,41 @@ export interface LabelDocument {
   copies?: number;
 }
 
+/**
+ * QR byte-mode data capacity per symbol version, indexed by ECC level.
+ *
+ * Versions 1–20; a label QR past v20 has modules too fine to scan reliably
+ * off a 203 dpi thermal print anyway. Symbol side in modules is
+ * `17 + 4 * version`, so the printed size is `(17 + 4v) * cell` dots.
+ *
+ * This exists because the physical size of a `QRCODE` command is NOT implied
+ * by its arguments — it is driven by the payload length, which the firmware
+ * resolves at print time. Placing a QR without computing this prints a symbol
+ * that silently runs off the edge of the stock.
+ */
+const QR_BYTE_CAPACITY: Readonly<Record<TsplEcc, readonly number[]>> = {
+  L: [17, 32, 53, 78, 106, 134, 154, 192, 230, 271, 321, 367, 425, 458, 520, 586, 644, 718, 792, 858],
+  M: [14, 26, 42, 62, 84, 106, 122, 152, 180, 213, 251, 287, 331, 362, 412, 450, 504, 560, 624, 666],
+  Q: [11, 20, 32, 46, 60, 74, 86, 108, 130, 151, 177, 203, 241, 258, 292, 322, 364, 394, 442, 482],
+  H: [7, 14, 24, 34, 44, 58, 64, 84, 98, 119, 137, 155, 177, 194, 220, 250, 280, 310, 338, 382],
+};
+
+/**
+ * Symbol side, in modules, for a payload at the given ECC level.
+ *
+ * Returns null when the payload exceeds v20 capacity — the caller must then
+ * shorten it or drop to a weaker ECC rather than emit an unprintable symbol.
+ * Counts UTF-8 BYTES, not characters, because QR byte mode encodes bytes.
+ */
+export function qrModuleCount(payload: string, ecc: TsplEcc): number | null {
+  const bytes = new TextEncoder().encode(payload).length;
+  const table = QR_BYTE_CAPACITY[ecc];
+  for (let v = 0; v < table.length; v++) {
+    if (bytes <= table[v]) return 17 + 4 * (v + 1);
+  }
+  return null;
+}
+
 /** Thrown when a document cannot be rendered to valid TSPL. */
 export class TsplRenderError extends Error {
   constructor(message: string) {

--- a/src/lib/tsplEncoder.ts
+++ b/src/lib/tsplEncoder.ts
@@ -242,21 +242,29 @@ export function dotsToMm(dots: number, dpi: number = DPI_203): number {
 /**
  * Transliteration table for characters outside 7-bit ASCII.
  *
- * WHY TRANSLITERATE RATHER THAN PICK A CODEPAGE
- *   TSPL wants single bytes, but which byte depends on the printer's
- *   active codepage, and the two obvious candidates disagree on exactly
- *   the characters this app produces: `°` is 0xF8 in cp437 but 0xB0 in
- *   latin1, and `³` exists in latin1 (0xB3) but has NO cp437 codepoint
- *   at all. The reference generator used cp437 with errors="replace", so
- *   `mm³/s` silently degraded to `mm?/s` there.
+ * WHY TRANSLITERATE — SETTLED ON HARDWARE 2026-07-28
+ *   Originally a safe default pending a codepage probe. The probe has now
+ *   run on the Y813BT and the answer is stronger than expected: THERE IS
+ *   NO CODEPAGE TO SWITCH TO, and a raw high byte is DESTRUCTIVE.
  *
- *   All four golden fixtures are pure ASCII, so they cannot validate any
- *   encoding choice — this needs its own targeted test, and ultimately a
- *   codepage probe on hardware. Until that lands, transliterating to
- *   strict ASCII is the choice that is deterministic, testable, needs no
- *   CODEPAGE command, and cannot silently emit a byte the firmware reads
- *   as something else. Swap in a real codepage map here once the probe
- *   settles it; the rest of the emitter is unaffected.
+ *   A stage-05 probe printed `°`, `³`, `²`, `ä` and `ß` at both their
+ *   latin1 and cp437 byte values, in three blocks — with no CODEPAGE
+ *   command, after `CODEPAGE 1252`, and after `CODEPAGE 437`. Every one of
+ *   the twelve high-byte rows printed as `[` and then STOPPED: the closing
+ *   `]` never appeared. So a byte >= 0x80 inside a quoted TEXT literal
+ *   truncates the string at that point and the remainder of the line is
+ *   silently lost. The CODEPAGE commands are accepted (they did not abort
+ *   the job) and ignored — the B and C blocks failed identically to A.
+ *   The pure-ASCII control row rendered perfectly.
+ *
+ *   So folding to ASCII is not a lossy compromise, it is what prevents
+ *   DATA LOSS: without it a filament named "Grün" prints as "Gr" and drops
+ *   the rest of its row. That also makes the >= 0x80 guard in asciiBytes
+ *   genuinely load-bearing rather than a defensive nicety, and it is why
+ *   fitRowText measures the SANITIZED string — the transliteration is
+ *   mandatory, so its length changes are part of the real output.
+ *
+ *   Do not "simplify" this back to a codepage. The hardware says no.
  */
 const TRANSLITERATIONS: ReadonlyMap<string, string> = new Map([
   // Units and symbols this app actually produces.

--- a/src/models/Location.ts
+++ b/src/models/Location.ts
@@ -16,6 +16,14 @@ export interface ILocation extends Document {
   kind: string;
   /** Optional humidity reading (%RH) for dryboxes the user updates manually. */
   humidity: number | null;
+  /**
+   * When the desiccant was last changed. Meaningful for `kind: "drybox"`,
+   * where it drives the "DESICCANT CHANGED" line on a printed dry-box label
+   * and answers the only question a glance at the box can't: whether the
+   * beads are still doing anything. Null on every other kind, and optional
+   * even on dryboxes.
+   */
+  desiccantChangedAt: Date | null;
   notes: string;
   _deletedAt: Date | null;
   createdAt: Date;
@@ -28,6 +36,7 @@ const LocationSchema = new Schema<ILocation>(
     syncId: { type: String, unique: true, sparse: true, index: true },
     kind: { type: String, default: "shelf", index: true },
     humidity: { type: Number, default: null, min: 0, max: 100 },
+    desiccantChangedAt: { type: Date, default: null },
     notes: { type: String, default: "" },
     _deletedAt: { type: Date, default: null },
   },

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -128,6 +128,15 @@ interface ElectronAPI {
         detail?: string;
       }
   >;
+  /** KNAON Y813BT dry-box label printer (TSPL) — a SECOND, independent device
+   *  selection from the Brother one above. There is no `tsplPrinterListDevices`
+   *  on purpose: `labelPrinterListDevices` is printer-agnostic (it lists every
+   *  CUPS queue / usb:// device / Windows printer) and both pickers share it. */
+  tsplPrinterGetDevicePath: () => Promise<string | null>;
+  tsplPrinterSetDevicePath: (devicePath: string | null) => Promise<{ ok: boolean }>;
+  /** Bytes come from `render()` in src/lib/tsplEncoder.ts, not from the
+   *  Brother raster encoder. Serialized through IPC as a plain number[]. */
+  tsplPrinterPrint: (bytes: number[]) => Promise<{ ok: boolean }>;
 
   /** Runtime-environment flags. Used by the DevModeBanner to warn the
    *  user when their connection-mode wizard selection has no effect on

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -185,22 +185,37 @@ describe("dryBoxLabel — contents manifest", () => {
   });
 
   it("keeps every row above the footer, whatever the stock height", () => {
-    // The invariant a printed label would otherwise reveal by running rows
-    // off the bottom edge or over the barcode.
-    for (const heightMm of [100, 150, 200]) {
+    // Rows are selected STRUCTURALLY (x === rows.x is unique to manifest rows;
+    // every other text sits at x=40) rather than by a y-range filter. The
+    // previous version filtered on `y < footerTop` and then asserted
+    // `y < footerTop`, so any offending row was removed before the assertion
+    // and the test could not fail for any implementation.
+    for (const heightMm of [65, 70, 100, 150, 200]) {
       const spec = { ...DRY_BOX_SPEC, heightMm };
-      const doc = dryBoxLabel(input({ items: many(200), spec: { heightMm } }));
-      const footerTop = mmToDots(heightMm, spec.dpi) - DRY_BOX_LAYOUT.footerHeight;
       const g = dryBoxGeometry(spec, QR);
-      const rowYs = doc.commands
-        .filter((c): c is Extract<TsplCommand, { kind: "text" }> => c.kind === "text")
-        .map((c) => c.y)
-        .filter((y) => y >= g.firstRowY && y < footerTop);
-      for (const y of rowYs) expect(y).toBeLessThan(footerTop);
+      const doc = dryBoxLabel(input({ items: many(200), spec: { heightMm } }));
+      const rows = doc.commands.filter(
+        (c): c is Extract<TsplCommand, { kind: "text" }> =>
+          c.kind === "text" && c.x === DRY_BOX_LAYOUT.rows.x,
+      );
+      expect(rows.length).toBeLessThanOrEqual(g.capacity);
+      for (const r of rows) {
+        expect(r.y).toBeGreaterThanOrEqual(g.firstRowY);
+        expect(r.y).toBeLessThan(g.footerTop);
+      }
       // And the barcode stays on the sheet.
       const bc = doc.commands.find((c): c is Extract<TsplCommand, { kind: "barcode" }> => c.kind === "barcode")!;
       expect(bc.y + bc.height).toBeLessThan(mmToDots(heightMm, spec.dpi));
     }
+  });
+
+  it("emits no manifest at all on stock too short for one row", () => {
+    // 65mm leaves capacity 0. Emitting a row anyway printed it over the
+    // footer rule and barcode.
+    const g = dryBoxGeometry({ ...DRY_BOX_SPEC, heightMm: 65 }, QR);
+    expect(g.capacity).toBe(0);
+    const doc = dryBoxLabel(input({ items: many(5), spec: { heightMm: 65 } }));
+    expect(doc.commands.filter((c) => c.kind === "text" && c.x === DRY_BOX_LAYOUT.rows.x)).toHaveLength(0);
   });
 });
 
@@ -324,5 +339,62 @@ describe("fitRowText / maxRowChars", () => {
     const row = texts(doc.commands).find((s) => s.startsWith("- Q"))!;
     expect(row.length).toBeLessThanOrEqual(maxRowChars(DRY_BOX_SPEC));
     expect(row.endsWith("...")).toBe(true);
+  });
+});
+
+describe("describeItem — whole-token type dedup", () => {
+  it("keeps the material when its code merely occurs inside another word", () => {
+    // A bare substring test swallowed short material codes hiding in colour
+    // and vendor words. On a dry-box manifest the material is the one thing a
+    // glance needs, so dropping it is the worst available failure.
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "Space Gray", filamentType: "PA" }))
+      .toBe("Prusa Space Gray PA");
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "Papaya", filamentType: "PA" }))
+      .toBe("Prusa Papaya PA");
+    expect(describeItem({ filamentVendor: "Elegoo", filamentName: "Sapphire Blue", filamentType: "PP" }))
+      .toBe("Elegoo Sapphire Blue PP");
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "Petrol Blue", filamentType: "PET" }))
+      .toBe("Prusa Petrol Blue PET");
+  });
+
+  it("still drops a genuinely duplicated material token", () => {
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "PLA Galaxy", filamentType: "PLA" }))
+      .toBe("Prusa PLA Galaxy");
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "Galaxy PLA", filamentType: "pla" }))
+      .toBe("Prusa Galaxy PLA");
+  });
+
+  it("normalises separators so a hyphenated type matches a spaced name", () => {
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "PC ABS Blend", filamentType: "PC-ABS" }))
+      .toBe("Prusa PC ABS Blend");
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "Tough Blend", filamentType: "PC-ABS" }))
+      .toBe("Prusa Tough Blend PC-ABS");
+  });
+});
+
+describe("header fields share their row with the QR", () => {
+  it("truncates a long location name rather than overprinting the QR", () => {
+    // The name is font 5 (32 dots wide) at x=40 and the QR column starts at
+    // x=560, so only 16 characters fit — well inside normal naming.
+    const g = dryBoxGeometry(DRY_BOX_SPEC, QR);
+    const doc = dryBoxLabel(input({ location: { name: "Garage Cabinet Drybox #2" } }));
+    const name = texts(doc.commands)[0];
+    expect(name.length).toBeLessThanOrEqual(g.nameChars);
+    expect(name.endsWith("...")).toBe(true);
+    expect(DRY_BOX_LAYOUT.name.x + name.length * 32).toBeLessThanOrEqual(DRY_BOX_LAYOUT.qr.x);
+  });
+
+  it("truncates the subtitle too", () => {
+    const g = dryBoxGeometry(DRY_BOX_SPEC, QR);
+    const doc = dryBoxLabel(input({ location: { name: "B", humidity: 18 } }), {
+      ...DEFAULT_DRY_BOX_STRINGS,
+      subtitle: "A VERY LONG LOCALIZED SUBTITLE THAT WOULD RUN INTO THE QR",
+    });
+    const subtitle = texts(doc.commands)[1];
+    expect(subtitle.length).toBeLessThanOrEqual(g.subtitleChars);
+  });
+
+  it("leaves a short name untouched", () => {
+    expect(texts(dryBoxLabel(input()).commands)[0]).toBe("BOX-07");
   });
 });

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -687,3 +687,32 @@ describe("PR #1042 review round 6 — Code 128 quiet zone", () => {
     expect(fitBarcode("X".repeat(200), 751)).toBeNull();
   });
 });
+
+describe("PR #1042 review round 7 — vendor prefix collision", () => {
+  it("keeps a vendor that merely begins the name", () => {
+    // `startsWith` suppressed any vendor that was a raw prefix, so real
+    // brands vanished from the manifest whenever a colour name happened to
+    // start with the same letters. Same flaw the type dedup already had.
+    expect(describeItem({ filamentVendor: "Sun", filamentName: "Sunset Orange", filamentType: "PLA" }))
+      .toBe("Sun Sunset Orange PLA");
+    expect(describeItem({ filamentVendor: "Pol", filamentName: "Polar White", filamentType: "PETG" }))
+      .toBe("Pol Polar White PETG");
+  });
+
+  it("still collapses a vendor that IS the leading token", () => {
+    // The case the guard was written for.
+    expect(describeItem({ filamentVendor: "Prusament", filamentName: "Prusament PLA", filamentType: "PLA" }))
+      .toBe("Prusament PLA");
+    // Multi-word vendors collapse too. No type here, so the assertion
+    // isolates the vendor rule rather than mixing in the type dedup.
+    expect(describeItem({ filamentVendor: "Fiberon PA6", filamentName: "Fiberon PA6 CF20" }))
+      .toBe("Fiberon PA6 CF20");
+  });
+
+  it("prefers a redundant word over a lost brand", () => {
+    // "Prusa" + "Prusament PLA" is a partial-token match. Repeating is
+    // cosmetic; dropping the vendor loses information the manifest needs.
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "Prusament PLA", filamentType: "PLA" }))
+      .toBe("Prusa Prusament PLA");
+  });
+});

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -25,7 +25,10 @@ import { render, mmToDots, sanitizeTsplLiteral, qrModuleCount, type TsplCommand 
  * running off the bottom of the stock.
  */
 
-const AS_OF = new Date("2026-07-28T12:00:00.000Z");
+// Local noon, not a UTC instant: isoDate reads LOCAL components so that it
+// agrees with an injected locale formatter, and a UTC literal would make
+// this expectation timezone-dependent.
+const AS_OF = new Date(2026, 6, 28, 12, 0, 0);
 const QR = "https://example.test/inventory?location=abc123";
 const capacityOf = (spec = DRY_BOX_SPEC, qr = QR) => dryBoxGeometry(spec, qr).capacity;
 
@@ -83,7 +86,7 @@ describe("dryBoxGeometry — capacity", () => {
 
   it("taller stock fits more rows; stock too short fits none rather than going negative", () => {
     expect(capacityOf({ ...DRY_BOX_SPEC, heightMm: 300 })).toBeGreaterThan(capacityOf());
-    expect(capacityOf({ ...DRY_BOX_SPEC, heightMm: 20 })).toBe(0);
+    expect(() => capacityOf({ ...DRY_BOX_SPEC, heightMm: 20 })).toThrow(/too small|too short/);
   });
 
   it("keeps the QR inside the sheet and the header box for any payload length", () => {
@@ -242,7 +245,7 @@ describe("dryBoxLabel — dates", () => {
       dryBoxLabel(
         input({
           location: { name: "B", desiccantChangedAt: "2026-07-12T00:00:00.000Z" },
-          formatDate: (d) => `${d.getUTCDate()}.${d.getUTCMonth() + 1}.${d.getUTCFullYear()}`,
+          formatDate: (d) => `${d.getDate()}.${d.getMonth() + 1}.${d.getFullYear()}`,
         }),
       ).commands,
     );
@@ -296,13 +299,22 @@ describe("fitQr — payload-aware sizing", () => {
     const long = "https://filament-db.example.com/inventory?location=507f1f77bcf86cd799439011&spool=507f191e810c19729de860ea";
     const fitted = fitQr(long, 160);
     expect(fitted.cell).toBeGreaterThanOrEqual(4);
-    expect(["Q", "M", "L"]).toContain(fitted.ecc);
+    expect(["H", "Q", "M", "L"]).toContain(fitted.ecc);
   });
 
   it("never returns a symbol larger than the region it was given", () => {
-    for (const dots of [60, 100, 160, 231, 300]) {
+    // Not every payload fits every region — a 46-char link needs 41 modules
+    // at H, so 164 dots minimum. The invariant is conditional: WHEN fitQr
+    // returns, the symbol fits; otherwise it throws rather than overflow.
+    for (const dots of [84, 100, 160, 231, 300]) {
       for (const payload of ["x", QR, "y".repeat(120)]) {
-        expect(fitQr(payload, dots).sizeDots).toBeLessThanOrEqual(dots);
+        let fitted: ReturnType<typeof fitQr> | null = null;
+        try {
+          fitted = fitQr(payload, dots);
+        } catch {
+          fitted = null; // too long for this region — the documented outcome
+        }
+        if (fitted) expect(fitted.sizeDots).toBeLessThanOrEqual(dots);
       }
     }
   });
@@ -506,6 +518,77 @@ describe("fitBarcode", () => {
       expect(DRY_BOX_LAYOUT.footer.x + modules * bc.narrow).toBeLessThanOrEqual(
         mmToDots(DRY_BOX_SPEC.widthMm, DRY_BOX_SPEC.dpi),
       );
+    }
+  });
+});
+
+describe("PR #1042 review round 4", () => {
+  it("refuses a QR that cannot reach the readable module floor", () => {
+    // QR_MIN_CELL is a floor, not a preference. A 2- or 3-dot symbol at
+    // 203 dpi does not scan, and a label carrying one is indistinguishable
+    // from a working label until the user tries it.
+    expect(() => fitQr("x".repeat(400), 231)).toThrow(/too long to print legibly/);
+    // Still fits comfortably at realistic deep-link lengths.
+    expect(fitQr(QR, 231).cell).toBeGreaterThanOrEqual(4);
+  });
+
+  it("renders the desiccant calendar date without a timezone shift", () => {
+    // Stored as midnight UTC by the date input; handing that instant to a
+    // local-time formatter renders the PREVIOUS day west of UTC. This repo
+    // hit exactly that in v1.60.1's analytics day labels.
+    const out = texts(
+      dryBoxLabel(input({
+        location: { name: "B", desiccantChangedAt: "2026-07-12T00:00:00.000Z" },
+        formatDate: (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`,
+      })).commands,
+    );
+    expect(out).toContain("DESICCANT CHANGED  2026-07-12");
+  });
+
+  it("rejects stock with no room between header and footer", () => {
+    // 20mm gives footerTop = 160 - 240 = -80; the label was previously
+    // emitted with off-sheet negative coordinates. Now that the QR is bounded
+    // on both axes this trips the size check first — either message is a
+    // diagnosable refusal, which is the point.
+    expect(() => dryBoxLabel(input({ spec: { heightMm: 20 } }))).toThrow(/too small|too short/);
+    expect(() => dryBoxLabel(input({ spec: { widthMm: 60 } }))).toThrow(/too small|too short/);
+    // The footer guard has its own narrow window: a SHORT payload shrinks the
+    // QR fine, but the 180-dot minimum header still overruns the footer on
+    // mid-height stock. 50mm is that case; 55mm clears it.
+    expect(() => dryBoxLabel(input({ qrPayload: "x", spec: { heightMm: 50 } })))
+      .toThrow(/too short/);
+    expect(() => dryBoxLabel(input({ qrPayload: "x", spec: { heightMm: 55 } }))).not.toThrow();
+  });
+
+  it("derives header box and rules from the stock width", () => {
+    // The fixture's fixed x1=796 header box and 740-dot rules overflow 90mm
+    // stock, which is only 719 dots wide.
+    for (const widthMm of [90, 100, 120]) {
+      const doc = dryBoxLabel(input({ spec: { widthMm } }));
+      const dots = mmToDots(widthMm, DRY_BOX_SPEC.dpi);
+      const box = doc.commands.find((c): c is Extract<TsplCommand, { kind: "box" }> => c.kind === "box")!;
+      expect(box.x1).toBeLessThanOrEqual(dots);
+      for (const bar of doc.commands.filter((c): c is Extract<TsplCommand, { kind: "bar" }> => c.kind === "bar")) {
+        expect(bar.x + bar.width).toBeLessThanOrEqual(dots);
+      }
+    }
+  });
+
+  it("emits no negative coordinates on any supported stock", () => {
+    for (const widthMm of [90, 100, 120]) {
+      for (const heightMm of [70, 100, 150, 200]) {
+        const doc = dryBoxLabel(input({ items: [{ filamentName: "PLA" }], spec: { widthMm, heightMm } }));
+        for (const c of doc.commands) {
+          for (const v of [
+            (c as { x?: number }).x,
+            (c as { y?: number }).y,
+            (c as { x0?: number }).x0,
+            (c as { y0?: number }).y0,
+          ]) {
+            if (v !== undefined) expect(v).toBeGreaterThanOrEqual(0);
+          }
+        }
+      }
     }
   });
 });

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -297,9 +297,14 @@ describe("fitQr — payload-aware sizing", () => {
     // modules; dropping ECC keeps the symbol scannable instead. This is the
     // trade-off the handoff spec calls for past ~60 characters.
     const long = "https://filament-db.example.com/inventory?location=507f1f77bcf86cd799439011&spool=507f191e810c19729de860ea";
-    const fitted = fitQr(long, 160);
+    // 200 dots: H needs a 260-dot footprint at the 4-dot floor, so it steps
+    // down to M, which fits in 196. (The numbers moved when the quiet zone
+    // became part of the footprint — the behaviour did not.)
+    const fitted = fitQr(long, 200);
     expect(fitted.cell).toBeGreaterThanOrEqual(4);
-    expect(["H", "Q", "M", "L"]).toContain(fitted.ecc);
+    expect(fitted.ecc).toBe("M");
+    // Given more room it keeps the stronger correction.
+    expect(fitQr(long, 260).ecc).toBe("H");
   });
 
   it("never returns a symbol larger than the region it was given", () => {
@@ -553,11 +558,12 @@ describe("PR #1042 review round 4", () => {
     expect(() => dryBoxLabel(input({ spec: { heightMm: 20 } }))).toThrow(/too small|too short/);
     expect(() => dryBoxLabel(input({ spec: { widthMm: 60 } }))).toThrow(/too small|too short/);
     // The footer guard has its own narrow window: a SHORT payload shrinks the
-    // QR fine, but the 180-dot minimum header still overruns the footer on
-    // mid-height stock. 50mm is that case; 55mm clears it.
-    expect(() => dryBoxLabel(input({ qrPayload: "x", spec: { heightMm: 50 } })))
+    // QR fine, but the 180-dot MINIMUM header still overruns the footer.
+    // Reserving the quiet zone narrowed it to roughly 52-53mm — below that
+    // the QR itself can no longer fit, above it the header clears.
+    expect(() => dryBoxLabel(input({ qrPayload: "x", spec: { heightMm: 52 } })))
       .toThrow(/too short/);
-    expect(() => dryBoxLabel(input({ qrPayload: "x", spec: { heightMm: 55 } }))).not.toThrow();
+    expect(() => dryBoxLabel(input({ qrPayload: "x", spec: { heightMm: 53 } }))).not.toThrow();
   });
 
   it("derives header box and rules from the stock width", () => {
@@ -590,5 +596,56 @@ describe("PR #1042 review round 4", () => {
         }
       }
     }
+  });
+});
+
+describe("PR #1042 review round 5 — QR quiet zone", () => {
+  const symbolBox = (spec = DRY_BOX_SPEC, qr = QR) => {
+    const g = dryBoxGeometry(spec, qr);
+    const x = DRY_BOX_LAYOUT.qr.x + g.qr.quietDots;
+    const y = DRY_BOX_LAYOUT.qr.y + g.qr.quietDots;
+    return { g, x, y, right: x + g.qr.sizeDots, bottom: y + g.qr.sizeDots };
+  };
+
+  it("reserves four clear modules on every side of the symbol", () => {
+    // A QR with an intruded quiet zone is the same failure class as one
+    // clipped at the edge: it prints, it looks correct, and it never scans.
+    // src/lib/labelBitmap.ts already reserves this via `margin: 4`.
+    for (const widthMm of [100, 120]) {
+      for (const heightMm of [100, 150, 200]) {
+        const spec = { ...DRY_BOX_SPEC, widthMm, heightMm };
+        const { g, x, y, right, bottom } = symbolBox(spec);
+        const q = g.qr.quietDots;
+        expect(q).toBe(4 * g.qr.cell);
+        expect(g.headerBottom - bottom).toBeGreaterThanOrEqual(q);
+        expect(g.headerRight - right).toBeGreaterThanOrEqual(q);
+        expect(y - DRY_BOX_LAYOUT.headerBox.y0).toBeGreaterThanOrEqual(q);
+        expect(x - DRY_BOX_LAYOUT.headerBox.x0).toBeGreaterThanOrEqual(q);
+      }
+    }
+  });
+
+  it("emits the symbol inset by its quiet zone, not at the footprint origin", () => {
+    const { g } = symbolBox();
+    const qr = dryBoxLabel(input()).commands.find(
+      (c): c is Extract<TsplCommand, { kind: "qrcode" }> => c.kind === "qrcode",
+    )!;
+    expect(qr.x).toBe(DRY_BOX_LAYOUT.qr.x + g.qr.quietDots);
+    expect(qr.y).toBe(DRY_BOX_LAYOUT.qr.y + g.qr.quietDots);
+  });
+
+  it("counts the quiet zone as part of what must fit", () => {
+    // Sizing the data area alone let a symbol claim to fit while its clear
+    // space overflowed the region.
+    for (const dots of [200, 231, 300]) {
+      const f = fitQr(QR, dots);
+      expect(f.footprintDots).toBe(f.sizeDots + 2 * f.quietDots);
+      expect(f.footprintDots).toBeLessThanOrEqual(dots);
+    }
+  });
+
+  it("still keeps the whole footprint on the sheet", () => {
+    const { g, right } = symbolBox();
+    expect(right + g.qr.quietDots).toBeLessThanOrEqual(g.widthDots);
   });
 });

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -118,7 +118,8 @@ describe("dryBoxLabel — structure", () => {
     const job = new TextDecoder().decode(bytes);
     expect(job).toContain("SIZE 100 mm,150 mm\r\n");
     expect(job).toContain("QRCODE");
-    expect(job).toContain('BARCODE 40,');
+    // Not a hardcoded x — the barcode is inset by its quiet zone.
+    expect(job).toMatch(/BARCODE \d+,\d+,"128"/);
     expect(job.endsWith("PRINT 1,1\r\n")).toBe(true);
   });
 
@@ -647,5 +648,42 @@ describe("PR #1042 review round 5 — QR quiet zone", () => {
   it("still keeps the whole footprint on the sheet", () => {
     const { g, right } = symbolBox();
     expect(right + g.qr.quietDots).toBeLessThanOrEqual(g.widthDots);
+  });
+});
+
+describe("PR #1042 review round 6 — Code 128 quiet zone", () => {
+  const CODE128_QUIET_MODULES = 10;
+  const modulesFor = (payload: string) => 11 * payload.length + 35;
+
+  it("reserves 10 clear modules on each side when fitting", () => {
+    // The QR fix one commit earlier reserved the 2D quiet zone and left this
+    // one unreserved — same defect, sibling symbology. A 27-character payload
+    // on 90mm stock fits on bars alone (664 of 671 dots) but needs 704 with
+    // its quiet zones, so 2-dot bars must be refused in favour of 1.
+    const avail = mmToDots(90, DRY_BOX_SPEC.dpi) - DRY_BOX_LAYOUT.footer.x - 8;
+    const payload = "X".repeat(27);
+    expect(modulesFor(payload) * 2).toBeLessThanOrEqual(avail); // bars alone fit
+    expect(fitBarcode(payload, avail)).toEqual({ narrow: 1 }); // footprint does not
+  });
+
+  it("keeps both quiet zones on the sheet for every stock width", () => {
+    for (const widthMm of [90, 100, 120]) {
+      for (const nameLen of [1, 6, 20, 27, 40]) {
+        const doc = dryBoxLabel(input({ location: { name: "X".repeat(nameLen) }, spec: { widthMm } }));
+        const bc = doc.commands.find((c): c is Extract<TsplCommand, { kind: "barcode" }> => c.kind === "barcode");
+        if (!bc) continue; // omitted rather than clipped — also valid
+        const quiet = CODE128_QUIET_MODULES * bc.narrow;
+        // Left quiet zone sits inside the sheet, not off the edge.
+        expect(bc.x - DRY_BOX_LAYOUT.footer.x).toBeGreaterThanOrEqual(quiet);
+        // Right quiet zone ends on the sheet.
+        expect(bc.x + modulesFor(bc.content) * bc.narrow + quiet).toBeLessThanOrEqual(
+          mmToDots(widthMm, DRY_BOX_SPEC.dpi),
+        );
+      }
+    }
+  });
+
+  it("still omits the barcode outright when even 1-dot bars cannot fit", () => {
+    expect(fitBarcode("X".repeat(200), 751)).toBeNull();
   });
 });

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -12,7 +12,7 @@ import {
   type DryBoxLabelInput,
   type DryBoxLabelItem,
 } from "@/lib/dryBoxLabel";
-import { render, mmToDots, type TsplCommand } from "@/lib/tsplEncoder";
+import { render, mmToDots, sanitizeTsplLiteral, type TsplCommand } from "@/lib/tsplEncoder";
 
 /**
  * Coverage for the dry-box label template.
@@ -396,5 +396,57 @@ describe("header fields share their row with the QR", () => {
 
   it("leaves a short name untouched", () => {
     expect(texts(dryBoxLabel(input()).commands)[0]).toBe("BOX-07");
+  });
+});
+
+describe("PR #1042 review round 2", () => {
+  it("suppresses the whole contents block — heading and rule too — when nothing fits", () => {
+    // Suppressing only the rows still printed a "CONTENTS" heading and its
+    // rule on top of the footer: at 65mm the heading lands at y=303 against a
+    // footer starting at 279.
+    const g = dryBoxGeometry({ ...DRY_BOX_SPEC, heightMm: 65 }, QR);
+    expect(g.capacity).toBe(0);
+    const doc = dryBoxLabel(input({ items: [{ filamentName: "PLA" }], spec: { heightMm: 65 } }));
+    expect(texts(doc.commands).some((s) => s.includes("CONTENTS"))).toBe(false);
+    // No command anywhere may land in the footer band except the footer's own.
+    const strays = doc.commands.filter(
+      (c) => (c.kind === "text" || c.kind === "bar") && c.y >= g.headingY && c.y < g.footerTop,
+    );
+    expect(strays).toEqual([]);
+  });
+
+  it("still emits the contents block on normal stock", () => {
+    expect(texts(dryBoxLabel(input()).commands).some((s) => s.includes("CONTENTS"))).toBe(true);
+  });
+
+  it("budgets width AFTER ASCII expansion, not before", () => {
+    // The encoder folds to 7-bit ASCII on the way out and several of those
+    // substitutions GROW the string, so measuring the raw input under-counts
+    // the printed width. Sixteen "ß" print as thirty-two "s".
+    for (const raw of ["ß".repeat(16), "240°C ".repeat(6), "€".repeat(20), "±3 mm³/s"]) {
+      const fitted = fitRowText(raw, 16);
+      expect(fitted.length).toBeLessThanOrEqual(16);
+      // Already sanitized, so the encoder's own fold cannot grow it further.
+      expect(sanitizeTsplLiteral(fitted).length).toBeLessThanOrEqual(16);
+    }
+  });
+
+  it("keeps a manifest row within budget even when its text expands", () => {
+    const doc = dryBoxLabel(input({ items: [{ filamentName: "ß".repeat(60) }] }));
+    const row = texts(doc.commands).find((s) => s.startsWith("- s"))!;
+    expect(row.length).toBeLessThanOrEqual(maxRowChars(DRY_BOX_SPEC));
+  });
+
+  it("treats PLA+ as a distinct material from PLA", () => {
+    // Collapsing "+" made tokenized("PLA+") equal tokenized("PLA"), so a PLA+
+    // spool whose name mentions PLA printed as plain PLA — the label
+    // understating the material.
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "PLA Galaxy", filamentType: "PLA+" }))
+      .toBe("Prusa PLA Galaxy PLA+");
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "PLA+ Galaxy", filamentType: "PLA+" }))
+      .toBe("Prusa PLA+ Galaxy");
+    // Hyphen collapsing still works — that is what matches PC-ABS to PC ABS.
+    expect(describeItem({ filamentVendor: "Prusa", filamentName: "PC ABS Blend", filamentType: "PC-ABS" }))
+      .toBe("Prusa PC ABS Blend");
   });
 });

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   dryBoxLabel,
   describeItem,
-  maxContentRows,
+  dryBoxGeometry,
+  fitQr,
+  fitRowText,
+  maxRowChars,
   DRY_BOX_SPEC,
   DRY_BOX_LAYOUT,
   DEFAULT_DRY_BOX_STRINGS,
@@ -22,12 +25,14 @@ import { render, mmToDots, type TsplCommand } from "@/lib/tsplEncoder";
  */
 
 const AS_OF = new Date("2026-07-28T12:00:00.000Z");
+const QR = "https://example.test/inventory?location=abc123";
+const capacityOf = (spec = DRY_BOX_SPEC, qr = QR) => dryBoxGeometry(spec, qr).capacity;
 
 function input(over: Partial<DryBoxLabelInput> = {}): DryBoxLabelInput {
   return {
     location: { name: "BOX-07" },
     items: [],
-    qrPayload: "https://example.test/inventory?location=abc123",
+    qrPayload: QR,
     asOf: AS_OF,
     ...over,
   };
@@ -66,20 +71,40 @@ describe("describeItem", () => {
   });
 });
 
-describe("maxContentRows", () => {
-  it("derives capacity from the configured stock height", () => {
-    const rows = maxContentRows(DRY_BOX_SPEC);
-    const height = mmToDots(DRY_BOX_SPEC.heightMm, DRY_BOX_SPEC.dpi);
-    const available = height - DRY_BOX_LAYOUT.footerHeight - DRY_BOX_LAYOUT.rows.firstY;
-    expect(rows).toBe(Math.floor(available / DRY_BOX_LAYOUT.rows.pitch));
-    // Sanity: the whole point of reflowing is fitting well more than the
-    // three rows the original fixture hardcoded.
-    expect(rows).toBeGreaterThan(12);
+describe("dryBoxGeometry — capacity", () => {
+  it("derives capacity from the stock height and the space the QR leaves", () => {
+    const g = dryBoxGeometry(DRY_BOX_SPEC, QR);
+    expect(g.capacity).toBe(Math.floor((g.footerTop - g.firstRowY) / DRY_BOX_LAYOUT.rows.pitch));
+    // The whole point of reflowing is fitting well more than the three rows
+    // the original fixture hardcoded.
+    expect(g.capacity).toBeGreaterThan(8);
   });
 
   it("taller stock fits more rows; stock too short fits none rather than going negative", () => {
-    expect(maxContentRows({ ...DRY_BOX_SPEC, heightMm: 300 })).toBeGreaterThan(maxContentRows(DRY_BOX_SPEC));
-    expect(maxContentRows({ ...DRY_BOX_SPEC, heightMm: 20 })).toBe(0);
+    expect(capacityOf({ ...DRY_BOX_SPEC, heightMm: 300 })).toBeGreaterThan(capacityOf());
+    expect(capacityOf({ ...DRY_BOX_SPEC, heightMm: 20 })).toBe(0);
+  });
+
+  it("keeps the QR inside the sheet and the header box for any payload length", () => {
+    // The bug this guards: the fixture's cell 7 was fine for its 16-byte
+    // payload (29 modules = 203 dots) but a real 67-byte deep link is 49
+    // modules = 343 dots, which runs 104 dots past the edge of 100mm stock
+    // and simply is not printed. Note a SHORT payload can yield a LARGER
+    // symbol than a long one, because it saturates the max cell size — so
+    // the invariant is containment, not monotonicity.
+    for (const payload of [
+      "x",
+      "fdb://box/B1",
+      QR,
+      "https://filament-db.example.com/inventory?location=507f1f77bcf86cd799439011",
+      "https://filament-db.example.com/inventory?location=507f1f77bcf86cd799439011&spool=507f191e810c19729de860ea",
+    ]) {
+      const g = dryBoxGeometry(DRY_BOX_SPEC, payload);
+      expect(DRY_BOX_LAYOUT.qr.x + g.qr.sizeDots).toBeLessThanOrEqual(g.widthDots);
+      expect(DRY_BOX_LAYOUT.qr.y + g.qr.sizeDots).toBeLessThanOrEqual(g.headerBottom);
+      expect(g.capacity).toBeGreaterThan(0);
+      expect(g.firstRowY).toBeGreaterThan(g.headerBottom);
+    }
   });
 });
 
@@ -102,7 +127,7 @@ describe("dryBoxLabel — structure", () => {
     const doc = dryBoxLabel(input());
     expect(texts(doc.commands)).toContain("BOX-07");
     const qr = doc.commands.find((c) => c.kind === "qrcode");
-    expect(qr && qr.kind === "qrcode" && qr.content).toBe("https://example.test/inventory?location=abc123");
+    expect(qr && qr.kind === "qrcode" && qr.content).toBe(QR);
   });
 
   it("defaults the barcode to the location name but honours an override", () => {
@@ -145,7 +170,7 @@ describe("dryBoxLabel — contents manifest", () => {
   it("reports overflow instead of silently truncating", () => {
     // A label that shows 16 of 40 spools with no indication would read as a
     // complete inventory — the failure mode this guards.
-    const capacity = maxContentRows(DRY_BOX_SPEC);
+    const capacity = capacityOf();
     const out = texts(dryBoxLabel(input({ items: many(capacity + 10) })).commands);
     const shown = out.filter((s) => s.startsWith("- ")).length;
     expect(shown).toBe(capacity - 1);
@@ -153,7 +178,7 @@ describe("dryBoxLabel — contents manifest", () => {
   });
 
   it("fills the sheet exactly at capacity with no overflow row", () => {
-    const capacity = maxContentRows(DRY_BOX_SPEC);
+    const capacity = capacityOf();
     const out = texts(dryBoxLabel(input({ items: many(capacity) })).commands);
     expect(out.filter((s) => s.startsWith("- ")).length).toBe(capacity);
     expect(out.some((s) => s.includes("more"))).toBe(false);
@@ -166,10 +191,11 @@ describe("dryBoxLabel — contents manifest", () => {
       const spec = { ...DRY_BOX_SPEC, heightMm };
       const doc = dryBoxLabel(input({ items: many(200), spec: { heightMm } }));
       const footerTop = mmToDots(heightMm, spec.dpi) - DRY_BOX_LAYOUT.footerHeight;
+      const g = dryBoxGeometry(spec, QR);
       const rowYs = doc.commands
         .filter((c): c is Extract<TsplCommand, { kind: "text" }> => c.kind === "text")
         .map((c) => c.y)
-        .filter((y) => y >= DRY_BOX_LAYOUT.rows.firstY && y < footerTop);
+        .filter((y) => y >= g.firstRowY && y < footerTop);
       for (const y of rowYs) expect(y).toBeLessThan(footerTop);
       // And the barcode stays on the sheet.
       const bc = doc.commands.find((c): c is Extract<TsplCommand, { kind: "barcode" }> => c.kind === "barcode")!;
@@ -230,7 +256,7 @@ describe("dryBoxLabel — localization", () => {
   });
 
   it("substitutes the overflow count into the supplied template", () => {
-    const capacity = maxContentRows(DRY_BOX_SPEC);
+    const capacity = capacityOf();
     const out = texts(
       dryBoxLabel(
         input({ items: Array.from({ length: capacity + 5 }, (_, i) => ({ filamentName: `F${i}` })) }),
@@ -238,5 +264,65 @@ describe("dryBoxLabel — localization", () => {
       ).commands,
     );
     expect(out).toContain(`und ${capacity + 5 - (capacity - 1)} weitere`);
+  });
+});
+
+describe("fitQr — payload-aware sizing", () => {
+  it("prefers the strongest ECC that still prints at a scannable module size", () => {
+    // A short payload leaves room for full error correction.
+    expect(fitQr("fdb://box/B1", 231).ecc).toBe("H");
+  });
+
+  it("steps ECC down rather than shrinking modules below readability", () => {
+    // Squeezed into a small region, a long payload at H would need 2-dot
+    // modules; dropping ECC keeps the symbol scannable instead. This is the
+    // trade-off the handoff spec calls for past ~60 characters.
+    const long = "https://filament-db.example.com/inventory?location=507f1f77bcf86cd799439011&spool=507f191e810c19729de860ea";
+    const fitted = fitQr(long, 160);
+    expect(fitted.cell).toBeGreaterThanOrEqual(4);
+    expect(["Q", "M", "L"]).toContain(fitted.ecc);
+  });
+
+  it("never returns a symbol larger than the region it was given", () => {
+    for (const dots of [60, 100, 160, 231, 300]) {
+      for (const payload of ["x", QR, "y".repeat(120)]) {
+        expect(fitQr(payload, dots).sizeDots).toBeLessThanOrEqual(dots);
+      }
+    }
+  });
+
+  it("throws rather than emit an unprintable symbol", () => {
+    // Better a caught error in the dialog than a label with a QR clipped at
+    // the sheet edge that scans as nothing.
+    expect(() => fitQr("z".repeat(400), 40)).toThrow(/too long to print/);
+  });
+});
+
+describe("fitRowText / maxRowChars", () => {
+  it("computes how many font-3 characters fit the stock", () => {
+    // 799 printable dots - 56 (row x) - 8 (edge margin) = 735; / 16 = 45.
+    expect(maxRowChars(DRY_BOX_SPEC)).toBe(45);
+    expect(maxRowChars({ ...DRY_BOX_SPEC, widthMm: 200 })).toBeGreaterThan(maxRowChars(DRY_BOX_SPEC));
+  });
+
+  it("truncates with an ellipsis rather than running off the edge", () => {
+    // TSPL TEXT neither wraps nor clips — an over-long label silently loses
+    // its tail with no indication that anything was cut.
+    expect(fitRowText("short", 46)).toBe("short");
+    expect(fitRowText("x".repeat(60), 10)).toBe("xxxxxxx...");
+    expect(fitRowText("x".repeat(60), 10)).toHaveLength(10);
+  });
+
+  it("degrades sanely at tiny widths", () => {
+    expect(fitRowText("abcdef", 3)).toBe("abc");
+    expect(fitRowText("abcdef", 0)).toBe("");
+    expect(fitRowText("abcdef", -1)).toBe("");
+  });
+
+  it("truncates over-long manifest rows in a real label", () => {
+    const doc = dryBoxLabel(input({ items: [{ filamentName: "Q".repeat(200) }] }));
+    const row = texts(doc.commands).find((s) => s.startsWith("- Q"))!;
+    expect(row.length).toBeLessThanOrEqual(maxRowChars(DRY_BOX_SPEC));
+    expect(row.endsWith("...")).toBe(true);
   });
 });

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -5,6 +5,7 @@ import {
   dryBoxGeometry,
   fitQr,
   fitRowText,
+  fitBarcode,
   maxRowChars,
   DRY_BOX_SPEC,
   DRY_BOX_LAYOUT,
@@ -12,7 +13,7 @@ import {
   type DryBoxLabelInput,
   type DryBoxLabelItem,
 } from "@/lib/dryBoxLabel";
-import { render, mmToDots, sanitizeTsplLiteral, type TsplCommand } from "@/lib/tsplEncoder";
+import { render, mmToDots, sanitizeTsplLiteral, qrModuleCount, type TsplCommand } from "@/lib/tsplEncoder";
 
 /**
  * Coverage for the dry-box label template.
@@ -448,5 +449,63 @@ describe("PR #1042 review round 2", () => {
     // Hyphen collapsing still works — that is what matches PC-ABS to PC ABS.
     expect(describeItem({ filamentVendor: "Prusa", filamentName: "PC ABS Blend", filamentType: "PC-ABS" }))
       .toBe("Prusa PC ABS Blend");
+  });
+});
+
+describe("PR #1042 review round 3", () => {
+  it("sizes the QR from the SANITIZED payload the printer receives", () => {
+    // renderCommand sanitizes on the way out and some substitutions GROW the
+    // string ("GBP" for "£"), so sizing against the raw input under-counts.
+    // Twelve "£" sized a 203-dot symbol and printed a 259-dot one. This bit
+    // the manifest rows first, then the QR — hence a structural fix.
+    const payload = "£".repeat(12);
+    const g = dryBoxGeometry(DRY_BOX_SPEC, sanitizeTsplLiteral(payload));
+    const doc = dryBoxLabel(input({ qrPayload: payload }));
+    const qr = doc.commands.find((c): c is Extract<TsplCommand, { kind: "qrcode" }> => c.kind === "qrcode")!;
+    // The emitted payload is the sanitized one...
+    expect(qr.content).toBe("GBP".repeat(12));
+    // ...and the symbol it produces genuinely fits.
+    const actual = qrModuleCount(qr.content, qr.ecc)! * qr.cell;
+    expect(DRY_BOX_LAYOUT.qr.x + actual).toBeLessThanOrEqual(g.widthDots);
+    expect(actual).toBeLessThanOrEqual(g.qr.sizeDots);
+  });
+
+  it("emits the sanitized barcode payload too", () => {
+    const doc = dryBoxLabel(input({ barcodePayload: "BOX £7" }));
+    const bc = doc.commands.find((c): c is Extract<TsplCommand, { kind: "barcode" }> => c.kind === "barcode")!;
+    expect(bc.content).toBe("BOX GBP7");
+  });
+});
+
+describe("fitBarcode", () => {
+  it("uses 2-dot bars when they fit and falls back to 1", () => {
+    expect(fitBarcode("BOX-07", 751)).toEqual({ narrow: 2 });
+    // 40 chars at 2 dots is 950 dots; at 1 dot it is 475 and fits.
+    expect(fitBarcode("X".repeat(40), 751)).toEqual({ narrow: 1 });
+  });
+
+  it("returns null rather than a clipped barcode", () => {
+    // A Code 128 without its stop pattern scans as nothing while still
+    // LOOKING like a barcode — worse than no barcode at all.
+    expect(fitBarcode("X".repeat(200), 751)).toBeNull();
+  });
+
+  it("omits the barcode from the label when it cannot fit", () => {
+    const long = dryBoxLabel(input({ location: { name: "X".repeat(200) } }));
+    expect(long.commands.some((c) => c.kind === "barcode")).toBe(false);
+    // The QR still carries the identity.
+    expect(long.commands.some((c) => c.kind === "qrcode")).toBe(true);
+  });
+
+  it("keeps the barcode within the printable width for every name length", () => {
+    for (const n of [1, 6, 24, 30, 40, 60]) {
+      const doc = dryBoxLabel(input({ location: { name: "X".repeat(n) } }));
+      const bc = doc.commands.find((c): c is Extract<TsplCommand, { kind: "barcode" }> => c.kind === "barcode");
+      if (!bc) continue;
+      const modules = 11 * bc.content.length + 35;
+      expect(DRY_BOX_LAYOUT.footer.x + modules * bc.narrow).toBeLessThanOrEqual(
+        mmToDots(DRY_BOX_SPEC.widthMm, DRY_BOX_SPEC.dpi),
+      );
+    }
   });
 });

--- a/tests/dryBoxLabel.test.ts
+++ b/tests/dryBoxLabel.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import {
+  dryBoxLabel,
+  describeItem,
+  maxContentRows,
+  DRY_BOX_SPEC,
+  DRY_BOX_LAYOUT,
+  DEFAULT_DRY_BOX_STRINGS,
+  type DryBoxLabelInput,
+  type DryBoxLabelItem,
+} from "@/lib/dryBoxLabel";
+import { render, mmToDots, type TsplCommand } from "@/lib/tsplEncoder";
+
+/**
+ * Coverage for the dry-box label template.
+ *
+ * The template's job is to turn a Location plus its spools into a
+ * LabelDocument matching the hardware-verified 04_drybox_label.prn geometry,
+ * with the contents list reflowed to fill the sheet. These tests pin the
+ * layout invariants that a printed label would otherwise expose only by
+ * running off the bottom of the stock.
+ */
+
+const AS_OF = new Date("2026-07-28T12:00:00.000Z");
+
+function input(over: Partial<DryBoxLabelInput> = {}): DryBoxLabelInput {
+  return {
+    location: { name: "BOX-07" },
+    items: [],
+    qrPayload: "https://example.test/inventory?location=abc123",
+    asOf: AS_OF,
+    ...over,
+  };
+}
+
+const texts = (cmds: TsplCommand[]): string[] =>
+  cmds.filter((c): c is Extract<TsplCommand, { kind: "text" }> => c.kind === "text").map((c) => c.content);
+
+describe("describeItem", () => {
+  const item = (o: Partial<DryBoxLabelItem>): DryBoxLabelItem => ({ filamentName: "", ...o });
+
+  it("prefers the spool's own label — it is what's written on the physical roll", () => {
+    expect(describeItem(item({ label: "Roll 12", filamentName: "PLA", filamentVendor: "Prusa" }))).toBe("Roll 12");
+  });
+
+  it("falls back to vendor + name + type", () => {
+    expect(describeItem(item({ filamentName: "Galaxy Black", filamentVendor: "Prusa", filamentType: "PLA" })))
+      .toBe("Prusa Galaxy Black PLA");
+  });
+
+  it("does not repeat a vendor already leading the name", () => {
+    // "Prusament PLA" must not become "Prusament Prusament PLA".
+    expect(describeItem(item({ filamentName: "Prusament PLA", filamentVendor: "Prusament" }))).toBe("Prusament PLA");
+  });
+
+  it("does not repeat a type already present in vendor or name", () => {
+    expect(describeItem(item({ filamentName: "PLA Galaxy", filamentVendor: "Prusa", filamentType: "PLA" })))
+      .toBe("Prusa PLA Galaxy");
+  });
+
+  it("tolerates missing, null and whitespace-only fields", () => {
+    expect(describeItem(item({ filamentName: "PLA" }))).toBe("PLA");
+    expect(describeItem(item({ filamentName: "PLA", filamentVendor: null, filamentType: null }))).toBe("PLA");
+    expect(describeItem(item({ filamentName: "  ", label: "   " }))).toBe("");
+    expect(describeItem(item({ filamentName: "", filamentVendor: "Prusa" }))).toBe("Prusa");
+  });
+});
+
+describe("maxContentRows", () => {
+  it("derives capacity from the configured stock height", () => {
+    const rows = maxContentRows(DRY_BOX_SPEC);
+    const height = mmToDots(DRY_BOX_SPEC.heightMm, DRY_BOX_SPEC.dpi);
+    const available = height - DRY_BOX_LAYOUT.footerHeight - DRY_BOX_LAYOUT.rows.firstY;
+    expect(rows).toBe(Math.floor(available / DRY_BOX_LAYOUT.rows.pitch));
+    // Sanity: the whole point of reflowing is fitting well more than the
+    // three rows the original fixture hardcoded.
+    expect(rows).toBeGreaterThan(12);
+  });
+
+  it("taller stock fits more rows; stock too short fits none rather than going negative", () => {
+    expect(maxContentRows({ ...DRY_BOX_SPEC, heightMm: 300 })).toBeGreaterThan(maxContentRows(DRY_BOX_SPEC));
+    expect(maxContentRows({ ...DRY_BOX_SPEC, heightMm: 20 })).toBe(0);
+  });
+});
+
+describe("dryBoxLabel — structure", () => {
+  it("renders to valid TSPL through the encoder", () => {
+    const bytes = render(dryBoxLabel(input({ items: [{ filamentName: "PLA" }] })));
+    const job = new TextDecoder().decode(bytes);
+    expect(job).toContain("SIZE 100 mm,150 mm\r\n");
+    expect(job).toContain("QRCODE");
+    expect(job).toContain('BARCODE 40,');
+    expect(job.endsWith("PRINT 1,1\r\n")).toBe(true);
+  });
+
+  it("is deterministic — same input, byte-identical output", () => {
+    const doc = () => render(dryBoxLabel(input({ items: [{ filamentName: "PLA" }] })));
+    expect(doc()).toEqual(doc());
+  });
+
+  it("puts the location name in the header and the QR payload in the QR", () => {
+    const doc = dryBoxLabel(input());
+    expect(texts(doc.commands)).toContain("BOX-07");
+    const qr = doc.commands.find((c) => c.kind === "qrcode");
+    expect(qr && qr.kind === "qrcode" && qr.content).toBe("https://example.test/inventory?location=abc123");
+  });
+
+  it("defaults the barcode to the location name but honours an override", () => {
+    const bc = (d: ReturnType<typeof dryBoxLabel>) =>
+      d.commands.find((c): c is Extract<TsplCommand, { kind: "barcode" }> => c.kind === "barcode")!.content;
+    expect(bc(dryBoxLabel(input()))).toBe("BOX-07");
+    expect(bc(dryBoxLabel(input({ barcodePayload: "LOC-42" })))).toBe("LOC-42");
+  });
+
+  it("appends humidity to the subtitle only when it is set", () => {
+    expect(texts(dryBoxLabel(input()).commands)).toContain("FILAMENT DRY BOX");
+    expect(texts(dryBoxLabel(input({ location: { name: "B", humidity: 18 } })).commands))
+      .toContain("FILAMENT DRY BOX  18% RH");
+    // 0% RH is a real reading, not "unset" — it must still render.
+    expect(texts(dryBoxLabel(input({ location: { name: "B", humidity: 0 } })).commands))
+      .toContain("FILAMENT DRY BOX  0% RH");
+  });
+});
+
+describe("dryBoxLabel — contents manifest", () => {
+  const many = (n: number): DryBoxLabelItem[] =>
+    Array.from({ length: n }, (_, i) => ({ filamentName: `Filament ${i + 1}` }));
+
+  it("lists each spool on its own row, bulleted", () => {
+    const out = texts(dryBoxLabel(input({ items: [{ filamentName: "PLA" }, { filamentName: "PETG" }] })).commands);
+    expect(out).toContain("- PLA");
+    expect(out).toContain("- PETG");
+  });
+
+  it("says so when the box is empty rather than printing a bare rule", () => {
+    expect(texts(dryBoxLabel(input({ items: [] })).commands)).toContain("(empty)");
+  });
+
+  it("drops items that describe to nothing", () => {
+    const out = texts(dryBoxLabel(input({ items: [{ filamentName: "  " }, { filamentName: "PLA" }] })).commands);
+    expect(out).toContain("- PLA");
+    expect(out).not.toContain("- ");
+  });
+
+  it("reports overflow instead of silently truncating", () => {
+    // A label that shows 16 of 40 spools with no indication would read as a
+    // complete inventory — the failure mode this guards.
+    const capacity = maxContentRows(DRY_BOX_SPEC);
+    const out = texts(dryBoxLabel(input({ items: many(capacity + 10) })).commands);
+    const shown = out.filter((s) => s.startsWith("- ")).length;
+    expect(shown).toBe(capacity - 1);
+    expect(out).toContain(`+${capacity + 10 - (capacity - 1)} more`);
+  });
+
+  it("fills the sheet exactly at capacity with no overflow row", () => {
+    const capacity = maxContentRows(DRY_BOX_SPEC);
+    const out = texts(dryBoxLabel(input({ items: many(capacity) })).commands);
+    expect(out.filter((s) => s.startsWith("- ")).length).toBe(capacity);
+    expect(out.some((s) => s.includes("more"))).toBe(false);
+  });
+
+  it("keeps every row above the footer, whatever the stock height", () => {
+    // The invariant a printed label would otherwise reveal by running rows
+    // off the bottom edge or over the barcode.
+    for (const heightMm of [100, 150, 200]) {
+      const spec = { ...DRY_BOX_SPEC, heightMm };
+      const doc = dryBoxLabel(input({ items: many(200), spec: { heightMm } }));
+      const footerTop = mmToDots(heightMm, spec.dpi) - DRY_BOX_LAYOUT.footerHeight;
+      const rowYs = doc.commands
+        .filter((c): c is Extract<TsplCommand, { kind: "text" }> => c.kind === "text")
+        .map((c) => c.y)
+        .filter((y) => y >= DRY_BOX_LAYOUT.rows.firstY && y < footerTop);
+      for (const y of rowYs) expect(y).toBeLessThan(footerTop);
+      // And the barcode stays on the sheet.
+      const bc = doc.commands.find((c): c is Extract<TsplCommand, { kind: "barcode" }> => c.kind === "barcode")!;
+      expect(bc.y + bc.height).toBeLessThan(mmToDots(heightMm, spec.dpi));
+    }
+  });
+});
+
+describe("dryBoxLabel — dates", () => {
+  it("formats the desiccant date, and says so when it was never recorded", () => {
+    expect(texts(dryBoxLabel(input({ location: { name: "B", desiccantChangedAt: "2026-07-12T00:00:00.000Z" } })).commands))
+      .toContain("DESICCANT CHANGED  2026-07-12");
+    expect(texts(dryBoxLabel(input({ location: { name: "B", desiccantChangedAt: new Date("2026-01-02T00:00:00Z") } })).commands))
+      .toContain("DESICCANT CHANGED  2026-01-02");
+    expect(texts(dryBoxLabel(input()).commands)).toContain("DESICCANT CHANGED  not recorded");
+    expect(texts(dryBoxLabel(input({ location: { name: "B", desiccantChangedAt: null } })).commands))
+      .toContain("DESICCANT CHANGED  not recorded");
+  });
+
+  it("stamps the manifest with the as-of date so a stale label is obvious", () => {
+    expect(texts(dryBoxLabel(input()).commands)).toContain("CONTENTS  (as of 2026-07-28)");
+  });
+
+  it("uses an injected formatter so preview and print agree across locales", () => {
+    // Reading the host locale inside the template would make the same
+    // document render differently on the preview canvas and the print head.
+    const out = texts(
+      dryBoxLabel(
+        input({
+          location: { name: "B", desiccantChangedAt: "2026-07-12T00:00:00.000Z" },
+          formatDate: (d) => `${d.getUTCDate()}.${d.getUTCMonth() + 1}.${d.getUTCFullYear()}`,
+        }),
+      ).commands,
+    );
+    expect(out).toContain("DESICCANT CHANGED  12.7.2026");
+    expect(out).toContain("CONTENTS  (as of 28.7.2026)");
+  });
+});
+
+describe("dryBoxLabel — localization", () => {
+  it("carries no English of its own when strings are supplied", () => {
+    const de = {
+      ...DEFAULT_DRY_BOX_STRINGS,
+      subtitle: "FILAMENT-TROCKENBOX",
+      contents: "INHALT",
+      desiccantChanged: "TROCKENMITTEL GEWECHSELT",
+      desiccantNever: "nicht erfasst",
+      empty: "(leer)",
+      asOf: "Stand",
+      more: "+{count} weitere",
+    };
+    const out = texts(dryBoxLabel(input({ items: [] }), de).commands);
+    expect(out).toContain("FILAMENT-TROCKENBOX");
+    expect(out).toContain("INHALT  (Stand 2026-07-28)");
+    expect(out).toContain("TROCKENMITTEL GEWECHSELT  nicht erfasst");
+    expect(out).toContain("(leer)");
+    expect(out.join("|")).not.toMatch(/DRY BOX|CONTENTS|DESICCANT/);
+  });
+
+  it("substitutes the overflow count into the supplied template", () => {
+    const capacity = maxContentRows(DRY_BOX_SPEC);
+    const out = texts(
+      dryBoxLabel(
+        input({ items: Array.from({ length: capacity + 5 }, (_, i) => ({ filamentName: `F${i}` })) }),
+        { ...DEFAULT_DRY_BOX_STRINGS, more: "und {count} weitere" },
+      ).commands,
+    );
+    expect(out).toContain(`und ${capacity + 5 - (capacity - 1)} weitere`);
+  });
+});

--- a/tests/fixtures/tspl/05_codepage_probe.prn
+++ b/tests/fixtures/tspl/05_codepage_probe.prn
@@ -1,0 +1,33 @@
+SIZE 100 mm,150 mm
+GAP 3 mm,0 mm
+DENSITY 8
+SPEED 4
+REFERENCE 0,0
+DIRECTION 1
+CLS
+TEXT 24,24,"4",0,1,1,"CODEPAGE PROBE"
+TEXT 24,64,"2",0,1,1,"Report which numbered rows show the RIGHT glyph."
+BAR 24,96,760,4
+TEXT 24,120,"3",0,1,1,"A  no CODEPAGE cmd (firmware default)"
+TEXT 44,160,"3",0,1,1,"A1 degree 0xB0 -> [°]"
+TEXT 44,200,"3",0,1,1,"A2 degree 0xF8 -> [ø]"
+TEXT 44,240,"3",0,1,1,"A3 sup3   0xB3 -> [³]"
+TEXT 44,280,"3",0,1,1,"A4 sup2   0xFD -> [ý]"
+CODEPAGE 1252
+TEXT 24,340,"3",0,1,1,"B  after CODEPAGE 1252"
+TEXT 44,380,"3",0,1,1,"B1 degree 0xB0 -> [°]"
+TEXT 44,420,"3",0,1,1,"B2 sup3   0xB3 -> [³]"
+TEXT 44,460,"3",0,1,1,"B3 a-uml  0xE4 -> [ä]"
+TEXT 44,500,"3",0,1,1,"B4 eszett 0xDF -> [ß]"
+CODEPAGE 437
+TEXT 24,560,"3",0,1,1,"C  after CODEPAGE 437"
+TEXT 44,600,"3",0,1,1,"C1 degree 0xF8 -> [ø]"
+TEXT 44,640,"3",0,1,1,"C2 sup2   0xFD -> [ý]"
+TEXT 44,680,"3",0,1,1,"C3 a-uml  0x84 -> [„]"
+TEXT 44,720,"3",0,1,1,"C4 eszett 0xE1 -> [á]"
+BAR 24,780,760,4
+TEXT 24,800,"2",0,1,1,"Blank/garbage = that codepage is not active."
+TEXT 24,832,"2",0,1,1,"cp437 has NO superscript-3 at any byte, by design."
+TEXT 24,880,"3",0,1,1,"ASCII control (always works):"
+TEXT 44,920,"3",0,1,1,"D1 240degC   12 mm3/s   Gruen   Strasse"
+PRINT 1,1

--- a/tests/inventorySort.test.ts
+++ b/tests/inventorySort.test.ts
@@ -30,7 +30,7 @@ function row(id: string, over: Partial<InventoryRow> = {}): Row {
 }
 
 function loc(id: string, name: string) {
-  return { _id: id, name, kind: "shelf", humidity: null, notes: "" };
+  return { _id: id, name, kind: "shelf", humidity: null, desiccantChangedAt: null, notes: "" };
 }
 
 describe("inventoryRemainingGrams", () => {

--- a/tests/ipc-contract-parity.test.ts
+++ b/tests/ipc-contract-parity.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Drift guard for the three-file Electron IPC contract.
+ *
+ * A channel is declared in THREE places with no compile-time link between
+ * them:
+ *   1. `electron/main.ts` (or a sibling) — `ipcMain.handle("channel", …)`
+ *   2. `electron/preload.ts` — `ipcRenderer.invoke("channel")` behind a
+ *      contextBridge method
+ *   3. `src/types/electron.d.ts` — the typed `ElectronAPI` surface
+ *
+ * Only the (3)→renderer edge is typechecked. Channel names are plain strings
+ * on both sides of the preload boundary, so a typo yields a runtime
+ * "No handler registered for 'x'" rejection and never a build error; and
+ * preload is bundled separately by esbuild, so nothing links (2) to (3)
+ * either.
+ *
+ * This has already bitten in production: GH #1006 F4, where preload's local
+ * NfcStatus silently omitted `lastError` and the typecheck could not see it.
+ * These tests make that class of drift a CI failure.
+ */
+
+const ELECTRON_DIR = join(__dirname, "..", "electron");
+const PRELOAD = readFileSync(join(ELECTRON_DIR, "preload.ts"), "utf8");
+const DTS = readFileSync(join(__dirname, "..", "src", "types", "electron.d.ts"), "utf8");
+
+/**
+ * Every string literal appearing under electron/, EXCLUDING preload.ts.
+ *
+ * Channel names registered from a table (see LABEL_PRINTER_CHANNELS in
+ * main.ts) are not literal at the `ipcMain.handle(` call site, so matching on
+ * `handle(` alone would report false failures — but the literal still has to
+ * exist somewhere on the main-process side.
+ *
+ * Excluding preload.ts is what makes the check meaningful. Including it let
+ * the scan find a channel literal in preload's OWN source, so a typo'd
+ * `ipcRenderer.invoke("tspl-printer-prnt")` matched itself and passed — the
+ * exact drift this test exists to catch.
+ */
+function mainProcessStringLiterals(): Set<string> {
+  const out = new Set<string>();
+  for (const entry of readdirSync(ELECTRON_DIR, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".ts")) continue;
+    if (entry.name === "preload.ts") continue;
+    const src = readFileSync(join(ELECTRON_DIR, entry.name), "utf8");
+    for (const m of src.matchAll(/"([^"\\\n]+)"/g)) out.add(m[1]);
+  }
+  return out;
+}
+
+/** Top-level keys of the object passed to contextBridge.exposeInMainWorld.
+ *  Brace-depth tracked so nested type literals (the NfcStatus shape, the
+ *  disableBidi union) don't masquerade as bridge methods. */
+function contextBridgeKeys(): string[] {
+  const start = PRELOAD.indexOf("exposeInMainWorld");
+  expect(start).toBeGreaterThan(-1);
+  const open = PRELOAD.indexOf("{", start);
+  const keys: string[] = [];
+  let depth = 0;
+  let lineStart = open;
+  for (let i = open; i < PRELOAD.length; i++) {
+    const ch = PRELOAD[i];
+    if (ch === "{" || ch === "(" || ch === "[") depth++;
+    else if (ch === "}" || ch === ")" || ch === "]") {
+      depth--;
+      if (depth === 0) break;
+    } else if (ch === "\n") {
+      lineStart = i + 1;
+      continue;
+    }
+    // A top-level key sits at depth 1 immediately after a newline.
+    if (depth === 1 && i === lineStart) {
+      const line = PRELOAD.slice(i, PRELOAD.indexOf("\n", i));
+      const m = line.match(/^\s*([a-zA-Z_$][\w$]*)\s*:/);
+      if (m) keys.push(m[1]);
+    }
+  }
+  return keys;
+}
+
+/** Declared member names of `interface ElectronAPI`, brace-depth tracked for
+ *  the same reason. */
+function electronApiMembers(): Set<string> {
+  const start = DTS.indexOf("interface ElectronAPI");
+  expect(start).toBeGreaterThan(-1);
+  const open = DTS.indexOf("{", start);
+  const out = new Set<string>();
+  let depth = 0;
+  let lineStart = open;
+  for (let i = open; i < DTS.length; i++) {
+    const ch = DTS[i];
+    if (ch === "{" || ch === "(" || ch === "[") depth++;
+    else if (ch === "}" || ch === ")" || ch === "]") {
+      depth--;
+      if (depth === 0) break;
+    } else if (ch === "\n") {
+      lineStart = i + 1;
+      continue;
+    }
+    if (depth === 1 && i === lineStart) {
+      const line = DTS.slice(i, DTS.indexOf("\n", i));
+      const m = line.match(/^\s*(?:readonly\s+)?([a-zA-Z_$][\w$]*)\??\s*:/);
+      if (m) out.add(m[1]);
+    }
+  }
+  return out;
+}
+
+describe("Electron IPC contract parity", () => {
+  it("every channel preload invokes is registered somewhere under electron/", () => {
+    const literals = mainProcessStringLiterals();
+    const invoked = [...PRELOAD.matchAll(/ipcRenderer\.invoke\(\s*"([^"]+)"/g)].map((m) => m[1]);
+    // Sanity floor so a regex that silently stops matching can't pass vacuously.
+    expect(invoked.length).toBeGreaterThan(20);
+    const orphaned = invoked.filter((c) => !literals.has(c));
+    expect(orphaned).toEqual([]);
+  });
+
+  it("every contextBridge method is declared on ElectronAPI", () => {
+    const keys = contextBridgeKeys();
+    const declared = electronApiMembers();
+    expect(keys.length).toBeGreaterThan(20);
+    expect(declared.size).toBeGreaterThan(20);
+    const undeclared = keys.filter((k) => !declared.has(k));
+    expect(undeclared).toEqual([]);
+  });
+
+  it("both label printers expose a complete, symmetric channel set", () => {
+    // The Brother and TSPL printers are independent device selections driven
+    // by one shared handler table in main.ts. If a future edit adds a channel
+    // to one and forgets the other, the two pickers diverge silently — this
+    // pins the symmetry that table is there to guarantee.
+    const literals = mainProcessStringLiterals();
+    const declared = electronApiMembers();
+    for (const verb of ["get-device-path", "set-device-path", "print"]) {
+      expect(literals.has(`label-printer-${verb}`)).toBe(true);
+      expect(literals.has(`tspl-printer-${verb}`)).toBe(true);
+    }
+    for (const method of ["GetDevicePath", "SetDevicePath", "Print"]) {
+      expect(declared.has(`labelPrinter${method}`)).toBe(true);
+      expect(declared.has(`tsplPrinter${method}`)).toBe(true);
+    }
+    // Device listing is deliberately NOT duplicated — the lister is
+    // printer-agnostic and both pickers share it.
+    expect(declared.has("tsplPrinterListDevices")).toBe(false);
+  });
+});

--- a/tests/label-printer.test.ts
+++ b/tests/label-printer.test.ts
@@ -84,6 +84,8 @@ import {
 
 const BYTES = new Uint8Array([0x1b, 0x40, 0x41, 0x42]);
 const BROTHER_URI = "usb://Brother/PT-P710BT?serial=000M5G671606";
+/** The second label printer — KNAON Y813BT, 4x6 dry-box labels over TSPL. */
+const KNAON_URI = "usb://KNAON/Y813BT?serial=Y813B0042";
 
 beforeEach(() => {
   h.state.execCalls = [];
@@ -226,6 +228,80 @@ d("printLabel (CUPS)", () => {
     };
     await expect(printLabel(BROTHER_URI, BYTES)).resolves.toBeUndefined();
     expect(h.state.execCalls.some((c) => c.cmd === "lpadmin")).toBe(false);
+  });
+
+  // The app drives two USB label printers. ensureManagedQueue REBINDS its
+  // queue to whichever device is printing, so a single shared queue name
+  // would let a Brother print and a dry-box print rebind it away from each
+  // other — and CUPS delivery is asynchronous, so a spooled job could drain
+  // to the WRONG PHYSICAL PRINTER. These pin the per-kind separation.
+  it("binds the TSPL printer to its OWN managed queue, never the Brother one", async () => {
+    // Only the queue-existence probe fails (queue not created yet);
+    // lpadmin itself must succeed or we are testing the wrong path.
+    h.state.execImpl = (cmd) =>
+      cmd === "lpstat" ? { error: new Error("lpstat: unknown printer") } : { stdout: "" };
+    await expect(printLabel(KNAON_URI, BYTES, "tspl")).resolves.toBeUndefined();
+    const lpadmin = h.state.execCalls.find((c) => c.cmd === "lpadmin");
+    expect(lpadmin!.args).toEqual(
+      expect.arrayContaining(["-p", "FilamentDB_Label_TSPL", "-v", KNAON_URI, "-E"]),
+    );
+    const lp = h.state.spawnCalls.find((c) => c.cmd === "lp");
+    expect(lp!.args).toEqual(["-d", "FilamentDB_Label_TSPL", "-o", "raw"]);
+  });
+
+  it("defaults to the Brother queue so existing installs are untouched", async () => {
+    // Only the queue-existence probe fails (queue not created yet);
+    // lpadmin itself must succeed or we are testing the wrong path.
+    h.state.execImpl = (cmd) =>
+      cmd === "lpstat" ? { error: new Error("lpstat: unknown printer") } : { stdout: "" };
+    // No kind argument — the pre-existing call shape.
+    await expect(printLabel(BROTHER_URI, BYTES)).resolves.toBeUndefined();
+    const lp = h.state.spawnCalls.find((c) => c.cmd === "lp");
+    expect(lp!.args).toEqual(["-d", "FilamentDB_Label", "-o", "raw"]);
+  });
+
+  it("gives the two queues distinct descriptions so they aren't duplicates in the OS printer list", async () => {
+    // Only the queue-existence probe fails (queue not created yet);
+    // lpadmin itself must succeed or we are testing the wrong path.
+    h.state.execImpl = (cmd) =>
+      cmd === "lpstat" ? { error: new Error("lpstat: unknown printer") } : { stdout: "" };
+    await printLabel(KNAON_URI, BYTES, "tspl");
+    const tsplAdmin = h.state.execCalls.find((c) => c.cmd === "lpadmin");
+    const dIdx = tsplAdmin!.args.indexOf("-D");
+    expect(tsplAdmin!.args[dIdx + 1]).toBe("Filament DB Dry-Box Label Printer");
+  });
+
+  it("checks the TSPL queue's own binding, not the Brother queue's", async () => {
+    // Brother queue already bound to the Brother; TSPL queue already bound to
+    // the KNAON. A TSPL print must consult the TSPL queue and skip lpadmin.
+    h.state.execImpl = (cmd, args) => {
+      if (cmd === "lpstat" && args.includes("FilamentDB_Label_TSPL")) {
+        return { stdout: `device for FilamentDB_Label_TSPL: ${KNAON_URI}\n` };
+      }
+      if (cmd === "lpstat" && args.includes("FilamentDB_Label")) {
+        return { stdout: `device for FilamentDB_Label: ${BROTHER_URI}\n` };
+      }
+      return { stdout: "" };
+    };
+    await expect(printLabel(KNAON_URI, BYTES, "tspl")).resolves.toBeUndefined();
+    expect(h.state.execCalls.some((c) => c.cmd === "lpadmin")).toBe(false);
+  });
+
+  it("surfaces BOTH managed queues as their underlying usb devices", async () => {
+    h.state.execImpl = (cmd, args) => {
+      if (cmd === "lpstat" && args[0] === "-v") {
+        return {
+          stdout:
+            `device for FilamentDB_Label: ${BROTHER_URI}\n` +
+            `device for FilamentDB_Label_TSPL: ${KNAON_URI}\n`,
+        };
+      }
+      return { stdout: "" };
+    };
+    const devices = await listLabelPrinters();
+    expect(devices.map((x) => x.path).sort()).toEqual([BROTHER_URI, KNAON_URI].sort());
+    // Neither managed queue name leaks as a selectable target.
+    expect(devices.some((x) => x.path.startsWith("FilamentDB_Label"))).toBe(false);
   });
 
   it("rejects with lp's stderr when the print job fails", async () => {

--- a/tests/locations-route.test.ts
+++ b/tests/locations-route.test.ts
@@ -246,6 +246,47 @@ describe("/api/locations", () => {
       expect(body.name).toBe("New");
       expect(body.notes).toBe("updated");
     });
+
+    it("persists desiccantChangedAt and accepts null to clear it", async () => {
+      const loc = await Location.create({ name: "Drybox 1", kind: "drybox" });
+      const put = (payload: unknown) =>
+        updateLocation(
+          new NextRequest(`http://localhost/api/locations/${loc._id}`, {
+            method: "PUT",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+          }),
+          { params: Promise.resolve({ id: String(loc._id) }) },
+        );
+
+      const set = await put({ desiccantChangedAt: "2026-07-12" });
+      expect(new Date((await set.json()).desiccantChangedAt).toISOString()).toBe(
+        "2026-07-12T00:00:00.000Z",
+      );
+
+      const cleared = await put({ desiccantChangedAt: null });
+      expect((await cleared.json()).desiccantChangedAt).toBeNull();
+    });
+
+    it("rejects an ISO-shaped but impossible desiccantChangedAt", async () => {
+      // Mongoose ROLLS OVER an impossible date rather than rejecting it, so
+      // "2026-02-30" would silently persist as March 2nd. Same trap the spool
+      // date fields hit in GH #372 — validate the string before it casts.
+      const loc = await Location.create({ name: "Drybox 2", kind: "drybox" });
+      for (const bad of ["2026-02-30", "2026-13-01", "2026-04-31", "not-a-date", 12345]) {
+        const res = await updateLocation(
+          new NextRequest(`http://localhost/api/locations/${loc._id}`, {
+            method: "PUT",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ desiccantChangedAt: bad }),
+          }),
+          { params: Promise.resolve({ id: String(loc._id) }) },
+        );
+        expect(res.status).toBe(400);
+      }
+      const after = await Location.findById(loc._id).lean();
+      expect(after!.desiccantChangedAt).toBeNull();
+    });
   });
 
   describe("DELETE /api/locations/[id]", () => {

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -104,7 +104,7 @@ describe("snapshot route — bedTypes round-trip", () => {
     expect(body.legacyNozzleCleanupComplete).toBe(false);
     // r13: v5 — provenance-carrying snapshots must be REJECTED by pre-#1022
     // builds (their #953 guard), which would otherwise drop the flag.
-    expect(body.version).toBe(5);
+    expect(body.version).toBe(6);
 
     await mongoose.connection.db!.collection("_migrations").insertOne({
       _id: "legacyNozzleConditions" as never,
@@ -951,9 +951,14 @@ describe("snapshot route — Location + PrintHistory round-trip", () => {
     it("rejects a snapshot from a newer version with 400 and does NOT wipe", async () => {
       const canary = await Location.create({ name: "Canary Loc" });
       const res = await postSnapshot({
-        version: 6,
+        // Deliberately far above CURRENT_SNAPSHOT_VERSION rather than
+        // "current + 1": this test asserts the guard, not any particular
+        // version, and hardcoding the next number silently breaks the guard's
+        // own coverage on every bump (it did, when v6 landed).
+        version: 999,
         createdAt: new Date().toISOString(),
-        // A v6 file could carry a new/renamed collection the v5 restore would drop.
+        // A newer file could carry a new/renamed collection this restore would
+        // drop, so it must fail closed rather than partially restore.
         collections: { filaments: [], nozzles: [], printers: [], bedTypes: [] },
       });
       expect(res.status).toBe(400);

--- a/tests/tsplEncoder.test.ts
+++ b/tests/tsplEncoder.test.ts
@@ -378,7 +378,17 @@ describe("mmToDots / dotsToMm", () => {
   });
 });
 
-describe("toAscii — the encoding decision the fixtures cannot cover", () => {
+describe("toAscii — the encoding decision, settled on hardware", () => {
+  // tests/fixtures/tspl/05_codepage_probe.prn is a DIAGNOSTIC, not a render
+  // target — it is committed so the result is reproducible, and is
+  // deliberately not compared against render() output (it is hand-authored
+  // with raw high bytes the emitter refuses to produce, which is the point).
+  //
+  // Printed on a Y813BT 2026-07-28: all twelve high-byte rows truncated at
+  // the offending byte, under no CODEPAGE and under both CODEPAGE 1252 and
+  // CODEPAGE 437. There is no codepage to switch to, and a raw high byte
+  // costs the remainder of the line. See the docblock in src/lib/tsplEncoder.ts.
+
   it("transliterates the units this app actually produces", () => {
     // °C and mm³/s are everywhere in filament data and neither is ASCII.
     // cp437 has ° but NO ³ at all; latin1 has both at different bytes.

--- a/tests/tsplEncoder.test.ts
+++ b/tests/tsplEncoder.test.ts
@@ -8,6 +8,7 @@ import {
   toAscii,
   sanitizeTsplLiteral,
   assertCrlfFramed,
+  qrModuleCount,
   TsplRenderError,
   DPI_203,
   type LabelDocument,
@@ -571,5 +572,45 @@ describe("assertCrlfFramed", () => {
     for (const name of ["01_probe_minimal", "02_probe_text", "03_probe_full", "04_drybox_label"]) {
       expect(() => assertCrlfFramed(goldenFixture(`${name}.prn`))).not.toThrow();
     }
+  });
+});
+
+describe("qrModuleCount — symbol sizing", () => {
+  it("returns the symbol side in modules for the payload's version", () => {
+    // A QRCODE command's printed size is NOT implied by its arguments — the
+    // firmware picks the version from the payload at print time, so a caller
+    // that wants the symbol to fit the stock has to compute it. Side is
+    // 17 + 4*version.
+    expect(qrModuleCount("x", "H")).toBe(21); // v1, 21x21
+    expect(qrModuleCount("x".repeat(24), "H")).toBe(29); // v3
+    expect(qrModuleCount("x".repeat(46), "H")).toBe(41); // v6
+    // 46 bytes exceeds v2 L capacity (32), so v3 — still far smaller than
+    // the 41 modules the same payload needs at H.
+    expect(qrModuleCount("x".repeat(46), "L")).toBe(29);
+  });
+
+  it("counts UTF-8 BYTES, not characters — QR byte mode encodes bytes", () => {
+    // Seven 3-byte characters is 21 bytes, which exceeds v2's 14-byte H
+    // capacity even though it is only 7 characters long.
+    const seven = "日本語日本語日";
+    expect(new TextEncoder().encode(seven).length).toBe(21);
+    expect(qrModuleCount(seven, "H")).toBe(qrModuleCount("x".repeat(21), "H"));
+  });
+
+  it("returns null past v20 rather than a symbol too fine to scan at 203 dpi", () => {
+    expect(qrModuleCount("x".repeat(382), "H")).toBe(97); // v20, the last we table
+    expect(qrModuleCount("x".repeat(383), "H")).toBeNull();
+    expect(qrModuleCount("x".repeat(5000), "L")).toBeNull();
+  });
+
+  it("stronger ECC costs capacity at every level", () => {
+    const payload = "x".repeat(100);
+    const h = qrModuleCount(payload, "H")!;
+    const q = qrModuleCount(payload, "Q")!;
+    const m = qrModuleCount(payload, "M")!;
+    const l = qrModuleCount(payload, "L")!;
+    expect(h).toBeGreaterThan(q);
+    expect(q).toBeGreaterThan(m);
+    expect(m).toBeGreaterThan(l);
   });
 });


### PR DESCRIPTION
Phases 2 and 3 of the TSPL dry-box label work, building on #1038. **Partial by design** — this is the transport, schema and template. The Settings picker, the `/inventory` print entry point and a bring-up CLI are follow-up commits on this branch; there is no end-to-end print path from the UI yet.

Makes the KNAON Y813BT an **independent second label printer** alongside the Brother PT-P710BT. They never print the same thing — Brother/24mm tape/spool labels, KNAON/4×6 stock/dry-box labels — so they get separate device settings rather than a shared "which kind" toggle.

## Phase 2 — transport

**No new native module.** The handoff spec recommended `usb` + `@electron/rebuild`, but GH #588 deliberately *removed* `serialport` from this path in favour of the OS print system, and `electron/label-printer.ts` is already a byte-agnostic raw pump (`lp -o raw` / winspool `RAW`). The in-repo comment notes `-o raw` sends bytes "verbatim regardless of any driver attached to the queue", so TSPL reaches the print head exactly as Brother raster does. This also sidesteps `LIBUSB_ERROR_ACCESS` on macOS and the Windows Zadig problem entirely. (`asarUnpack` was moot regardless — `asar: false`.)

### It fixes a wrong-printer race

`MANAGED_QUEUE = "FilamentDB_Label"` was a single module-global CUPS queue name, and `ensureManagedQueue` **rebinds** its queue to whichever device is printing. With two USB label printers both selected as raw `usb://` URIs, a Brother print and a dry-box print overlapping in time would rebind the queue away from each other — and because CUPS delivery is asynchronous (the `lp` job is spooled after the rebind but drains later), a job could be delivered to the **wrong physical printer**.

Managed queues are now per-kind, with distinct `lpadmin -D` descriptions so they aren't duplicates in the user's system printer list. **The Brother queue keeps its original name**, so existing installs are untouched by the upgrade.

### One handler table, not two copies

The three label-printer IPC handlers are registered from one table for both printers. These handlers are mirrored by hand across `electron/main.ts`, `electron/preload.ts` and `src/types/electron.d.ts` with **no compile-time link** between them, and that mirroring has already drifted in production (GH #1006 F4, where preload's local `NfcStatus` silently omitted a field). Two hand-copied ~50-line print handlers would be the same trap: a validation guard tightened on one and missed on the other is a security fix that only half-lands.

`tests/ipc-contract-parity.test.ts` is a new permanent guard on that contract — every channel preload invokes must be registered main-side, every contextBridge method must be declared on `ElectronAPI`, and both printers must expose a symmetric channel set. **Both drift classes were verified to fail it before being restored.** Worth noting the first version of that test was itself broken: it passed on a deliberately typo'd channel because the literal scan included `preload.ts` and matched the typo against itself.

Device listing is deliberately **not** duplicated — `listLabelPrinters` is printer-agnostic and both pickers share it.

## Phase 3 — schema + template

`Location.desiccantChangedAt` (optional date) answers the one question a glance at a drybox can't. Plumbed through the PUT allowlist (GH #424), POST, the `by-location` `$project`, snapshot `DATE_FIELDS` so restore revives it as a `Date` rather than an ISO string, the shared `InventoryLocation` type, and the location form as a date input.

Both write paths validate with `isValidIsoDateString` **before** the cast: Mongoose *rolls over* an impossible-but-ISO-shaped date rather than rejecting it, so `"2026-02-30"` would silently persist as March 2nd — the same trap the spool date fields hit in GH #372. There's a test asserting the stored value is untouched after a rejected write.

`src/lib/dryBoxLabel.ts` generalizes the hardware-verified `04_drybox_label.prn` geometry: the header block, contents rule, desiccant line and Code 128 keep their proven positions, while the contents list reflows to fill the sheet (16 rows on 100×150mm, vs the three the fixture hardcoded) with the footer pinned to the bottom of whatever stock is configured.

Three choices worth a reviewer's attention:

- **Overflow is reported, not truncated.** A label showing 16 of 40 spools with no indication reads as a complete inventory; past capacity the last row becomes `+N more`.
- **The manifest is stamped "as of \<date\>".** A printed contents list is a point-in-time snapshot and spools move. The app already made this call for Brother spool labels (no remaining-grams field, because a printed amount goes stale) — but for a dry box the manifest *is* the point of the label, so it prints, dated, and the QR resolves the live view.
- **`asOf`, `formatDate` and all strings are injected**, not read from the clock or locale. Calling `toLocaleDateString` inside the template would make the same document render differently on the preview canvas and the print head; reading the clock would break determinism.

## Gates

- `src/lib/dryBoxLabel.ts` at **100%** statements / branches / functions / lines, 23 tests — including the invariant that no manifest row or the barcode can land below the footer at any stock height
- ESLint, `tsc --noEmit`, and `electron:typecheck` all clean
- en/de both at 1681 keys, i18n invariant green

## Deliberately inert

`dryBoxLabel()` has no caller yet, and the `tspl-printer-*` channels have no UI. That's the same shape as #1038 — the risky, testable parts land reviewable on their own. Nothing is half-wired: there's no dead path a user can reach today.

## Follow-ups on this branch

Settings picker · `scripts/print-tspl.ts` bring-up CLI · `/inventory` group-header print entry point.

Still open: a **codepage probe** on hardware to settle `°`/`³` (the emitter currently folds to strict ASCII — deterministic and safe, but `mm³/s` renders as `mm3/s`). The probe job is written and only needs `send_tspl.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
