### PR TITLE
feat(inventory): larger rounded-square color swatch on spool rows

### DIFF
--- a/src/app/api/spools/by-location/route.ts
+++ b/src/app/api/spools/by-location/route.ts
@@ -71,7 +71,15 @@ interface AggregatedSpool {
   filamentName: string;
   filamentVendor: string;
   filamentType: string;
-  filamentColor: string;
+  /** Raw variant primary — null for coextruded filaments (OpenPrintTag
+   * spec key 19), whose colors live in `secondaryColors`. */
+  filamentColor: string | null;
+  /** GH #1050: EFFECTIVE color arrays (variant's own non-empty array, else
+   * the parent's — the GH #477 array-fallback rule) so the /inventory row
+   * swatch renders multi-color arrangements and finishes like the home
+   * list does. */
+  secondaryColors: string[];
+  optTags: number[];
   /** Variant's own values; null falls back to `parent*` on the client. */
   spoolWeight: number | null;
   netFilamentWeight: number | null;
@@ -162,6 +170,13 @@ export async function GET(request: NextRequest) {
                 netFilamentWeight: 1,
                 type: 1,
                 vendor: 1,
+                // GH #1050: carry the parent's color arrays so the row
+                // projection below can apply the array-fallback inheritance
+                // rule (variant's empty array inherits the parent's whole
+                // array — see resolveFilament / GH #477). Without these the
+                // /inventory swatch renders an inheriting variant single-color.
+                secondaryColors: 1,
+                optTags: 1,
               },
             },
           ],
