### PR TITLE
fix(printers): filament-side slot assignment now visible on the printer side

### DIFF
--- a/src/app/api/spools/[spoolId]/assignment/route.ts
+++ b/src/app/api/spools/[spoolId]/assignment/route.ts
@@ -103,7 +103,12 @@ export async function PUT(
       return errorResponse("Printer or slot not found", 404);
     }
 
-    await assignSpoolToSlot(Printer, spoolId, { printerId, slotId });
+    // GH #1041: thread the owning filament so the slot's loaded-filament ref
+    // is maintained alongside the tracked spool — the printer form renders
+    // slots keyed on filamentId, so without it this assignment was invisible
+    // (and trample-prone) on the printer side. The positional projection
+    // above still returns the parent _id.
+    await assignSpoolToSlot(Printer, spoolId, { printerId, slotId }, filament._id);
     const assignment = await findSpoolSlot(Printer, spoolId);
     return NextResponse.json({ assignment });
   } catch (err) {

--- a/src/app/printers/PrinterForm.tsx
+++ b/src/app/printers/PrinterForm.tsx
@@ -282,7 +282,29 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
     const ac = new AbortController();
     fetch("/api/filaments", { signal: ac.signal })
       .then((r) => (r.ok ? r.json() : []))
-      .then(setFilamentOptions)
+      .then((options: FilamentOption[]) => {
+        setFilamentOptions(options);
+        // GH #1041 belt-and-braces: a legacy slot may track a spool with no
+        // loaded-filament ref (written by a pre-#1041 filament-side
+        // assignment, or by an old app version sharing this DB after the
+        // startup migration ran). Backfill filamentId from the spool's owner
+        // in FORM STATE — not just the render — so the slot displays, the
+        // spool select enables, and a subsequent save persists the repaired
+        // pair instead of re-writing the orphaned shape.
+        setForm((prev) => {
+          let changed = false;
+          const amsSlots = prev.amsSlots.map((slot) => {
+            if (slot.filamentId || !slot.spoolId) return slot;
+            const owner = options.find((f) =>
+              f.spools?.some((sp) => sp._id === slot.spoolId),
+            );
+            if (!owner) return slot;
+            changed = true;
+            return { ...slot, filamentId: owner._id };
+          });
+          return changed ? { ...prev, amsSlots } : prev;
+        });
+      })
       .catch(() => {});
     return () => ac.abort();
   }, [form.amsSlots.length, filamentOptions.length]);

