### PR TITLE
fix(filaments): show remaining grams on the home list when no percentage denominator exists

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1058,7 +1058,17 @@ export default function Home() {
                 // column doesn't shift between the two tiers.
                 <span
                   className="text-xs text-gray-500 dark:text-gray-400 w-[86px] text-right"
-                  title={t("filaments.remainingGramsOnly")}
+                  title={
+                    // The tooltip names the input(s) the percentage actually
+                    // lacks — grams tolerates a missing tare (#954) but the
+                    // bar needs both weights, so "set net weight" would name
+                    // an already-set field for a tare-less record.
+                    display.missing === "tare"
+                      ? t("filaments.remainingGramsOnlyTare")
+                      : display.missing === "both"
+                        ? t("filaments.remainingGramsOnlyBoth")
+                        : t("filaments.remainingGramsOnly")
+                  }
                 >
                   {formatGrams(display.grams)}g
                 </span>
@@ -1192,7 +1202,15 @@ export default function Home() {
                     // branch's 48+6+32px footprint.
                     <span
                       className="text-xs text-gray-500 dark:text-gray-400 w-[86px] text-right"
-                      title={t("filaments.remainingGramsOnly")}
+                      title={
+                        // Tooltip keyed by the actually-missing input(s) —
+                        // see the renderRow twin.
+                        display.missing === "tare"
+                          ? t("filaments.remainingGramsOnlyTare")
+                          : display.missing === "both"
+                            ? t("filaments.remainingGramsOnlyBoth")
+                            : t("filaments.remainingGramsOnly")
+                      }
                     >
                       {formatGrams(display.grams)}g
                     </span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import { deriveArrangement } from "@/lib/filamentColors";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import type { FilamentSummary } from "@/types/filament";
-import { getRemainingGrams, getRemainingPct, getSpoolCount } from "@/lib/inventoryStats";
+import { getRemainingDisplay, getRemainingGrams, getSpoolCount } from "@/lib/inventoryStats";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { compareFilaments, nextSortState, earliestSpoolDate, type SortKey, type SortDir } from "@/lib/sortFilamentList";
 import { useDateFormat } from "@/hooks/useDateFormat";
@@ -1036,23 +1036,41 @@ export default function Home() {
       </td>
       <td className="py-2 px-2 text-right">
         {(() => {
-          const pct = getRemainingPct(f);
+          // GH #1048: three-tier cell (bar / grams-only / em-dash) — the
+          // decision lives in getRemainingDisplay so it's unit-testable.
+          // A legacy record with no netFilamentWeight has no percentage
+          // denominator but a perfectly computable gram figure; it used
+          // to fall through to the em-dash while the detail page showed
+          // the grams. Mirrors the inventory page's remaining cell.
+          const display = getRemainingDisplay(f);
           const spoolCt = getSpoolCount(f);
           const color =
-            pct == null ? "" : pct > 25 ? "bg-green-500" : pct > 10 ? "bg-yellow-500" : "bg-red-500";
+            display.kind !== "bar"
+              ? ""
+              : display.pct > 25 ? "bg-green-500" : display.pct > 10 ? "bg-yellow-500" : "bg-red-500";
           return (
             <div className="flex items-center gap-1.5 justify-end">
-              {pct == null ? (
+              {display.kind === "none" ? (
                 <span className="text-gray-400">—</span>
+              ) : display.kind === "grams" ? (
+                // w-[86px] matches the bar branch's footprint (w-12 bar +
+                // gap-1.5 + w-8 pct span = 48+6+32px) so the fixed-width
+                // column doesn't shift between the two tiers.
+                <span
+                  className="text-xs text-gray-500 dark:text-gray-400 w-[86px] text-right"
+                  title={t("filaments.remainingGramsOnly")}
+                >
+                  {formatGrams(display.grams)}g
+                </span>
               ) : (
                 <div
                   className="flex items-center gap-1.5"
-                  title={spoolCt > 1 ? t("filaments.remainingWithSpools", { pct, spools: spoolCt }) : t("filaments.remaining", { pct })}
+                  title={spoolCt > 1 ? t("filaments.remainingWithSpools", { pct: display.pct, spools: spoolCt }) : t("filaments.remaining", { pct: display.pct })}
                 >
                   <div className="w-12 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                    <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+                    <div className={`h-2 rounded-full ${color}`} style={{ width: `${display.pct}%` }} />
                   </div>
-                  <span className="text-xs text-gray-500 w-8 text-right">{pct}%</span>
+                  <span className="text-xs text-gray-500 w-8 text-right">{display.pct}%</span>
                 </div>
               )}
               {/* #717: per-spool location panel toggle (shared with parents) */}
@@ -1156,19 +1174,34 @@ export default function Home() {
           </td>
           <td className="py-2 px-2 text-right">
             {(() => {
-              const pct = getRemainingPct(f);
+              // GH #1048: same three-tier cell as renderRow. `f` here is
+              // the parent itself, so both the bar and the grams fallback
+              // describe the parent's OWN spools (#552/#616 legacy
+              // carrying preserved) — never a variant aggregate.
+              const display = getRemainingDisplay(f);
               const color =
-                pct == null ? "" : pct > 25 ? "bg-green-500" : pct > 10 ? "bg-yellow-500" : "bg-red-500";
+                display.kind !== "bar"
+                  ? ""
+                  : display.pct > 25 ? "bg-green-500" : display.pct > 10 ? "bg-yellow-500" : "bg-red-500";
               return (
                 <div className="flex items-center gap-1.5 justify-end">
-                  {pct == null ? (
+                  {display.kind === "none" ? (
                     <span className="text-gray-400">—</span>
+                  ) : display.kind === "grams" ? (
+                    // w-[86px]: see the renderRow twin — matches the bar
+                    // branch's 48+6+32px footprint.
+                    <span
+                      className="text-xs text-gray-500 dark:text-gray-400 w-[86px] text-right"
+                      title={t("filaments.remainingGramsOnly")}
+                    >
+                      {formatGrams(display.grams)}g
+                    </span>
                   ) : (
-                    <div className="flex items-center gap-1.5" title={t("filaments.remaining", { pct })}>
+                    <div className="flex items-center gap-1.5" title={t("filaments.remaining", { pct: display.pct })}>
                       <div className="w-12 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                        <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+                        <div className={`h-2 rounded-full ${color}`} style={{ width: `${display.pct}%` }} />
                       </div>
-                      <span className="text-xs text-gray-500 w-8 text-right">{pct}%</span>
+                      <span className="text-xs text-gray-500 w-8 text-right">{display.pct}%</span>
                     </div>
                   )}
                   {/* #717: a parent can carry its own spools (Codex P2 on #721) */}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -71,6 +71,7 @@
   "filaments.expandAll": "Alle ausklappen",
   "filaments.remaining": "{pct}% verbleibend",
   "filaments.remainingWithSpools": "{pct}% verbleibend ({spools} Spulen)",
+  "filaments.remainingGramsOnly": "Netto-Filamentgewicht festlegen, um den Prozentwert zu sehen",
   "filaments.spools.expand": "Spulen & Standorte anzeigen",
   "filaments.spools.collapse": "Spulen ausblenden",
   "filaments.spools.location": "Standort",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -72,6 +72,8 @@
   "filaments.remaining": "{pct}% verbleibend",
   "filaments.remainingWithSpools": "{pct}% verbleibend ({spools} Spulen)",
   "filaments.remainingGramsOnly": "Netto-Filamentgewicht festlegen, um den Prozentwert zu sehen",
+  "filaments.remainingGramsOnlyTare": "Spulengewicht (leere Spule) festlegen, um den Prozentwert zu sehen",
+  "filaments.remainingGramsOnlyBoth": "Spulen- und Netto-Filamentgewicht festlegen, um den Prozentwert zu sehen",
   "filaments.spools.expand": "Spulen & Standorte anzeigen",
   "filaments.spools.collapse": "Spulen ausblenden",
   "filaments.spools.location": "Standort",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -71,6 +71,7 @@
   "filaments.expandAll": "Expand all",
   "filaments.remaining": "{pct}% remaining",
   "filaments.remainingWithSpools": "{pct}% remaining ({spools} spools)",
+  "filaments.remainingGramsOnly": "Set net filament weight to see percentage",
   "filaments.spools.expand": "Show spools & locations",
   "filaments.spools.collapse": "Hide spools",
   "filaments.spools.location": "Location",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -72,6 +72,8 @@
   "filaments.remaining": "{pct}% remaining",
   "filaments.remainingWithSpools": "{pct}% remaining ({spools} spools)",
   "filaments.remainingGramsOnly": "Set net filament weight to see percentage",
+  "filaments.remainingGramsOnlyTare": "Set spool (empty spool) weight to see percentage",
+  "filaments.remainingGramsOnlyBoth": "Set spool and net filament weights to see percentage",
   "filaments.spools.expand": "Show spools & locations",
   "filaments.spools.collapse": "Hide spools",
   "filaments.spools.location": "Location",

--- a/src/lib/inventoryStats.ts
+++ b/src/lib/inventoryStats.ts
@@ -71,6 +71,36 @@ export function getRemainingGrams(f: InventoryFilament): number | null {
   return Math.max(0, f.totalWeight - f.spoolWeight);
 }
 
+/** Three-tier decision for a "remaining" table cell (GH #1048).
+ *
+ * The home list used to branch only on `getRemainingPct` and rendered a
+ * bare em-dash whenever the percentage was null — but the percentage
+ * needs `netFilamentWeight` as a denominator while the gram math does
+ * not (see the #310 note on `getRemainingGrams`). A legacy record like
+ * { totalWeight: 1035, spoolWeight: 184, netFilamentWeight: null }
+ * therefore showed "851 g" on the detail page and "—" on the list.
+ *
+ * Tiers, matching the inventory page's cell:
+ *   1. pct computable        → "bar"   (percentage bar)
+ *   2. only grams computable → "grams" (plain gram figure)
+ *   3. neither               → "none"  (em-dash)
+ *
+ * Extracted here (rather than inlined in the client page) so the
+ * decision is unit-testable — the home page is a `use client` component
+ * the node-only vitest env can't render. */
+export type RemainingDisplay =
+  | { kind: "bar"; pct: number }
+  | { kind: "grams"; grams: number }
+  | { kind: "none" };
+
+export function getRemainingDisplay(f: InventoryFilament): RemainingDisplay {
+  const pct = getRemainingPct(f);
+  if (pct != null) return { kind: "bar", pct };
+  const grams = getRemainingGrams(f);
+  if (grams != null) return { kind: "grams", grams };
+  return { kind: "none" };
+}
+
 /** Percentage remaining (0-100, integer). Excludes retired spools so
  * the bar matches the low-stock chip. Falls back to legacy
  * single-spool math when `spools` is empty. */

--- a/src/lib/inventoryStats.ts
+++ b/src/lib/inventoryStats.ts
@@ -90,14 +90,39 @@ export function getRemainingGrams(f: InventoryFilament): number | null {
  * the node-only vitest env can't render. */
 export type RemainingDisplay =
   | { kind: "bar"; pct: number }
-  | { kind: "grams"; grams: number }
+  | { kind: "grams"; grams: number; missing: RemainingPctMissing }
   | { kind: "none" };
+
+/** Which percentage-only input(s) block the bar tier while the grams
+ * tier still renders. `getRemainingGrams` tolerates a null `spoolWeight`
+ * in the spools-array branch (0 g tare fallback, GH #954) but
+ * `getRemainingPct` needs BOTH weights, so the grams tier can be
+ * blocked by the net weight, the tare, or both — the tooltip has to
+ * name the right one(s), not always "set net weight". */
+export type RemainingPctMissing = "net" | "tare" | "both";
 
 export function getRemainingDisplay(f: InventoryFilament): RemainingDisplay {
   const pct = getRemainingPct(f);
   if (pct != null) return { kind: "bar", pct };
   const grams = getRemainingGrams(f);
-  if (grams != null) return { kind: "grams", grams };
+  if (grams != null) {
+    // Derived from getRemainingPct's own guards, per branch:
+    //   spools-array: needs spoolWeight != null AND netFilamentWeight > 0
+    //     (≥1 active weighted spool is already guaranteed here — grams
+    //     being non-null in that branch means one exists, so validCount
+    //     can't be the blocker);
+    //   legacy: needs totalWeight, spoolWeight, netFilamentWeight > 0 —
+    //     and grams non-null in the legacy path already required
+    //     totalWeight AND spoolWeight, so only the net can be missing.
+    // Hence: tare can only be the blocker in the spools-array branch
+    // (the #954 0-tare fallback), and at least one of the two flags is
+    // set whenever this tier is reached.
+    const netMissing = f.netFilamentWeight == null || f.netFilamentWeight <= 0;
+    const tareMissing = f.spoolWeight == null;
+    const missing: RemainingPctMissing =
+      netMissing && tareMissing ? "both" : tareMissing ? "tare" : "net";
+    return { kind: "grams", grams, missing };
+  }
   return { kind: "none" };
 }
 

--- a/tests/inventoryStats.test.ts
+++ b/tests/inventoryStats.test.ts
@@ -278,14 +278,71 @@ describe("inventoryStats", () => {
     it("falls back to grams-only when only the gram math has inputs", () => {
       // The reported #1048 shape: legacy record, no netFilamentWeight.
       // Pre-fix the list rendered the em-dash tier here while the
-      // detail page showed 851 g.
+      // detail page showed 851 g. The legacy gram math itself requires
+      // spoolWeight, so in the legacy shape the missing input can only
+      // ever be the net weight.
       expect(
         getRemainingDisplay({
           totalWeight: 1035,
           spoolWeight: 184,
           netFilamentWeight: null,
         }),
-      ).toEqual({ kind: "grams", grams: 851 });
+      ).toEqual({ kind: "grams", grams: 851, missing: "net" });
+    });
+
+    it("reports the tare as missing for weighted spools with net set but no spoolWeight", () => {
+      // The Codex shape: getRemainingGrams tolerates a null spoolWeight in
+      // the spools-array branch (0-tare fallback, #954) but getRemainingPct
+      // needs BOTH weights — so the pre-fix tooltip told the user to set
+      // the net weight, which was already set and couldn't fix the bar.
+      expect(
+        getRemainingDisplay({
+          spoolWeight: null,
+          netFilamentWeight: 800,
+          totalWeight: null,
+          spools: [{ totalWeight: 800 }],
+        }),
+      ).toEqual({ kind: "grams", grams: 800, missing: "tare" });
+    });
+
+    it("reports the net as missing for weighted spools with a tare but no net weight", () => {
+      // Spools-array twin of the legacy #1048 shape (#310): tare present,
+      // denominator absent.
+      expect(
+        getRemainingDisplay({
+          spoolWeight: 200,
+          netFilamentWeight: null,
+          totalWeight: null,
+          spools: [{ totalWeight: 800 }],
+        }),
+      ).toEqual({ kind: "grams", grams: 600, missing: "net" });
+    });
+
+    it("reports both as missing when neither weight is set but spools are weighted", () => {
+      // 0-tare fallback still yields grams; the percentage lacks both the
+      // tare and the denominator.
+      expect(
+        getRemainingDisplay({
+          spoolWeight: null,
+          netFilamentWeight: null,
+          totalWeight: null,
+          spools: [{ totalWeight: 800 }],
+        }),
+      ).toEqual({ kind: "grams", grams: 800, missing: "both" });
+    });
+
+    it("treats a non-positive net weight as missing (matches getRemainingPct's > 0 guard)", () => {
+      // netFilamentWeight: 0 is set-but-unusable — getRemainingPct's guard
+      // is `netFilamentWeight > 0`, so the missing-input report must agree
+      // with the pct branch logic, not just null-check the field.
+      expect(
+        getRemainingDisplay({
+          spoolWeight: 200,
+          netFilamentWeight: 0,
+          totalWeight: null,
+          spools: [{ totalWeight: 800 }],
+        }),
+      ).toEqual({ kind: "grams", grams: 600, missing: "net" });
     });
 
     it("renders the em-dash tier when neither figure is computable", () => {
@@ -309,6 +366,26 @@ describe("inventoryStats", () => {
       expect(getRemainingDisplay({ ...reported, netFilamentWeight: 1000 })).toEqual({
         kind: "bar",
         pct: 85,
+      });
+    });
+
+    it("agrees with the tare tooltip's remedy: setting spoolWeight upgrades grams to bar", () => {
+      // The tare-missing tooltip names spoolWeight — verify that setting it
+      // (net already present) is in fact what flips the tier.
+      const codexShape: InventoryFilament = {
+        spoolWeight: null,
+        netFilamentWeight: 800,
+        totalWeight: null,
+        spools: [{ totalWeight: 1000 }],
+      };
+      expect(getRemainingDisplay(codexShape)).toEqual({
+        kind: "grams",
+        grams: 1000,
+        missing: "tare",
+      });
+      expect(getRemainingDisplay({ ...codexShape, spoolWeight: 200 })).toEqual({
+        kind: "bar",
+        pct: 100, // (1000-200)/800
       });
     });
   });

--- a/tests/inventoryStats.test.ts
+++ b/tests/inventoryStats.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   getSpoolCount,
+  getRemainingDisplay,
   getRemainingGrams,
   getRemainingPct,
   type InventoryFilament,
@@ -137,6 +138,21 @@ describe("inventoryStats", () => {
       ).toBe(0);
     });
 
+    it("computes legacy no-spools grams when netFilamentWeight is blank (#310/#1048)", () => {
+      // The reported #1048 record: a pre-migration filament with no
+      // spools[] and no net weight. The grams need no denominator —
+      // 1035 - 184 = 851 shows on the detail page and must not be
+      // suppressed. (The #310 case above pins the same rule for the
+      // spools-array shape; this is its legacy-shape twin.)
+      expect(
+        getRemainingGrams({
+          totalWeight: 1035,
+          spoolWeight: 184,
+          netFilamentWeight: null,
+        }),
+      ).toBe(851);
+    });
+
     it("returns null in the legacy path when totalWeight or spoolWeight is missing", () => {
       expect(
         getRemainingGrams({ ...baseTracked, totalWeight: null, spools: [] }),
@@ -215,6 +231,20 @@ describe("inventoryStats", () => {
       ).toBeNull();
     });
 
+    it("is null without a net weight but recovers once it's set (#1048)", () => {
+      // The reported record: grams are computable (851, above) but the
+      // percentage has no denominator — null, NOT 0 or NaN.
+      const reported: InventoryFilament = {
+        totalWeight: 1035,
+        spoolWeight: 184,
+        netFilamentWeight: null,
+      };
+      expect(getRemainingPct(reported)).toBeNull();
+      // Setting the net weight is the documented remedy (the grams-only
+      // tooltip says so): 851/1000 = 85.1 → 85.
+      expect(getRemainingPct({ ...reported, netFilamentWeight: 1000 })).toBe(85);
+    });
+
     it("clamps to 0..100", () => {
       // Over-full spool (e.g. brand new + extra) should clamp to 100, not 110+
       const over: InventoryFilament = {
@@ -231,6 +261,55 @@ describe("inventoryStats", () => {
         spools: [{ totalWeight: 100 }], // would be -12.5%
       };
       expect(getRemainingPct(under)).toBe(0);
+    });
+  });
+
+  describe("getRemainingDisplay (#1048)", () => {
+    // The home list's remaining cell can't be render-tested (client
+    // component, node-only vitest env), so the three-tier decision it
+    // delegates to is pinned here instead.
+
+    it("picks the bar tier whenever a percentage is computable", () => {
+      expect(
+        getRemainingDisplay({ ...baseTracked, totalWeight: 600, spools: [] }),
+      ).toEqual({ kind: "bar", pct: 50 });
+    });
+
+    it("falls back to grams-only when only the gram math has inputs", () => {
+      // The reported #1048 shape: legacy record, no netFilamentWeight.
+      // Pre-fix the list rendered the em-dash tier here while the
+      // detail page showed 851 g.
+      expect(
+        getRemainingDisplay({
+          totalWeight: 1035,
+          spoolWeight: 184,
+          netFilamentWeight: null,
+        }),
+      ).toEqual({ kind: "grams", grams: 851 });
+    });
+
+    it("renders the em-dash tier when neither figure is computable", () => {
+      expect(
+        getRemainingDisplay({
+          totalWeight: null,
+          spoolWeight: null,
+          netFilamentWeight: null,
+          spools: [],
+        }),
+      ).toEqual({ kind: "none" });
+    });
+
+    it("agrees with the tooltip's remedy: setting net weight upgrades grams to bar", () => {
+      const reported: InventoryFilament = {
+        totalWeight: 1035,
+        spoolWeight: 184,
+        netFilamentWeight: null,
+      };
+      expect(getRemainingDisplay(reported).kind).toBe("grams");
+      expect(getRemainingDisplay({ ...reported, netFilamentWeight: 1000 })).toEqual({
+        kind: "bar",
+        pct: 85,
+      });
     });
   });
 });


### PR DESCRIPTION
The reported row ("Pro PCTG Midnight Black", 851 g) was never showing a bar — this isn't a below-100% rendering bug. The percentage needs `netFilamentWeight` as its denominator, and the record (a legacy no-spools shape) has it null on both the variant and the parent, while the grams need no denominator at all (`totalWeight − spoolWeight` = 1035 − 184 = 851), which is why the detail page shows them. The home list rendered a bare em-dash for exactly the rows where only the grams exist.

## Fix

The list now uses the Inventory page's established three-tier pattern, via a new pure helper (`getRemainingDisplay` in `src/lib/inventoryStats.ts` — the pct/grams math is untouched):

1. **bar** when the percentage exists (markup unchanged);
2. **grams-only text** ("851g") with a *"Set net filament weight to see percentage"* tooltip when only grams exist;
3. **em-dash** when neither does.

Applied symmetrically to the child/standalone and parent row renderers. The parent cell keeps describing the parent's **own** spools (#552/#616 posture), and a post-#605 template with no own inventory keeps the em-dash. A fabricated denominator was deliberately rejected: defaulting to 1000 g mislabels 500 g/750 g/2.3 kg spools, and `totalWeight − spoolWeight` as denominator degenerates to a constant 100%.

## Data note for the reporter's instance

No code needed for the bar to appear today: set **Net Filament Weight = 1000 on the parent "Pro PCTG"** — inheritance flows it to every color variant and the row shows an 85% green bar (851/1000).

## Verification

Tests pin the reported record's arithmetic (pct null at 1035/184/null; 85% once net = 1000; grams 851) and all three display tiers with full branch coverage on the new helper. i18n key parity (en+de, 1743 keys each); tsc and eslint clean; full suite in CI.

Fixes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)