@@ -339,6 +354,28 @@ export async function GET(request: NextRequest) {
               filamentVendor: "$_effectiveVendor",
               filamentType: "$_effectiveType",
               filamentColor: "$color",
+              // GH #1050: effective (parent-fallback) color arrays for the
+              // /inventory row swatch. Same array-fallback merge as the
+              // /api/filaments list aggregation (GH #477): a variant's own
+              // non-empty array wins; an empty/missing array inherits the
+              // parent's whole array. Without these, a coextruded filament
+              // (null primary, colors in secondaryColors) renders as the
+              // gray #808080 sentinel on /inventory — the exact "can't find
+              // my spool by color" complaint in GH #1050.
+              secondaryColors: {
+                $cond: [
+                  { $gt: [{ $size: { $ifNull: ["$secondaryColors", []] } }, 0] },
+                  "$secondaryColors",
+                  { $ifNull: [{ $arrayElemAt: ["$_parent.secondaryColors", 0] }, []] },
+                ],
+              },
+              optTags: {
+                $cond: [
+                  { $gt: [{ $size: { $ifNull: ["$optTags", []] } }, 0] },
+                  "$optTags",
+                  { $ifNull: [{ $arrayElemAt: ["$_parent.optTags", 0] }, []] },
+                ],
+              },
               spoolWeight: "$spoolWeight",
               netFilamentWeight: "$netFilamentWeight",
               parentSpoolWeight: {

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -17,6 +17,9 @@ import {
 } from "@/lib/inventorySort";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { isKnownLocationKind } from "@/lib/locationKind";
+import FilamentSwatch from "@/components/FilamentSwatch";
+import { deriveArrangement } from "@/lib/filamentColors";
+import { deriveFinish } from "@/lib/filamentFinish";
 
 // Loaded on demand — the dialog pulls in the TSPL emitter + the qrcode
 // package for its preview, none of which the page needs until a print is
@@ -72,7 +75,17 @@ interface SpoolRow {
   filamentName: string;
   filamentVendor: string;
   filamentType: string;
-  filamentColor: string;
+  /** Raw variant primary — null for coextruded filaments, whose colors
+   * live in `secondaryColors`. Don't coalesce to a gray before handing it
+   * to FilamentSwatch; the swatch's own secondaryColors fallback handles
+   * the null-primary case (GH #1050). */
+  filamentColor: string | null;
+  /** GH #1050: effective (parent-fallback) color arrays from the
+   * aggregation — drive the multi-color / finish swatch treatment.
+   * Optional so a stale client cache of the pre-#1050 payload shape
+   * doesn't explode. */
+  secondaryColors?: string[];
+  optTags?: number[];
   spoolWeight: number | null;
   netFilamentWeight: number | null;
   parentSpoolWeight: number | null;
@@ -1103,18 +1116,28 @@ function SpoolEditRow({
       <tr className="border-b border-gray-100 dark:border-gray-900">
         <td className="py-2 px-2" aria-hidden="true" />
         <td className="py-2 px-3">
-          <div className="flex items-center gap-2 min-w-0">
-            <span
-              className="inline-block w-3.5 h-3.5 rounded-full border border-gray-300 dark:border-gray-700 shrink-0"
-              style={{ backgroundColor: row.filamentColor || "#808080" }}
-              aria-hidden="true"
+          {/* GH #1050: 32px rounded-square swatch spanning both text lines —
+              larger color area without growing the row. */}
+          <div className="flex items-center gap-2.5 min-w-0">
+            <FilamentSwatch
+              color={row.filamentColor}
+              secondaryColors={row.secondaryColors}
+              arrangement={deriveArrangement(row.optTags)}
+              finish={deriveFinish(row.optTags)}
+              shape="square"
+              size={32}
+              title={row.filamentColor ?? undefined}
             />
-            <Link href={`/filaments/${row.filamentId}`} className="text-blue-600 hover:underline truncate">
-              {row.filamentName}
-            </Link>
-            <span className="text-xs text-gray-500 shrink-0">{row.filamentType}</span>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 min-w-0">
+                <Link href={`/filaments/${row.filamentId}`} className="text-blue-600 hover:underline truncate">
+                  {row.filamentName}
+                </Link>
+                <span className="text-xs text-gray-500 shrink-0">{row.filamentType}</span>
+              </div>
+              <div className="text-xs text-gray-500 truncate">{row.filamentVendor}</div>
+            </div>
           </div>
-          <div className="text-xs text-gray-500 truncate">{row.filamentVendor}</div>
         </td>
         <td className="py-2 px-3">
           <span
@@ -1152,23 +1175,34 @@ function SpoolEditRow({
         />
       </td>
       <td className="py-2 px-3">
-        <div className="flex items-center gap-2 min-w-0">
-          <span
-            className="inline-block w-3.5 h-3.5 rounded-full border border-gray-300 dark:border-gray-700 shrink-0"
-            style={{ backgroundColor: row.filamentColor || "#808080" }}
-            aria-hidden="true"
+        {/* GH #1050: 32px rounded-square swatch spanning both text lines —
+            larger color area without growing the row. Multi-color and
+            finish treatments now render here like on the home list. */}
+        <div className="flex items-center gap-2.5 min-w-0">
+          <FilamentSwatch
+            color={row.filamentColor}
+            secondaryColors={row.secondaryColors}
+            arrangement={deriveArrangement(row.optTags)}
+            finish={deriveFinish(row.optTags)}
+            shape="square"
+            size={32}
+            title={row.filamentColor ?? undefined}
           />
-          <Link
-            href={`/filaments/${row.filamentId}`}
-            className="text-blue-600 hover:underline truncate"
-          >
-            {row.filamentName}
-          </Link>
-          <span className="text-xs text-gray-500 shrink-0">{row.filamentType}</span>
-        </div>
-        <div className="text-xs text-gray-500 truncate">
-          {row.filamentVendor}
-          {row.lotNumber && ` · lot ${row.lotNumber}`}
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 min-w-0">
+              <Link
+                href={`/filaments/${row.filamentId}`}
+                className="text-blue-600 hover:underline truncate"
+              >
+                {row.filamentName}
+              </Link>
+              <span className="text-xs text-gray-500 shrink-0">{row.filamentType}</span>
+            </div>
+            <div className="text-xs text-gray-500 truncate">
+              {row.filamentVendor}
+              {row.lotNumber && ` · lot ${row.lotNumber}`}
+            </div>
+          </div>
         </div>
       </td>
       <td className="py-2 px-3">

--- a/src/components/FilamentSwatch.tsx
+++ b/src/components/FilamentSwatch.tsx
@@ -57,6 +57,11 @@ interface FilamentSwatchProps {
   finish?: Finish | null;
   /** Pixel size for both width and height. Defaults to 20px (w-5 h-5). */
   size?: number;
+  /** GH #1050: outer shape. "circle" (default) keeps the classic round
+   *  dot; "square" renders a rounded square, which shows noticeably more
+   *  color area at the same footprint — the /inventory rows use it so a
+   *  color can be judged at a glance. */
+  shape?: "circle" | "square";
   /** Optional extra class names (border styling, ring, etc.). */
   className?: string;
   /** Native `title` attribute — appears on hover. */
@@ -83,10 +88,15 @@ export default function FilamentSwatch({
   variantColors = [],
   finish = null,
   size = 20,
+  shape = "circle",
   className = "",
   title,
   ariaLabel,
 }: FilamentSwatchProps) {
+  // GH #1050: every render path below shares the same outer rounding, so
+  // the shape resolves once here. `rounded-md` (not `-lg`/`-xl`) keeps the
+  // square clearly square at the 16–32px sizes callers actually use.
+  const roundedClass = shape === "square" ? "rounded-md" : "rounded-full";
   // GH #638: the fallback labels were hardcoded English, so German SR
   // users heard "Color swatch: …" — translate through the shared catalog
   // (the context carries an en-based default, so the component still
@@ -136,7 +146,7 @@ export default function FilamentSwatch({
             };
       return (
         <div
-          className={`rounded-full border border-gray-300 dark:border-gray-600 flex-shrink-0 ${className}`}
+          className={`${roundedClass} border border-gray-300 dark:border-gray-600 flex-shrink-0 ${className}`}
           style={groupStyle}
           title={title ?? label}
           aria-label={label}
@@ -158,7 +168,7 @@ export default function FilamentSwatch({
     };
     return (
       <div
-        className={`rounded-full border border-gray-400 dark:border-gray-500 flex-shrink-0 dark:bg-gray-700 ${className}`}
+        className={`${roundedClass} border border-gray-400 dark:border-gray-500 flex-shrink-0 dark:bg-gray-700 ${className}`}
         style={hatchStyle}
         title={title ?? t("swatch.colorGroup")}
         aria-label={finalLabel}
@@ -240,7 +250,7 @@ export default function FilamentSwatch({
     const gap = finish === "translucent" ? 6 : 7;
     return (
       <div
-        className={`rounded-full border border-gray-400 dark:border-gray-500 flex-shrink-0 relative overflow-hidden ${className}`}
+        className={`${roundedClass} border border-gray-400 dark:border-gray-500 flex-shrink-0 relative overflow-hidden ${className}`}
         style={{ ...dimensionStyle, backgroundColor: baseColor }}
         title={finalTitle}
         aria-label={finalLabel}
@@ -295,7 +305,7 @@ export default function FilamentSwatch({
     const overlay = solidFinishOverlay(finish, rgb);
     return (
       <div
-        className={`rounded-full border border-gray-300 dark:border-gray-600 flex-shrink-0 relative overflow-hidden ${className}`}
+        className={`${roundedClass} border border-gray-300 dark:border-gray-600 flex-shrink-0 relative overflow-hidden ${className}`}
         style={baseStyle}
         title={finalTitle}
         aria-label={finalLabel}
@@ -317,7 +327,7 @@ export default function FilamentSwatch({
   const overlay = solidFinishOverlay(finish, rgb);
   return (
     <div
-      className={`rounded-full border border-gray-300 dark:border-gray-600 flex-shrink-0 relative overflow-hidden ${className}`}
+      className={`${roundedClass} border border-gray-300 dark:border-gray-600 flex-shrink-0 relative overflow-hidden ${className}`}
       style={{ ...dimensionStyle, backgroundColor: baseColor }}
       title={finalTitle}
       aria-label={finalLabel}

--- a/tests/spools-by-location-route.test.ts
+++ b/tests/spools-by-location-route.test.ts
@@ -428,6 +428,74 @@ describe("GET /api/spools/by-location", () => {
     expect(spool.parentNetFilamentWeight).toBe(1000);
   });
 
+  it("GH #1050: surfaces EFFECTIVE secondaryColors + optTags for the /inventory swatch (own wins; empty inherits parent's)", async () => {
+    const shelf = await Location.create({ name: "Shelf A", kind: "shelf" });
+
+    // Coextruded standalone: null primary (explicit — the schema default
+    // is the #808080 sentinel), colors in its own secondaryColors.
+    await Filament.create({
+      name: "Coex Green Purple",
+      vendor: "QA",
+      type: "PLA",
+      diameter: 1.75,
+      color: null,
+      secondaryColors: ["#00FF00", "#800080"],
+      optTags: [28], // dual_color → coextruded
+      spools: [{ label: "C1", totalWeight: 1000, locationId: shelf._id }],
+    });
+
+    // Variant with EMPTY arrays under a multi-color parent → inherits the
+    // parent's whole arrays (GH #477 array-fallback rule, mirroring the
+    // /api/filaments list aggregation's merge).
+    const parent = await Filament.create({
+      name: "Rainbow Parent",
+      vendor: "QA",
+      type: "PLA",
+      diameter: 1.75,
+      secondaryColors: ["#FF0000", "#0000FF"],
+      optTags: [27], // gradient
+    });
+    await Filament.create({
+      name: "Rainbow Variant",
+      vendor: "QA",
+      type: "PLA",
+      diameter: 1.75,
+      parentId: parent._id,
+      spools: [{ label: "V1", totalWeight: 1000, locationId: shelf._id }],
+    });
+
+    // Plain standalone with no arrays anywhere → empty arrays, not
+    // null/missing, so the client can index without guards.
+    await Filament.create({
+      name: "Plain Black",
+      vendor: "QA",
+      type: "PLA",
+      diameter: 1.75,
+      color: "#111111",
+      spools: [{ label: "P1", totalWeight: 1000, locationId: shelf._id }],
+    });
+
+    const { GET } = await import("@/app/api/spools/by-location/route");
+    const body = await (await GET(req())).json();
+    const spools = body.groups[0].spools;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const byName = Object.fromEntries(spools.map((s: any) => [s.filamentName, s]));
+
+    // Own arrays win; the null primary rides through un-coalesced so the
+    // swatch falls back to secondaryColors[0] instead of rendering gray.
+    expect(byName["Coex Green Purple"].filamentColor).toBeNull();
+    expect(byName["Coex Green Purple"].secondaryColors).toEqual(["#00FF00", "#800080"]);
+    expect(byName["Coex Green Purple"].optTags).toEqual([28]);
+
+    // Empty own arrays inherit the parent's whole arrays.
+    expect(byName["Rainbow Variant"].secondaryColors).toEqual(["#FF0000", "#0000FF"]);
+    expect(byName["Rainbow Variant"].optTags).toEqual([27]);
+
+    // No arrays anywhere → empties.
+    expect(byName["Plain Black"].secondaryColors).toEqual([]);
+    expect(byName["Plain Black"].optTags).toEqual([]);
+  });
+
   it("excludes soft-deleted filaments and their spools", async () => {
     const shelf = await Location.create({ name: "Shelf A", kind: "shelf" });
     await Filament.create({


### PR DESCRIPTION
Fixes #1050

## What

The `/inventory` spool rows showed only a ~14px colored dot next to the filament name. The reporter wants to scan the page by color; the dot was too small — and sometimes plain wrong: the by-location aggregation projected only the raw variant `color`, so a coextruded filament (null primary, colors in `secondaryColors`) rendered as the gray `#808080` sentinel (visible in the issue's own screenshot on the "Dual Color Green Purple" row), and finish/arrangement treatments didn't render at all.

## How

- **`FilamentSwatch`**: new `shape?: "circle" | "square"` prop (default `"circle"`, so all existing callers are untouched). Square maps to `rounded-md` across all five render paths (parent composite, parent hatch, translucent/transparent, multi-color, solid).
- **`GET /api/spools/by-location`**: the spool projection now carries effective `secondaryColors` + `optTags` — the same GH #477 array-fallback merge the `/api/filaments` list aggregation uses (own non-empty array wins, else the parent's whole array; the parent `$lookup` already existed for `spoolWeight`). `filamentColor` is typed honestly as `string | null`.
- **`/inventory`**: both row renderers (normal + GH #783 legacy read-only) replace the bare `<span>` dot with a 32px square `FilamentSwatch` spanning both text lines — larger color area with **zero row-height growth**. Arrangement + finish are derived via `deriveArrangement`/`deriveFinish` exactly like the home list, so coextruded stripes, gradients, silk/matte/translucent/etc. now render here too. The raw `filamentColor` is passed un-coalesced so the swatch's own `secondaryColors[0]` fallback handles null primaries.

## Tests

- New route case pinning the effective-array projection: own arrays win; a variant's empty arrays inherit the parent's whole arrays; a filament with no arrays emits empties; a null primary rides through un-coalesced.
- Full suite: 182 files / 3860 tests green. `tsc --noEmit` + ESLint clean.

## Verified in browser (light + dark, production data)

All visible rows render `rounded-md` 32px swatches; finish treatments (translucent hatch, matte, transparent, silk) confirmed rendering on real rows; row heights unchanged. No coextruded-with-spools rows exist in the verification DB — that path is pinned by the route test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)