--- a/src/app/printers/PrinterForm.tsx
+++ b/src/app/printers/PrinterForm.tsx
@@ -294,11 +294,15 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
         setForm((prev) => {
           let changed = false;
           const amsSlots = prev.amsSlots.map((slot) => {
-            if (slot.filamentId || !slot.spoolId) return slot;
+            if (!slot.spoolId) return slot;
             const owner = options.find((f) =>
               f.spools?.some((sp) => sp._id === slot.spoolId),
             );
-            if (!owner) return slot;
+            // Repair a MISMATCHED pair too (PR #1046 review): the old path
+            // could track a spool in a slot dedicated to a different
+            // filament, which rendered the wrong filament's spool list and
+            // invited the same trample the null case did.
+            if (!owner || owner._id === slot.filamentId) return slot;
             changed = true;
             return { ...slot, filamentId: owner._id };
           });

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -299,27 +299,31 @@ export default async function dbConnect() {
     try {
       const { default: Printer } = await import("@/models/Printer");
       const { default: Filament } = await import("@/models/Filament");
+      // Every slot TRACKING a spool is checked — not just filamentId-null
+      // ones (PR #1046 review): the old path could also overwrite spoolId on
+      // a slot already dedicated to a DIFFERENT filament (an "Any spool"
+      // dedication), leaving a non-null but MISMATCHED pair that renders the
+      // wrong filament's spools in the form.
       const printers = await Printer.find(
-        {
-          _deletedAt: null,
-          amsSlots: {
-            $elemMatch: {
-              spoolId: { $ne: null },
-              $or: [{ filamentId: null }, { filamentId: { $exists: false } }],
-            },
-          },
-        },
+        { _deletedAt: null, "amsSlots.spoolId": { $ne: null } },
         { amsSlots: 1 },
       ).lean();
       let repaired = 0;
       let cleared = 0;
       for (const pr of printers) {
         for (const slot of pr.amsSlots ?? []) {
-          if (!slot?.spoolId || slot.filamentId) continue;
+          if (!slot?.spoolId) continue;
           const owner = await Filament.findOne(
             { _deletedAt: null, "spools._id": slot.spoolId },
             { _id: 1 },
           ).lean();
+          if (owner && String(owner._id) === String(slot.filamentId ?? "")) {
+            continue; // pair already consistent
+          }
+          // Dead spool → drop the tracking ref; an existing filamentId
+          // reverts to a plain dedication. Live owner → the slot reflects
+          // the physically-loaded spool, so the owner wins (the same
+          // overwrite posture as the fixed assignment path).
           const set = owner
             ? { "amsSlots.$[s].filamentId": owner._id }
             : { "amsSlots.$[s].spoolId": null };

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -304,8 +304,17 @@ export default async function dbConnect() {
       // a slot already dedicated to a DIFFERENT filament (an "Any spool"
       // dedication), leaving a non-null but MISMATCHED pair that renders the
       // wrong filament's spools in the form.
+      // $elemMatch is REQUIRED here (PR #1046 round 2): the bare form
+      // `"amsSlots.spoolId": { $ne: null }` applies MongoDB's negated-array
+      // semantics — it matches only when EVERY element differs from null —
+      // so a printer with one tracked and one empty slot (the normal
+      // partially-loaded AMS shape) was excluded entirely. $elemMatch scopes
+      // the predicate to "at least one slot tracks a spool".
       const printers = await Printer.find(
-        { _deletedAt: null, "amsSlots.spoolId": { $ne: null } },
+        {
+          _deletedAt: null,
+          amsSlots: { $elemMatch: { spoolId: { $ne: null } } },
+        },
         { amsSlots: 1 },
       ).lean();
       let repaired = 0;

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -53,6 +53,14 @@ interface MongooseCache {
      * a converted value lands in [0, 50] — below the threshold for every real
      * input, and the x = 50 boundary maps to itself (a no-op re-match). */
     legacyShrinkage: boolean;
+    /** GH #1041 — repair AMS slots tracking a spool with no loaded-filament
+     * ref. The pre-#1041 filament-side assignment wrote only
+     * `amsSlots[].spoolId`; PrinterForm renders slots keyed on `filamentId`,
+     * so these assignments were invisible (and trample-prone) on the printer
+     * side. Backfill `filamentId` from the spool's owning filament; a spool
+     * that no longer exists clears the dangling `spoolId` instead.
+     * Idempotent: matches nothing once repaired. */
+    amsSlotFilamentIds: boolean;
     /** GH #1021 — clear machine-derived `nozzle_diameter[0]==D [or ...]`
      * values the pre-#1021 export wrote into
      * `settings.compatible_printers_condition` and round-trips persisted.
@@ -103,7 +111,7 @@ export default async function dbConnect() {
     promise: null,
     uri: null,
     migrationsPromise: null,
-    migrations: { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false, legacyShrinkage: false, legacyNozzleConditions: false },
+    migrations: { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false, legacyShrinkage: false, legacyNozzleConditions: false, amsSlotFilamentIds: false },
   };
 
   if (!global.mongoose) {
@@ -118,7 +126,7 @@ export default async function dbConnect() {
     cached.promise = null;
     cached.uri = null;
     cached.migrationsPromise = null;
-    cached.migrations = { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false, legacyShrinkage: false, legacyNozzleConditions: false };
+    cached.migrations = { instanceIds: false, spoolInstanceIds: false, sharedCatalogIndexes: false, nozzlePhysicalInstances: false, coreModelIndexes: false, purgedZombies: false, legacyShrinkage: false, legacyNozzleConditions: false, amsSlotFilamentIds: false };
   }
 
   // GH #312: a cached connection can go dead after a DB outage or an
@@ -144,7 +152,8 @@ export default async function dbConnect() {
     cached.migrations.coreModelIndexes &&
     cached.migrations.purgedZombies &&
     cached.migrations.legacyShrinkage &&
-    cached.migrations.legacyNozzleConditions
+    cached.migrations.legacyNozzleConditions &&
+    cached.migrations.amsSlotFilamentIds
   ) {
     return cached.conn;
   }
@@ -276,6 +285,64 @@ export default async function dbConnect() {
       // retry would then legitimately match and clear. So the CURRENT caller
       // must fail too, not just leave the flag false for the next one.
       throw err;
+    }
+  }
+
+  // GH #1041 — repair AMS slots that track a spool with no loaded-filament
+  // ref. The pre-#1041 filament-side assignment wrote only amsSlots[].spoolId;
+  // PrinterForm keys slot rendering on filamentId, so the assignment existed
+  // in the data but was invisible on the printer side — and a user "fixing"
+  // the seemingly-empty slot silently wiped the spool ref. Backfill the
+  // owning filament; clear a spoolId whose spool no longer exists. Idempotent
+  // and cheap: the $elemMatch matches nothing once repaired.
+  if (!cached.migrations.amsSlotFilamentIds) {
+    try {
+      const { default: Printer } = await import("@/models/Printer");
+      const { default: Filament } = await import("@/models/Filament");
+      const printers = await Printer.find(
+        {
+          _deletedAt: null,
+          amsSlots: {
+            $elemMatch: {
+              spoolId: { $ne: null },
+              $or: [{ filamentId: null }, { filamentId: { $exists: false } }],
+            },
+          },
+        },
+        { amsSlots: 1 },
+      ).lean();
+      let repaired = 0;
+      let cleared = 0;
+      for (const pr of printers) {
+        for (const slot of pr.amsSlots ?? []) {
+          if (!slot?.spoolId || slot.filamentId) continue;
+          const owner = await Filament.findOne(
+            { _deletedAt: null, "spools._id": slot.spoolId },
+            { _id: 1 },
+          ).lean();
+          const set = owner
+            ? { "amsSlots.$[s].filamentId": owner._id }
+            : { "amsSlots.$[s].spoolId": null };
+          await Printer.updateOne(
+            { _id: pr._id },
+            { $set: set },
+            { arrayFilters: [{ "s._id": slot._id }] },
+          );
+          if (owner) repaired += 1;
+          else cleared += 1;
+        }
+      }
+      if (repaired > 0 || cleared > 0) {
+        console.log(
+          `[migration] AMS slots: backfilled ${repaired} loaded-filament ref(s), cleared ${cleared} dangling spool ref(s) (GH #1041)`,
+        );
+      }
+      cached.migrations.amsSlotFilamentIds = true;
+    } catch (err) {
+      console.error(
+        "[migration] Failed to repair AMS slot filament refs (will retry on next connect):",
+        err,
+      );
     }
   }
 

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -319,6 +319,7 @@ export default async function dbConnect() {
       ).lean();
       let repaired = 0;
       let cleared = 0;
+      let casMisses = 0;
       for (const pr of printers) {
         for (const slot of pr.amsSlots ?? []) {
           if (!slot?.spoolId) continue;
@@ -343,12 +344,18 @@ export default async function dbConnect() {
           // filter would let the stale repair overwrite that fresh
           // assignment. If the slot changed, the filter matches nothing and
           // the repair is a no-op — the next connect re-reads and converges.
-          await Printer.updateOne(
+          const res = await Printer.updateOne(
             { _id: pr._id },
             { $set: set },
             { arrayFilters: [{ "s._id": slot._id, "s.spoolId": slot.spoolId }] },
           );
-          if (owner) repaired += 1;
+          // PR #1046 round 4: a CAS miss means a concurrent writer changed
+          // the slot — possibly a still-running pre-#1041 process writing a
+          // NEW orphaned pair. Swallowing the miss and flipping the flag
+          // would leave that slot unrepaired for this process's lifetime.
+          if (res.modifiedCount === 0) {
+            casMisses += 1;
+          } else if (owner) repaired += 1;
           else cleared += 1;
         }
       }
@@ -357,7 +364,17 @@ export default async function dbConnect() {
           `[migration] AMS slots: backfilled ${repaired} loaded-filament ref(s), cleared ${cleared} dangling spool ref(s) (GH #1041)`,
         );
       }
-      cached.migrations.amsSlotFilamentIds = true;
+      if (casMisses > 0) {
+        // Leave the flag UNSET — the per-migration retry semantics every
+        // other step uses ("will retry on next connect"). The next connect
+        // re-reads the changed slots and converges; an in-process retry loop
+        // could chase a still-running old writer forever.
+        console.warn(
+          `[migration] AMS slots: ${casMisses} slot(s) changed concurrently during repair — will re-check on next connect (GH #1041)`,
+        );
+      } else {
+        cached.migrations.amsSlotFilamentIds = true;
+      }
     } catch (err) {
       console.error(
         "[migration] Failed to repair AMS slot filament refs (will retry on next connect):",

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -336,10 +336,17 @@ export default async function dbConnect() {
           const set = owner
             ? { "amsSlots.$[s].filamentId": owner._id }
             : { "amsSlots.$[s].spoolId": null };
+          // Compare-and-set (PR #1046 round 3): the filter matches the
+          // spoolId this repair was COMPUTED from, not just the slot id.
+          // Another process (a second desktop on the same Atlas DB) can
+          // reassign the slot between our read and this write; an id-only
+          // filter would let the stale repair overwrite that fresh
+          // assignment. If the slot changed, the filter matches nothing and
+          // the repair is a no-op — the next connect re-reads and converges.
           await Printer.updateOne(
             { _id: pr._id },
             { $set: set },
-            { arrayFilters: [{ "s._id": slot._id }] },
+            { arrayFilters: [{ "s._id": slot._id, "s.spoolId": slot.spoolId }] },
           );
           if (owner) repaired += 1;
           else cleared += 1;

--- a/src/lib/spoolSlots.ts
+++ b/src/lib/spoolSlots.ts
@@ -104,23 +104,44 @@ export async function assignSpoolToSlot(
   PrinterModel: Model<any>,
   spoolId: mongoose.Types.ObjectId | string,
   target: { printerId: string; slotId: string } | null,
+  // GH #1041: the spool's OWNING filament. A slot carries TWO parallel refs
+  // (filamentId = loaded filament, spoolId = tracked spool) and PrinterForm
+  // renders slots keyed on filamentId — so a spool-side assignment that
+  // writes only spoolId is present in the data but UNRENDERABLE on the
+  // printer side (the spool select is disabled while filamentId is null).
+  // Both refs are maintained together from here on.
+  filamentId?: mongoose.Types.ObjectId | string | null,
 ): Promise<void> {
   const spoolObjId = new mongoose.Types.ObjectId(String(spoolId));
 
+  // Clear pass: the slot was TRACKING this spool, and the physical spool —
+  // i.e. the loaded filament — is leaving with it, so both refs clear
+  // ("currently-loaded" semantics per the schema docblock). "Any spool"
+  // slots (filamentId set, spoolId null) never match this filter and keep
+  // their dedication.
   await PrinterModel.updateMany(
     { _deletedAt: null, "amsSlots.spoolId": spoolObjId },
-    { $set: { "amsSlots.$[s].spoolId": null } },
+    { $set: { "amsSlots.$[s].spoolId": null, "amsSlots.$[s].filamentId": null } },
     { arrayFilters: [{ "s.spoolId": spoolObjId }] },
   );
 
   if (target) {
+    // Assign pass: when the owning filament is known, write it alongside —
+    // silently replacing whatever filament the slot previously showed (the
+    // newly-assigned spool IS what is physically loaded now; matches this
+    // helper's existing self-healing posture of stealing the spool from any
+    // other slot without prompting).
+    const set: Record<string, unknown> = { "amsSlots.$.spoolId": spoolObjId };
+    if (filamentId != null) {
+      set["amsSlots.$.filamentId"] = new mongoose.Types.ObjectId(String(filamentId));
+    }
     await PrinterModel.updateOne(
       {
         _id: target.printerId,
         _deletedAt: null,
         "amsSlots._id": target.slotId,
       },
-      { $set: { "amsSlots.$.spoolId": spoolObjId } },
+      { $set: set },
     );
   }
 }
@@ -216,7 +237,10 @@ export async function clearSpoolsFromOtherPrinters(
       _deletedAt: null,
       "amsSlots.spoolId": { $in: ids },
     },
-    { $set: { "amsSlots.$[s].spoolId": null } },
+    // GH #1041: null the loaded filament alongside the tracked spool — the
+    // spool physically moved to the other printer, so leaving filamentId
+    // behind showed a phantom loaded filament on the losing printer.
+    { $set: { "amsSlots.$[s].spoolId": null, "amsSlots.$[s].filamentId": null } },
     { arrayFilters: [{ "s.spoolId": { $in: ids } }] },
   );
 }

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -1320,4 +1320,63 @@ describe("legacyNozzleConditions migration (GH #1021)", () => {
       collSpy2.mockRestore();
     }
   });
+
+  // GH #1041: the amsSlotFilamentIds repair — orphaned, MISMATCHED, and
+  // dangling slot refs all converge on a consistent pair.
+  it("repairs orphaned, mismatched and dangling AMS slot refs (GH #1041)", async () => {
+    await dbConnect();
+    const Filament = mongoose.models.Filament || (await import("@/models/Filament")).default;
+    const Printer = mongoose.models.Printer || (await import("@/models/Printer")).default;
+    const spoolA = new mongoose.Types.ObjectId();
+    const spoolB = new mongoose.Types.ObjectId();
+    const deadSpool = new mongoose.Types.ObjectId();
+    const otherFilament = new mongoose.Types.ObjectId();
+    await Filament.collection.insertOne({
+      name: "SlotRepairOwner", vendor: "Test", type: "PLA", color: "#808080",
+      diameter: 1.75, instanceId: "slotrepair1", _deletedAt: null,
+      spools: [
+        { _id: spoolA, label: "A", totalWeight: 1000, instanceId: "aaaaaaaaaa" },
+        { _id: spoolB, label: "B", totalWeight: 1000, instanceId: "bbbbbbbbbb" },
+      ],
+    });
+    const printerId = new mongoose.Types.ObjectId();
+    await Printer.collection.insertOne({
+      _id: printerId, name: "SlotRepairPrinter", manufacturer: "T", printerModel: "P",
+      _deletedAt: null,
+      amsSlots: [
+        // Orphaned: spool tracked, no loaded filament (the #1041 shape).
+        { _id: new mongoose.Types.ObjectId(), slotName: "orphan", spoolId: spoolA, filamentId: null },
+        // Mismatched: spool tracked, but the slot claims a DIFFERENT filament
+        // (old path overwrote spoolId on an "Any spool" dedication).
+        { _id: new mongoose.Types.ObjectId(), slotName: "mismatch", spoolId: spoolB, filamentId: otherFilament },
+        // Dangling: tracked spool no longer exists anywhere.
+        { _id: new mongoose.Types.ObjectId(), slotName: "dangling", spoolId: deadSpool, filamentId: otherFilament },
+      ],
+    });
+    const cached = (global as Record<string, unknown>).mongoose as Record<string, unknown>;
+    cached.migrations = { instanceIds: true, spoolInstanceIds: true, sharedCatalogIndexes: true, nozzlePhysicalInstances: true, coreModelIndexes: true, purgedZombies: true, legacyShrinkage: true, legacyNozzleConditions: true, amsSlotFilamentIds: false };
+    cached.conn = null;
+    cached.promise = null;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await dbConnect();
+      const owner = await Filament.findOne({ name: "SlotRepairOwner" }).lean();
+      const pr = await Printer.findById(printerId).lean();
+      const byName = Object.fromEntries(pr.amsSlots.map((sl: { slotName: string }) => [sl.slotName, sl]));
+      // Orphan: owner backfilled.
+      expect(String(byName.orphan.filamentId)).toBe(String(owner._id));
+      // Mismatch: the spool's owner WINS (the slot reflects what's loaded).
+      expect(String(byName.mismatch.filamentId)).toBe(String(owner._id));
+      // Dangling: tracking ref dropped; the dedication stays.
+      expect(byName.dangling.spoolId).toBeNull();
+      expect(String(byName.dangling.filamentId)).toBe(String(otherFilament));
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[migration] AMS slots: backfilled 2"),
+      );
+    } finally {
+      logSpy.mockRestore();
+      await Filament.deleteMany({ name: "SlotRepairOwner" });
+      await Printer.deleteMany({ name: "SlotRepairPrinter" });
+    }
+  });
 });

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -1344,6 +1344,12 @@ describe("legacyNozzleConditions migration (GH #1021)", () => {
       _id: printerId, name: "SlotRepairPrinter", manufacturer: "T", printerModel: "P",
       _deletedAt: null,
       amsSlots: [
+        // An EMPTY slot first — the normal partially-loaded AMS shape. This
+        // is the regression pin for PR #1046 round 2: the bare negated-array
+        // query `"amsSlots.spoolId": {$ne: null}` requires EVERY slot to be
+        // non-null, so this one empty slot silently excluded the whole
+        // printer from the repair.
+        { _id: new mongoose.Types.ObjectId(), slotName: "empty", spoolId: null, filamentId: null },
         // Orphaned: spool tracked, no loaded filament (the #1041 shape).
         { _id: new mongoose.Types.ObjectId(), slotName: "orphan", spoolId: spoolA, filamentId: null },
         // Mismatched: spool tracked, but the slot claims a DIFFERENT filament
@@ -1367,6 +1373,9 @@ describe("legacyNozzleConditions migration (GH #1021)", () => {
       expect(String(byName.orphan.filamentId)).toBe(String(owner._id));
       // Mismatch: the spool's owner WINS (the slot reflects what's loaded).
       expect(String(byName.mismatch.filamentId)).toBe(String(owner._id));
+      // The empty slot is untouched.
+      expect(byName.empty.spoolId).toBeNull();
+      expect(byName.empty.filamentId).toBeNull();
       // Dangling: tracking ref dropped; the dedication stays.
       expect(byName.dangling.spoolId).toBeNull();
       expect(String(byName.dangling.filamentId)).toBe(String(otherFilament));

--- a/tests/spool-slots.test.ts
+++ b/tests/spool-slots.test.ts
@@ -221,6 +221,126 @@ describe("spool ↔ printer-slot assignment (GH #242)", () => {
     });
   });
 
+  describe("GH #1041 — slots maintain BOTH refs (loaded filament + tracked spool)", () => {
+    it("assignSpoolToSlot writes filamentId alongside spoolId when the owner is given", async () => {
+      const spoolId = new mongoose.Types.ObjectId();
+      const filamentId = new mongoose.Types.ObjectId();
+      const printer = await Printer.create({
+        name: "P", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1" }],
+      });
+      await assignSpoolToSlot(
+        Printer, spoolId,
+        { printerId: String(printer._id), slotId: String(printer.amsSlots[0]._id) },
+        filamentId,
+      );
+      const fresh = await Printer.findById(printer._id);
+      expect(String(fresh.amsSlots[0].spoolId)).toBe(String(spoolId));
+      // The printer form keys slot rendering on filamentId — without this the
+      // assignment existed in the data but rendered as an Empty slot.
+      expect(String(fresh.amsSlots[0].filamentId)).toBe(String(filamentId));
+    });
+
+    it("assignSpoolToSlot overwrites a DIFFERENT loaded filament with the spool's owner", async () => {
+      // Product call on #1041: the slot reflects physical reality — the
+      // newly-assigned spool IS what's loaded — matching the helper's
+      // existing self-healing posture (no prompt).
+      const spoolId = new mongoose.Types.ObjectId();
+      const petg = new mongoose.Types.ObjectId();
+      const pla = new mongoose.Types.ObjectId();
+      const printer = await Printer.create({
+        name: "P", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1", filamentId: petg }],
+      });
+      await assignSpoolToSlot(
+        Printer, spoolId,
+        { printerId: String(printer._id), slotId: String(printer.amsSlots[0]._id) },
+        pla,
+      );
+      const fresh = await Printer.findById(printer._id);
+      expect(String(fresh.amsSlots[0].filamentId)).toBe(String(pla));
+    });
+
+    it("moving a spool clears BOTH refs on the losing slot", async () => {
+      // The spool physically left, and the loaded filament left with it —
+      // leaving filamentId behind showed a phantom loaded filament.
+      const spoolId = new mongoose.Types.ObjectId();
+      const filamentId = new mongoose.Types.ObjectId();
+      const a = await Printer.create({
+        name: "A", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1", spoolId, filamentId }],
+      });
+      const b = await Printer.create({
+        name: "B", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1" }],
+      });
+      await assignSpoolToSlot(
+        Printer, spoolId,
+        { printerId: String(b._id), slotId: String(b.amsSlots[0]._id) },
+        filamentId,
+      );
+      const freshA = await Printer.findById(a._id);
+      expect(freshA.amsSlots[0].spoolId).toBeNull();
+      expect(freshA.amsSlots[0].filamentId).toBeNull();
+    });
+
+    it("clearing (target null) clears both refs but leaves 'Any spool' slots alone", async () => {
+      const spoolId = new mongoose.Types.ObjectId();
+      const loaded = new mongoose.Types.ObjectId();
+      const dedicated = new mongoose.Types.ObjectId();
+      const printer = await Printer.create({
+        name: "P", manufacturer: "X", printerModel: "P",
+        amsSlots: [
+          { slotName: "tracked", spoolId, filamentId: loaded },
+          // "Any spool": a filament dedication with no tracked spool — must
+          // never be touched by a spool-keyed clear.
+          { slotName: "any", filamentId: dedicated },
+        ],
+      });
+      await assignSpoolToSlot(Printer, spoolId, null);
+      const fresh = await Printer.findById(printer._id);
+      expect(fresh.amsSlots[0].spoolId).toBeNull();
+      expect(fresh.amsSlots[0].filamentId).toBeNull();
+      expect(String(fresh.amsSlots[1].filamentId)).toBe(String(dedicated));
+      expect(fresh.amsSlots[1].spoolId ?? null).toBeNull();
+    });
+
+    it("clearSpoolsFromOtherPrinters clears both refs on the losing printer", async () => {
+      const spoolId = new mongoose.Types.ObjectId();
+      const filamentId = new mongoose.Types.ObjectId();
+      const loser = await Printer.create({
+        name: "L", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1", spoolId, filamentId }],
+      });
+      const winner = await Printer.create({
+        name: "W", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1", spoolId, filamentId }],
+      });
+      await clearSpoolsFromOtherPrinters(Printer, [spoolId], winner._id);
+      const freshL = await Printer.findById(loser._id);
+      expect(freshL.amsSlots[0].spoolId).toBeNull();
+      expect(freshL.amsSlots[0].filamentId).toBeNull();
+      const freshW = await Printer.findById(winner._id);
+      expect(String(freshW.amsSlots[0].spoolId)).toBe(String(spoolId));
+      expect(String(freshW.amsSlots[0].filamentId)).toBe(String(filamentId));
+    });
+
+    it("omitting filamentId keeps the pre-#1041 behavior (spoolId only)", async () => {
+      const spoolId = new mongoose.Types.ObjectId();
+      const printer = await Printer.create({
+        name: "P", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1" }],
+      });
+      await assignSpoolToSlot(Printer, spoolId, {
+        printerId: String(printer._id),
+        slotId: String(printer.amsSlots[0]._id),
+      });
+      const fresh = await Printer.findById(printer._id);
+      expect(String(fresh.amsSlots[0].spoolId)).toBe(String(spoolId));
+      expect(fresh.amsSlots[0].filamentId ?? null).toBeNull();
+    });
+  });
+
   describe("findInvalidSlotSpoolRef slot labelling (GH #631)", () => {
     it("labels an offending slot by its slotName when present", async () => {
       // Named slot with an invalid ObjectId — the message quotes the name.
@@ -324,6 +444,27 @@ describe("spool ↔ printer-slot assignment (GH #242)", () => {
       expect(
         String((await Printer.findById(printer._id)).amsSlots[0].spoolId),
       ).toBe(String(spoolId));
+    });
+
+    it("GH #1041 — PUT writes the owning filament onto the slot, visible to the printer form", async () => {
+      // The core of the issue: the filament-side assignment wrote only
+      // spoolId, and PrinterForm keys slot rendering on filamentId, so the
+      // assignment rendered as an Empty slot on the printer side.
+      const { filament, spoolId } = await makeSpool("PLA both refs");
+      const printer = await Printer.create({
+        name: "P", manufacturer: "X", printerModel: "P",
+        amsSlots: [{ slotName: "S1" }],
+      });
+      const res = await putAssignment(
+        ...req(spoolId, "PUT", {
+          printerId: String(printer._id),
+          slotId: String(printer.amsSlots[0]._id),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const slot = (await Printer.findById(printer._id)).amsSlots[0];
+      expect(String(slot.spoolId)).toBe(String(spoolId));
+      expect(String(slot.filamentId)).toBe(String(filament._id));
     });
 
     it("PUT moves the spool, clearing its previous slot", async () => {


### PR DESCRIPTION
Fixes #1041.

**Root cause — data-model divergence, not a stale view.** An AMS slot carries two parallel refs (`filamentId` = loaded filament, `spoolId` = tracked spool). The filament-side assignment path wrote only `spoolId`; `PrinterForm` keys slot rendering on `filamentId` (spool select disabled until a filament is chosen) — so the assignment existed in the data, was fetched fresh on mount, and rendered as an **Empty slot**. Worse: "fixing" the seemingly-empty slot by re-selecting the filament silently wiped the spool ref. The reverse direction worked because the printer form writes both refs while the filament page reads only `spoolId`.

**Fix**: the shared `assignSpoolToSlot` now maintains both refs (the route already had the owning filament in hand), and every spool-keyed clear — the move pass and `clearSpoolsFromOtherPrinters` — nulls both, ending the phantom-loaded-filament staleness. `"Any spool"` dedications (filament set, no tracked spool) never match the spool-keyed filters and are untouched.

**Product calls** (confirmed): overwrite a different loaded filament silently (the assigned spool *is* what's loaded — matches the helper's existing self-healing posture); clearing a tracked spool clears the loaded filament with it.

**Legacy repair**: `amsSlotFilamentIds` startup migration backfills the owner onto orphaned slots (and clears dangling refs to deleted spools), plus a PrinterForm form-state backfill as belt-and-braces so a save persists the repaired pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)