### PR TITLE
fix(slicer): disambiguate same-diameter HF/standard nozzles in the exported condition

### DIFF
--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -9,7 +9,7 @@ import { errorResponse, errorResponseFromCaught, handleDuplicateKeyError, isDupl
 import { assertSameOriginRequest, assertSafeUpdateBody } from "@/lib/requestGuard";
 import { mergeSlicerSettings } from "@/lib/slicerSettings";
 import { stripLegacyMachineCondition } from "@/lib/stripLegacyNozzleCondition";
-import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
+import { resolveSyncBackColor, isMachineDerivedPerNozzleCondition } from "@/lib/prusaSlicerBundle";
 import { splitInheritedImportSet } from "@/lib/importFilaments";
 import { escapeRegex } from "@/lib/matchFilament";
 import { assignSpoolToSlot } from "@/lib/spoolSlots";
@@ -948,6 +948,28 @@ export async function POST(
     // legitimately lives there.
     if (Object.prototype.hasOwnProperty.call(config, "compatible_printers_condition")) {
       await stripLegacyMachineCondition(merge.settings, filament);
+      // GH #1040: a recognized per-nozzle preset's condition is machine-written
+      // by construction — the export bakes it from the hinted nozzle and the
+      // fork echoes every key back on sync (build_sync_body serializes the
+      // whole preset). Persisting it would freeze ONE sibling's condition into
+      // the SHARED settings bag, and the export gate then stamps it on every
+      // fan-out section (for the HF-tailed shape that hides the standard
+      // preset outright; for the plain shape on a mixed-diameter fan-out it
+      // pins the wrong diameter onto the other sibling — a latent pre-#1040
+      // bug on tick-less filaments, since stripLegacyMachineCondition bails
+      // without ticks provenance). Shape-matched via the same module that
+      // emits it, so the two can't drift; a user-authored condition — even one
+      // referencing these variables — doesn't match and persists.
+      if (
+        isPerNozzlePreset &&
+        Number.isFinite(hintDiameter) &&
+        isMachineDerivedPerNozzleCondition(
+          merge.settings["compatible_printers_condition"],
+          hintDiameter,
+        )
+      ) {
+        merge.settings["compatible_printers_condition"] = "";
+      }
     }
     update.settings = merge.settings;
 

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -374,16 +374,23 @@ export function isMachineDerivedPerNozzleCondition(
 
 /**
  * Matches ANY condition string a Filament DB exporter (any vintage) can have
- * machine-written: one or more `nozzle_diameter[n]==D` terms joined by
+ * machine-written: one or more `nozzle_diameter[0]==D` terms joined by
  * ` or `, each optionally carrying the HF discriminator tail. The
  * single-nozzle predicate above anchors to ONE known diameter; this one is
  * the diameter-agnostic union used where the writing nozzle is unknown —
  * the bulk-import collapse and the export-time normalization in the bake.
+ *
+ * INDEX [0] ONLY (PR #1045 round 2): every exporter vintage has only ever
+ * written extruder index 0 — the bake, the or-joined derivation, and the
+ * #1021 legacy strip all say `[0]`. A user's multi-extruder pin such as
+ * `nozzle_diameter[1]==0.4` is NOT a shape we ever emitted, and a `\d+`
+ * index here classified it as machine-derived — overwriting a legitimate
+ * pin with an index-0 bake.
  */
 export function isAnyMachineDerivedNozzleCondition(value: unknown): boolean {
   return (
     typeof value === "string" &&
-    /^nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?(?: or nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?)*$/.test(
+    /^nozzle_diameter\[0\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[0\])?(?: or nozzle_diameter\[0\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[0\])?)*$/.test(
       value,
     )
   );

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -283,9 +283,16 @@ export function collapsePerNozzleImportSections(
         // ` or `-joined set). A substring test would wrongly strip a legitimate
         // user pin that merely REFERENCES a nozzle diameter, e.g.
         // `printer_model==MK4 and nozzle_diameter[0]==0.4`.
+        // GH #1040: each term may carry the HF discriminator tail the new bake
+        // emits (` and nozzle_high_flow[0]` / ` and ! nozzle_high_flow[0]`,
+        // spaced `! ` only — the machine shape). Without this, one sibling's
+        // HF-tailed condition would be misread as a user pin, frozen into the
+        // base filament's settings bag, and stamped on EVERY fan-out section by
+        // the export gate — hiding the standard preset from standard printers,
+        // worse than the bug it fixes.
         const isDerived =
           typeof v === "string" &&
-          /^nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: or nozzle_diameter\[\d+\]==\d+(?:\.\d+)?)*$/.test(v);
+          /^nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?(?: or nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?)*$/.test(v);
         const isEmpty = v === "" || v === undefined;
         if (isDerived || isEmpty) delete settings[k];
         // else: user pin (non-derived string) or nil (null) → keep for round-trip.
@@ -323,6 +330,50 @@ export function collapsePerNozzleImportSections(
   return out;
 }
 
+/**
+ * The baked per-nozzle `compatible_printers_condition` (GH #1040).
+ *
+ * `includeHfTerm` appends the high-flow discriminator, using the fork's
+ * per-extruder `nozzle_high_flow` printer option — the exact construct
+ * Prusa's own MK4S system profiles use (`... and nozzle_high_flow[0]` /
+ * `... and ! nozzle_high_flow[0]`; note the SPACED `! `, matching those
+ * field-tested profiles). It is emitted ONLY when the fan-out group carries
+ * two same-diameter nozzles differing in highFlow — the one case diameter
+ * alone cannot disambiguate. Unambiguous exports keep the plain diameter
+ * condition so nothing that is visible today disappears (the GH #1021
+ * lesson). On a slicer without `nozzle_high_flow` the expression fails
+ * open — visible everywhere, i.e. today's behavior.
+ */
+export function perNozzleCondition(
+  nz: { diameter: number; highFlow?: boolean | null },
+  includeHfTerm: boolean,
+): string {
+  const base = `nozzle_diameter[0]==${nz.diameter}`;
+  if (!includeHfTerm) return base;
+  return nz.highFlow ? `${base} and nozzle_high_flow[0]` : `${base} and ! nozzle_high_flow[0]`;
+}
+
+/**
+ * Matches every condition string the per-nozzle bake (either vintage) can
+ * MACHINE-WRITE for a nozzle of `diameter`: the pre-#1040 plain shape and
+ * both HF-tailed polarities. Byte-shape matching on purpose — a user pin
+ * that merely REFERENCES these variables (`printer_model=="MK4" and
+ * nozzle_diameter[0]==0.4`, or an unspaced `!nozzle_high_flow[0]` someone
+ * typed by hand) does NOT match and is preserved.
+ */
+export function isMachineDerivedPerNozzleCondition(
+  value: unknown,
+  diameter: number,
+): boolean {
+  if (typeof value !== "string") return false;
+  // A DB diameter is a plain number; escaping the dot is all a numeric
+  // string can need, and avoids fragile character-class escapes here.
+  const d = String(diameter).replace(/\./g, "\\.");
+  return new RegExp(
+    `^nozzle_diameter\\[0\\]==${d}(?: and (?:! )?nozzle_high_flow\\[0\\])?$`,
+  ).test(value);
+}
+
 export function filamentToSlicerKeys(
   filament: FilamentDoc,
   // #872: when present, BAKE this per-nozzle calibration's filament-level values
@@ -330,6 +381,10 @@ export function filamentToSlicerKeys(
   // PrusaSlicer has no parent/child for user presets). Pressure advance is
   // printer-scoped and stays dynamic via the /calibration endpoint — not baked.
   calibration?: FilamentDoc,
+  // GH #1040: append the high-flow discriminator to the baked condition —
+  // set by the fan-out when THIS nozzle's diameter appears in the group with
+  // both highFlow states (see perNozzleCondition).
+  includeHfTerm = false,
 ): Record<string, string | null> {
   // Start with the settings bag as the base — these are passthrough
   // PrusaSlicer keys preserved from a previous import
@@ -450,7 +505,7 @@ export function filamentToSlicerKeys(
         !("compatible_printers_condition" in keys) ||
         keys.compatible_printers_condition === ""
       ) {
-        keys.compatible_printers_condition = `nozzle_diameter[0]==${nz.diameter}`;
+        keys.compatible_printers_condition = perNozzleCondition(nz, includeHfTerm);
       }
       keys.filamentdb_nozzle = nozzleSuffix(nz);
     }
@@ -564,11 +619,25 @@ export function generatePrusaSlicerBundle(filaments: FilamentDoc[]): string {
       // parent/child for USER filament presets. Each bakes its nozzle's filament-level
       // calibration; all share one filamentdb_id and carry a filamentdb_nozzle hint
       // so the sync-back routes updates to the right per-nozzle calibration entry.
+      //
+      // GH #1040: when a diameter appears with BOTH highFlow states in the group,
+      // diameter alone cannot disambiguate the two presets and each section's
+      // condition additionally encodes its nozzle's HF flag. Diameters present in
+      // only one state keep the plain condition (today's visibility).
+      const hfStatesByDiameter = new Map<number, Set<boolean>>();
       for (const cal of byNozzle.values()) {
+        const nz = cal.nozzle as { diameter: number; highFlow?: boolean | null };
+        const states = hfStatesByDiameter.get(nz.diameter) ?? new Set<boolean>();
+        states.add(!!nz.highFlow);
+        hfStatesByDiameter.set(nz.diameter, states);
+      }
+      for (const cal of byNozzle.values()) {
+        const nz = cal.nozzle as { diameter: number };
+        const ambiguous = (hfStatesByDiameter.get(nz.diameter)?.size ?? 0) > 1;
         writeSection(
           lines,
           `${filament.name} ${nozzleSuffix(cal.nozzle)}`,
-          filamentToSlicerKeys(filament, cal),
+          filamentToSlicerKeys(filament, cal, ambiguous),
         );
       }
     } else {

--- a/src/lib/prusaSlicerBundle.ts
+++ b/src/lib/prusaSlicerBundle.ts
@@ -290,9 +290,7 @@ export function collapsePerNozzleImportSections(
         // base filament's settings bag, and stamped on EVERY fan-out section by
         // the export gate — hiding the standard preset from standard printers,
         // worse than the bug it fixes.
-        const isDerived =
-          typeof v === "string" &&
-          /^nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?(?: or nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?)*$/.test(v);
+        const isDerived = isAnyMachineDerivedNozzleCondition(v);
         const isEmpty = v === "" || v === undefined;
         if (isDerived || isEmpty) delete settings[k];
         // else: user pin (non-derived string) or nil (null) → keep for round-trip.
@@ -372,6 +370,23 @@ export function isMachineDerivedPerNozzleCondition(
   return new RegExp(
     `^nozzle_diameter\\[0\\]==${d}(?: and (?:! )?nozzle_high_flow\\[0\\])?$`,
   ).test(value);
+}
+
+/**
+ * Matches ANY condition string a Filament DB exporter (any vintage) can have
+ * machine-written: one or more `nozzle_diameter[n]==D` terms joined by
+ * ` or `, each optionally carrying the HF discriminator tail. The
+ * single-nozzle predicate above anchors to ONE known diameter; this one is
+ * the diameter-agnostic union used where the writing nozzle is unknown —
+ * the bulk-import collapse and the export-time normalization in the bake.
+ */
+export function isAnyMachineDerivedNozzleCondition(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    /^nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?(?: or nozzle_diameter\[\d+\]==\d+(?:\.\d+)?(?: and (?:! )?nozzle_high_flow\[\d+\])?)*$/.test(
+      value,
+    )
+  );
 }
 
 export function filamentToSlicerKeys(
@@ -501,9 +516,20 @@ export function filamentToSlicerKeys(
       // `nil` inheritance marker (null) must win. Only set when the key is absent
       // or an empty-string "no restriction". `filamentdb_nozzle` stays
       // unconditional — it's a routing hint for THIS nozzle, not a user setting.
+      // PR #1045 review: ALSO re-derive over a MACHINE-SHAPED bag value. The
+      // pre-fix tick-less sync leak kept re-polluting the shared bag AFTER
+      // the #1021 one-shot cleanup, so "post-cleanup pure nozzle condition =
+      // user pin by construction" does not hold on real installs — a stale
+      // `nozzle_diameter[0]==0.4` in the bag would win this gate and keep
+      // the HF fix inert until the next lucky sync re-stripped it. Scoped to
+      // the per-nozzle BAKE path (these sections are machine-generated); a
+      // user pin byte-identical to a machine shape being re-derived here is
+      // the same accepted residue as the existing #1021/#950 guards. Genuine
+      // pins (compound conditions, unspaced `!`) never match and still win.
       if (
         !("compatible_printers_condition" in keys) ||
-        keys.compatible_printers_condition === ""
+        keys.compatible_printers_condition === "" ||
+        isAnyMachineDerivedNozzleCondition(keys.compatible_printers_condition)
       ) {
         keys.compatible_printers_condition = perNozzleCondition(nz, includeHfTerm);
       }

--- a/tests/api-route-correctness.test.ts
+++ b/tests/api-route-correctness.test.ts
@@ -648,6 +648,62 @@ describe("API route correctness", () => {
     expect(fresh.settings?.filamentdb_nozzle).toBeUndefined(); // routing hint, not stored
   });
 
+  it("GH #1040 — a hinted per-nozzle sync strips its own machine-derived condition from the bag", async () => {
+    // build_sync_body serializes EVERY preset key, so the fork echoes the
+    // baked compatible_printers_condition back on each sync. Persisting it
+    // would freeze ONE sibling's condition into the SHARED settings bag —
+    // and the export gate then stamps it on every fan-out section (the
+    // HF-tailed shape would hide the standard preset from standard
+    // printers). Covers the new HF-tailed shapes AND the plain-diameter
+    // shape, which on a tick-less filament previously slipped through
+    // stripLegacyMachineCondition (provenance bail) into the shared bag.
+    const hf = await Nozzle.create({ name: "0.4 Brass HF", diameter: 0.4, type: "Brass", highFlow: true });
+    const f = await Filament.create({ name: "PLA", vendor: "X", type: "PLA", compatibleNozzles: [] });
+    void hf;
+    for (const cond of [
+      "nozzle_diameter[0]==0.4 and nozzle_high_flow[0]",
+      "nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]",
+      "nozzle_diameter[0]==0.4",
+    ]) {
+      const res = await slicerSync(
+        jsonReq("http://localhost/api/filaments/PLA%200.4%20Brass%20HF", {
+          config: {
+            filamentdb_id: String(f._id),
+            filamentdb_nozzle: "0.4 Brass HF",
+            compatible_printers_condition: cond,
+          },
+        }),
+        { params: Promise.resolve({ id: "PLA 0.4 Brass HF" }) },
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.settings?.compatible_printers_condition).toBe(""); // stripped, re-derived on export
+    }
+  });
+
+  it("GH #1040 — a hinted sync KEEPS a user-authored condition, even one referencing the HF variable", async () => {
+    const f = await Filament.create({ name: "PLA", vendor: "X", type: "PLA", compatibleNozzles: [] });
+    for (const cond of [
+      'printer_model=="MK4S" and nozzle_diameter[0]==0.4', // compound user pin
+      "nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]", // hand-typed unspaced ! — not the machine shape
+      "nozzle_diameter[0]==0.6", // machine shape but for a DIFFERENT diameter than the hint
+    ]) {
+      const res = await slicerSync(
+        jsonReq("http://localhost/api/filaments/PLA%200.4%20Brass%20HF", {
+          config: {
+            filamentdb_id: String(f._id),
+            filamentdb_nozzle: "0.4 Brass HF",
+            compatible_printers_condition: cond,
+          },
+        }),
+        { params: Promise.resolve({ id: "PLA 0.4 Brass HF" }) },
+      );
+      expect(res.status).toBe(200);
+      const fresh = await Filament.findById(f._id);
+      expect(fresh.settings?.compatible_printers_condition).toBe(cond); // user pin persists
+    }
+  });
+
   it("#872 — a per-nozzle preset disambiguates same-diameter nozzles by type", async () => {
     const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
     const diamond = await Nozzle.create({ name: "0.4 Diamondback", diameter: 0.4, type: "Diamondback" });

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -219,10 +219,13 @@ describe("filamentToSlicerKeys", () => {
     }
   });
 
-  it("#1021/#1022: a bag-pinned nozzle condition WINS over the calibration bake (pin precedence)", () => {
-    // Post-migration a bag value is a user pin, and #950's rule applies: the
-    // per-nozzle calibration bake only sets the condition when it is
-    // absent-or-empty — it never overwrites a pin.
+  it("#1021/#1022 → PR #1045: a machine-SHAPED bag value is re-derived by the bake; genuine pins win", () => {
+    // SUPERSEDED CONTRACT. This test used to pin "post-migration a pure
+    // nozzle condition in the bag is a user pin" — but the tick-less sync
+    // leak (#1040/#1045) kept machine values landing AFTER the one-shot
+    // cleanup, so that construction never held on real installs. On the
+    // machine-generated per-nozzle bake path, a machine-derivable shape now
+    // re-derives (here: the 0.8 stale value replaced by THIS nozzle's 0.4)…
     const keys = filamentToSlicerKeys(
       {
         name: "PinnedCalibrated",
@@ -235,7 +238,22 @@ describe("filamentToSlicerKeys", () => {
       },
       { nozzle: { diameter: 0.4, type: "Brass" }, extrusionMultiplier: 1.02 } as never,
     );
-    expect(keys.compatible_printers_condition).toBe("nozzle_diameter[0]==0.8");
+    expect(keys.compatible_printers_condition).toBe("nozzle_diameter[0]==0.4");
+    // …while a condition that is NOT a machine shape — a genuine user pin —
+    // still wins over the bake, exactly as before.
+    const pinned = filamentToSlicerKeys(
+      {
+        name: "PinnedCalibrated",
+        vendor: "X",
+        type: "PLA",
+        diameter: 1.75,
+        temperatures: {},
+        settings: { compatible_printers_condition: 'printer_model=="MK4" and nozzle_diameter[0]==0.8' },
+        compatibleNozzles: [{ diameter: 0.8 }],
+      },
+      { nozzle: { diameter: 0.4, type: "Brass" }, extrusionMultiplier: 1.02 } as never,
+    );
+    expect(pinned.compatible_printers_condition).toBe('printer_model=="MK4" and nozzle_diameter[0]==0.8');
   });
 
   it("#1021: an EMPTY round-tripped condition stays empty (no nozzle derivation over it)", () => {
@@ -1655,6 +1673,42 @@ describe("GH #1040 — high-flow discriminator in compatible_printers_condition"
       null,
       42,
     ]) expect(isMachineDerivedPerNozzleCondition(v, 0.4)).toBe(false);
+  });
+
+  it("PR #1045 review — a STALE machine-shaped bag value is re-derived, not treated as a pin", () => {
+    // The pre-fix tick-less sync leak left `nozzle_diameter[0]==0.4` in real
+    // installs' settings bags AFTER the #1021 cleanup. Treating it as a user
+    // pin froze all fan-out siblings on the stale plain condition and made
+    // the HF fix inert until the next sync happened to strip it. The bake
+    // now re-derives over any machine-derivable shape — first export after
+    // upgrading is already correct.
+    const stale = generatePrusaSlicerBundle([
+      {
+        name: "PLA", vendor: "Generic", type: "PLA", diameter: 1.75,
+        temperatures: { nozzle: 210 },
+        settings: { compatible_printers_condition: "nozzle_diameter[0]==0.4" },
+        calibrations: [
+          { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95 },
+          { nozzle: { name: "0.4 Brass HF", diameter: 0.4, type: "Brass", highFlow: true }, printer: null, extrusionMultiplier: 0.9 },
+        ],
+      },
+    ]);
+    expect(stale).toContain("nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]");
+    expect(stale).toContain("nozzle_diameter[0]==0.4 and nozzle_high_flow[0]");
+    // The or-joined legacy multi-term shape re-derives too.
+    const multi = generatePrusaSlicerBundle([
+      {
+        name: "PLA", vendor: "Generic", type: "PLA", diameter: 1.75,
+        temperatures: { nozzle: 210 },
+        settings: { compatible_printers_condition: "nozzle_diameter[0]==0.4 or nozzle_diameter[0]==0.6" },
+        calibrations: [
+          { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95 },
+          { nozzle: { name: "0.4 Brass HF", diameter: 0.4, type: "Brass", highFlow: true }, printer: null, extrusionMultiplier: 0.9 },
+        ],
+      },
+    ]);
+    expect(multi).toContain("nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]");
+    expect(multi).not.toContain("nozzle_diameter[0]==0.4 or nozzle_diameter[0]==0.6");
   });
 
   it("bulk-import collapse strips both HF-tailed machine shapes but keeps hand-written pins", () => {

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -4,8 +4,7 @@ import {
   generatePrusaSlicerBundle,
   collapsePerNozzleImportSections,
   resolveSyncBackColor,
-  nozzleSuffix,
-} from "@/lib/prusaSlicerBundle";
+  nozzleSuffix, perNozzleCondition, isMachineDerivedPerNozzleCondition } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
 
 describe("filamentToSlicerKeys", () => {
@@ -1555,5 +1554,125 @@ describe("resolveSyncBackColor (#883)", () => {
   it("returns undefined for an absent incoming color", () => {
     expect(resolveSyncBackColor({ color: null, secondaryColors: ["#112233"] }, null)).toBeUndefined();
     expect(resolveSyncBackColor({ color: "#000000" }, "")).toBeUndefined();
+  });
+});
+
+describe("GH #1040 — high-flow discriminator in compatible_printers_condition", () => {
+  const filamentWith = (cals: object[]) => ({
+    name: "PLA",
+    vendor: "Generic",
+    type: "PLA",
+    diameter: 1.75,
+    temperatures: { nozzle: 210 },
+    settings: {},
+    calibrations: cals,
+  });
+
+  it("same-diameter std/HF pair: each section encodes its nozzle's HF state", () => {
+    // The reported bug: both sections carried the identical
+    // `nozzle_diameter[0]==0.4`, so PrusaSlicer showed each preset as
+    // compatible with BOTH printers. The exact strings below are the
+    // construct Prusa's own MK4S system profiles use (spaced `! `).
+    const bundle = generatePrusaSlicerBundle([
+      filamentWith([
+        { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95 },
+        { nozzle: { name: "0.4 Brass HF", diameter: 0.4, type: "Brass", highFlow: true }, printer: null, extrusionMultiplier: 0.9 },
+      ]),
+    ]);
+    const sections = bundle.split(/(?=\[filament:)/).filter((s) => s.startsWith("[filament:"));
+    const std = sections.find((s) => s.includes("[filament:PLA 0.4 Brass]"))!;
+    const hf = sections.find((s) => s.includes("[filament:PLA 0.4 Brass HF]"))!;
+    expect(std).toContain("compatible_printers_condition = nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]");
+    expect(hf).toContain("compatible_printers_condition = nozzle_diameter[0]==0.4 and nozzle_high_flow[0]");
+  });
+
+  it("different-diameter fan-out stays on the plain condition (only-when-ambiguous)", () => {
+    // Diameter alone already disambiguates 0.4 vs 0.8 — adding the HF term
+    // would newly HIDE a 0.4-standard preset from a 0.4-HF printer where
+    // users see it today (the GH #1021 surprise class).
+    const bundle = generatePrusaSlicerBundle([
+      filamentWith([
+        { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95 },
+        { nozzle: { name: "0.8 Brass", diameter: 0.8, type: "Brass" }, printer: null, extrusionMultiplier: 0.9 },
+      ]),
+    ]);
+    expect(bundle).toContain("compatible_printers_condition = nozzle_diameter[0]==0.4\n");
+    expect(bundle).toContain("compatible_printers_condition = nozzle_diameter[0]==0.8\n");
+    expect(bundle).not.toContain("nozzle_high_flow");
+  });
+
+  it("mixed group: only the ambiguous diameter gets the HF term", () => {
+    // 0.4 exists in both states; 0.8 exists only as HF. The 0.8 section keeps
+    // the plain condition — its diameter alone finds the right printer, and
+    // hiding it from a hypothetical 0.8-standard printer would be the #1021
+    // regression again.
+    const bundle = generatePrusaSlicerBundle([
+      filamentWith([
+        { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95 },
+        { nozzle: { name: "0.4 Brass HF", diameter: 0.4, type: "Brass", highFlow: true }, printer: null, extrusionMultiplier: 0.9 },
+        { nozzle: { name: "0.8 Brass HF", diameter: 0.8, type: "Brass", highFlow: true }, printer: null, extrusionMultiplier: 0.85 },
+      ]),
+    ]);
+    expect(bundle).toContain("nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]");
+    expect(bundle).toContain("nozzle_diameter[0]==0.4 and nozzle_high_flow[0]");
+    expect(bundle).toContain("compatible_printers_condition = nozzle_diameter[0]==0.8\n");
+  });
+
+  it("a settings-bag user pin still wins over the HF-aware bake", () => {
+    const bundle = generatePrusaSlicerBundle([
+      filamentWith([
+        { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95 },
+        { nozzle: { name: "0.4 Brass HF", diameter: 0.4, type: "Brass", highFlow: true }, printer: null, extrusionMultiplier: 0.9 },
+      ]),
+    ].map((f) => ({ ...f, settings: { compatible_printers_condition: 'printer_model=="MK4"' } })));
+    const count = (bundle.match(/compatible_printers_condition = printer_model=="MK4"/g) ?? []).length;
+    expect(count).toBe(2);
+    expect(bundle).not.toContain("nozzle_high_flow");
+  });
+
+  it("perNozzleCondition emits the three shapes exactly", () => {
+    expect(perNozzleCondition({ diameter: 0.4 }, false)).toBe("nozzle_diameter[0]==0.4");
+    expect(perNozzleCondition({ diameter: 0.4, highFlow: true }, true)).toBe(
+      "nozzle_diameter[0]==0.4 and nozzle_high_flow[0]",
+    );
+    expect(perNozzleCondition({ diameter: 0.4, highFlow: false }, true)).toBe(
+      "nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]",
+    );
+  });
+
+  it("isMachineDerivedPerNozzleCondition matches machine shapes only", () => {
+    for (const v of [
+      "nozzle_diameter[0]==0.4",
+      "nozzle_diameter[0]==0.4 and nozzle_high_flow[0]",
+      "nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]",
+    ]) expect(isMachineDerivedPerNozzleCondition(v, 0.4)).toBe(true);
+    for (const v of [
+      "nozzle_diameter[0]==0.6", // different diameter
+      'printer_model=="MK4" and nozzle_diameter[0]==0.4', // user pin referencing it
+      "nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]", // unspaced ! — hand-typed
+      "nozzle_diameter[0]==0.4 and nozzle_high_flow[0] and 1", // extra term
+      "", // empty
+      null,
+      42,
+    ]) expect(isMachineDerivedPerNozzleCondition(v, 0.4)).toBe(false);
+  });
+
+  it("bulk-import collapse strips both HF-tailed machine shapes but keeps hand-written pins", () => {
+    // Without this, one sibling's HF-tailed condition round-trips into the
+    // base filament's settings bag as a fake "user pin" and the export gate
+    // stamps it on EVERY fan-out section — hiding the standard preset.
+    const parse = (cond: string) =>
+      parseIniFilaments(
+        `[filament:PLA 0.4 Brass HF]\nfilament_type = PLA\nfilamentdb_nozzle = 0.4 Brass HF\ncompatible_printers_condition = ${cond}\n`,
+      );
+    const stripped = collapsePerNozzleImportSections(parse("nozzle_diameter[0]==0.4 and nozzle_high_flow[0]"))[0];
+    expect("compatible_printers_condition" in stripped.settings).toBe(false);
+    const strippedNeg = collapsePerNozzleImportSections(parse("nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]"))[0];
+    expect("compatible_printers_condition" in strippedNeg.settings).toBe(false);
+    // A hand-typed variant (unspaced !) is NOT the machine shape — kept.
+    const kept = collapsePerNozzleImportSections(parse("nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]"))[0];
+    expect(kept.settings.compatible_printers_condition).toBe(
+      "nozzle_diameter[0]==0.4 and !nozzle_high_flow[0]",
+    );
   });
 });

--- a/tests/prusaSlicerBundle.test.ts
+++ b/tests/prusaSlicerBundle.test.ts
@@ -4,7 +4,7 @@ import {
   generatePrusaSlicerBundle,
   collapsePerNozzleImportSections,
   resolveSyncBackColor,
-  nozzleSuffix, perNozzleCondition, isMachineDerivedPerNozzleCondition } from "@/lib/prusaSlicerBundle";
+  nozzleSuffix, perNozzleCondition, isMachineDerivedPerNozzleCondition, isAnyMachineDerivedNozzleCondition } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
 
 describe("filamentToSlicerKeys", () => {
@@ -1709,6 +1709,29 @@ describe("GH #1040 — high-flow discriminator in compatible_printers_condition"
     ]);
     expect(multi).toContain("nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]");
     expect(multi).not.toContain("nozzle_diameter[0]==0.4 or nozzle_diameter[0]==0.6");
+  });
+
+  it("PR #1045 round 2 — a multi-extruder user pin (index != 0) is NOT machine-shaped and survives", () => {
+    // No exporter vintage ever wrote an extruder index other than 0, so
+    // `nozzle_diameter[1]==0.4` can only be a user's multi-extruder pin. A
+    // \d+ index in the predicate classified it as machine-derived and the
+    // bake overwrote it with an index-0 condition.
+    expect(isAnyMachineDerivedNozzleCondition("nozzle_diameter[1]==0.4")).toBe(false);
+    expect(isAnyMachineDerivedNozzleCondition("nozzle_diameter[0]==0.4 and nozzle_high_flow[1]")).toBe(false);
+    const bundle = generatePrusaSlicerBundle([
+      {
+        name: "PLA", vendor: "Generic", type: "PLA", diameter: 1.75,
+        temperatures: { nozzle: 210 },
+        settings: { compatible_printers_condition: "nozzle_diameter[1]==0.4" },
+        calibrations: [
+          { nozzle: { name: "0.4 Brass", diameter: 0.4, type: "Brass" }, printer: null, extrusionMultiplier: 0.95 },
+          { nozzle: { name: "0.4 Brass HF", diameter: 0.4, type: "Brass", highFlow: true }, printer: null, extrusionMultiplier: 0.9 },
+        ],
+      },
+    ]);
+    const pins = (bundle.match(/compatible_printers_condition = nozzle_diameter\[1\]==0\.4/g) ?? []).length;
+    expect(pins).toBe(2); // the pin wins on every fan-out section
+    expect(bundle).not.toContain("nozzle_high_flow");
   });
 
   it("bulk-import collapse strips both HF-tailed machine shapes but keeps hand-written pins", () => {


### PR DESCRIPTION
Fixes #1040.

The per-nozzle fan-out groups and names by diameter+type+highFlow, but the baked `compatible_printers_condition` read only the diameter — so a 0.4-std + 0.4-HF pair exported two presets with identical conditions, each visible on both printers.

**Mechanism verified against the fork source**: `nozzle_high_flow` is a per-extruder printer option, present in `s_Preset_printer_options`, and Prusa's own MK4S system profiles use exactly `nozzle_diameter[0]==0.4 and nozzle_high_flow[0]` / `and ! nozzle_high_flow[0]` (spaced `! `, which this follows). Old slicers fail open — today's visibility.

**Emitted only when ambiguous** (product call): the HF term appears only when a diameter exists in both highFlow states within the fan-out group. Unambiguous exports are byte-identical to today, so nothing currently visible disappears (the #1021 lesson).

**The real work is round-trip persistence** — both ingestion paths now recognize the new machine shape so it can never freeze into the shared settings bag as a fake user pin (which the export gate would then stamp onto every sibling, hiding the standard preset outright):
- bulk-import collapse regex widened for the HF-tailed shapes
- the fork sync-back strips a condition shape-matching the bake for the *hinted* nozzle, via the same module that emits it — this also fixes a latent pre-existing leak where a tick-less filament persisted the plain diameter condition into the shared bag on every sync

User pins survive everywhere: compound conditions, hand-typed unspaced `!`, and machine shapes for a different diameter than the hint.

Reproduced per the issue's snapshot scenario in tests: the std/HF pair now exports
```ini
compatible_printers_condition = nozzle_diameter[0]==0.4 and ! nozzle_high_flow[0]
compatible_printers_condition = nozzle_diameter[0]==0.4 and nozzle_high_flow[0]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)