### PR TITLE
Bump version to 1.74.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.73.0",
+      "version": "1.74.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.73.0",
+    "version": "1.74.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Routine version bump across the three canonical spots (`package.json`, both `package-lock.json` occurrences, `public/openapi.json` `info.version`) ahead of tagging v1.74.0.

Ships since v1.73.0:
- #1067 — surface + edit the PrusaSlicer printer restriction; lift synced `inherits` top-level (fixes #1066)
- #1064 — close the v1.68–v1.73 documentation drift
- #1065 — electron 41.10.4 (clears GHSA-v3j7-r9gq-3gjw / GHSA-r4w5-6pfg-jxp5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)