### PR TITLE
Bump version to 1.76.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.75.0",
+      "version": "1.76.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.75.0",
+    "version": "1.76.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Version bump for the v1.76.0 release: `package.json`, both `package-lock.json` occurrences, and `public/openapi.json`.

Bumped **minor**, not patch: v1.76.0 adds a schema constraint (`trim: true` on `name` across five models), a startup migration that rewrites stored data, and new hybrid-sync behaviour.

Bump-before-tag is machine-enforced (#1037) — the CI gate fails a `v*` tag whose version does not match `package.json`, so this must land before the tag is pushed.

Reference snapshot is current (`REFERENCE_WIKI_SHA = 96c5d7a`; the scheduled drift check passed 2026-08-10), so no `npm run fetch:reference` refresh is needed for this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)