### PR TITLE
fix(inventory): stop an empty weight field saving as 0 g (#1105)

### DIFF
--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -10,6 +10,7 @@ import { useDateFormat } from "@/hooks/useDateFormat";
 import { Skeleton, SkeletonRegion } from "@/components/Skeleton";
 import {
   groupAndSortInventory,
+  summarizeInventoryGroups,
   INVENTORY_NO_GROUP_KEY,
   type InventoryGroupBy,
   type InventorySortKey,
@@ -17,6 +18,7 @@ import {
 } from "@/lib/inventorySort";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { isKnownLocationKind } from "@/lib/locationKind";
+import { parseWeightInput, type WeightInputProblem } from "@/lib/parseWeightInput";
 import FilamentSwatch from "@/components/FilamentSwatch";
 import { deriveArrangement } from "@/lib/filamentColors";
 import { deriveFinish } from "@/lib/filamentFinish";
@@ -462,23 +464,14 @@ export default function InventoryPage() {
       .filter((g) => g.spools.length > 0);
   }, [data, debouncedSearch]);
 
-  // Stats for the header — derived from the SERVER groups so they
-  // reflect the active server filters, not the client-side text search
-  // (which is a "find within results" rather than a true filter).
-  const stats = useMemo(() => {
-    if (!data) return { spoolCount: 0, locationCount: 0, totalGrams: 0 };
-    return {
-      spoolCount: data.totalSpools,
-      // #575.5: count every group the inventory is spread across, including
-      // the synthetic "no location" bucket when it holds spools. Counting
-      // only real locations rendered "LOCATIONS 0" while 13 spools sat under
-      // "No location" — confusing, and out of step with the groups actually
-      // shown on the page. (Empty groups are never emitted by the
-      // aggregation, so this is exactly the number of buckets on screen.)
-      locationCount: data.groups.length,
-      totalGrams: data.groups.reduce((s, g) => s + g.totalGrams, 0),
-    };
-  }, [data]);
+  // Stats for the header. #1117(f): these used to read straight off the
+  // server response, so they tracked the server-side filters but NOT the
+  // client-side text search — searching down to one spool still headlined
+  // "SPOOLS 74 · TOTAL WEIGHT 50.65 kg". Deriving from `filteredGroups`
+  // covers both, and matches the group headers, which have recomputed under
+  // search since PR #391 round 2. With an empty search `filteredGroups` IS
+  // `data.groups` verbatim, so the unsearched numbers are unchanged.
+  const stats = useMemo(() => summarizeInventoryGroups(filteredGroups), [filteredGroups]);
 
   // GH #795: regroup (location / type / vendor / none) + sort within each
   // group. Pure transform over the already-search-filtered rows — the
@@ -628,6 +621,13 @@ export default function InventoryPage() {
         <StatCard label={t("inventory.stats.locations")} value={stats.locationCount.toString()} />
         <StatCard label={t("inventory.stats.totalWeight")} value={`${formatNumber(stats.totalGrams / 1000, { minDecimals: 2, maxDecimals: 2, trimTrailingZeros: false })} kg`} />
       </div>
+      {/* Now that the cards follow the search, say so — a shrunken total
+          should read as "filtered", never as data loss. */}
+      {debouncedSearch.trim() !== "" && (
+        <p className="-mt-4 mb-6 text-xs text-gray-500 dark:text-gray-400">
+          {t("inventory.stats.searchNote")}
+        </p>
+      )}
 
       {/* Filters */}
       <div className="flex flex-wrap items-end gap-3 mb-6 p-3 bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 rounded-lg">
@@ -1048,6 +1048,7 @@ function SpoolEditRow({
   const [editingWeight, setEditingWeight] = useState(false);
   const [weightDraft, setWeightDraft] = useState(row.totalWeight?.toString() ?? "");
   const [saving, setSaving] = useState(false);
+  const [weightError, setWeightError] = useState<WeightInputProblem | null>(null);
 
   const saveWeight = async () => {
     // GH #509: short-circuit re-entry while a save is in flight. The
@@ -1057,14 +1058,43 @@ function SpoolEditRow({
     // raced a second PUT against the refresh. Mirrors the
     // movePending / retirePending guards added for #404.
     if (saving) return;
-    const n = Number(weightDraft);
-    if (!Number.isFinite(n) || n < 0) return;
+    // GH #1105: this used to be `Number(weightDraft)` behind a
+    // `!Number.isFinite(n) || n < 0` guard, which an EMPTY field passes —
+    // Number("") is 0. Clearing the box and saving silently wrote 0 g and
+    // took the spool's weight out of the location and library totals.
+    const parsed = parseWeightInput(weightDraft);
+    if (!parsed.ok) {
+      setWeightError(parsed.reason);
+      return;
+    }
+    setWeightError(null);
+    const patch: Record<string, unknown> = { totalWeight: parsed.grams };
+    // Set `saving` BEFORE the confirm below, so the Enter-key re-entry guard
+    // above covers the dialog's whole lifetime.
     setSaving(true);
-    const ok = await updateSpool(row, { totalWeight: n });
-    setSaving(false);
-    if (ok) {
-      setEditingWeight(false);
-      onChanged();
+    try {
+      // GH #381: zeroing the remaining weight is the canonical "I finished
+      // this spool" moment, and the detail page has prompted to retire on it
+      // since v1.30.4. This path skipped the prompt entirely. Same skips as
+      // the detail page: never when already retired, never when the prior
+      // weight was already 0 (no real transition). A null prior weight is
+      // `!== 0`, so it prompts — matching the detail page exactly.
+      if (parsed.grams === 0 && !row.retired && row.totalWeight !== 0) {
+        const alsoRetire = await confirmRetire({
+          message: t("detail.spool.confirmRetireOnZero"),
+          confirmLabel: t("inventory.retire"),
+        });
+        if (alsoRetire) patch.retired = true;
+      }
+      const ok = await updateSpool(row, patch);
+      if (ok) {
+        setEditingWeight(false);
+        onChanged();
+      }
+    } finally {
+      // try/finally because of the await above: a throw inside the confirm
+      // would otherwise strand this row disabled with no way back.
+      setSaving(false);
     }
   };
 
@@ -1223,44 +1253,62 @@ function SpoolEditRow({
       </td>
       <td className="py-2 px-3 text-right">
         {editingWeight ? (
-          <span className="inline-flex items-center gap-1">
-            <input
-              type="number"
-              min="0"
-              step="1"
-              autoFocus
-              value={weightDraft}
-              onChange={(e) => setWeightDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") saveWeight();
-                if (e.key === "Escape") {
+          <span className="inline-flex flex-col items-end gap-0.5">
+            <span className="inline-flex items-center gap-1">
+              <input
+                type="number"
+                min="0"
+                step="1"
+                autoFocus
+                value={weightDraft}
+                onChange={(e) => {
+                  setWeightDraft(e.target.value);
+                  setWeightError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") saveWeight();
+                  if (e.key === "Escape") {
+                    setWeightDraft(row.totalWeight?.toString() ?? "");
+                    setWeightError(null);
+                    setEditingWeight(false);
+                  }
+                }}
+                aria-label={t("inventory.updateWeight")}
+                aria-invalid={weightError != null}
+                className="w-20 px-2 py-0.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-transparent"
+              />
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={saveWeight}
+                // GH #1105: also disabled while the field is empty, matching
+                // the detail page's editor.
+                disabled={saving || weightDraft.trim() === ""}
+                className="px-2 py-0.5 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 disabled:opacity-50"
+              >
+                {saving ? "…" : t("common.save")}
+              </button>
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
                   setWeightDraft(row.totalWeight?.toString() ?? "");
+                  setWeightError(null);
                   setEditingWeight(false);
-                }
-              }}
-              aria-label={t("inventory.updateWeight")}
-              className="w-20 px-2 py-0.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-transparent"
-            />
-            <button
-              type="button"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={saveWeight}
-              disabled={saving}
-              className="px-2 py-0.5 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 disabled:opacity-50"
-            >
-              {saving ? "…" : t("common.save")}
-            </button>
-            <button
-              type="button"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => {
-                setWeightDraft(row.totalWeight?.toString() ?? "");
-                setEditingWeight(false);
-              }}
-              className="px-2 py-0.5 border border-gray-300 dark:border-gray-700 rounded text-xs hover:bg-gray-100 dark:hover:bg-gray-800"
-            >
-              {t("common.cancel")}
-            </button>
+                }}
+                className="px-2 py-0.5 border border-gray-300 dark:border-gray-700 rounded text-xs hover:bg-gray-100 dark:hover:bg-gray-800"
+              >
+                {t("common.cancel")}
+              </button>
+            </span>
+            {/* This editor is pre-seeded with the current value, so a silent
+                no-op on Enter reads as "the app is broken" more than it would
+                on the detail page's blank "new reading" field. */}
+            {weightError && (
+              <span role="alert" className="text-xs text-amber-600 dark:text-amber-400">
+                {t("detail.weight.invalidInput")}
+              </span>
+            )}
           </span>
         ) : (
           // GH #445: visible affordance for the inline weight editor.
@@ -1280,6 +1328,7 @@ function SpoolEditRow({
               // would write the old weight back. Mirrors the GH #263
               // SpoolCard label-edit fix.
               setWeightDraft(row.totalWeight?.toString() ?? "");
+              setWeightError(null);
               setEditingWeight(true);
             }}
             className="inline-flex items-center gap-1 border-b border-dashed border-gray-400 dark:border-gray-600 hover:text-blue-600 hover:border-blue-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 transition-colors"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -138,6 +138,7 @@
   "inventory.stats.spools": "Spulen",
   "inventory.stats.locations": "Standorte",
   "inventory.stats.totalWeight": "Gesamtgewicht",
+  "inventory.stats.searchNote": "Die Summen beziehen sich auf Ihre aktuelle Suche.",
   "inventory.filter.search": "Suchen",
   "inventory.filter.searchPlaceholder": "Filament, Bezeichnung, Charge…",
   "inventory.filter.kind": "Art",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -138,6 +138,7 @@
   "inventory.stats.spools": "Spools",
   "inventory.stats.locations": "Locations",
   "inventory.stats.totalWeight": "Total weight",
+  "inventory.stats.searchNote": "Totals reflect your current search.",
   "inventory.filter.search": "Search",
   "inventory.filter.searchPlaceholder": "Filament, label, lot…",
   "inventory.filter.kind": "Kind",

--- a/src/lib/inventorySort.ts
+++ b/src/lib/inventorySort.ts
@@ -228,3 +228,42 @@ export function groupAndSortInventory<R extends InventoryRow>(
 
   return out;
 }
+
+/** Header totals for the Spool Inventory page. */
+export interface InventorySummary {
+  spoolCount: number;
+  locationCount: number;
+  totalGrams: number;
+}
+
+/**
+ * Summarise the groups the user can actually see (#1117 f).
+ *
+ * The page's stat cards used to read straight off the server response, so they
+ * tracked the four server-side filters (kind / type / vendor / includeRetired)
+ * but not the client-side text search: searching down to one spool still
+ * headlined "SPOOLS 74 · TOTAL WEIGHT 50.65 kg". That was inconsistent one
+ * level down too — the GROUP headers have recomputed under search since PR
+ * #391 round 2, so search-aware group headers sat under search-blind page
+ * totals.
+ *
+ * Deriving from the already-filtered groups covers both filter kinds with no
+ * new math. With an empty search the caller passes the server groups verbatim,
+ * so the unsearched numbers are unchanged.
+ *
+ * `locationCount` counts every bucket on screen INCLUDING the synthetic "no
+ * location" one — #575.5: counting only real locations rendered "LOCATIONS 0"
+ * while spools sat under "No location". Empty buckets are never emitted, so
+ * this is exactly the number of groups rendered.
+ */
+export function summarizeInventoryGroups(
+  groups: readonly InventorySourceGroup[],
+): InventorySummary {
+  let spoolCount = 0;
+  let totalGrams = 0;
+  for (const g of groups) {
+    spoolCount += g.count;
+    totalGrams += g.totalGrams;
+  }
+  return { spoolCount, locationCount: groups.length, totalGrams };
+}

--- a/src/lib/parseWeightInput.ts
+++ b/src/lib/parseWeightInput.ts
@@ -1,0 +1,44 @@
+/**
+ * Validator for a hand-typed spool weight in grams.
+ *
+ * Extracted so the inventory page and the detail page can agree, and so the
+ * rule is unit-testable — the pages themselves are client components the
+ * node-only vitest env can't render.
+ *
+ * ## The bug this exists to prevent (GH #1105)
+ *
+ * `Number("") === 0`. The inventory page's inline editor guarded with
+ * `!Number.isFinite(n) || n < 0`, which an empty field sails straight through:
+ * clearing the box and clicking Save wrote `totalWeight: 0`, dropping the
+ * remaining bar to 0%, and taking that spool's weight out of the location and
+ * library totals — with no validation error. Whitespace was equally lethal
+ * (`Number(" ") === 0`).
+ *
+ * So the empty check MUST come first and MUST be on the trimmed string. That
+ * is the whole point of this module; a future "simplification" that folds it
+ * into the finite check reintroduces the bug exactly.
+ *
+ * `Number` rather than `parseFloat` is also deliberate: `parseFloat("12abc")`
+ * is 12, which would silently accept a typo as a real reading.
+ *
+ * No decimal-separator handling belongs here — `<input type="number">`
+ * normalises the separator to `.` before we ever see the value, regardless of
+ * the user's locale or their v1.66 number-format preference.
+ */
+
+/** Why a typed weight was rejected. Callers map this to a message. */
+export type WeightInputProblem = "empty" | "invalid" | "negative";
+
+export type ParsedWeightInput =
+  | { ok: true; grams: number }
+  | { ok: false; reason: WeightInputProblem };
+
+export function parseWeightInput(raw: string): ParsedWeightInput {
+  const trimmed = raw.trim();
+  // Must precede the Number() call — see the docblock.
+  if (trimmed === "") return { ok: false, reason: "empty" };
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return { ok: false, reason: "invalid" };
+  if (n < 0) return { ok: false, reason: "negative" };
+  return { ok: true, grams: n };
+}

--- a/tests/inventorySort.test.ts
+++ b/tests/inventorySort.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   groupAndSortInventory,
   inventoryRemainingGrams,
+  summarizeInventoryGroups,
   INVENTORY_NO_GROUP_KEY,
   INVENTORY_ALL_KEY,
   type InventoryRow,
@@ -315,5 +316,58 @@ describe("groupAndSortInventory — group ordering edge cases", () => {
     const out = groupAndSortInventory(source, "type", "name", "asc");
     // ABS before TPU (label localeCompare at the group comparator's last arm)
     expect(out.map((g) => g.label)).toEqual(["ABS", "TPU"]);
+  });
+});
+
+describe("summarizeInventoryGroups (#1117 f)", () => {
+  const group = (
+    locationId: string | null,
+    count: number,
+    totalGrams: number,
+  ): InventorySourceGroup => ({
+    locationId,
+    location: null,
+    spools: [],
+    count,
+    totalGrams,
+  });
+
+  it("sums counts and grams across every group", () => {
+    expect(summarizeInventoryGroups([group("a", 3, 1500), group("b", 2, 900)])).toEqual({
+      spoolCount: 5,
+      locationCount: 2,
+      totalGrams: 2400,
+    });
+  });
+
+  it("counts the synthetic no-location bucket as a location (#575.5)", () => {
+    // Counting only real locations rendered "LOCATIONS 0" while spools sat
+    // under "No location".
+    expect(summarizeInventoryGroups([group(null, 13, 6000)]).locationCount).toBe(1);
+  });
+
+  it("returns zeros for an empty result rather than throwing", () => {
+    expect(summarizeInventoryGroups([])).toEqual({
+      spoolCount: 0,
+      locationCount: 0,
+      totalGrams: 0,
+    });
+  });
+
+  it("reads the group's own count, not spools.length", () => {
+    // The search path rebuilds groups with a recomputed `count`; the summary
+    // must follow that, which is the whole point of #1117(f).
+    const searched: InventorySourceGroup = {
+      locationId: "a",
+      location: null,
+      spools: [],
+      count: 1,
+      totalGrams: 420,
+    };
+    expect(summarizeInventoryGroups([searched])).toEqual({
+      spoolCount: 1,
+      locationCount: 1,
+      totalGrams: 420,
+    });
   });
 });

--- a/tests/parseWeightInput.test.ts
+++ b/tests/parseWeightInput.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parseWeightInput } from "@/lib/parseWeightInput";
+
+describe("parseWeightInput", () => {
+  it("rejects an empty field instead of reading it as 0 g", () => {
+    // GH #1105: `Number("")` is 0, so the old `!Number.isFinite(n) || n < 0`
+    // guard accepted a cleared field and wrote totalWeight: 0 — dropping the
+    // remaining bar to 0% and removing that spool's weight from the location
+    // and library totals, with no validation error.
+    expect(parseWeightInput("")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("rejects whitespace-only input, which Number() also reads as 0", () => {
+    for (const raw of [" ", "   ", "\t", "\n"]) {
+      expect(parseWeightInput(raw)).toEqual({ ok: false, reason: "empty" });
+    }
+  });
+
+  it("accepts a plain integer reading", () => {
+    expect(parseWeightInput("842")).toEqual({ ok: true, grams: 842 });
+  });
+
+  it("accepts a decimal reading from a scale", () => {
+    expect(parseWeightInput("842.5")).toEqual({ ok: true, grams: 842.5 });
+  });
+
+  it("tolerates surrounding whitespace on an otherwise valid value", () => {
+    expect(parseWeightInput("  842.5  ")).toEqual({ ok: true, grams: 842.5 });
+  });
+
+  it("accepts a real zero — that is a legitimate reading, not an empty field", () => {
+    // This is the case that triggers the retire prompt, so it must parse.
+    expect(parseWeightInput("0")).toEqual({ ok: true, grams: 0 });
+    expect(parseWeightInput("0.0")).toEqual({ ok: true, grams: 0 });
+  });
+
+  it("rejects a negative weight", () => {
+    expect(parseWeightInput("-1")).toEqual({ ok: false, reason: "negative" });
+    expect(parseWeightInput("-0.5")).toEqual({ ok: false, reason: "negative" });
+  });
+
+  it("rejects trailing garbage rather than silently truncating it", () => {
+    // parseFloat("12abc") is 12 — a typo would have been accepted as a real
+    // reading. Number() returns NaN, which is why this module uses it.
+    expect(parseWeightInput("12abc")).toEqual({ ok: false, reason: "invalid" });
+    expect(parseWeightInput("abc")).toEqual({ ok: false, reason: "invalid" });
+  });
+
+  it("rejects the non-finite literals", () => {
+    expect(parseWeightInput("Infinity")).toEqual({ ok: false, reason: "invalid" });
+    expect(parseWeightInput("NaN")).toEqual({ ok: false, reason: "invalid" });
+    // -Infinity is non-finite, so it must be reported as invalid rather than
+    // reaching the negative branch.
+    expect(parseWeightInput("-Infinity")).toEqual({ ok: false, reason: "invalid" });
+  });
+});


### PR DESCRIPTION
Fixes #1105. Covers #1117 item (f).

## The bug

`Number("") === 0`. The inline weight editor guarded with `!Number.isFinite(n) || n < 0`, which an empty field sails straight through: clearing the box and saving wrote `totalWeight: 0`, dropped the remaining bar to 0%, and took that spool's weight out of the location and library totals — with **no validation error**. Whitespace was equally lethal (`Number(" ")` is also 0).

The detail page's editor already refused the same input, and already prompted *"weight is now 0 — retire this spool?"* on a real zero (GH #381). This path did neither, so the same gesture behaved two different ways depending on which screen you were on.

## The fix

The rule moves to `src/lib/parseWeightInput.ts` so it's unit-testable, and so a future "simplification" that folds the empty check into the finite check has a test explaining why it can't. It uses `Number` rather than `parseFloat` for the same reason the detail page does — `parseFloat("12abc")` is `12`, which would take a typo for a reading.

The retire prompt is ported by **reusing the detail page's message string** and its existing `ConfirmDialog` (already in scope on this page for the plain retire toggle), so the two surfaces can't drift apart in wording. Same three skips: never when already retired, never when the prior weight was already 0.

`saving` is set *before* the confirm await and released in a `finally`, so the GH #509 Enter-key re-entry guard covers the dialog's whole lifetime and a throw can't strand the row disabled.

## #1117(f) — stat cards ignored the search

The cards read straight off the server response, so they tracked the four server-side filters but not the client-side text search: searching down to one spool still headlined "SPOOLS 74 · TOTAL WEIGHT 50.65 kg".

That was inconsistent one level down too — the **group** headers have recomputed under search since PR #391 round 2, so search-aware group headers sat under search-blind page totals. I filtered rather than relabelled: relabelling them "library totals" would be actively false the moment a type filter is set, since they already track those.

Deriving from the already-filtered groups covers both filter kinds with no new math — with an empty search the input **is** `data.groups` verbatim, so unsearched numbers are unchanged, and `locationCount` keeps its #575.5 semantics. Plus a one-line note so a shrunken total reads as filtered rather than as data loss.

## Verification

Done in the browser **with every mutation intercepted**, so nothing reached the database:

| Case | Result |
|---|---|
| Clear field → Save | button disabled |
| Clear field → Enter (the path that bypassed the button) | **zero requests fired**; "Enter a valid weight in grams" + `aria-invalid="true"` |
| Type a real `0` → Enter | same retire dialog the detail page shows, same copy |
| Decline the retire | still saves the weight, without `retired` — matching the detail page |
| Search "Easy PA" | cards drop to 1 spool / 0.00 kg with the note, matching the group header |

Confirmed afterwards that the spool is still 100 g and not retired, and the library is still at 73 spools.

Full suite green (194 files / 4129 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
