### PR TITLE
fix(lists): carry filter state in the URL so a view can be shared (#1141)

### DIFF
--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -11,6 +11,7 @@ import {
   withCurrentValue,
 } from "@/lib/listFilterParams";
 import {
+  parseStoredPrefs,
   INVENTORY_FILTER_SPEC,
   INVENTORY_PREFS_KEY,
   INVENTORY_PERSISTED_KEYS,
@@ -572,8 +573,11 @@ export default function InventoryPage() {
   useEffect(() => {
     if (!seeded || prefsTouchedRef.current.size === 0) return;
     try {
-      const raw = window.localStorage.getItem(INVENTORY_PREFS_KEY);
-      const stored = raw ? (JSON.parse(raw) as Partial<InventoryPrefs>) : {};
+      // Tolerant parse (Codex P2) — a corrupt blob merges as `{}` and this
+      // write replaces it. See the home page's twin comment.
+      const stored = parseStoredPrefs(
+        window.localStorage.getItem(INVENTORY_PREFS_KEY),
+      ) as Partial<InventoryPrefs>;
       const live: InventoryPrefs = { groupBy, sortKey, sortDir, includeRetired };
       const next: InventoryPrefs = { ...DEFAULT_INVENTORY_PREFS, ...stored };
       for (const key of prefsTouchedRef.current) next[key] = live[key] as never;

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -543,10 +543,13 @@ export default function InventoryPage() {
     // to the same query looks like another page write — type `pla`, click the
     // header link to the bare route, press Back, and the URL returns to
     // `?q=pla` while the list stays unfiltered. A marker is good for one echo.
-    if (ownUrlWriteRef.current === nextSearch) {
-      ownUrlWriteRef.current = null;
-      return;
-    }
+    // One OBSERVATION, one chance (Codex P2) — see the home page's twin
+    // comment: a normalization-only replace is invisible to useSearchParams,
+    // and a marker consumed only on match survives to mis-claim a later
+    // genuine navigation to the same canonical query.
+    const own = ownUrlWriteRef.current;
+    ownUrlWriteRef.current = null;
+    if (own === nextSearch) return;
     const url = parseFilterParams(nextSearch, INVENTORY_FILTER_SPEC);
     const present = presentFilterKeys(nextSearch, INVENTORY_FILTER_SPEC);
     setSearch(url.search);

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -7,7 +7,6 @@ import { KNOWN_LOCATION_KINDS } from "@/lib/locationKind";
 import {
   parseFilterParams,
   nextFilterHref,
-  serializeFilterParams,
   oneOf,
   boolParam,
   textParam,
@@ -512,31 +511,14 @@ export default function InventoryPage() {
   // `?location=` — encoded into printed dry-box QR stickers — is preserved
   // because the spec does not own it. Gated on `prefsLoaded` so it cannot run
   // before the seed above and blank the query string.
-  /** What this page's filters serialize to — the value it writes, and what
-   *  SearchParamsSync needs in order to keep its own notion current (see
-   *  its docblock: useSearchParams does not observe a manual replaceState). */
-  const mirroredQuery = useMemo(
-    () => serializeFilterParams(
-      typeof window === "undefined" ? "" : window.location.search,
-      INVENTORY_FILTER_SPEC,
-      {
-      search,
-      kind,
-      type,
-      vendor,
-      includeRetired,
-      groupBy,
-      sortKey,
-      sortDir,
-    },
-    ),
-    [search, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir],
-  );
-
   useEffect(() => {
     if (!prefsLoaded.current) return;
     const href = nextFilterHref(window.location, INVENTORY_FILTER_SPEC, {
-      search,
+      // The DEBOUNCED value (Codex P2). Serializing the raw one fired a
+      // `router.replace` per keystroke — a client navigation each time, and
+      // overlapping query transitions on fast typing. The home page already
+      // mirrors its debounced value; this now matches.
+      search: debouncedSearch,
       kind,
       type,
       vendor,
@@ -558,7 +540,7 @@ export default function InventoryPage() {
       // URL. `scroll: false` keeps the list position; already debounced.
       router.replace(href, { scroll: false });
     }
-  }, [search, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir, router]);
+  }, [debouncedSearch, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir, router]);
 
   // GH #1141 (Codex P2): re-seed when something ELSE changes the query string.
   //
@@ -578,6 +560,9 @@ export default function InventoryPage() {
     }
     const url = parseFilterParams(nextSearch, INVENTORY_FILTER_SPEC);
     setSearch(url.search);
+    // Both, or the debounce timer would re-write the pre-navigation value a
+    // moment later and undo the re-seed.
+    setDebouncedSearch(url.search);
     setKind(url.kind);
     setType(url.type);
     setVendor(url.vendor);
@@ -798,7 +783,7 @@ export default function InventoryPage() {
     <>
       {/* GH #1141: only THIS child suspends, so the page still prerenders. */}
       <Suspense fallback={null}>
-        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={mirroredQuery} />
+        <SearchParamsSync onExternalChange={reseedFromUrl} />
       </Suspense>
     <main id="main-content" className="w-full max-w-7xl mx-auto px-4 py-8">
       <div className="flex items-start justify-between mb-6 gap-4">

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -3,17 +3,20 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Suspense } from "react";
 import SearchParamsSync from "@/components/SearchParamsSync";
-import { KNOWN_LOCATION_KINDS } from "@/lib/locationKind";
 import {
   parseFilterParams,
   presentFilterKeys,
   nextFilterHref,
-  oneOf,
-  boolParam,
-  textParam,
+  seedFilterState,
   withCurrentValue,
-  type FilterSpec,
 } from "@/lib/listFilterParams";
+import {
+  INVENTORY_FILTER_SPEC,
+  INVENTORY_PREFS_KEY,
+  INVENTORY_PERSISTED_KEYS,
+  DEFAULT_INVENTORY_PREFS,
+  type InventoryPrefs,
+} from "@/lib/listFilterSpecs";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -31,7 +34,6 @@ import {
   type InventorySortDir,
   INVENTORY_GROUP_BYS,
   INVENTORY_SORT_KEYS,
-  INVENTORY_SORT_DIRS,
 } from "@/lib/inventorySort";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { isKnownLocationKind } from "@/lib/locationKind";
@@ -173,25 +175,6 @@ function remainingPct(row: SpoolRow): number | null {
  * corrupt/old blob can't wedge the page. `includeRetired` rides along since it
  * also drives the server query.
  */
-const INVENTORY_PREFS_KEY = "filamentdb-inventory-prefs";
-const GROUP_BY_VALUES: InventoryGroupBy[] = ["location", "type", "vendor", "none"];
-const SORT_KEY_VALUES: InventorySortKey[] = ["remaining", "name", "type", "vendor", "purchase", "opened"];
-
-interface InventoryPrefs {
-  groupBy: InventoryGroupBy;
-  sortKey: InventorySortKey;
-  sortDir: InventorySortDir;
-  includeRetired: boolean;
-}
-const DEFAULT_INVENTORY_PREFS: InventoryPrefs = {
-  groupBy: "location",
-  // #795: default to remaining-weight ascending — surfaces near-empty spools to
-  // reorder, the issue's primary use case.
-  sortKey: "remaining",
-  sortDir: "asc",
-  includeRetired: false,
-};
-
 function loadInventoryPrefs(): InventoryPrefs {
   if (typeof window === "undefined") return DEFAULT_INVENTORY_PREFS;
   try {
@@ -199,13 +182,13 @@ function loadInventoryPrefs(): InventoryPrefs {
     if (!raw) return DEFAULT_INVENTORY_PREFS;
     const p = JSON.parse(raw) as Partial<InventoryPrefs>;
     return {
-      groupBy: GROUP_BY_VALUES.includes(p.groupBy as InventoryGroupBy)
+      groupBy: (INVENTORY_GROUP_BYS as readonly InventoryGroupBy[]).includes(p.groupBy as InventoryGroupBy)
         ? (p.groupBy as InventoryGroupBy)
         : DEFAULT_INVENTORY_PREFS.groupBy,
-      sortKey: SORT_KEY_VALUES.includes(p.sortKey as InventorySortKey)
+      sortKey: (INVENTORY_SORT_KEYS as readonly InventorySortKey[]).includes(p.sortKey as InventorySortKey)
         ? (p.sortKey as InventorySortKey)
         : DEFAULT_INVENTORY_PREFS.sortKey,
-      sortDir: p.sortDir === "desc" ? "desc" : "asc",
+      sortDir: p.sortDir === "desc" ? "desc" : DEFAULT_INVENTORY_PREFS.sortDir,
       includeRetired: p.includeRetired === true,
     };
   } catch {
@@ -230,37 +213,6 @@ const NEW_LOCATION_OPTION = "__new_location__";
  * link encoded into printed dry-box QR stickers, not a filter, and
  * `serializeFilterParams` preserves it precisely because it is unowned.
  */
-const INVENTORY_FILTER_SPEC = {
-  search: { param: "q", fallback: "", ...textParam },
-  // Validated against the SELECTABLE kinds (Codex P2), not free text. The
-  // select renders exactly these five options, so a stale or hand-typed
-  // `?kind=garage` would leave React displaying "All kinds" while the hidden
-  // state kept filtering — and re-choosing the option already shown may emit
-  // no change event, so the filter would be invisible AND unclearable.
-  kind: { param: "kind", fallback: "", parse: oneOf(["", ...KNOWN_LOCATION_KINDS]) },
-  type: { param: "type", fallback: "", ...textParam },
-  vendor: { param: "vendor", fallback: "", ...textParam },
-  includeRetired: {
-    param: "includeRetired",
-    fallback: DEFAULT_INVENTORY_PREFS.includeRetired,
-    ...boolParam,
-  },
-  groupBy: {
-    param: "group",
-    fallback: DEFAULT_INVENTORY_PREFS.groupBy,
-    parse: oneOf(INVENTORY_GROUP_BYS),
-  },
-  sortKey: {
-    param: "sort",
-    fallback: DEFAULT_INVENTORY_PREFS.sortKey,
-    parse: oneOf(INVENTORY_SORT_KEYS),
-  },
-  sortDir: {
-    param: "dir",
-    fallback: DEFAULT_INVENTORY_PREFS.sortDir,
-    parse: oneOf(INVENTORY_SORT_DIRS),
-  },
-} satisfies FilterSpec;
 
 export default function InventoryPage() {
   const router = useRouter();
@@ -298,6 +250,9 @@ export default function InventoryPage() {
   // `/inventory?q=pla` landed bare. A state flag is only true from the commit
   // AFTER the seed. Verified on the home page, which had the identical shape.
   const [seeded, setSeeded] = useState(false);
+  /** Preference keys the USER changed this session — the only ones written
+   *  back to storage. See the persist effect. */
+  const prefsTouchedRef = useRef<Set<(typeof INVENTORY_PERSISTED_KEYS)[number]>>(new Set());
   /** The query string this page last wrote, so its own replaceState does not
    *  come back through SearchParamsSync as an external change. */
   const ownUrlWriteRef = useRef<string | null>(null);
@@ -375,6 +330,10 @@ export default function InventoryPage() {
     // are bucket values, not location ids, and the target simply would not
     // exist (PR #1043 P2). Forcing location grouping is what the user asked
     // for by scanning a BOX label; it persists like any manual switch.
+    // PR #1043 P2: this forced switch persists like a manual one — the user
+    // scanned a location QR, so location grouping is what they asked for.
+    // Recorded explicitly now that persistence is per-key (GH #1141).
+    prefsTouchedRef.current.add("groupBy");
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setGroupBy("location");
     // Groups default to expanded (`collapsed` holds collapsed keys), so the
@@ -476,29 +435,36 @@ export default function InventoryPage() {
     // the two sides (the Codex P2 recorded in src/app/locations/new/page.tsx).
     // The server HTML and the first client paint therefore both use the
     // defaults, and the URL is adopted immediately after.
-    const url = parseFilterParams(window.location.search, INVENTORY_FILTER_SPEC);
-    const present = presentFilterKeys(window.location.search, INVENTORY_FILTER_SPEC);
+    // Group/sort/retired fall back to the PERSISTED pref when the URL is
+    // silent, so a bare /inventory still opens the way the user left it, while
+    // a link that carries them applies them for the visit. `seedFilterState`
+    // owns that rule for both this seed and the re-seed below.
+    const url = seedFilterState(window.location.search, INVENTORY_FILTER_SPEC, p);
 
     setSearch(url.search); // eslint-disable-line react-hooks/set-state-in-effect -- URL + persisted prefs
     setKind(url.kind);
     setType(url.type);
     setVendor(url.vendor);
-    // Group/sort fall back to the PERSISTED pref when the URL is silent, so a
-    // bare /inventory still opens the way the user left it.
-    setGroupBy(present.has("groupBy") ? url.groupBy : p.groupBy);
-    setSortKey(present.has("sortKey") ? url.sortKey : p.sortKey);
-    setSortDir(present.has("sortDir") ? url.sortDir : p.sortDir);
+    setGroupBy(url.groupBy);
+    setSortKey(url.sortKey);
+    setSortDir(url.sortDir);
     // GH #1106: `?includeRetired=1` overrides the persisted pref for this
-    // visit. The /locations "location is still in use" panel links here to
-    // show the retired spools that are blocking a delete — without this the
-    // link lands with the pref off, the aggregation returns no group for that
-    // location, and the deep-link handler below toasts "no active spools",
-    // i.e. the escape hatch would tell the user the spools don't exist. The
-    // persist effect writes it back like any manual toggle, which is right:
-    // the user followed a link asking to see them. That precedent is kept for
-    // THIS key only — a shared link's other filters apply to the visit but are
-    // not written into the recipient's stored preferences.
-    setIncludeRetired(present.has("includeRetired") ? url.includeRetired : p.includeRetired);
+    // visit — the /locations "location is still in use" panel links here to
+    // show the retired spools blocking a delete, and without it the link lands
+    // with the pref off, the aggregation returns no group for that location,
+    // and the deep-link handler below toasts "no active spools". I.e. the
+    // escape hatch would tell the user the spools do not exist. That still
+    // works: the value is adopted for the visit like any other sticky key.
+    //
+    // What CHANGED (GH #1141, Codex P1): it is no longer WRITTEN into the
+    // recipient's stored preferences. It cannot be — `includeRetired` is
+    // sticky, so every non-bare /inventory URL now carries it explicitly, and
+    // "the URL mentions it" no longer distinguishes "someone asked to see
+    // retired spools" from "the serializer emitted a default". Persisting on
+    // that signal would let any shared link rewrite the recipient's saved
+    // prefs, which is the opposite of the intent — and a one-off "show
+    // retired" link should not permanently flip a stored setting anyway.
+    setIncludeRetired(url.includeRetired);
     setSeeded(true);
   }, []);
 
@@ -586,16 +552,30 @@ export default function InventoryPage() {
     setSortDir((cur) => (present.has("sortDir") ? url.sortDir : cur));
   }, []);
 
-  // Persist prefs whenever they change (after the initial load).
+  // Persist ONLY what the user chose (GH #1141, Codex P1).
+  //
+  // Sticky keys are now emitted into every non-bare URL, which is what makes a
+  // shared link deterministic — but it also means every shared /inventory link
+  // MENTIONS the grouping, the sort and includeRetired. An ungated persist
+  // effect would let a friend's link permanently overwrite the recipient's
+  // saved preferences just by being opened. Tracking which keys the user
+  // actually touched, and merging those over what is stored, keeps "applies to
+  // this visit" and "is my preference" separate.
+  //
+  // Per-key rather than a single boolean because the record is one blob: a
+  // boolean cannot express "store the direction I just flipped, leave the
+  // grouping alone".
   useEffect(() => {
-    if (!seeded) return;
+    if (!seeded || prefsTouchedRef.current.size === 0) return;
     try {
-      window.localStorage.setItem(
-        INVENTORY_PREFS_KEY,
-        JSON.stringify({ groupBy, sortKey, sortDir, includeRetired }),
-      );
+      const raw = window.localStorage.getItem(INVENTORY_PREFS_KEY);
+      const stored = raw ? (JSON.parse(raw) as Partial<InventoryPrefs>) : {};
+      const live: InventoryPrefs = { groupBy, sortKey, sortDir, includeRetired };
+      const next: InventoryPrefs = { ...DEFAULT_INVENTORY_PREFS, ...stored };
+      for (const key of prefsTouchedRef.current) next[key] = live[key] as never;
+      window.localStorage.setItem(INVENTORY_PREFS_KEY, JSON.stringify(next));
     } catch {
-      /* ignore quota / disabled storage */
+      /* ignore quota / disabled storage / a corrupt stored blob */
     }
   }, [seeded, groupBy, sortKey, sortDir, includeRetired]);
 
@@ -898,7 +878,10 @@ export default function InventoryPage() {
           <select
             id="inv-groupby"
             value={groupBy}
-            onChange={(e) => setGroupBy(e.target.value as InventoryGroupBy)}
+            onChange={(e) => {
+              prefsTouchedRef.current.add("groupBy");
+              setGroupBy(e.target.value as InventoryGroupBy);
+            }}
             className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
           >
             <option value="location">{t("inventory.groupBy.location")}</option>
@@ -915,7 +898,10 @@ export default function InventoryPage() {
             <select
               id="inv-sortby"
               value={sortKey}
-              onChange={(e) => setSortKey(e.target.value as InventorySortKey)}
+              onChange={(e) => {
+                prefsTouchedRef.current.add("sortKey");
+                setSortKey(e.target.value as InventorySortKey);
+              }}
               className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
             >
               <option value="remaining">{t("inventory.sort.remaining")}</option>
@@ -927,7 +913,10 @@ export default function InventoryPage() {
             </select>
             <button
               type="button"
-              onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+              onClick={() => {
+                prefsTouchedRef.current.add("sortDir");
+                setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+              }}
               aria-label={t(sortDir === "asc" ? "inventory.sort.asc" : "inventory.sort.desc")}
               title={t(sortDir === "asc" ? "inventory.sort.asc" : "inventory.sort.desc")}
               className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
@@ -940,7 +929,10 @@ export default function InventoryPage() {
           <input
             type="checkbox"
             checked={includeRetired}
-            onChange={(e) => setIncludeRetired(e.target.checked)}
+            onChange={(e) => {
+              prefsTouchedRef.current.add("includeRetired");
+              setIncludeRetired(e.target.checked);
+            }}
             className="accent-blue-600"
           />
           {t("inventory.filter.includeRetired")}

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -267,7 +267,10 @@ export default function InventoryPage() {
   // side because the search runs purely client-side here.
   const [debouncedSearch, setDebouncedSearch] = useState(search);
   useEffect(() => {
-    const id = setTimeout(() => setDebouncedSearch(search), 200);
+    // Trimmed at the debounce (Codex P2) — the parser trims on read, so an
+    // untrimmed live value diverged from its own mirrored URL. See the home
+    // page's twin comment; the input keeps the raw text.
+    const id = setTimeout(() => setDebouncedSearch(search.trim()), 200);
     return () => clearTimeout(id);
   }, [search]);
 
@@ -486,7 +489,10 @@ export default function InventoryPage() {
   // before the seed above and blank the query string.
   useEffect(() => {
     if (!seeded) return;
-    const href = nextFilterHref(window.location, INVENTORY_FILTER_SPEC, {
+    const href = nextFilterHref(
+      window.location,
+      INVENTORY_FILTER_SPEC,
+      {
       // The DEBOUNCED value (Codex P2). Serializing the raw one fired a
       // `router.replace` per keystroke — a client navigation each time, and
       // overlapping query transitions on fast typing. The home page already
@@ -499,7 +505,13 @@ export default function InventoryPage() {
       groupBy,
       sortKey,
       sortDir,
-    });
+    },
+      // Fresh persisted values (Codex P2) — the sticky keys stay encoded while
+      // the view's group/sort/retired differ from the stored ones, or clearing
+      // the last filter drops the URL to bare and a reload silently swaps the
+      // shared link's view for the persisted one. See the home page's twin.
+      loadInventoryPrefs(),
+    );
     if (href) {
       // Record what we wrote so the re-seed can tell our own change from
       // someone else's and not loop on it.

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -7,9 +7,11 @@ import { KNOWN_LOCATION_KINDS } from "@/lib/locationKind";
 import {
   parseFilterParams,
   nextFilterHref,
+  serializeFilterParams,
   oneOf,
   boolParam,
   textParam,
+  withCurrentValue,
   type FilterSpec,
 } from "@/lib/listFilterParams";
 import { useRouter } from "next/navigation";
@@ -261,6 +263,7 @@ const INVENTORY_FILTER_SPEC = {
 } satisfies FilterSpec;
 
 export default function InventoryPage() {
+  const router = useRouter();
   const { t } = useTranslation();
   const { formatNumber } = useNumberFormat();
   const { toast } = useToast();
@@ -509,6 +512,27 @@ export default function InventoryPage() {
   // `?location=` — encoded into printed dry-box QR stickers — is preserved
   // because the spec does not own it. Gated on `prefsLoaded` so it cannot run
   // before the seed above and blank the query string.
+  /** What this page's filters serialize to — the value it writes, and what
+   *  SearchParamsSync needs in order to keep its own notion current (see
+   *  its docblock: useSearchParams does not observe a manual replaceState). */
+  const mirroredQuery = useMemo(
+    () => serializeFilterParams(
+      typeof window === "undefined" ? "" : window.location.search,
+      INVENTORY_FILTER_SPEC,
+      {
+      search,
+      kind,
+      type,
+      vendor,
+      includeRetired,
+      groupBy,
+      sortKey,
+      sortDir,
+    },
+    ),
+    [search, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir],
+  );
+
   useEffect(() => {
     if (!prefsLoaded.current) return;
     const href = nextFilterHref(window.location, INVENTORY_FILTER_SPEC, {
@@ -522,12 +546,19 @@ export default function InventoryPage() {
       sortDir,
     });
     if (href) {
-      // Record what we wrote so SearchParamsSync can tell our own change from
+      // Record what we wrote so the re-seed can tell our own change from
       // someone else's and not loop on it.
       ownUrlWriteRef.current = href.includes("?") ? href.slice(href.indexOf("?") + 1) : "";
-      window.history.replaceState(window.history.state, "", href);
+      // Through the ROUTER, not `window.history` directly. A raw
+      // `replaceState` leaves the router's own model of the URL untouched, so
+      // `useSearchParams` keeps reporting the pre-write value — and a later
+      // Link click to the same route then looks like no change at all, which
+      // is exactly the navigation the re-seed exists to catch. Verified in the
+      // browser: with a raw replaceState the list stayed filtered under a bare
+      // URL. `scroll: false` keeps the list position; already debounced.
+      router.replace(href, { scroll: false });
     }
-  }, [search, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir]);
+  }, [search, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir, router]);
 
   // GH #1141 (Codex P2): re-seed when something ELSE changes the query string.
   //
@@ -536,6 +567,15 @@ export default function InventoryPage() {
   // reuses this page, so the URL goes bare while the state stays filtered and
   // the next refresh clears what was still on screen.
   const reseedFromUrl = useCallback((nextSearch: string) => {
+    // Our own replaceState comes back through here; CONSUME the marker rather
+    // than just testing it (Codex P2). Left set, a later external navigation
+    // to the same query looks like another page write — type `pla`, click the
+    // header link to the bare route, press Back, and the URL returns to
+    // `?q=pla` while the list stays unfiltered. A marker is good for one echo.
+    if (ownUrlWriteRef.current === nextSearch) {
+      ownUrlWriteRef.current = null;
+      return;
+    }
     const url = parseFilterParams(nextSearch, INVENTORY_FILTER_SPEC);
     setSearch(url.search);
     setKind(url.kind);
@@ -758,7 +798,7 @@ export default function InventoryPage() {
     <>
       {/* GH #1141: only THIS child suspends, so the page still prerenders. */}
       <Suspense fallback={null}>
-        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={ownUrlWriteRef} />
+        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={mirroredQuery} />
       </Suspense>
     <main id="main-content" className="w-full max-w-7xl mx-auto px-4 py-8">
       <div className="flex items-start justify-between mb-6 gap-4">
@@ -827,7 +867,7 @@ export default function InventoryPage() {
             className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
           >
             <option value="">{t("inventory.filter.allTypes")}</option>
-            {types.map((tp) => (
+            {withCurrentValue(types, type).map((tp) => (
               <option key={tp} value={tp}>
                 {tp}
               </option>
@@ -845,7 +885,7 @@ export default function InventoryPage() {
             className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
           >
             <option value="">{t("inventory.filter.allVendors")}</option>
-            {vendors.map((vn) => (
+            {withCurrentValue(vendors, vendor).map((vn) => (
               <option key={vn} value={vn}>
                 {vn}
               </option>
@@ -1192,10 +1232,10 @@ function SpoolEditRow({
   onToggleSelected,
   selectLabel,
 }: RowProps) {
+  const router = useRouter();
   const { t } = useTranslation();
   const { formatDate } = useDateFormat();
   const { formatGrams } = useNumberFormat();
-  const router = useRouter();
   // #1117(h): carry the CURRENT url back, so a detour to create a location
   // returns to THIS page rather than stranding the user on /locations. The
   // query string (`?location=`, `?includeRetired=`) and the localStorage

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  parseFilterParams,
+  nextFilterHref,
+  oneOf,
+  boolParam,
+  textParam,
+  type FilterSpec,
+} from "@/lib/listFilterParams";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -16,6 +24,9 @@ import {
   type InventoryGroupBy,
   type InventorySortKey,
   type InventorySortDir,
+  INVENTORY_GROUP_BYS,
+  INVENTORY_SORT_KEYS,
+  INVENTORY_SORT_DIRS,
 } from "@/lib/inventorySort";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { isKnownLocationKind } from "@/lib/locationKind";
@@ -201,6 +212,45 @@ function loadInventoryPrefs(): InventoryPrefs {
  *  (#1117 item h). Shared spelling with the filament list; not a valid
  *  ObjectId, so it can never collide with a real location id. */
 const NEW_LOCATION_OPTION = "__new_location__";
+
+/**
+ * GH #1141: the filters this page mirrors into the URL, so a filtered view can
+ * be shared, bookmarked and survive a refresh.
+ *
+ * `includeRetired` keeps its existing spelling — `/locations` already links
+ * here with it (`src/app/locations/page.tsx`), and that link is a supported
+ * entry point.
+ *
+ * `location` is deliberately NOT here. It is a one-shot scroll/highlight deep
+ * link encoded into printed dry-box QR stickers, not a filter, and
+ * `serializeFilterParams` preserves it precisely because it is unowned.
+ */
+const INVENTORY_FILTER_SPEC = {
+  search: { param: "q", fallback: "", ...textParam },
+  kind: { param: "kind", fallback: "", ...textParam },
+  type: { param: "type", fallback: "", ...textParam },
+  vendor: { param: "vendor", fallback: "", ...textParam },
+  includeRetired: {
+    param: "includeRetired",
+    fallback: DEFAULT_INVENTORY_PREFS.includeRetired,
+    ...boolParam,
+  },
+  groupBy: {
+    param: "group",
+    fallback: DEFAULT_INVENTORY_PREFS.groupBy,
+    parse: oneOf(INVENTORY_GROUP_BYS),
+  },
+  sortKey: {
+    param: "sort",
+    fallback: DEFAULT_INVENTORY_PREFS.sortKey,
+    parse: oneOf(INVENTORY_SORT_KEYS),
+  },
+  sortDir: {
+    param: "dir",
+    fallback: DEFAULT_INVENTORY_PREFS.sortDir,
+    parse: oneOf(INVENTORY_SORT_DIRS),
+  },
+} satisfies FilterSpec;
 
 export default function InventoryPage() {
   const { t } = useTranslation();
@@ -399,9 +449,26 @@ export default function InventoryPage() {
   // doesn't clobber storage with the defaults before this runs.
   useEffect(() => {
     const p = loadInventoryPrefs();
-    setGroupBy(p.groupBy); // eslint-disable-line react-hooks/set-state-in-effect -- persisted prefs
-    setSortKey(p.sortKey);
-    setSortDir(p.sortDir);
+    // GH #1141: the URL wins over the persisted pref, for the keys it carries.
+    //
+    // Read post-mount, defaults-then-adopt — NOT a lazy `useState` initializer
+    // with a `typeof window` check, which produces different first renders on
+    // the two sides (the Codex P2 recorded in src/app/locations/new/page.tsx).
+    // The server HTML and the first client paint therefore both use the
+    // defaults, and the URL is adopted immediately after.
+    const url = parseFilterParams(window.location.search, INVENTORY_FILTER_SPEC);
+    const hasParam = (key: keyof typeof INVENTORY_FILTER_SPEC) =>
+      new URLSearchParams(window.location.search).has(INVENTORY_FILTER_SPEC[key].param);
+
+    setSearch(url.search); // eslint-disable-line react-hooks/set-state-in-effect -- URL + persisted prefs
+    setKind(url.kind);
+    setType(url.type);
+    setVendor(url.vendor);
+    // Group/sort fall back to the PERSISTED pref when the URL is silent, so a
+    // bare /inventory still opens the way the user left it.
+    setGroupBy(hasParam("groupBy") ? url.groupBy : p.groupBy);
+    setSortKey(hasParam("sortKey") ? url.sortKey : p.sortKey);
+    setSortDir(hasParam("sortDir") ? url.sortDir : p.sortDir);
     // GH #1106: `?includeRetired=1` overrides the persisted pref for this
     // visit. The /locations "location is still in use" panel links here to
     // show the retired spools that are blocking a delete — without this the
@@ -409,11 +476,42 @@ export default function InventoryPage() {
     // location, and the deep-link handler below toasts "no active spools",
     // i.e. the escape hatch would tell the user the spools don't exist. The
     // persist effect writes it back like any manual toggle, which is right:
-    // the user followed a link asking to see them.
-    const wantRetired = new URLSearchParams(window.location.search).get("includeRetired");
-    setIncludeRetired(wantRetired === "1" || p.includeRetired);
+    // the user followed a link asking to see them. That precedent is kept for
+    // THIS key only — a shared link's other filters apply to the visit but are
+    // not written into the recipient's stored preferences.
+    setIncludeRetired(hasParam("includeRetired") ? url.includeRetired : p.includeRetired);
     prefsLoaded.current = true;
   }, []);
+
+  // GH #1141: mirror the filters into the URL so a view can be shared,
+  // bookmarked and survive a refresh.
+  //
+  // `replaceState`, not `pushState`: a history entry per dropdown change would
+  // make leaving the page take N Back presses. Back still leaves in one.
+  //
+  // It MUST go through the patched `window.history` method — Next copies its
+  // internal `__NA` marker onto the state, and its popstate handler
+  // full-page-reloads an entry without it.
+  //
+  // `nextFilterHref` returns null when nothing would change, so this is a
+  // no-op on the renders that merely recompute the same state. And it MERGES:
+  // `?location=` — encoded into printed dry-box QR stickers — is preserved
+  // because the spec does not own it. Gated on `prefsLoaded` so it cannot run
+  // before the seed above and blank the query string.
+  useEffect(() => {
+    if (!prefsLoaded.current) return;
+    const href = nextFilterHref(window.location, INVENTORY_FILTER_SPEC, {
+      search,
+      kind,
+      type,
+      vendor,
+      includeRetired,
+      groupBy,
+      sortKey,
+      sortDir,
+    });
+    if (href) window.history.replaceState(window.history.state, "", href);
+  }, [search, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir]);
 
   // Persist prefs whenever they change (after the initial load).
   useEffect(() => {

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -6,6 +6,7 @@ import SearchParamsSync from "@/components/SearchParamsSync";
 import { KNOWN_LOCATION_KINDS } from "@/lib/locationKind";
 import {
   parseFilterParams,
+  presentFilterKeys,
   nextFilterHref,
   oneOf,
   boolParam,
@@ -290,7 +291,13 @@ export default function InventoryPage() {
   const [groupBy, setGroupBy] = useState<InventoryGroupBy>(DEFAULT_INVENTORY_PREFS.groupBy);
   const [sortKey, setSortKey] = useState<InventorySortKey>(DEFAULT_INVENTORY_PREFS.sortKey);
   const [sortDir, setSortDir] = useState<InventorySortDir>(DEFAULT_INVENTORY_PREFS.sortDir);
-  const prefsLoaded = useRef(false);
+  // STATE, not a ref (GH #1141, Codex P1). Effects in one commit run in
+  // declaration order, so a ref set by the seed effect is already true when the
+  // mirror effect runs in that SAME commit, still closed over the initial
+  // defaults — it wrote those over the URL it had just read, and a shared
+  // `/inventory?q=pla` landed bare. A state flag is only true from the commit
+  // AFTER the seed. Verified on the home page, which had the identical shape.
+  const [seeded, setSeeded] = useState(false);
   /** The query string this page last wrote, so its own replaceState does not
    *  come back through SearchParamsSync as an external change. */
   const ownUrlWriteRef = useRef<string | null>(null);
@@ -458,7 +465,7 @@ export default function InventoryPage() {
 
   // GH #795: load persisted group/sort prefs once, after mount, so the first
   // client paint matches the server HTML (both use the defaults), then adopt
-  // the stored values. The persist effect below is gated on `prefsLoaded` so it
+  // the stored values. The persist effect below is gated on `seeded` so it
   // doesn't clobber storage with the defaults before this runs.
   useEffect(() => {
     const p = loadInventoryPrefs();
@@ -470,8 +477,7 @@ export default function InventoryPage() {
     // The server HTML and the first client paint therefore both use the
     // defaults, and the URL is adopted immediately after.
     const url = parseFilterParams(window.location.search, INVENTORY_FILTER_SPEC);
-    const hasParam = (key: keyof typeof INVENTORY_FILTER_SPEC) =>
-      new URLSearchParams(window.location.search).has(INVENTORY_FILTER_SPEC[key].param);
+    const present = presentFilterKeys(window.location.search, INVENTORY_FILTER_SPEC);
 
     setSearch(url.search); // eslint-disable-line react-hooks/set-state-in-effect -- URL + persisted prefs
     setKind(url.kind);
@@ -479,9 +485,9 @@ export default function InventoryPage() {
     setVendor(url.vendor);
     // Group/sort fall back to the PERSISTED pref when the URL is silent, so a
     // bare /inventory still opens the way the user left it.
-    setGroupBy(hasParam("groupBy") ? url.groupBy : p.groupBy);
-    setSortKey(hasParam("sortKey") ? url.sortKey : p.sortKey);
-    setSortDir(hasParam("sortDir") ? url.sortDir : p.sortDir);
+    setGroupBy(present.has("groupBy") ? url.groupBy : p.groupBy);
+    setSortKey(present.has("sortKey") ? url.sortKey : p.sortKey);
+    setSortDir(present.has("sortDir") ? url.sortDir : p.sortDir);
     // GH #1106: `?includeRetired=1` overrides the persisted pref for this
     // visit. The /locations "location is still in use" panel links here to
     // show the retired spools that are blocking a delete — without this the
@@ -492,8 +498,8 @@ export default function InventoryPage() {
     // the user followed a link asking to see them. That precedent is kept for
     // THIS key only — a shared link's other filters apply to the visit but are
     // not written into the recipient's stored preferences.
-    setIncludeRetired(hasParam("includeRetired") ? url.includeRetired : p.includeRetired);
-    prefsLoaded.current = true;
+    setIncludeRetired(present.has("includeRetired") ? url.includeRetired : p.includeRetired);
+    setSeeded(true);
   }, []);
 
   // GH #1141: mirror the filters into the URL so a view can be shared,
@@ -509,10 +515,10 @@ export default function InventoryPage() {
   // `nextFilterHref` returns null when nothing would change, so this is a
   // no-op on the renders that merely recompute the same state. And it MERGES:
   // `?location=` — encoded into printed dry-box QR stickers — is preserved
-  // because the spec does not own it. Gated on `prefsLoaded` so it cannot run
+  // because the spec does not own it. Gated on `seeded` so it cannot run
   // before the seed above and blank the query string.
   useEffect(() => {
-    if (!prefsLoaded.current) return;
+    if (!seeded) return;
     const href = nextFilterHref(window.location, INVENTORY_FILTER_SPEC, {
       // The DEBOUNCED value (Codex P2). Serializing the raw one fired a
       // `router.replace` per keystroke — a client navigation each time, and
@@ -540,7 +546,7 @@ export default function InventoryPage() {
       // URL. `scroll: false` keeps the list position; already debounced.
       router.replace(href, { scroll: false });
     }
-  }, [debouncedSearch, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir, router]);
+  }, [seeded, debouncedSearch, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir, router]);
 
   // GH #1141 (Codex P2): re-seed when something ELSE changes the query string.
   //
@@ -559,6 +565,7 @@ export default function InventoryPage() {
       return;
     }
     const url = parseFilterParams(nextSearch, INVENTORY_FILTER_SPEC);
+    const present = presentFilterKeys(nextSearch, INVENTORY_FILTER_SPEC);
     setSearch(url.search);
     // Both, or the debounce timer would re-write the pre-navigation value a
     // moment later and undo the re-seed.
@@ -566,15 +573,22 @@ export default function InventoryPage() {
     setKind(url.kind);
     setType(url.type);
     setVendor(url.vendor);
-    setIncludeRetired(url.includeRetired);
-    setGroupBy(url.groupBy);
-    setSortKey(url.sortKey);
-    setSortDir(url.sortDir);
+    // Group, sort and includeRetired are PERSISTED, so an absent param means
+    // "unchanged", not "default" (GH #1141, Codex P2). A navigation to a bare
+    // /inventory clears the filters; resetting these too would then have the
+    // persist effect below overwrite the user's stored group/sort with the
+    // defaults — a saved preference destroyed by a navigation that never
+    // mentioned it. The mount seed already reads a bare URL this way.
+    // Functional updates so the callback keeps no state deps.
+    setIncludeRetired((cur) => (present.has("includeRetired") ? url.includeRetired : cur));
+    setGroupBy((cur) => (present.has("groupBy") ? url.groupBy : cur));
+    setSortKey((cur) => (present.has("sortKey") ? url.sortKey : cur));
+    setSortDir((cur) => (present.has("sortDir") ? url.sortDir : cur));
   }, []);
 
   // Persist prefs whenever they change (after the initial load).
   useEffect(() => {
-    if (!prefsLoaded.current) return;
+    if (!seeded) return;
     try {
       window.localStorage.setItem(
         INVENTORY_PREFS_KEY,
@@ -583,7 +597,7 @@ export default function InventoryPage() {
     } catch {
       /* ignore quota / disabled storage */
     }
-  }, [groupBy, sortKey, sortDir, includeRetired]);
+  }, [seeded, groupBy, sortKey, sortDir, includeRetired]);
 
   const toggleCollapse = (key: string) => {
     setCollapsed((prev) => {

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -550,6 +550,10 @@ export default function InventoryPage() {
     setGroupBy((cur) => (present.has("groupBy") ? url.groupBy : cur));
     setSortKey((cur) => (present.has("sortKey") ? url.sortKey : cur));
     setSortDir((cur) => (present.has("sortDir") ? url.sortDir : cur));
+    // Any touch still armed here is DEAD — a real one was consumed by the
+    // persist effect at its own commit, before this navigation could be
+    // processed. See the home page's twin comment.
+    prefsTouchedRef.current.clear();
   }, []);
 
   // Persist ONLY what the user chose (GH #1141, Codex P1).
@@ -574,6 +578,11 @@ export default function InventoryPage() {
       const next: InventoryPrefs = { ...DEFAULT_INVENTORY_PREFS, ...stored };
       for (const key of prefsTouchedRef.current) next[key] = live[key] as never;
       window.localStorage.setItem(INVENTORY_PREFS_KEY, JSON.stringify(next));
+      // CONSUME the touches (Codex P2). A touch authorizes ONE write — the
+      // change that armed it, now stored. Left armed, it authorized every
+      // later state change too, letting a Back through an old shared URL
+      // overwrite the preference the user had just set. Mirrors the home page.
+      prefsTouchedRef.current.clear();
     } catch {
       /* ignore quota / disabled storage / a corrupt stored blob */
     }

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense } from "react";
+import SearchParamsSync from "@/components/SearchParamsSync";
+import { KNOWN_LOCATION_KINDS } from "@/lib/locationKind";
 import {
   parseFilterParams,
   nextFilterHref,
@@ -227,7 +230,12 @@ const NEW_LOCATION_OPTION = "__new_location__";
  */
 const INVENTORY_FILTER_SPEC = {
   search: { param: "q", fallback: "", ...textParam },
-  kind: { param: "kind", fallback: "", ...textParam },
+  // Validated against the SELECTABLE kinds (Codex P2), not free text. The
+  // select renders exactly these five options, so a stale or hand-typed
+  // `?kind=garage` would leave React displaying "All kinds" while the hidden
+  // state kept filtering — and re-choosing the option already shown may emit
+  // no change event, so the filter would be invisible AND unclearable.
+  kind: { param: "kind", fallback: "", parse: oneOf(["", ...KNOWN_LOCATION_KINDS]) },
   type: { param: "type", fallback: "", ...textParam },
   vendor: { param: "vendor", fallback: "", ...textParam },
   includeRetired: {
@@ -281,6 +289,9 @@ export default function InventoryPage() {
   const [sortKey, setSortKey] = useState<InventorySortKey>(DEFAULT_INVENTORY_PREFS.sortKey);
   const [sortDir, setSortDir] = useState<InventorySortDir>(DEFAULT_INVENTORY_PREFS.sortDir);
   const prefsLoaded = useRef(false);
+  /** The query string this page last wrote, so its own replaceState does not
+   *  come back through SearchParamsSync as an external change. */
+  const ownUrlWriteRef = useRef<string | null>(null);
 
   // GH #444: debounce the search input. The filtered-groups memo
   // walks every group + every spool on each keystroke; on a slow
@@ -510,8 +521,31 @@ export default function InventoryPage() {
       sortKey,
       sortDir,
     });
-    if (href) window.history.replaceState(window.history.state, "", href);
+    if (href) {
+      // Record what we wrote so SearchParamsSync can tell our own change from
+      // someone else's and not loop on it.
+      ownUrlWriteRef.current = href.includes("?") ? href.slice(href.indexOf("?") + 1) : "";
+      window.history.replaceState(window.history.state, "", href);
+    }
   }, [search, kind, type, vendor, includeRetired, groupBy, sortKey, sortDir]);
+
+  // GH #1141 (Codex P2): re-seed when something ELSE changes the query string.
+  //
+  // The seed above runs once on mount, which misses a client-side navigation
+  // to the SAME route — clicking the header's Inventory link while filtered
+  // reuses this page, so the URL goes bare while the state stays filtered and
+  // the next refresh clears what was still on screen.
+  const reseedFromUrl = useCallback((nextSearch: string) => {
+    const url = parseFilterParams(nextSearch, INVENTORY_FILTER_SPEC);
+    setSearch(url.search);
+    setKind(url.kind);
+    setType(url.type);
+    setVendor(url.vendor);
+    setIncludeRetired(url.includeRetired);
+    setGroupBy(url.groupBy);
+    setSortKey(url.sortKey);
+    setSortDir(url.sortDir);
+  }, []);
 
   // Persist prefs whenever they change (after the initial load).
   useEffect(() => {
@@ -721,6 +755,11 @@ export default function InventoryPage() {
   );
 
   return (
+    <>
+      {/* GH #1141: only THIS child suspends, so the page still prerenders. */}
+      <Suspense fallback={null}>
+        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={ownUrlWriteRef} />
+      </Suspense>
     <main id="main-content" className="w-full max-w-7xl mx-auto px-4 py-8">
       <div className="flex items-start justify-between mb-6 gap-4">
         <div>
@@ -1118,6 +1157,7 @@ export default function InventoryPage() {
         />
       )}
     </main>
+    </>
   );
 }
 

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -8,6 +8,7 @@ import {
   presentFilterKeys,
   nextFilterHref,
   seedFilterState,
+  queryStringOf,
   withCurrentValue,
 } from "@/lib/listFilterParams";
 import {
@@ -515,7 +516,10 @@ export default function InventoryPage() {
     if (href) {
       // Record what we wrote so the re-seed can tell our own change from
       // someone else's and not loop on it.
-      ownUrlWriteRef.current = href.includes("?") ? href.slice(href.indexOf("?") + 1) : "";
+      // Query component ONLY (Codex P2): the href keeps the hash, the echo
+      // through useSearchParams never has one, and a mismatched marker turns
+      // our own write into a "external" re-seed that clobbers live input.
+      ownUrlWriteRef.current = queryStringOf(href);
       // Through the ROUTER, not `window.history` directly. A raw
       // `replaceState` leaves the router's own model of the URL untouched, so
       // `useSearchParams` keeps reporting the pre-write value — and a later

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -380,15 +380,26 @@ export default function Home() {
   // than rebuilding, so params this page does not own survive.
   useEffect(() => {
     if (!seeded) return;
-    const href = nextFilterHref(window.location, HOME_FILTER_SPEC, {
-      search: debouncedSearch,
-      typeFilter,
-      vendorFilter,
-      quickFilter,
-      showOutOfStock,
-      sortKey,
-      sortDir,
-    });
+    const href = nextFilterHref(
+      window.location,
+      HOME_FILTER_SPEC,
+      {
+        search: debouncedSearch,
+        typeFilter,
+        vendorFilter,
+        quickFilter,
+        showOutOfStock,
+        sortKey,
+        sortDir,
+      },
+      // The persisted sort, read fresh each run (Codex P2): the sticky keys
+      // must stay encoded while the VIEW's sort differs from the stored one,
+      // or clearing the last filter drops the URL to bare while the page
+      // still shows a shared link's sort — and a reload then silently swaps
+      // it for the persisted one. Bare means "use my prefs"; it has to be
+      // true before the URL is allowed to say it.
+      loadHomePrefs(),
+    );
     if (href) {
       // Record what we wrote so the re-seed can tell our own change from
       // someone else's and not loop on it.
@@ -506,7 +517,13 @@ export default function Home() {
 
   // Debounce search input by 300ms
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    // Trimmed at the debounce (Codex P2): the parser trims on read, so an
+    // untrimmed live value made the view disagree with its own mirrored URL —
+    // `" pla "` filtered differently before and after a refresh. The INPUT
+    // keeps the raw text (trimming state mid-typing would eat the space the
+    // user just typed); everything downstream — the fetch and the mirror —
+    // reads the canonical form.
+    const timer = setTimeout(() => setDebouncedSearch(search.trim()), 300);
     return () => clearTimeout(timer);
   }, [search]);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import React, { useEffect, useState, useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import {
+  parseFilterParams,
+  nextFilterHref,
+  oneOf,
+  boolParam,
+  textParam,
+  type FilterSpec,
+} from "@/lib/listFilterParams";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useToast } from "@/components/Toast";
@@ -8,7 +16,7 @@ import { useConfirm } from "@/components/ConfirmDialog";
 import ImportAtlasDialog from "@/components/ImportAtlasDialog";
 import PrusamentImportDialog from "@/components/PrusamentImportDialog";
 import SpoolCsvImportDialog from "@/components/SpoolCsvImportDialog";
-import QuickFilterChips, { type QuickFilter } from "@/components/QuickFilterChips";
+import QuickFilterChips, { QUICK_FILTERS, type QuickFilter } from "@/components/QuickFilterChips";
 import FilamentSwatch from "@/components/FilamentSwatch";
 import FinishChip from "@/components/FinishChip";
 import { Skeleton, SkeletonRegion } from "@/components/Skeleton";
@@ -21,7 +29,15 @@ import type { FilamentSummary } from "@/types/filament";
 import { getRemainingDisplay, getRemainingGrams, getSpoolCount } from "@/lib/inventoryStats";
 import { formatSkipReport } from "@/lib/importSkipReport";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
-import { compareFilaments, nextSortState, earliestSpoolDate, type SortKey, type SortDir } from "@/lib/sortFilamentList";
+import {
+  compareFilaments,
+  nextSortState,
+  earliestSpoolDate,
+  SORT_KEYS,
+  SORT_DIRS,
+  type SortKey,
+  type SortDir,
+} from "@/lib/sortFilamentList";
 import { useDateFormat } from "@/hooks/useDateFormat";
 import { buildFilamentGroups } from "@/lib/groupFilaments";
 
@@ -185,6 +201,43 @@ function loadHomePrefs(): { sortKey: SortKey; sortDir: SortDir } {
  *  location id. */
 const NEW_LOCATION_OPTION = "__new_location__";
 
+/**
+ * GH #1141: the filters this list mirrors into the URL.
+ *
+ * `family=1` is deliberately absent — it is an outbound API query param
+ * (`/api/filaments?family=1`), never a page URL param, so it is not state to
+ * carry. `?spool=` and friends on other routes are likewise unowned and are
+ * preserved by `serializeFilterParams`.
+ */
+/**
+ * Distinct type + vendor values for the filter dropdowns.
+ *
+ * Shared by the mount effect and the post-import refresh so the two cannot
+ * drift. Cheap distinct queries — the same endpoints /inventory uses.
+ */
+async function fetchFilterOptions(
+  signal: AbortSignal,
+): Promise<{ types: string[]; vendors: string[] }> {
+  const [typeList, vendorList] = await Promise.all([
+    fetch("/api/filaments/types", { signal }).then((r) => (r.ok ? r.json() : [])),
+    fetch("/api/filaments/vendors", { signal }).then((r) => (r.ok ? r.json() : [])),
+  ]);
+  return {
+    types: Array.isArray(typeList) ? typeList : [],
+    vendors: Array.isArray(vendorList) ? vendorList : [],
+  };
+}
+
+const HOME_FILTER_SPEC = {
+  search: { param: "q", fallback: "", ...textParam },
+  typeFilter: { param: "type", fallback: "", ...textParam },
+  vendorFilter: { param: "vendor", fallback: "", ...textParam },
+  quickFilter: { param: "quick", fallback: "all" as QuickFilter, parse: oneOf(QUICK_FILTERS) },
+  showOutOfStock: { param: "oos", fallback: false, ...boolParam },
+  sortKey: { param: "sort", fallback: "name" as SortKey, parse: oneOf(SORT_KEYS) },
+  sortDir: { param: "dir", fallback: "asc" as SortDir, parse: oneOf(SORT_DIRS) },
+} satisfies FilterSpec;
+
 export default function Home() {
   const { t } = useTranslation();
   const { format: formatCurrency } = useCurrency();
@@ -278,10 +331,62 @@ export default function Home() {
   // avoid a hydration mismatch), then persist on change. Mirrors /inventory.
   useEffect(() => {
     const p = loadHomePrefs();
-    setSortKey(p.sortKey); // eslint-disable-line react-hooks/set-state-in-effect -- persisted prefs
-    setSortDir(p.sortDir);
+    // GH #1141: the URL wins over the persisted pref, for the keys it carries.
+    //
+    // Read post-mount, defaults-then-adopt — NOT a lazy `useState` initializer
+    // with a `typeof window` check, which produces different first renders on
+    // the two sides (the Codex P2 in src/app/locations/new/page.tsx).
+    const url = parseFilterParams(window.location.search, HOME_FILTER_SPEC);
+    const present = new URLSearchParams(window.location.search);
+    const hasParam = (key: keyof typeof HOME_FILTER_SPEC) =>
+      present.has(HOME_FILTER_SPEC[key].param);
+
+    setSearch(url.search); // eslint-disable-line react-hooks/set-state-in-effect -- URL + persisted prefs
+    setDebouncedSearch(url.search);
+    setTypeFilter(url.typeFilter);
+    setVendorFilter(url.vendorFilter);
+    setQuickFilter(url.quickFilter);
+    setShowOutOfStock(url.showOutOfStock);
+    // Sort falls back to the PERSISTED pref when the URL is silent, so a bare
+    // "/" still opens the way the user left it. A shared link's sort applies
+    // to the visit; the persist effect below then stores it, matching how a
+    // manual sort behaves.
+    setSortKey(hasParam("sortKey") ? url.sortKey : p.sortKey);
+    setSortDir(hasParam("sortDir") ? url.sortDir : p.sortDir);
     homePrefsLoaded.current = true;
   }, []);
+
+  // GH #1141: mirror the filters into the URL — shareable, bookmarkable, and
+  // surviving a refresh.
+  //
+  // `replaceState`, not `pushState`: a history entry per dropdown change would
+  // make leaving the page take N Back presses. It must go through the patched
+  // `window.history` method, because Next copies its internal `__NA` marker
+  // onto the state and full-page-reloads a popstate entry without it.
+  //
+  // `nextFilterHref` returns null when nothing would change, and MERGES rather
+  // than rebuilding, so params this page does not own survive.
+  useEffect(() => {
+    if (!homePrefsLoaded.current) return;
+    const href = nextFilterHref(window.location, HOME_FILTER_SPEC, {
+      search: debouncedSearch,
+      typeFilter,
+      vendorFilter,
+      quickFilter,
+      showOutOfStock,
+      sortKey,
+      sortDir,
+    });
+    if (href) window.history.replaceState(window.history.state, "", href);
+  }, [
+    debouncedSearch,
+    typeFilter,
+    vendorFilter,
+    quickFilter,
+    showOutOfStock,
+    sortKey,
+    sortDir,
+  ]);
   useEffect(() => {
     if (!homePrefsLoaded.current) return;
     try {
@@ -347,13 +452,6 @@ export default function Home() {
       }
       const data = await res.json();
       setFilaments(data);
-      // Derive filter options from unfiltered results (initial load / no filters)
-      if (!debouncedSearch && !typeFilter && !vendorFilter) {
-        const typeList = [...new Set(data.map((f: Filament) => f.type))].sort() as string[];
-        const vendorList = [...new Set(data.map((f: Filament) => f.vendor))].sort() as string[];
-        setTypes(typeList);
-        setVendors(vendorList);
-      }
       setLoading(false);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
@@ -362,28 +460,49 @@ export default function Home() {
     }
   }, [debouncedSearch, typeFilter, vendorFilter, toast, t]);
 
-  // Refresh the type / vendor filter dropdowns from the full, unfiltered
-  // filament list. fetchFilaments only recomputes these when no filter
-  // is active, so an import performed while a filter is on would leave
-  // the dropdowns stale without this. GH #292: own AbortController so it
-  // doesn't race the main list fetch un-cancellably or setState after
-  // unmount.
+  // GH #795 / #1141: the type + vendor dropdown options come from dedicated
+  // distinct-value endpoints, NOT from the list response.
+  //
+  // They used to be derived from an UNFILTERED list fetch, which made them a
+  // side effect of having no filter active. That breaks the moment a filter is
+  // seeded from the URL (#1141): the seeded fetch is filtered, the derivation
+  // is skipped, and the Type <select> renders with only "All types" — so a
+  // shared /?type=PLA link shows a filter that is invisible AND unclearable.
+  //
+  // These endpoints are cheap distinct queries and are what /inventory already
+  // uses. GH #292: own AbortController so this doesn't race the list fetch
+  // un-cancellably or setState after unmount.
   const refreshFilterOptions = useCallback(async () => {
     filterOptionsAcRef.current?.abort();
     const ac = new AbortController();
     filterOptionsAcRef.current = ac;
     try {
-      const res = await fetch("/api/filaments", { signal: ac.signal });
-      if (!res.ok) return;
-      const all = await res.json();
+      const { types: t1, vendors: v1 } = await fetchFilterOptions(ac.signal);
       if (ac.signal.aborted) return;
-      setTypes([...new Set(all.map((f: Filament) => f.type))].sort() as string[]);
-      setVendors([...new Set(all.map((f: Filament) => f.vendor))].sort() as string[]);
-    } catch (err) {
-      // Non-fatal — the list itself still refreshed via fetchFilaments.
-      if (err instanceof DOMException && err.name === "AbortError") return;
+      setTypes(t1);
+      setVendors(v1);
+    } catch {
+      /* best-effort: the dropdowns keep their current options */
     }
   }, []);
+
+  // Populate them once on mount, independently of the list fetch and of
+  // whatever filter the URL seeded. Fetched inline (rather than calling
+  // `refreshFilterOptions`) so the state updates land in a `.then`, which is
+  // the shape `react-hooks/set-state-in-effect` accepts and the same one
+  // /inventory uses.
+  useEffect(() => {
+    const ac = new AbortController();
+    fetchFilterOptions(ac.signal)
+      .then(({ types: t1, vendors: v1 }) => {
+        if (ac.signal.aborted) return;
+        setTypes(t1);
+        setVendors(v1);
+      })
+      .catch(() => {});
+    return () => ac.abort();
+  }, []);
+
 
   // Close import/export dropdown on outside click
   useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -439,10 +439,20 @@ export default function Home() {
     // to the same query looks like another page write — type `pla`, click the
     // header link to the bare route, press Back, and the URL returns to
     // `?q=pla` while the list stays unfiltered. A marker is good for one echo.
-    if (ownUrlWriteRef.current === nextSearch) {
-      ownUrlWriteRef.current = null;
-      return;
-    }
+    // One OBSERVATION, one chance (Codex P2, fourth marker pass). Consuming
+    // only on a match left the marker armed whenever our own write produced
+    // no observable change — a normalization-only replace (`?q=foo%20bar` →
+    // `q=foo+bar`) is invisible to useSearchParams, which already reported
+    // the canonical form. The stale marker then matched a LATER genuine
+    // navigation to that same query: click the bare header link, press Back,
+    // and the restored filtered URL was mistaken for our own echo — list
+    // unfiltered under a filtered URL, the original bug re-entered through
+    // the encoding. Whatever the next observed change is, the marker's write
+    // either was it, produced nothing observable, or was superseded; in all
+    // three it is spent.
+    const own = ownUrlWriteRef.current;
+    ownUrlWriteRef.current = null;
+    if (own === nextSearch) return;
     const url = parseFilterParams(nextSearch, HOME_FILTER_SPEC);
     const present = presentFilterKeys(nextSearch, HOME_FILTER_SPEC);
     setSearch(url.search);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Suspense } from "react";
 import SearchParamsSync from "@/components/SearchParamsSync";
 import {
   parseFilterParams,
+  presentFilterKeys,
   nextFilterHref,
   oneOf,
   boolParam,
@@ -288,7 +289,17 @@ export default function Home() {
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   // #831: gate the persist effect so it doesn't fire on the default state
   // before the post-mount load runs.
-  const homePrefsLoaded = useRef(false);
+  //
+  // STATE, not a ref (GH #1141, Codex P1). Effects in one commit run in
+  // declaration order, so a ref set by the seed effect is already true when the
+  // mirror effect below runs — in the SAME commit, still closed over the
+  // initial defaults. It then serialized those defaults over the URL that had
+  // just been read, and `/?type=PLA` landed on a bare `/`: the second run saw
+  // `window.location` not yet updated by the pending `router.replace`, found
+  // nothing to change, and never wrote the filter back. A state flag is only
+  // true from the commit AFTER the seed, so the mirror first runs with the
+  // seeded values.
+  const [seeded, setSeeded] = useState(false);
   /** The query string this page last wrote, so its own replaceState does not
    *  come back through SearchParamsSync as an external change. */
   const ownUrlWriteRef = useRef<string | null>(null);
@@ -343,9 +354,7 @@ export default function Home() {
     // with a `typeof window` check, which produces different first renders on
     // the two sides (the Codex P2 in src/app/locations/new/page.tsx).
     const url = parseFilterParams(window.location.search, HOME_FILTER_SPEC);
-    const present = new URLSearchParams(window.location.search);
-    const hasParam = (key: keyof typeof HOME_FILTER_SPEC) =>
-      present.has(HOME_FILTER_SPEC[key].param);
+    const present = presentFilterKeys(window.location.search, HOME_FILTER_SPEC);
 
     setSearch(url.search); // eslint-disable-line react-hooks/set-state-in-effect -- URL + persisted prefs
     setDebouncedSearch(url.search);
@@ -357,9 +366,9 @@ export default function Home() {
     // "/" still opens the way the user left it. A shared link's sort applies
     // to the visit; the persist effect below then stores it, matching how a
     // manual sort behaves.
-    setSortKey(hasParam("sortKey") ? url.sortKey : p.sortKey);
-    setSortDir(hasParam("sortDir") ? url.sortDir : p.sortDir);
-    homePrefsLoaded.current = true;
+    setSortKey(present.has("sortKey") ? url.sortKey : p.sortKey);
+    setSortDir(present.has("sortDir") ? url.sortDir : p.sortDir);
+    setSeeded(true);
   }, []);
 
   // GH #1141: mirror the filters into the URL — shareable, bookmarkable, and
@@ -373,7 +382,7 @@ export default function Home() {
   // `nextFilterHref` returns null when nothing would change, and MERGES rather
   // than rebuilding, so params this page does not own survive.
   useEffect(() => {
-    if (!homePrefsLoaded.current) return;
+    if (!seeded) return;
     const href = nextFilterHref(window.location, HOME_FILTER_SPEC, {
       search: debouncedSearch,
       typeFilter,
@@ -397,6 +406,7 @@ export default function Home() {
       router.replace(href, { scroll: false });
     }
   }, [
+    seeded,
     debouncedSearch,
     typeFilter,
     vendorFilter,
@@ -422,23 +432,31 @@ export default function Home() {
       return;
     }
     const url = parseFilterParams(nextSearch, HOME_FILTER_SPEC);
+    const present = presentFilterKeys(nextSearch, HOME_FILTER_SPEC);
     setSearch(url.search);
     setDebouncedSearch(url.search);
     setTypeFilter(url.typeFilter);
     setVendorFilter(url.vendorFilter);
     setQuickFilter(url.quickFilter);
     setShowOutOfStock(url.showOutOfStock);
-    setSortKey(url.sortKey);
-    setSortDir(url.sortDir);
+    // Sort is PERSISTED, so an absent param means "unchanged", not "default"
+    // (GH #1141, Codex P2). Clicking the header link while filtered navigates
+    // to a bare `/`; resetting to the fallback there would then have the
+    // persist effect below overwrite the user's saved sort with `name`/`asc` —
+    // a stored preference destroyed by a navigation that never mentioned it.
+    // The mount seed already reads a bare URL this way; this keeps the two
+    // paths agreeing. Functional updates so the callback keeps no state deps.
+    setSortKey((cur) => (present.has("sortKey") ? url.sortKey : cur));
+    setSortDir((cur) => (present.has("sortDir") ? url.sortDir : cur));
   }, []);
   useEffect(() => {
-    if (!homePrefsLoaded.current) return;
+    if (!seeded) return;
     try {
       window.localStorage.setItem(HOME_PREFS_KEY, JSON.stringify({ sortKey, sortDir }));
     } catch {
       /* ignore quota / disabled storage */
     }
-  }, [sortKey, sortDir]);
+  }, [seeded, sortKey, sortDir]);
 
   // #717: load locations for the per-spool "move to" dropdowns. Best-effort —
   // if it fails the panel just shows the ids' current selection with no

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -444,6 +444,12 @@ export default function Home() {
     // the stored one; functional updates keep the callback free of state deps.
     setSortKey((cur) => (present.has("sortKey") ? url.sortKey : cur));
     setSortDir((cur) => (present.has("sortDir") ? url.sortDir : cur));
+    // Any touch still armed here is DEAD: a real one was consumed by the
+    // persist effect in the same commit as its state change, which necessarily
+    // ran before this external navigation could be processed. What survives is
+    // an armed-but-noop touch (a handler that did not change state), and it
+    // must not authorize persisting the values this re-seed just adopted.
+    prefsTouchedRef.current.clear();
   }, []);
   // Persist ONLY what the user chose (GH #1141, Codex P1).
   //
@@ -467,6 +473,13 @@ export default function Home() {
       const next: HomePrefs = { ...DEFAULT_HOME_PREFS, ...stored };
       for (const key of prefsTouchedRef.current) next[key] = live[key] as never;
       window.localStorage.setItem(HOME_PREFS_KEY, JSON.stringify(next));
+      // CONSUME the touches (Codex P2). A touch is an authorization for ONE
+      // write — the user's change, which has now been stored. Left armed, it
+      // authorized every LATER state change too, including URL-derived ones:
+      // open a shared sort link, change the sort yourself, press Back, and the
+      // re-seed restored the link's values while the stale touch let this
+      // effect write them over the choice you just made.
+      prefsTouchedRef.current.clear();
     } catch {
       /* ignore quota / disabled storage / a corrupt stored blob */
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import SearchParamsSync from "@/components/SearchParamsSync";
 import {
   parseFilterParams,
   nextFilterHref,
-  serializeFilterParams,
   oneOf,
   boolParam,
   textParam,
@@ -373,34 +372,6 @@ export default function Home() {
   //
   // `nextFilterHref` returns null when nothing would change, and MERGES rather
   // than rebuilding, so params this page does not own survive.
-  /** What this page's filters serialize to — the value it writes, and what
-   *  SearchParamsSync needs in order to keep its own notion current (see
-   *  its docblock: useSearchParams does not observe a manual replaceState). */
-  const mirroredQuery = useMemo(
-    () => serializeFilterParams(
-      typeof window === "undefined" ? "" : window.location.search,
-      HOME_FILTER_SPEC,
-      {
-      search: debouncedSearch,
-      typeFilter,
-      vendorFilter,
-      quickFilter,
-      showOutOfStock,
-      sortKey,
-      sortDir,
-    },
-    ),
-    [
-    debouncedSearch,
-    typeFilter,
-    vendorFilter,
-    quickFilter,
-    showOutOfStock,
-    sortKey,
-    sortDir,
-  ],
-  );
-
   useEffect(() => {
     if (!homePrefsLoaded.current) return;
     const href = nextFilterHref(window.location, HOME_FILTER_SPEC, {
@@ -1603,7 +1574,7 @@ export default function Home() {
     <>
       {/* GH #1141: only THIS child suspends, so the page still prerenders. */}
       <Suspense fallback={null}>
-        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={mirroredQuery} />
+        <SearchParamsSync onExternalChange={reseedFromUrl} />
       </Suspense>
     <main id="main-content" className="w-full px-4 py-8">
       {/* GH #411: visually-hidden h1 so screen-reader users navigating

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   presentFilterKeys,
   nextFilterHref,
   seedFilterState,
+  queryStringOf,
   withCurrentValue,
 } from "@/lib/listFilterParams";
 import {
@@ -403,7 +404,10 @@ export default function Home() {
     if (href) {
       // Record what we wrote so the re-seed can tell our own change from
       // someone else's and not loop on it.
-      ownUrlWriteRef.current = href.includes("?") ? href.slice(href.indexOf("?") + 1) : "";
+      // Query component ONLY (Codex P2): the href keeps the hash, the echo
+      // through useSearchParams never has one, and a mismatched marker turns
+      // our own write into a "external" re-seed that clobbers live input.
+      ownUrlWriteRef.current = queryStringOf(href);
       // Through the ROUTER, not `window.history` directly. A raw
       // `replaceState` leaves the router's own model of the URL untouched, so
       // `useSearchParams` keeps reporting the pre-write value — and a later

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,9 +6,11 @@ import SearchParamsSync from "@/components/SearchParamsSync";
 import {
   parseFilterParams,
   nextFilterHref,
+  serializeFilterParams,
   oneOf,
   boolParam,
   textParam,
+  withCurrentValue,
   type FilterSpec,
 } from "@/lib/listFilterParams";
 import { useRouter } from "next/navigation";
@@ -371,6 +373,34 @@ export default function Home() {
   //
   // `nextFilterHref` returns null when nothing would change, and MERGES rather
   // than rebuilding, so params this page does not own survive.
+  /** What this page's filters serialize to — the value it writes, and what
+   *  SearchParamsSync needs in order to keep its own notion current (see
+   *  its docblock: useSearchParams does not observe a manual replaceState). */
+  const mirroredQuery = useMemo(
+    () => serializeFilterParams(
+      typeof window === "undefined" ? "" : window.location.search,
+      HOME_FILTER_SPEC,
+      {
+      search: debouncedSearch,
+      typeFilter,
+      vendorFilter,
+      quickFilter,
+      showOutOfStock,
+      sortKey,
+      sortDir,
+    },
+    ),
+    [
+    debouncedSearch,
+    typeFilter,
+    vendorFilter,
+    quickFilter,
+    showOutOfStock,
+    sortKey,
+    sortDir,
+  ],
+  );
+
   useEffect(() => {
     if (!homePrefsLoaded.current) return;
     const href = nextFilterHref(window.location, HOME_FILTER_SPEC, {
@@ -383,10 +413,17 @@ export default function Home() {
       sortDir,
     });
     if (href) {
-      // Record what we wrote so SearchParamsSync can tell our own change from
+      // Record what we wrote so the re-seed can tell our own change from
       // someone else's and not loop on it.
       ownUrlWriteRef.current = href.includes("?") ? href.slice(href.indexOf("?") + 1) : "";
-      window.history.replaceState(window.history.state, "", href);
+      // Through the ROUTER, not `window.history` directly. A raw
+      // `replaceState` leaves the router's own model of the URL untouched, so
+      // `useSearchParams` keeps reporting the pre-write value — and a later
+      // Link click to the same route then looks like no change at all, which
+      // is exactly the navigation the re-seed exists to catch. Verified in the
+      // browser: with a raw replaceState the list stayed filtered under a bare
+      // URL. `scroll: false` keeps the list position; already debounced.
+      router.replace(href, { scroll: false });
     }
   }, [
     debouncedSearch,
@@ -396,6 +433,7 @@ export default function Home() {
     showOutOfStock,
     sortKey,
     sortDir,
+    router,
   ]);
 
   // GH #1141 (Codex P2): re-seed when something ELSE changes the query string.
@@ -403,6 +441,15 @@ export default function Home() {
   // clicking the header's home link while filtered reuses this page, so the
   // URL goes bare while the state stays filtered.
   const reseedFromUrl = useCallback((nextSearch: string) => {
+    // Our own replaceState comes back through here; CONSUME the marker rather
+    // than just testing it (Codex P2). Left set, a later external navigation
+    // to the same query looks like another page write — type `pla`, click the
+    // header link to the bare route, press Back, and the URL returns to
+    // `?q=pla` while the list stays unfiltered. A marker is good for one echo.
+    if (ownUrlWriteRef.current === nextSearch) {
+      ownUrlWriteRef.current = null;
+      return;
+    }
     const url = parseFilterParams(nextSearch, HOME_FILTER_SPEC);
     setSearch(url.search);
     setDebouncedSearch(url.search);
@@ -1556,7 +1603,7 @@ export default function Home() {
     <>
       {/* GH #1141: only THIS child suspends, so the page still prerenders. */}
       <Suspense fallback={null}>
-        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={ownUrlWriteRef} />
+        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={mirroredQuery} />
       </Suspense>
     <main id="main-content" className="w-full px-4 py-8">
       {/* GH #411: visually-hidden h1 so screen-reader users navigating
@@ -1793,7 +1840,7 @@ export default function Home() {
           className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
         >
           <option value="">{t("filaments.filter.allTypes")}</option>
-          {types.map((tp) => (
+          {withCurrentValue(types, typeFilter).map((tp) => (
             <option key={tp} value={tp}>
               {tp}
             </option>
@@ -1805,7 +1852,7 @@ export default function Home() {
           className="px-3 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
         >
           <option value="">{t("filaments.filter.allVendors")}</option>
-          {vendors.map((vn) => (
+          {withCurrentValue(vendors, vendorFilter).map((vn) => (
             <option key={vn} value={vn}>
               {vn}
             </option>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,12 +7,16 @@ import {
   parseFilterParams,
   presentFilterKeys,
   nextFilterHref,
-  oneOf,
-  boolParam,
-  textParam,
+  seedFilterState,
   withCurrentValue,
-  type FilterSpec,
 } from "@/lib/listFilterParams";
+import {
+  HOME_FILTER_SPEC,
+  HOME_PREFS_KEY,
+  HOME_PERSISTED_KEYS,
+  DEFAULT_HOME_PREFS,
+  type HomePrefs,
+} from "@/lib/listFilterSpecs";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useToast } from "@/components/Toast";
@@ -20,7 +24,7 @@ import { useConfirm } from "@/components/ConfirmDialog";
 import ImportAtlasDialog from "@/components/ImportAtlasDialog";
 import PrusamentImportDialog from "@/components/PrusamentImportDialog";
 import SpoolCsvImportDialog from "@/components/SpoolCsvImportDialog";
-import QuickFilterChips, { QUICK_FILTERS, type QuickFilter } from "@/components/QuickFilterChips";
+import QuickFilterChips, { type QuickFilter } from "@/components/QuickFilterChips";
 import FilamentSwatch from "@/components/FilamentSwatch";
 import FinishChip from "@/components/FinishChip";
 import { Skeleton, SkeletonRegion } from "@/components/Skeleton";
@@ -37,8 +41,6 @@ import {
   compareFilaments,
   nextSortState,
   earliestSpoolDate,
-  SORT_KEYS,
-  SORT_DIRS,
   type SortKey,
   type SortDir,
 } from "@/lib/sortFilamentList";
@@ -182,21 +184,22 @@ function FilamentStats({ filaments }: { filaments: Filament[] }) {
 // quick filters would land a returning user on a filtered subset of their
 // catalog, which reads as "filaments missing". Loaded post-mount so SSR /
 // first paint stay on defaults (no hydration mismatch).
-const HOME_PREFS_KEY = "filamentdb-home-prefs";
 const SORT_KEY_VALUES: SortKey[] = ["name", "vendor", "type", "nozzle", "bed", "cost", "remaining", "purchased", "opened"];
 
-function loadHomePrefs(): { sortKey: SortKey; sortDir: SortDir } {
-  if (typeof window === "undefined") return { sortKey: "name", sortDir: "asc" };
+function loadHomePrefs(): HomePrefs {
+  if (typeof window === "undefined") return DEFAULT_HOME_PREFS;
   try {
     const raw = window.localStorage.getItem(HOME_PREFS_KEY);
-    if (!raw) return { sortKey: "name", sortDir: "asc" };
+    if (!raw) return DEFAULT_HOME_PREFS;
     const p = JSON.parse(raw) as { sortKey?: unknown; sortDir?: unknown };
     return {
-      sortKey: SORT_KEY_VALUES.includes(p.sortKey as SortKey) ? (p.sortKey as SortKey) : "name",
-      sortDir: p.sortDir === "desc" ? "desc" : "asc",
+      sortKey: SORT_KEY_VALUES.includes(p.sortKey as SortKey)
+        ? (p.sortKey as SortKey)
+        : DEFAULT_HOME_PREFS.sortKey,
+      sortDir: p.sortDir === "desc" ? "desc" : DEFAULT_HOME_PREFS.sortDir,
     };
   } catch {
-    return { sortKey: "name", sortDir: "asc" };
+    return DEFAULT_HOME_PREFS;
   }
 }
 
@@ -232,15 +235,6 @@ async function fetchFilterOptions(
   };
 }
 
-const HOME_FILTER_SPEC = {
-  search: { param: "q", fallback: "", ...textParam },
-  typeFilter: { param: "type", fallback: "", ...textParam },
-  vendorFilter: { param: "vendor", fallback: "", ...textParam },
-  quickFilter: { param: "quick", fallback: "all" as QuickFilter, parse: oneOf(QUICK_FILTERS) },
-  showOutOfStock: { param: "oos", fallback: false, ...boolParam },
-  sortKey: { param: "sort", fallback: "name" as SortKey, parse: oneOf(SORT_KEYS) },
-  sortDir: { param: "dir", fallback: "asc" as SortDir, parse: oneOf(SORT_DIRS) },
-} satisfies FilterSpec;
 
 export default function Home() {
   const { t } = useTranslation();
@@ -300,6 +294,9 @@ export default function Home() {
   // true from the commit AFTER the seed, so the mirror first runs with the
   // seeded values.
   const [seeded, setSeeded] = useState(false);
+  /** Preference keys the USER changed this session — the only ones written
+   *  back to storage. See the persist effect. */
+  const prefsTouchedRef = useRef<Set<(typeof HOME_PERSISTED_KEYS)[number]>>(new Set());
   /** The query string this page last wrote, so its own replaceState does not
    *  come back through SearchParamsSync as an external change. */
   const ownUrlWriteRef = useRef<string | null>(null);
@@ -353,8 +350,11 @@ export default function Home() {
     // Read post-mount, defaults-then-adopt — NOT a lazy `useState` initializer
     // with a `typeof window` check, which produces different first renders on
     // the two sides (the Codex P2 in src/app/locations/new/page.tsx).
-    const url = parseFilterParams(window.location.search, HOME_FILTER_SPEC);
-    const present = presentFilterKeys(window.location.search, HOME_FILTER_SPEC);
+    // Sort falls back to the PERSISTED pref when the URL is silent, so a bare
+    // "/" still opens the way the user left it, while a link that carries the
+    // sort applies it for the visit. `seedFilterState` owns that rule for both
+    // this seed and the re-seed below — see its docblock.
+    const url = seedFilterState(window.location.search, HOME_FILTER_SPEC, p);
 
     setSearch(url.search); // eslint-disable-line react-hooks/set-state-in-effect -- URL + persisted prefs
     setDebouncedSearch(url.search);
@@ -362,12 +362,8 @@ export default function Home() {
     setVendorFilter(url.vendorFilter);
     setQuickFilter(url.quickFilter);
     setShowOutOfStock(url.showOutOfStock);
-    // Sort falls back to the PERSISTED pref when the URL is silent, so a bare
-    // "/" still opens the way the user left it. A shared link's sort applies
-    // to the visit; the persist effect below then stores it, matching how a
-    // manual sort behaves.
-    setSortKey(present.has("sortKey") ? url.sortKey : p.sortKey);
-    setSortDir(present.has("sortDir") ? url.sortDir : p.sortDir);
+    setSortKey(url.sortKey);
+    setSortDir(url.sortDir);
     setSeeded(true);
   }, []);
 
@@ -444,17 +440,35 @@ export default function Home() {
     // to a bare `/`; resetting to the fallback there would then have the
     // persist effect below overwrite the user's saved sort with `name`/`asc` —
     // a stored preference destroyed by a navigation that never mentioned it.
-    // The mount seed already reads a bare URL this way; this keeps the two
-    // paths agreeing. Functional updates so the callback keeps no state deps.
+    // Same rule as the mount seed, applied to the CURRENT state rather than
+    // the stored one; functional updates keep the callback free of state deps.
     setSortKey((cur) => (present.has("sortKey") ? url.sortKey : cur));
     setSortDir((cur) => (present.has("sortDir") ? url.sortDir : cur));
   }, []);
+  // Persist ONLY what the user chose (GH #1141, Codex P1).
+  //
+  // Sticky keys are now emitted into every non-bare URL, which is what makes a
+  // shared link deterministic — but it also means every shared link MENTIONS
+  // the sort. An ungated persist effect would therefore let a friend's link
+  // permanently overwrite the recipient's saved preference just by being
+  // opened. Tracking which keys the user actually touched, and merging those
+  // over whatever is stored, keeps "applies to this visit" and "is my
+  // preference" separate.
+  //
+  // Per-key rather than a single boolean because the record is one blob:
+  // a boolean cannot express "store the direction I just changed, leave the
+  // sort key alone".
   useEffect(() => {
-    if (!seeded) return;
+    if (!seeded || prefsTouchedRef.current.size === 0) return;
     try {
-      window.localStorage.setItem(HOME_PREFS_KEY, JSON.stringify({ sortKey, sortDir }));
+      const raw = window.localStorage.getItem(HOME_PREFS_KEY);
+      const stored = raw ? (JSON.parse(raw) as Partial<HomePrefs>) : {};
+      const live: HomePrefs = { sortKey, sortDir };
+      const next: HomePrefs = { ...DEFAULT_HOME_PREFS, ...stored };
+      for (const key of prefsTouchedRef.current) next[key] = live[key] as never;
+      window.localStorage.setItem(HOME_PREFS_KEY, JSON.stringify(next));
     } catch {
-      /* ignore quota / disabled storage */
+      /* ignore quota / disabled storage / a corrupt stored blob */
     }
   }, [seeded, sortKey, sortDir]);
 
@@ -913,6 +927,10 @@ export default function Home() {
 
   const handleSort = (key: SortKey) => {
     const next = nextSortState({ sortKey, sortDir }, key);
+    // The ONLY place a user chooses a sort here, so the only place that may
+    // record one (GH #1141, Codex P1). See the persist effect.
+    prefsTouchedRef.current.add("sortKey");
+    prefsTouchedRef.current.add("sortDir");
     setSortKey(next.sortKey);
     setSortDir(next.sortDir);
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
   withCurrentValue,
 } from "@/lib/listFilterParams";
 import {
+  parseStoredPrefs,
   HOME_FILTER_SPEC,
   HOME_PREFS_KEY,
   HOME_PERSISTED_KEYS,
@@ -467,8 +468,14 @@ export default function Home() {
   useEffect(() => {
     if (!seeded || prefsTouchedRef.current.size === 0) return;
     try {
-      const raw = window.localStorage.getItem(HOME_PREFS_KEY);
-      const stored = raw ? (JSON.parse(raw) as Partial<HomePrefs>) : {};
+      // Tolerant parse (Codex P2): a corrupt blob must not throw here — the
+      // catch below would skip the setItem, so nothing would ever overwrite
+      // the bad value and persistence would be dead until storage was cleared
+      // by hand. Parsed as `{}`, it merges against defaults and THIS write
+      // replaces it: the write path is the one chance to heal.
+      const stored = parseStoredPrefs(
+        window.localStorage.getItem(HOME_PREFS_KEY),
+      ) as Partial<HomePrefs>;
       const live: HomePrefs = { sortKey, sortDir };
       const next: HomePrefs = { ...DEFAULT_HOME_PREFS, ...stored };
       for (const key of prefsTouchedRef.current) next[key] = live[key] as never;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useEffect, useState, useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import { Suspense } from "react";
+import SearchParamsSync from "@/components/SearchParamsSync";
 import {
   parseFilterParams,
   nextFilterHref,
@@ -286,6 +288,9 @@ export default function Home() {
   // #831: gate the persist effect so it doesn't fire on the default state
   // before the post-mount load runs.
   const homePrefsLoaded = useRef(false);
+  /** The query string this page last wrote, so its own replaceState does not
+   *  come back through SearchParamsSync as an external change. */
+  const ownUrlWriteRef = useRef<string | null>(null);
   const [importing, setImporting] = useState(false);
   const mounted = useSyncExternalStore(
     () => () => {},
@@ -377,7 +382,12 @@ export default function Home() {
       sortKey,
       sortDir,
     });
-    if (href) window.history.replaceState(window.history.state, "", href);
+    if (href) {
+      // Record what we wrote so SearchParamsSync can tell our own change from
+      // someone else's and not loop on it.
+      ownUrlWriteRef.current = href.includes("?") ? href.slice(href.indexOf("?") + 1) : "";
+      window.history.replaceState(window.history.state, "", href);
+    }
   }, [
     debouncedSearch,
     typeFilter,
@@ -387,6 +397,22 @@ export default function Home() {
     sortKey,
     sortDir,
   ]);
+
+  // GH #1141 (Codex P2): re-seed when something ELSE changes the query string.
+  // The mount seed misses a client-side navigation to the SAME route —
+  // clicking the header's home link while filtered reuses this page, so the
+  // URL goes bare while the state stays filtered.
+  const reseedFromUrl = useCallback((nextSearch: string) => {
+    const url = parseFilterParams(nextSearch, HOME_FILTER_SPEC);
+    setSearch(url.search);
+    setDebouncedSearch(url.search);
+    setTypeFilter(url.typeFilter);
+    setVendorFilter(url.vendorFilter);
+    setQuickFilter(url.quickFilter);
+    setShowOutOfStock(url.showOutOfStock);
+    setSortKey(url.sortKey);
+    setSortDir(url.sortDir);
+  }, []);
   useEffect(() => {
     if (!homePrefsLoaded.current) return;
     try {
@@ -1527,6 +1553,11 @@ export default function Home() {
   };
 
   return (
+    <>
+      {/* GH #1141: only THIS child suspends, so the page still prerenders. */}
+      <Suspense fallback={null}>
+        <SearchParamsSync onExternalChange={reseedFromUrl} ownWrite={ownUrlWriteRef} />
+      </Suspense>
     <main id="main-content" className="w-full px-4 py-8">
       {/* GH #411: visually-hidden h1 so screen-reader users navigating
           by heading land on the page title. Sighted users already get
@@ -1959,5 +1990,6 @@ export default function Home() {
         />
       )}
     </main>
+    </>
   );
 }

--- a/src/components/QuickFilterChips.tsx
+++ b/src/components/QuickFilterChips.tsx
@@ -3,7 +3,10 @@
 import type { ReactNode } from "react";
 import { useTranslation } from "@/i18n/TranslationProvider";
 
-export type QuickFilter = "all" | "lowStock" | "hasSpools" | "noCalibration";
+/** GH #1141: runtime array so a URL-supplied value can be validated; the
+ *  union is derived so the two cannot drift. */
+export const QUICK_FILTERS = ["all", "lowStock", "hasSpools", "noCalibration"] as const;
+export type QuickFilter = (typeof QUICK_FILTERS)[number];
 
 interface Props {
   active: QuickFilter;

--- a/src/components/SearchParamsSync.tsx
+++ b/src/components/SearchParamsSync.tsx
@@ -30,25 +30,38 @@ import { useSearchParams } from "next/navigation";
  * </Suspense>
  * ```
  *
- * ## The feedback loop this must not create
+ * ## The feedback loop the CALLER must not create
  *
- * The page also WRITES the query string as its filters change. Those writes
- * come back through `useSearchParams`, so reporting them would re-seed the
- * state that just produced them — a loop, and one that would fight the user's
- * typing. The page therefore passes what it last wrote via `ownWrite`, and
- * anything matching it is ignored. Only a change from somewhere else — a link,
- * Back/Forward, an external `pushState` — is reported.
+ * The page also WRITES the query string as its filters change, and those
+ * writes come back through `useSearchParams`. Re-seeding from them would
+ * re-run the state that produced them — a loop that fights the user's typing.
+ *
+ * Filtering that out is the PAGE's job, not this component's: the page owns
+ * the record of what it last wrote, and it must CONSUME that record when it
+ * matches. A marker left set makes a later external navigation to the same
+ * query look like another page write — type `pla`, click the header link to
+ * the bare route, press Back, and the URL returns to `?q=pla` while the list
+ * stays unfiltered.
  */
 export default function SearchParamsSync({
   onExternalChange,
   ownWrite,
 }: {
-  /** Called with the new query string (no leading `?`) when something OTHER
-   *  than this page changed it. */
+  /** Called with the new query string (no leading `?`) whenever it changes
+   *  after mount. The caller filters out its own writes. */
   onExternalChange: (search: string) => void;
-  /** The query string this page most recently wrote, so its own writes can be
-   *  distinguished from everyone else's. */
-  ownWrite: React.RefObject<string | null>;
+  /**
+   * The query string the PAGE currently intends the URL to have — i.e. what
+   * its own filters serialize to.
+   *
+   * Needed because `useSearchParams` does NOT observe a manual
+   * `history.replaceState`, so without this the "last seen" value goes stale
+   * the moment the page writes the URL itself: at `/` it is `""`, the page
+   * writes `?q=pla`, and a later navigation back to `/` then compares `""`
+   * against `""` and reports nothing — leaving the list filtered under a bare
+   * URL. Caught by a browser test, not by reasoning.
+   */
+  ownWrite: string;
 }) {
   const params = useSearchParams();
   const search = params.toString();
@@ -58,6 +71,11 @@ export default function SearchParamsSync({
   // the home page would re-trigger the filter fetch.
   const seen = useRef<string | null>(null);
 
+  // Keep `seen` aligned with what the page itself put in the URL.
+  useEffect(() => {
+    seen.current = ownWrite;
+  }, [ownWrite]);
+
   useEffect(() => {
     if (seen.current === null) {
       seen.current = search;
@@ -65,9 +83,8 @@ export default function SearchParamsSync({
     }
     if (seen.current === search) return;
     seen.current = search;
-    if (ownWrite.current === search) return; // our own replaceState came back
     onExternalChange(search);
-  }, [search, onExternalChange, ownWrite]);
+  }, [search, onExternalChange]);
 
   return null;
 }

--- a/src/components/SearchParamsSync.tsx
+++ b/src/components/SearchParamsSync.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+
+/**
+ * Report query-string changes that this page did not make itself (GH #1141).
+ *
+ * ## Why it exists
+ *
+ * A list page seeds its filters from the URL once, on mount. That misses a
+ * client-side navigation to the SAME route: clicking the persistent header's
+ * `/` link while at `/?q=pla` reuses the mounted page, so the mount effect does
+ * not run again — the URL goes bare while React state stays filtered, and the
+ * next refresh then clears what the UI was still showing.
+ *
+ * ## Why it is a separate component
+ *
+ * `useSearchParams()` requires a Suspense boundary in a statically prerendered
+ * client page, or the production build fails. Wrapping a whole list page would
+ * ship an empty shell in the initial HTML. Isolating the subscription in a
+ * render-nothing child means only THIS component suspends — the page around it
+ * prerenders exactly as before.
+ *
+ * Mount it as:
+ *
+ * ```tsx
+ * <Suspense fallback={null}>
+ *   <SearchParamsSync onExternalChange={reseedFromUrl} />
+ * </Suspense>
+ * ```
+ *
+ * ## The feedback loop this must not create
+ *
+ * The page also WRITES the query string as its filters change. Those writes
+ * come back through `useSearchParams`, so reporting them would re-seed the
+ * state that just produced them — a loop, and one that would fight the user's
+ * typing. The page therefore passes what it last wrote via `ownWrite`, and
+ * anything matching it is ignored. Only a change from somewhere else — a link,
+ * Back/Forward, an external `pushState` — is reported.
+ */
+export default function SearchParamsSync({
+  onExternalChange,
+  ownWrite,
+}: {
+  /** Called with the new query string (no leading `?`) when something OTHER
+   *  than this page changed it. */
+  onExternalChange: (search: string) => void;
+  /** The query string this page most recently wrote, so its own writes can be
+   *  distinguished from everyone else's. */
+  ownWrite: React.RefObject<string | null>;
+}) {
+  const params = useSearchParams();
+  const search = params.toString();
+
+  // The mount value is what the page already seeded from, so skip it — firing
+  // on mount would re-run the seed with the same values for no reason, and on
+  // the home page would re-trigger the filter fetch.
+  const seen = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (seen.current === null) {
+      seen.current = search;
+      return;
+    }
+    if (seen.current === search) return;
+    seen.current = search;
+    if (ownWrite.current === search) return; // our own replaceState came back
+    onExternalChange(search);
+  }, [search, onExternalChange, ownWrite]);
+
+  return null;
+}

--- a/src/components/SearchParamsSync.tsx
+++ b/src/components/SearchParamsSync.tsx
@@ -36,32 +36,25 @@ import { useSearchParams } from "next/navigation";
  * writes come back through `useSearchParams`. Re-seeding from them would
  * re-run the state that produced them — a loop that fights the user's typing.
  *
- * Filtering that out is the PAGE's job, not this component's: the page owns
- * the record of what it last wrote, and it must CONSUME that record when it
- * matches. A marker left set makes a later external navigation to the same
- * query look like another page write — type `pla`, click the header link to
- * the bare route, press Back, and the URL returns to `?q=pla` while the list
- * stays unfiltered.
+ * Filtering that out is the PAGE's job: it owns the record of what it last
+ * wrote, and CONSUMES that record when it matches. This component reports
+ * every post-mount change and makes no judgement about who caused it.
+ *
+ * An earlier version took an `ownWrite` prop and advanced its own "last seen"
+ * value to it, to compensate for a raw `history.replaceState` that the router
+ * never observed. That is now unnecessary — the page writes through
+ * `router.replace`, so `useSearchParams` sees it — and it was actively
+ * harmful: advancing `seen` ahead of the router update meant the page's own
+ * write never came back through here, so the marker was never consumed and
+ * went stale, which is exactly the Back-restores-nothing bug it was meant to
+ * prevent.
  */
 export default function SearchParamsSync({
   onExternalChange,
-  ownWrite,
 }: {
   /** Called with the new query string (no leading `?`) whenever it changes
    *  after mount. The caller filters out its own writes. */
   onExternalChange: (search: string) => void;
-  /**
-   * The query string the PAGE currently intends the URL to have — i.e. what
-   * its own filters serialize to.
-   *
-   * Needed because `useSearchParams` does NOT observe a manual
-   * `history.replaceState`, so without this the "last seen" value goes stale
-   * the moment the page writes the URL itself: at `/` it is `""`, the page
-   * writes `?q=pla`, and a later navigation back to `/` then compares `""`
-   * against `""` and reports nothing — leaving the list filtered under a bare
-   * URL. Caught by a browser test, not by reasoning.
-   */
-  ownWrite: string;
 }) {
   const params = useSearchParams();
   const search = params.toString();
@@ -70,11 +63,6 @@ export default function SearchParamsSync({
   // on mount would re-run the seed with the same values for no reason, and on
   // the home page would re-trigger the filter fetch.
   const seen = useRef<string | null>(null);
-
-  // Keep `seen` aligned with what the page itself put in the URL.
-  useEffect(() => {
-    seen.current = ownWrite;
-  }, [ownWrite]);
 
   useEffect(() => {
     if (seen.current === null) {

--- a/src/lib/inventorySort.ts
+++ b/src/lib/inventorySort.ts
@@ -14,15 +14,29 @@
  * "blanks always sink to the bottom regardless of direction" rule.
  */
 
-export type InventoryGroupBy = "location" | "type" | "vendor" | "none";
-export type InventorySortKey =
-  | "remaining"
-  | "name"
-  | "type"
-  | "vendor"
-  | "purchase"
-  | "opened";
-export type InventorySortDir = "asc" | "desc";
+/**
+ * The allowed values, as runtime arrays.
+ *
+ * GH #1141 needs to VALIDATE these — a shared or hand-edited link can carry
+ * `?group=nonsense`, and a page seeded from an unchecked string would sit in a
+ * state its own controls cannot represent. Declaring the arrays and deriving
+ * the unions from them keeps the two in step: adding a sort key to the union
+ * without adding it here is a type error, not a silently unaccepted param.
+ */
+export const INVENTORY_GROUP_BYS = ["location", "type", "vendor", "none"] as const;
+export const INVENTORY_SORT_KEYS = [
+  "remaining",
+  "name",
+  "type",
+  "vendor",
+  "purchase",
+  "opened",
+] as const;
+export const INVENTORY_SORT_DIRS = ["asc", "desc"] as const;
+
+export type InventoryGroupBy = (typeof INVENTORY_GROUP_BYS)[number];
+export type InventorySortKey = (typeof INVENTORY_SORT_KEYS)[number];
+export type InventorySortDir = (typeof INVENTORY_SORT_DIRS)[number];
 
 /** Minimal row shape the transforms need; the page's `SpoolRow` is assignable. */
 export interface InventoryRow {

--- a/src/lib/listFilterParams.ts
+++ b/src/lib/listFilterParams.ts
@@ -47,6 +47,31 @@ export interface FilterParamSpec<T> {
   parse: (raw: string) => T | null;
   /** Value → raw string. Defaults to `String(value)`. */
   serialize?: (value: T) => string;
+  /**
+   * This key is backed by a PERSISTED preference, so its absence is
+   * ambiguous — and the ambiguity is a bug (GH #1141, Codex P1).
+   *
+   * Serialization normally omits a value equal to its fallback, which means a
+   * shared `?sort=cost` from a sender on ascending order says nothing about
+   * direction; a recipient whose saved direction is descending then opens the
+   * link sorted differently from the sender, and the mirror rewrites the URL
+   * to match. Two people, one link, two views.
+   *
+   * A sticky key is therefore emitted EXPLICITLY whenever the serializer
+   * emits anything at all, even at its fallback. Absence then means only one
+   * thing — "this URL is not talking about filters" — which is exactly when
+   * the persisted preference should win.
+   *
+   * A fully default view still serializes to a bare URL: nothing is emitted,
+   * so nothing is made sticky. That gate is load-bearing. Without it every
+   * printed dry-box QR (`/inventory?location=X`) would gain four preference
+   * params and reset the scanner's saved grouping.
+   *
+   * INVARIANT, asserted in the tests: a sticky key's fallback must not
+   * serialize to the empty string, or the delete branch below silently
+   * un-sticks it and reintroduces this bug for that key alone.
+   */
+  sticky?: boolean;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- a spec is heterogeneous
@@ -133,6 +158,11 @@ export function serializeFilterParams<S extends FilterSpec>(
   } catch {
     params = new URLSearchParams();
   }
+  // TWO passes, and the split is required rather than tidy: whether a sticky
+  // key must be emitted depends on whether ANY key emitted, which is not known
+  // until every key has been visited. Deciding inside one loop would make the
+  // output depend on `Object.keys(spec)` ordering.
+  let emittedAny = false;
   for (const key of Object.keys(spec) as (keyof S)[]) {
     const entry = spec[key];
     const value = state[key];
@@ -144,7 +174,22 @@ export function serializeFilterParams<S extends FilterSpec>(
     // A value that serializes to empty is indistinguishable from absent once
     // it round-trips, so drop it rather than emitting a bare `key=`.
     if (raw === "") params.delete(entry.param);
-    else params.set(entry.param, raw);
+    else {
+      params.set(entry.param, raw);
+      // Armed by an ACTUAL set, never by `value !== fallback` — the branch
+      // above deletes, and a non-default value that serializes to empty must
+      // not drag the sticky keys into an otherwise-bare URL.
+      emittedAny = true;
+    }
+  }
+  if (emittedAny) {
+    for (const key of Object.keys(spec) as (keyof S)[]) {
+      const entry = spec[key];
+      if (!entry.sticky) continue;
+      const value = state[key];
+      const raw = entry.serialize ? entry.serialize(value) : String(value);
+      if (raw !== "") params.set(entry.param, raw);
+    }
   }
   return params.toString();
 }
@@ -189,6 +234,41 @@ export function nextFilterHref<S extends FilterSpec>(
 export function withCurrentValue(options: string[], current: string): string[] {
   if (!current || options.includes(current)) return options;
   return [current, ...options];
+}
+
+/**
+ * Resolve the state a page should adopt from a query string.
+ *
+ * One rule, declared once: a STICKY key falls back to the persisted preference
+ * when the URL does not carry it; everything else takes the URL's value, which
+ * for an absent param is the spec fallback — i.e. a filter the URL is silent
+ * about is CLEARED, while a preference it is silent about is KEPT.
+ *
+ * This lives here rather than in the pages because it was seven hand-copied
+ * ternaries across two files, and stickiness declared in the spec but consumed
+ * by hand is the same drift class as the hand-mirrored IPC channels in
+ * `electron/main.ts`. It is also the only way to get the rule under the
+ * coverage gate at all — `vitest.config.ts` is `environment: "node"`, so the
+ * pages themselves cannot be exercised.
+ *
+ * Both callers use it: the mount seed passes the STORED preferences, and the
+ * re-seed (a same-route navigation) passes the CURRENT state, which is the
+ * same question asked at a different moment — "what should survive a URL that
+ * does not mention this?"
+ */
+export function seedFilterState<S extends FilterSpec>(
+  search: string,
+  spec: S,
+  persisted: Partial<FilterState<S>>,
+): FilterState<S> {
+  const url = parseFilterParams(search, spec);
+  const present = presentFilterKeys(search, spec);
+  const out = {} as FilterState<S>;
+  for (const key of Object.keys(spec) as (keyof S & string)[]) {
+    const usePersisted = spec[key].sticky && !present.has(key) && key in persisted;
+    out[key] = usePersisted ? (persisted[key] as FilterState<S>[typeof key]) : url[key];
+  }
+  return out;
 }
 
 /**

--- a/src/lib/listFilterParams.ts
+++ b/src/lib/listFilterParams.ts
@@ -151,6 +151,9 @@ export function serializeFilterParams<S extends FilterSpec>(
   current: string,
   spec: S,
   state: FilterState<S>,
+  /** The persisted values behind the sticky keys, when the caller has them.
+   *  See the second trigger below — without this the boundary case regresses. */
+  persistedSticky?: Partial<FilterState<S>>,
 ): string {
   let params: URLSearchParams;
   try {
@@ -182,7 +185,33 @@ export function serializeFilterParams<S extends FilterSpec>(
       emittedAny = true;
     }
   }
-  if (emittedAny) {
+  // Sticky keys are emitted on EITHER trigger (Codex P2, second pass):
+  //
+  //  1. anything else emitted — the original rule, which makes a shared link
+  //     deterministic; or
+  //  2. the sticky state DIFFERS from the caller's persisted values — the
+  //     boundary the first trigger alone missed. Open a shared sort link and
+  //     clear its search: pass 1 deletes everything (the link's sort may equal
+  //     the spec fallback), the URL went bare, and a reload then seeded the
+  //     PERSISTED sort while the page still showed the link's. A bare URL
+  //     means "use my prefs"; it is only truthful while the view actually
+  //     matches them, so the sticky keys stay encoded until it does.
+  //
+  // A fully-default view over matching prefs still serializes bare — the gate
+  // that keeps printed dry-box QRs clean — and callers without persisted
+  // values (or without sticky keys) get trigger 1 alone, the prior behaviour.
+  let emitSticky = emittedAny;
+  if (!emitSticky && persistedSticky) {
+    for (const key of Object.keys(spec) as (keyof S)[]) {
+      const entry = spec[key];
+      if (!entry.sticky || !(key in persistedSticky)) continue;
+      if (state[key] !== persistedSticky[key]) {
+        emitSticky = true;
+        break;
+      }
+    }
+  }
+  if (emitSticky) {
     for (const key of Object.keys(spec) as (keyof S)[]) {
       const entry = spec[key];
       if (!entry.sticky) continue;
@@ -205,8 +234,9 @@ export function nextFilterHref<S extends FilterSpec>(
   location: { pathname: string; search: string; hash: string },
   spec: S,
   state: FilterState<S>,
+  persistedSticky?: Partial<FilterState<S>>,
 ): string | null {
-  const query = serializeFilterParams(location.search, spec, state);
+  const query = serializeFilterParams(location.search, spec, state, persistedSticky);
   const next = `${location.pathname}${query ? `?${query}` : ""}${location.hash}`;
   const currentQuery = location.search.startsWith("?")
     ? location.search.slice(1)

--- a/src/lib/listFilterParams.ts
+++ b/src/lib/listFilterParams.ts
@@ -169,3 +169,24 @@ export function nextFilterHref<S extends FilterSpec>(
   const currentHref = `${location.pathname}${currentQuery ? `?${currentQuery}` : ""}${location.hash}`;
   return next === currentHref ? null : next;
 }
+
+/**
+ * The option list for a `<select>` whose current value may not be in it.
+ *
+ * A URL-supplied `?type=` / `?vendor=` is free text — the values come from the
+ * user's own data, so they cannot be validated against a fixed union the way
+ * `kind` or `sort` can. A stale bookmark or a hand-edited link can therefore
+ * carry a value the distinct-value endpoints no longer return, and a
+ * controlled `<select>` with no matching option renders as "All …": the filter
+ * is applied to the query, invisible in the control, and re-choosing the shown
+ * option may emit no change event, so it cannot even be cleared.
+ *
+ * Rendering the orphan as its own option keeps it visible and clearable.
+ * Preferred over dropping the value, because the option lists load
+ * asynchronously — clearing on absence would race the fetch and silently
+ * discard a filter the URL explicitly asked for.
+ */
+export function withCurrentValue(options: string[], current: string): string[] {
+  if (!current || options.includes(current)) return options;
+  return [current, ...options];
+}

--- a/src/lib/listFilterParams.ts
+++ b/src/lib/listFilterParams.ts
@@ -190,3 +190,35 @@ export function withCurrentValue(options: string[], current: string): string[] {
   if (!current || options.includes(current)) return options;
   return [current, ...options];
 }
+
+/**
+ * Which of the spec's keys the query string actually CARRIES.
+ *
+ * `parseFilterParams` deliberately cannot answer this: it returns the
+ * fallback for an absent param, which is what a fresh visit wants. But two
+ * callers need "absent" and "present with the default value" to differ,
+ * because some keys are backed by a persisted preference:
+ *
+ *   - the mount seed — a bare `/` opens the way the user left it, while
+ *     `?sortKey=cost` applies the link's sort for the visit;
+ *   - the re-seed on a same-route navigation — clicking the header link
+ *     clears the FILTERS but must not reset the sort the user has saved and
+ *     then let the persist effect overwrite storage with the fallback
+ *     (GH #1141, Codex P2).
+ *
+ * Presence means the param is there AND its value parses. A garbage value is
+ * treated as absent, which keeps the persisted preference rather than
+ * resetting to a default the URL never actually asked for.
+ */
+export function presentFilterKeys<S extends FilterSpec>(
+  search: string,
+  spec: S,
+): Set<keyof S & string> {
+  const params = new URLSearchParams(search);
+  const present = new Set<keyof S & string>();
+  for (const key of Object.keys(spec) as (keyof S & string)[]) {
+    const raw = params.get(spec[key].param);
+    if (raw !== null && spec[key].parse(raw) !== null) present.add(key);
+  }
+  return present;
+}

--- a/src/lib/listFilterParams.ts
+++ b/src/lib/listFilterParams.ts
@@ -96,13 +96,31 @@ export const boolParam = {
   serialize: (v: boolean): string => (v ? "1" : "0"),
 };
 
-/** Free text: any non-empty string. Trimmed, because a link ending in `%20`
- *  would otherwise filter on whitespace and show nothing. */
+/** Free text the USER TYPES — a substring query. Trimmed, because the pages
+ *  canonicalize the live value the same way (the debounce trims), so the
+ *  trimmed form IS the value; a link ending in `%20` would otherwise filter
+ *  on whitespace and show nothing. Use `exactTextParam` for values that are
+ *  keys into stored data. */
 export const textParam = {
   parse: (raw: string): string | null => {
     const t = raw.trim();
     return t === "" ? null : t;
   },
+};
+
+/**
+ * Free text that is an EXACT KEY into stored data — type and vendor
+ * (GH #1141, Codex P2, and the distinction is the finding). The Filament
+ * schema trims `name` but NOT `type`/`vendor`, and the list APIs compare both
+ * with exact `$eq` — so a stored `"PLA "` is a legitimately selectable value,
+ * and trimming it at the URL boundary broke the round trip: select it, filter
+ * correctly, refresh, and the parsed `"PLA"` matches nothing. The stored
+ * bytes are the value; the URL layer may not editorialize them. (A lone
+ * `?type=%20` therefore filters on a space, faithfully — GH #1149 tracks
+ * normalizing the FIELDS, after which this could trim again.)
+ */
+export const exactTextParam = {
+  parse: (raw: string): string | null => (raw === "" ? null : raw),
 };
 
 /**

--- a/src/lib/listFilterParams.ts
+++ b/src/lib/listFilterParams.ts
@@ -1,0 +1,171 @@
+/**
+ * Filter/search/sort state carried in the URL query string (GH #1141).
+ *
+ * The filament list and Spool Inventory kept every filter in a bare
+ * `useState`, so a filtered view could not be shared or bookmarked and a
+ * refresh — or a Back from a detail page — silently dropped the user to the
+ * unfiltered list. `src/app/page.tsx` documented the gap and deferred it;
+ * this is that deferral.
+ *
+ * ## Why a pure module
+ *
+ * `vitest.config.ts` runs `environment: "node"` with no jsdom and no component
+ * harness, so page-level behaviour is untestable here by construction. Putting
+ * the whole parse/serialize contract in `src/lib/**` is the only shape that
+ * can be pinned — and it lands under the coverage gate, where the traps below
+ * get permanent guards instead of review comments.
+ *
+ * ## The rule that must never be broken: MERGE, never rebuild
+ *
+ * `serializeFilterParams` starts from the CURRENT query string and edits only
+ * the keys it owns. It must never construct a fresh one.
+ *
+ * `/inventory` accepts `?location=<id>` as a deep link, and that link is
+ * encoded into **physically printed QR stickers on dry boxes**
+ * (`src/lib/labelDeepLink.ts`). Those cannot be reissued. Its consumer waits
+ * for the first fetch to resolve before reading the param, while a
+ * URL-writing effect fires on mount — so a serializer that rebuilt the query
+ * string would blank `?location=` before anything read it, and every printed
+ * label would silently scroll nowhere. `preservesUnknownParams` in the tests
+ * is the permanent guard on that.
+ *
+ * ## Defaults are omitted
+ *
+ * A value equal to its default is dropped, so an unfiltered list has a clean
+ * URL and `?q=&type=` never accumulates. Round-tripping is therefore
+ * idempotent: parse → serialize → parse yields the same state.
+ */
+
+/** How one piece of filter state maps to and from a query param. */
+export interface FilterParamSpec<T> {
+  /** The query-string key. Kept short — these end up in shared links. */
+  param: string;
+  /** The value meaning "not filtered". Omitted from the serialized string. */
+  fallback: T;
+  /** Raw string → value, or `null` when the value is not one this app accepts
+   *  (a hand-edited or stale link), in which case the fallback is used. */
+  parse: (raw: string) => T | null;
+  /** Value → raw string. Defaults to `String(value)`. */
+  serialize?: (value: T) => string;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- a spec is heterogeneous
+   by nature (string | boolean | union), and the exported helpers below are
+   generic over the caller's own state type, which is what actually type-checks
+   at the call sites. */
+export type FilterSpec = Record<string, FilterParamSpec<any>>;
+export type FilterState<S extends FilterSpec> = {
+  [K in keyof S]: S[K] extends FilterParamSpec<infer T> ? T : never;
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** A parser for a fixed set of allowed strings. */
+export function oneOf<T extends string>(allowed: readonly T[]): (raw: string) => T | null {
+  return (raw) => (allowed as readonly string[]).includes(raw) ? (raw as T) : null;
+}
+
+/** A parser for a flag written as `1` / `0`. Anything else is rejected, so a
+ *  hand-typed `?oos=yes` falls back rather than silently reading as true. */
+export const boolParam = {
+  parse: (raw: string): boolean | null => (raw === "1" ? true : raw === "0" ? false : null),
+  serialize: (v: boolean): string => (v ? "1" : "0"),
+};
+
+/** Free text: any non-empty string. Trimmed, because a link ending in `%20`
+ *  would otherwise filter on whitespace and show nothing. */
+export const textParam = {
+  parse: (raw: string): string | null => {
+    const t = raw.trim();
+    return t === "" ? null : t;
+  },
+};
+
+/**
+ * Read a fully-defaulted state object out of a query string.
+ *
+ * Every key is present in the result, so callers can seed state without
+ * per-key presence checks. An absent, empty or unparseable param yields that
+ * key's fallback.
+ */
+export function parseFilterParams<S extends FilterSpec>(
+  search: string,
+  spec: S,
+): FilterState<S> {
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(search);
+  } catch {
+    params = new URLSearchParams();
+  }
+  const out = {} as FilterState<S>;
+  for (const key of Object.keys(spec) as (keyof S)[]) {
+    const entry = spec[key];
+    const raw = params.get(entry.param);
+    if (raw === null) {
+      out[key] = entry.fallback;
+      continue;
+    }
+    const parsed = entry.parse(raw);
+    out[key] = (parsed === null ? entry.fallback : parsed) as FilterState<S>[keyof S];
+  }
+  return out;
+}
+
+/**
+ * Produce the query string for `state`, PRESERVING every param the spec does
+ * not own.
+ *
+ * Returns the string WITHOUT a leading `?` (empty when nothing is set), which
+ * is what `history.replaceState` wants alongside `location.pathname`.
+ *
+ * Keys the spec owns are rewritten from `state`; a value equal to its fallback
+ * is removed. Everything else in `current` is passed through untouched — see
+ * the printed-QR note at the top of this file.
+ */
+export function serializeFilterParams<S extends FilterSpec>(
+  current: string,
+  spec: S,
+  state: FilterState<S>,
+): string {
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(current);
+  } catch {
+    params = new URLSearchParams();
+  }
+  for (const key of Object.keys(spec) as (keyof S)[]) {
+    const entry = spec[key];
+    const value = state[key];
+    if (value === entry.fallback) {
+      params.delete(entry.param);
+      continue;
+    }
+    const raw = entry.serialize ? entry.serialize(value) : String(value);
+    // A value that serializes to empty is indistinguishable from absent once
+    // it round-trips, so drop it rather than emitting a bare `key=`.
+    if (raw === "") params.delete(entry.param);
+    else params.set(entry.param, raw);
+  }
+  return params.toString();
+}
+
+/**
+ * The full path to write, or `null` when it would not change the current URL.
+ *
+ * Returning null lets callers skip a no-op `replaceState`, which otherwise
+ * fires on every render pass that recomputes the same state — and each write
+ * re-renders the `useSearchParams` subtree elsewhere in the tree.
+ */
+export function nextFilterHref<S extends FilterSpec>(
+  location: { pathname: string; search: string; hash: string },
+  spec: S,
+  state: FilterState<S>,
+): string | null {
+  const query = serializeFilterParams(location.search, spec, state);
+  const next = `${location.pathname}${query ? `?${query}` : ""}${location.hash}`;
+  const currentQuery = location.search.startsWith("?")
+    ? location.search.slice(1)
+    : location.search;
+  const currentHref = `${location.pathname}${currentQuery ? `?${currentQuery}` : ""}${location.hash}`;
+  return next === currentHref ? null : next;
+}

--- a/src/lib/listFilterParams.ts
+++ b/src/lib/listFilterParams.ts
@@ -246,6 +246,28 @@ export function nextFilterHref<S extends FilterSpec>(
 }
 
 /**
+ * The query component of an href, without the `?` and WITHOUT the fragment.
+ *
+ * For the own-write marker (GH #1141, Codex P2, third pass): the pages record
+ * what they hand to `router.replace` so the echo through `useSearchParams` can
+ * be told apart from an external navigation. `nextFilterHref` preserves the
+ * hash — correctly, the skip link's `#main-content` must survive a write — but
+ * `useSearchParams().toString()` never contains one. A naive
+ * `href.slice(indexOf("?") + 1)` therefore stored `q=pla#main-content` while
+ * the echo reported `q=pla`: the marker never matched, the page misclassified
+ * its own write as external, and the re-seed clobbered live input — with the
+ * debounce trim, typing `"pla "` and pausing ate the separator space.
+ */
+export function queryStringOf(href: string): string {
+  // The fragment bounds the search: a `?` inside the hash is fragment text,
+  // not a query delimiter (`/#section?fake=1` has no query at all).
+  const h = href.indexOf("#");
+  const beforeHash = h === -1 ? href : href.slice(0, h);
+  const q = beforeHash.indexOf("?");
+  return q === -1 ? "" : beforeHash.slice(q + 1);
+}
+
+/**
  * The option list for a `<select>` whose current value may not be in it.
  *
  * A URL-supplied `?type=` / `?vendor=` is free text — the values come from the

--- a/src/lib/listFilterSpecs.ts
+++ b/src/lib/listFilterSpecs.ts
@@ -32,6 +32,32 @@ import {
 import { SORT_KEYS, SORT_DIRS, type SortKey, type SortDir } from "@/lib/sortFilamentList";
 import { QUICK_FILTERS, type QuickFilter } from "@/components/QuickFilterChips";
 
+/**
+ * Parse a stored preference blob, tolerating corruption (GH #1141, Codex P2).
+ *
+ * The persist effects READ the stored blob before writing, so they can merge
+ * per-key over it. Parsing it inline inside their catch-everything try meant a
+ * corrupt blob threw at the parse and skipped the `setItem` — so nothing ever
+ * OVERWROTE the bad value, and persistence was dead until the user cleared
+ * storage by hand. The load path already tolerated corruption; the write path
+ * choked on it, which is backwards: the write is the one chance to heal.
+ *
+ * Returns `{}` for anything that is not a plain JSON object — null, corrupt
+ * text, `"42"`, arrays (spreading an array yields index keys, not prefs) — so
+ * the caller merges against defaults and the next write replaces the blob.
+ */
+export function parseStoredPrefs(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
 /* ------------------------------------------------------------------ home */
 
 /** #831: persisted sort for the filament list. */

--- a/src/lib/listFilterSpecs.ts
+++ b/src/lib/listFilterSpecs.ts
@@ -18,6 +18,7 @@ import {
   oneOf,
   boolParam,
   textParam,
+  exactTextParam,
   type FilterSpec,
 } from "@/lib/listFilterParams";
 import { KNOWN_LOCATION_KINDS } from "@/lib/locationKind";
@@ -75,8 +76,12 @@ export const HOME_PERSISTED_KEYS = ["sortKey", "sortDir"] as const;
 
 export const HOME_FILTER_SPEC = {
   search: { param: "q", fallback: "", ...textParam },
-  typeFilter: { param: "type", fallback: "", ...textParam },
-  vendorFilter: { param: "vendor", fallback: "", ...textParam },
+  // Exact keys into stored data, NOT trimmed — the schema does not trim
+  // type/vendor and the API compares them with $eq, so a stored "PLA " must
+  // round-trip byte-exact (Codex P2). Search stays `textParam`: it is a
+  // substring query whose live value the debounce canonicalizes the same way.
+  typeFilter: { param: "type", fallback: "", ...exactTextParam },
+  vendorFilter: { param: "vendor", fallback: "", ...exactTextParam },
   quickFilter: { param: "quick", fallback: "all" as QuickFilter, parse: oneOf(QUICK_FILTERS) },
   showOutOfStock: { param: "oos", fallback: false, ...boolParam },
   sortKey: {
@@ -135,8 +140,9 @@ export const INVENTORY_FILTER_SPEC = {
   // state kept filtering — and re-choosing the option already shown may emit
   // no change event, so the filter would be invisible AND unclearable.
   kind: { param: "kind", fallback: "", parse: oneOf(["", ...KNOWN_LOCATION_KINDS]) },
-  type: { param: "type", fallback: "", ...textParam },
-  vendor: { param: "vendor", fallback: "", ...textParam },
+  // Exact keys, untrimmed — see the home spec's twin comment (Codex P2).
+  type: { param: "type", fallback: "", ...exactTextParam },
+  vendor: { param: "vendor", fallback: "", ...exactTextParam },
   includeRetired: {
     param: "includeRetired",
     fallback: DEFAULT_INVENTORY_PREFS.includeRetired,

--- a/src/lib/listFilterSpecs.ts
+++ b/src/lib/listFilterSpecs.ts
@@ -1,0 +1,138 @@
+/**
+ * The two list pages' URL filter specs, and the preference keys each one
+ * persists (GH #1141).
+ *
+ * These lived in the page files, which `vitest.config.ts` cannot exercise —
+ * it runs `environment: "node"` with no jsdom. Moving the pure data here puts
+ * two invariants under the coverage gate that nothing else can check:
+ *
+ *  1. every persisted key is marked `sticky`, so its absence from a URL is
+ *     unambiguous (see `FilterParamSpec.sticky`); and
+ *  2. no sticky key's fallback serializes to the empty string, which the
+ *     serializer's delete branch would silently un-stick.
+ *
+ * Both are the kind of thing a future preference would break quietly.
+ */
+
+import {
+  oneOf,
+  boolParam,
+  textParam,
+  type FilterSpec,
+} from "@/lib/listFilterParams";
+import { KNOWN_LOCATION_KINDS } from "@/lib/locationKind";
+import {
+  INVENTORY_GROUP_BYS,
+  INVENTORY_SORT_KEYS,
+  INVENTORY_SORT_DIRS,
+  type InventoryGroupBy,
+  type InventorySortKey,
+  type InventorySortDir,
+} from "@/lib/inventorySort";
+import { SORT_KEYS, SORT_DIRS, type SortKey, type SortDir } from "@/lib/sortFilamentList";
+import { QUICK_FILTERS, type QuickFilter } from "@/components/QuickFilterChips";
+
+/* ------------------------------------------------------------------ home */
+
+/** #831: persisted sort for the filament list. */
+export const HOME_PREFS_KEY = "filamentdb-home-prefs";
+
+export interface HomePrefs {
+  sortKey: SortKey;
+  sortDir: SortDir;
+}
+
+export const DEFAULT_HOME_PREFS: HomePrefs = { sortKey: "name", sortDir: "asc" };
+
+/** The keys the home page writes to `localStorage`. Must equal its sticky set. */
+export const HOME_PERSISTED_KEYS = ["sortKey", "sortDir"] as const;
+
+export const HOME_FILTER_SPEC = {
+  search: { param: "q", fallback: "", ...textParam },
+  typeFilter: { param: "type", fallback: "", ...textParam },
+  vendorFilter: { param: "vendor", fallback: "", ...textParam },
+  quickFilter: { param: "quick", fallback: "all" as QuickFilter, parse: oneOf(QUICK_FILTERS) },
+  showOutOfStock: { param: "oos", fallback: false, ...boolParam },
+  sortKey: {
+    param: "sort",
+    fallback: DEFAULT_HOME_PREFS.sortKey,
+    parse: oneOf(SORT_KEYS),
+    sticky: true,
+  },
+  sortDir: {
+    param: "dir",
+    fallback: DEFAULT_HOME_PREFS.sortDir,
+    parse: oneOf(SORT_DIRS),
+    sticky: true,
+  },
+} satisfies FilterSpec;
+
+/* ------------------------------------------------------------- inventory */
+
+/**
+ * GH #795 — persisted group/sort/filter prefs. A single JSON blob avoids key
+ * sprawl; unknown enum values fall back to the default so a corrupt or old
+ * blob cannot wedge the page. `includeRetired` rides along since it also
+ * drives the server query.
+ */
+export const INVENTORY_PREFS_KEY = "filamentdb-inventory-prefs";
+
+export interface InventoryPrefs {
+  groupBy: InventoryGroupBy;
+  sortKey: InventorySortKey;
+  sortDir: InventorySortDir;
+  includeRetired: boolean;
+}
+
+export const DEFAULT_INVENTORY_PREFS: InventoryPrefs = {
+  groupBy: "location",
+  // #795: default to remaining-weight ascending — surfaces near-empty spools
+  // to reorder, the issue's primary use case.
+  sortKey: "remaining",
+  sortDir: "asc",
+  includeRetired: false,
+};
+
+/** The keys /inventory writes to `localStorage`. Must equal its sticky set. */
+export const INVENTORY_PERSISTED_KEYS = [
+  "groupBy",
+  "sortKey",
+  "sortDir",
+  "includeRetired",
+] as const;
+
+export const INVENTORY_FILTER_SPEC = {
+  search: { param: "q", fallback: "", ...textParam },
+  // Validated against the SELECTABLE kinds (Codex P2), not free text. The
+  // select renders exactly these five options, so a stale or hand-typed
+  // `?kind=garage` would leave React displaying "All kinds" while the hidden
+  // state kept filtering — and re-choosing the option already shown may emit
+  // no change event, so the filter would be invisible AND unclearable.
+  kind: { param: "kind", fallback: "", parse: oneOf(["", ...KNOWN_LOCATION_KINDS]) },
+  type: { param: "type", fallback: "", ...textParam },
+  vendor: { param: "vendor", fallback: "", ...textParam },
+  includeRetired: {
+    param: "includeRetired",
+    fallback: DEFAULT_INVENTORY_PREFS.includeRetired,
+    ...boolParam,
+    sticky: true,
+  },
+  groupBy: {
+    param: "group",
+    fallback: DEFAULT_INVENTORY_PREFS.groupBy,
+    parse: oneOf(INVENTORY_GROUP_BYS),
+    sticky: true,
+  },
+  sortKey: {
+    param: "sort",
+    fallback: DEFAULT_INVENTORY_PREFS.sortKey,
+    parse: oneOf(INVENTORY_SORT_KEYS),
+    sticky: true,
+  },
+  sortDir: {
+    param: "dir",
+    fallback: DEFAULT_INVENTORY_PREFS.sortDir,
+    parse: oneOf(INVENTORY_SORT_DIRS),
+    sticky: true,
+  },
+} satisfies FilterSpec;

--- a/src/lib/sortFilamentList.ts
+++ b/src/lib/sortFilamentList.ts
@@ -21,17 +21,29 @@
 import type { FilamentSummary } from "@/types/filament";
 import { getRemainingPct, type InventoryFilament } from "@/lib/inventoryStats";
 
-export type SortKey =
-  | "name"
-  | "vendor"
-  | "type"
-  | "nozzle"
-  | "bed"
-  | "cost"
-  | "remaining"
-  | "purchased"
-  | "opened";
-export type SortDir = "asc" | "desc";
+/**
+ * The allowed sort values, as runtime arrays.
+ *
+ * GH #1141 validates these — a shared or hand-edited link can carry
+ * `?sort=nonsense`, and a page seeded from an unchecked string would sit in a
+ * state its own controls cannot represent. Deriving the unions from the arrays
+ * keeps them in step: adding a key to one without the other is a type error.
+ */
+export const SORT_KEYS = [
+  "name",
+  "vendor",
+  "type",
+  "nozzle",
+  "bed",
+  "cost",
+  "remaining",
+  "purchased",
+  "opened",
+] as const;
+export const SORT_DIRS = ["asc", "desc"] as const;
+
+export type SortKey = (typeof SORT_KEYS)[number];
+export type SortDir = (typeof SORT_DIRS)[number];
 
 /** #941: earliest date (across ALL of a filament's spools, retired included —
  * a purchase/open date is a historical fact regardless of retirement) for the

--- a/tests/listFilterParams.test.ts
+++ b/tests/listFilterParams.test.ts
@@ -326,6 +326,83 @@ describe("sticky keys", () => {
   });
 });
 
+describe("sticky keys at the clear-to-bare boundary (Codex P2, second pass)", () => {
+  const SPEC3 = {
+    search: { param: "q", fallback: "", ...textParam },
+    sortKey: { param: "sort", fallback: "name", parse: oneOf(["name", "cost"] as const), sticky: true },
+    sortDir: { param: "dir", fallback: "asc", parse: oneOf(["asc", "desc"] as const), sticky: true },
+  } satisfies FilterSpec;
+  const persisted = { sortKey: "cost", sortDir: "desc" } as const;
+
+  it("keeps the sticky keys encoded while the view differs from the persisted prefs", () => {
+    // The reported sequence, end to end. A recipient saved cost/desc opens a
+    // shared name/asc link and clears its search: pass 1 deletes everything
+    // (the link's sort equals the spec fallback), and pre-fix the URL went
+    // bare while the page still showed name/asc — so a reload silently
+    // swapped the view for cost/desc. Bare means "use my prefs"; it must be
+    // TRUE before the URL is allowed to say it.
+    const shared = "q=pla&sort=name&dir=asc";
+    const seeded = seedFilterState(shared, SPEC3, persisted);
+    expect(seeded.sortKey).toBe("name");
+
+    const cleared = serializeFilterParams(shared, SPEC3, { ...seeded, search: "" }, persisted);
+    expect(new URLSearchParams(cleared).get("sort")).toBe("name");
+    expect(new URLSearchParams(cleared).get("dir")).toBe("asc");
+
+    // The round trip is what matters: a reload of the produced URL shows
+    // exactly what the page was showing.
+    const reloaded = seedFilterState(cleared, SPEC3, persisted);
+    expect(reloaded.sortKey).toBe("name");
+    expect(reloaded.sortDir).toBe("asc");
+  });
+
+  it("goes bare exactly when bare is TRUE: view == prefs == the fallbacks", () => {
+    // A view matching NON-fallback prefs still encodes (pass 1 emits the
+    // non-default value, which arms the sticky pass) — fine, deterministic,
+    // and a refresh reproduces it either way. Bare is reserved for the one
+    // state it truthfully describes.
+    expect(
+      serializeFilterParams("sort=cost&dir=desc", SPEC3, {
+        search: "",
+        sortKey: "cost",
+        sortDir: "desc",
+      }, persisted),
+    ).toBe("sort=cost&dir=desc");
+    expect(
+      serializeFilterParams("sort=name&dir=asc", SPEC3, {
+        search: "",
+        sortKey: "name",
+        sortDir: "asc",
+      }, { sortKey: "name", sortDir: "asc" }),
+    ).toBe("");
+  });
+
+  it("still goes bare for an all-default view when nothing is persisted for the keys", () => {
+    // Back-compat: no persisted arg (or none of the keys present) keeps the
+    // original emitted-anything trigger alone.
+    expect(
+      serializeFilterParams("", SPEC3, { search: "", sortKey: "name", sortDir: "asc" }),
+    ).toBe("");
+    expect(
+      serializeFilterParams("", SPEC3, { search: "", sortKey: "name", sortDir: "asc" }, {}),
+    ).toBe("");
+  });
+
+  it("reaches a fixed point, so the mirror does not churn at the boundary", () => {
+    const state = { search: "", sortKey: "name", sortDir: "asc" } as const;
+    const href = nextFilterHref(
+      { pathname: "/", search: "?q=pla&sort=name&dir=asc", hash: "" },
+      SPEC3,
+      state,
+      persisted,
+    );
+    const written = href!.slice(href!.indexOf("?"));
+    expect(
+      nextFilterHref({ pathname: "/", search: written, hash: "" }, SPEC3, state, persisted),
+    ).toBeNull();
+  });
+});
+
 describe("seedFilterState", () => {
   const SPEC2 = {
     search: { param: "q", fallback: "", ...textParam },

--- a/tests/listFilterParams.test.ts
+++ b/tests/listFilterParams.test.ts
@@ -5,6 +5,7 @@ import {
   nextFilterHref,
   presentFilterKeys,
   seedFilterState,
+  queryStringOf,
   oneOf,
   boolParam,
   textParam,
@@ -438,5 +439,32 @@ describe("seedFilterState", () => {
 
   it("treats an unparseable sticky value as silence, not as a reset", () => {
     expect(seedFilterState("sort=bogus", SPEC2, { sortKey: "cost" }).sortKey).toBe("cost");
+  });
+});
+
+/**
+ * GH #1141 (Codex P2, third pass). The own-write marker must store exactly
+ * what `useSearchParams().toString()` will echo — which never includes a
+ * fragment, while `nextFilterHref` (correctly) preserves one. A marker with
+ * the hash baked in never matches, so the page misclassifies its own write as
+ * an external navigation and the re-seed clobbers live input.
+ */
+describe("queryStringOf", () => {
+  it("strips the fragment the skip link leaves on the URL", () => {
+    expect(queryStringOf("/?q=pla#main-content")).toBe("q=pla");
+  });
+
+  it("returns the query alone when there is no fragment", () => {
+    expect(queryStringOf("/inventory?q=pla&group=vendor")).toBe("q=pla&group=vendor");
+  });
+
+  it("returns empty for a bare path, with or without a fragment", () => {
+    expect(queryStringOf("/")).toBe("");
+    expect(queryStringOf("/#main-content")).toBe("");
+  });
+
+  it("ignores a ? that appears inside the fragment", () => {
+    // A hash may itself contain a ?; only the real query counts.
+    expect(queryStringOf("/#section?fake=1")).toBe("");
   });
 });

--- a/tests/listFilterParams.test.ts
+++ b/tests/listFilterParams.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFilterParams,
+  serializeFilterParams,
+  nextFilterHref,
+  oneOf,
+  boolParam,
+  textParam,
+  type FilterSpec,
+} from "@/lib/listFilterParams";
+
+/**
+ * GH #1141. The pages themselves are untestable here — `vitest.config.ts` is
+ * `environment: "node"` with no jsdom — so the whole contract lives in this
+ * pure module and is pinned here.
+ */
+
+const SPEC = {
+  search: { param: "q", fallback: "", ...textParam },
+  type: { param: "type", fallback: "", ...textParam },
+  quick: {
+    param: "quick",
+    fallback: "all" as const,
+    parse: oneOf(["all", "lowStock", "hasSpools", "noCalibration"] as const),
+  },
+  showOutOfStock: { param: "oos", fallback: false, ...boolParam },
+} satisfies FilterSpec;
+
+describe("parseFilterParams", () => {
+  it("returns every key, defaulted, for an empty query string", () => {
+    expect(parseFilterParams("", SPEC)).toEqual({
+      search: "",
+      type: "",
+      quick: "all",
+      showOutOfStock: false,
+    });
+  });
+
+  it("reads values, with or without the leading ?", () => {
+    const want = { search: "pla", type: "PETG", quick: "lowStock", showOutOfStock: true };
+    expect(parseFilterParams("?q=pla&type=PETG&quick=lowStock&oos=1", SPEC)).toEqual(want);
+    expect(parseFilterParams("q=pla&type=PETG&quick=lowStock&oos=1", SPEC)).toEqual(want);
+  });
+
+  it("falls back on a value this app does not accept", () => {
+    // A hand-edited or stale link must not put the UI in an impossible state.
+    expect(parseFilterParams("?quick=nonsense", SPEC).quick).toBe("all");
+    expect(parseFilterParams("?oos=yes", SPEC).showOutOfStock).toBe(false);
+  });
+
+  it("treats whitespace-only text as absent", () => {
+    // Otherwise a link ending in %20 filters on a space and shows nothing.
+    expect(parseFilterParams("?q=%20%20", SPEC).search).toBe("");
+    expect(parseFilterParams("?q=%20pla%20", SPEC).search).toBe("pla");
+  });
+});
+
+describe("serializeFilterParams", () => {
+  it("omits values equal to their default", () => {
+    expect(
+      serializeFilterParams("", SPEC, {
+        search: "",
+        type: "",
+        quick: "all",
+        showOutOfStock: false,
+      }),
+    ).toBe("");
+  });
+
+  it("writes only the keys that differ from their default", () => {
+    const out = serializeFilterParams("", SPEC, {
+      search: "pla",
+      type: "",
+      quick: "lowStock",
+      showOutOfStock: false,
+    });
+    expect(new URLSearchParams(out).get("q")).toBe("pla");
+    expect(new URLSearchParams(out).get("quick")).toBe("lowStock");
+    expect(new URLSearchParams(out).has("type")).toBe(false);
+    expect(new URLSearchParams(out).has("oos")).toBe(false);
+  });
+
+  /**
+   * THE LOAD-BEARING TEST.
+   *
+   * `?location=` is encoded into physically printed dry-box QR stickers
+   * (`src/lib/labelDeepLink.ts`) and cannot be reissued. Its consumer waits
+   * for the first fetch before reading it, while a URL-writing effect fires on
+   * mount — so a serializer that REBUILT the query string would blank the
+   * param before anything read it, and every printed label would silently
+   * scroll nowhere.
+   */
+  it("preserves params it does not own", () => {
+    const out = serializeFilterParams("?location=507f1f77bcf86cd799439011&spool=abc", SPEC, {
+      search: "pla",
+      type: "",
+      quick: "all",
+      showOutOfStock: false,
+    });
+    const p = new URLSearchParams(out);
+    expect(p.get("location")).toBe("507f1f77bcf86cd799439011");
+    expect(p.get("spool")).toBe("abc");
+    expect(p.get("q")).toBe("pla");
+  });
+
+  it("clears a param when its value returns to the default", () => {
+    const out = serializeFilterParams("?q=pla&location=xyz", SPEC, {
+      search: "",
+      type: "",
+      quick: "all",
+      showOutOfStock: false,
+    });
+    const p = new URLSearchParams(out);
+    expect(p.has("q")).toBe(false);
+    // ...without taking the unowned param with it.
+    expect(p.get("location")).toBe("xyz");
+  });
+
+  it("round-trips: parse -> serialize -> parse is stable", () => {
+    const first = parseFilterParams("?q=pla&quick=lowStock&oos=1", SPEC);
+    const again = parseFilterParams(serializeFilterParams("", SPEC, first), SPEC);
+    expect(again).toEqual(first);
+  });
+
+  it("survives a malformed query string instead of throwing", () => {
+    expect(() => serializeFilterParams("%%%", SPEC, parseFilterParams("%%%", SPEC))).not.toThrow();
+  });
+});
+
+describe("nextFilterHref", () => {
+  const loc = (search: string) => ({ pathname: "/inventory", search, hash: "" });
+
+  it("returns null when nothing would change", () => {
+    // No-op writes would otherwise fire on every render that recomputes the
+    // same state, each one re-rendering the useSearchParams subtree.
+    const state = parseFilterParams("?q=pla", SPEC);
+    expect(nextFilterHref(loc("?q=pla"), SPEC, state)).toBeNull();
+  });
+
+  it("returns null for an unfiltered state on a bare URL", () => {
+    expect(nextFilterHref(loc(""), SPEC, parseFilterParams("", SPEC))).toBeNull();
+  });
+
+  it("builds pathname + query when the state changed", () => {
+    const state = { ...parseFilterParams("", SPEC), search: "pla" };
+    expect(nextFilterHref(loc(""), SPEC, state)).toBe("/inventory?q=pla");
+  });
+
+  it("drops the query entirely when the last filter clears", () => {
+    const state = parseFilterParams("", SPEC);
+    expect(nextFilterHref(loc("?q=pla"), SPEC, state)).toBe("/inventory");
+  });
+
+  it("keeps the hash", () => {
+    const state = { ...parseFilterParams("", SPEC), search: "pla" };
+    expect(
+      nextFilterHref({ pathname: "/inventory", search: "", hash: "#spool-1" }, SPEC, state),
+    ).toBe("/inventory?q=pla#spool-1");
+  });
+
+  it("keeps an unowned param when the state changes", () => {
+    const state = { ...parseFilterParams("?location=xyz", SPEC), search: "pla" };
+    const href = nextFilterHref(loc("?location=xyz"), SPEC, state);
+    expect(href).not.toBeNull();
+    const p = new URLSearchParams(href!.split("?")[1]);
+    expect(p.get("location")).toBe("xyz");
+    expect(p.get("q")).toBe("pla");
+  });
+});

--- a/tests/listFilterParams.test.ts
+++ b/tests/listFilterParams.test.ts
@@ -4,6 +4,7 @@ import {
   serializeFilterParams,
   nextFilterHref,
   presentFilterKeys,
+  seedFilterState,
   oneOf,
   boolParam,
   textParam,
@@ -208,5 +209,157 @@ describe("presentFilterKeys", () => {
 
   it("accepts a leading ? like the other helpers", () => {
     expect(presentFilterKeys("?type=PLA", SPEC).has("type")).toBe(true);
+  });
+});
+
+/**
+ * GH #1141 (Codex P1). Serialization omits a value equal to its fallback, so a
+ * sender sorted cost/ASC shared `?sort=cost` and said nothing about direction —
+ * a recipient with a saved DESC opened the same link sorted differently, and
+ * the mirror then rewrote the URL to match. Two people, one link, two views.
+ *
+ * A sticky key is emitted explicitly whenever anything is emitted, so absence
+ * means exactly one thing: this URL is not talking about filters.
+ */
+describe("sticky keys", () => {
+  const STICKY_SPEC = {
+    search: { param: "q", fallback: "", ...textParam },
+    sortKey: { param: "sort", fallback: "name", parse: oneOf(["name", "cost"] as const), sticky: true },
+    sortDir: { param: "dir", fallback: "asc", parse: oneOf(["asc", "desc"] as const), sticky: true },
+  } satisfies FilterSpec;
+
+  it("emits a sticky key at its fallback once anything else is emitted", () => {
+    // The reported case: cost + ASC. Pre-fix this was `sort=cost` alone.
+    const q = serializeFilterParams("", STICKY_SPEC, {
+      search: "",
+      sortKey: "cost",
+      sortDir: "asc",
+    });
+    expect(new URLSearchParams(q).get("sort")).toBe("cost");
+    expect(new URLSearchParams(q).get("dir")).toBe("asc");
+  });
+
+  it("arms on a NON-sticky key too — a plain search carries the preferences", () => {
+    const q = serializeFilterParams("", STICKY_SPEC, {
+      search: "pla",
+      sortKey: "name",
+      sortDir: "asc",
+    });
+    expect(new URLSearchParams(q).get("q")).toBe("pla");
+    expect(new URLSearchParams(q).get("sort")).toBe("name");
+    expect(new URLSearchParams(q).get("dir")).toBe("asc");
+  });
+
+  it("stays BARE for an all-default view — the gate that keeps printed QRs clean", () => {
+    // Load-bearing: without it every `/inventory?location=X` sticker would
+    // gain four preference params and reset the scanner's saved grouping.
+    expect(
+      serializeFilterParams("", STICKY_SPEC, { search: "", sortKey: "name", sortDir: "asc" }),
+    ).toBe("");
+  });
+
+  it("is not a ratchet — clearing the last filter returns to bare", () => {
+    const filtered = serializeFilterParams("", STICKY_SPEC, {
+      search: "pla",
+      sortKey: "name",
+      sortDir: "asc",
+    });
+    expect(
+      serializeFilterParams(filtered, STICKY_SPEC, {
+        search: "",
+        sortKey: "name",
+        sortDir: "asc",
+      }),
+    ).toBe("");
+  });
+
+  it("does not arm on an unowned param alone", () => {
+    // `?location=` is printed on dry-box stickers and is not ours.
+    const q = serializeFilterParams("location=abc123", STICKY_SPEC, {
+      search: "",
+      sortKey: "name",
+      sortDir: "asc",
+    });
+    expect(new URLSearchParams(q).get("location")).toBe("abc123");
+    expect(new URLSearchParams(q).has("sort")).toBe(false);
+  });
+
+  it("still preserves unknown params when it does arm", () => {
+    const q = serializeFilterParams("location=abc123", STICKY_SPEC, {
+      search: "pla",
+      sortKey: "name",
+      sortDir: "asc",
+    });
+    expect(new URLSearchParams(q).get("location")).toBe("abc123");
+    expect(new URLSearchParams(q).get("sort")).toBe("name");
+  });
+
+  it("reaches a fixed point, so the mirror does not churn", () => {
+    const href = nextFilterHref(
+      { pathname: "/", search: "", hash: "" },
+      STICKY_SPEC,
+      { search: "pla", sortKey: "cost", sortDir: "desc" },
+    );
+    const written = href!.slice(href!.indexOf("?"));
+    expect(
+      nextFilterHref({ pathname: "/", search: written, hash: "" }, STICKY_SPEC, {
+        search: "pla",
+        sortKey: "cost",
+        sortDir: "desc",
+      }),
+    ).toBeNull();
+  });
+
+  it("round-trips a shared link identically regardless of the reader's prefs", () => {
+    // The whole point. Sender is cost/ASC; two recipients with opposite saved
+    // directions must both see the sender's view.
+    const shared = serializeFilterParams("", STICKY_SPEC, {
+      search: "",
+      sortKey: "cost",
+      sortDir: "asc",
+    });
+    for (const saved of ["asc", "desc"] as const) {
+      const seeded = seedFilterState(shared, STICKY_SPEC, { sortKey: "name", sortDir: saved });
+      expect(seeded.sortKey).toBe("cost");
+      expect(seeded.sortDir).toBe("asc");
+    }
+  });
+});
+
+describe("seedFilterState", () => {
+  const SPEC2 = {
+    search: { param: "q", fallback: "", ...textParam },
+    sortKey: { param: "sort", fallback: "name", parse: oneOf(["name", "cost"] as const), sticky: true },
+  } satisfies FilterSpec;
+
+  it("keeps the persisted value for a sticky key the URL does not carry", () => {
+    // A bare route means "use my preference" — the mount case, and the case
+    // that clicking the header link while filtered has to preserve.
+    expect(seedFilterState("", SPEC2, { sortKey: "cost" })).toEqual({
+      search: "",
+      sortKey: "cost",
+    });
+  });
+
+  it("CLEARS a non-sticky filter the URL does not carry", () => {
+    // The asymmetry is the feature: a filter the URL is silent about is
+    // cleared, a preference it is silent about is kept.
+    expect(seedFilterState("", SPEC2, { sortKey: "cost" }).search).toBe("");
+    expect(seedFilterState("sort=name", SPEC2, { sortKey: "cost" }).sortKey).toBe("name");
+  });
+
+  it("lets the URL win over the persisted value", () => {
+    expect(seedFilterState("q=pla&sort=cost", SPEC2, { sortKey: "name" })).toEqual({
+      search: "pla",
+      sortKey: "cost",
+    });
+  });
+
+  it("falls back to the spec default when nothing is persisted for the key", () => {
+    expect(seedFilterState("", SPEC2, {}).sortKey).toBe("name");
+  });
+
+  it("treats an unparseable sticky value as silence, not as a reset", () => {
+    expect(seedFilterState("sort=bogus", SPEC2, { sortKey: "cost" }).sortKey).toBe("cost");
   });
 });

--- a/tests/listFilterParams.test.ts
+++ b/tests/listFilterParams.test.ts
@@ -9,6 +9,7 @@ import {
   oneOf,
   boolParam,
   textParam,
+  exactTextParam,
   type FilterSpec,
 } from "@/lib/listFilterParams";
 
@@ -466,5 +467,35 @@ describe("queryStringOf", () => {
   it("ignores a ? that appears inside the fragment", () => {
     // A hash may itself contain a ?; only the real query counts.
     expect(queryStringOf("/#section?fake=1")).toBe("");
+  });
+});
+
+/**
+ * GH #1141 (Codex P2, fourth pass). Type and vendor are EXACT keys into
+ * stored data — the schema trims `name` but not these, and the list APIs
+ * compare them with `$eq` — so a stored `"PLA "` is a selectable value that
+ * must round-trip byte-exact. `textParam`'s trim broke the refresh: select
+ * it, filter correctly, reload, and the parsed `"PLA"` matches nothing.
+ */
+describe("exactTextParam", () => {
+  const SPEC4 = {
+    type: { param: "type", fallback: "", ...exactTextParam },
+  } satisfies FilterSpec;
+
+  it("round-trips a value with edge whitespace byte-exact", () => {
+    const q = serializeFilterParams("", SPEC4, { type: "PLA " });
+    expect(q).toBe("type=PLA+");
+    expect(parseFilterParams(q, SPEC4).type).toBe("PLA ");
+  });
+
+  it("treats an empty param as absent, like its trimming sibling", () => {
+    expect(parseFilterParams("type=", SPEC4).type).toBe("");
+    expect(exactTextParam.parse("")).toBeNull();
+  });
+
+  it("faithfully passes a whitespace-only value through", () => {
+    // `?type=%20` filters on a literal space — probably an empty result, but
+    // exact means exact; editorializing here is how the round trip broke.
+    expect(parseFilterParams("type=%20", SPEC4).type).toBe(" ");
   });
 });

--- a/tests/listFilterParams.test.ts
+++ b/tests/listFilterParams.test.ts
@@ -3,6 +3,7 @@ import {
   parseFilterParams,
   serializeFilterParams,
   nextFilterHref,
+  presentFilterKeys,
   oneOf,
   boolParam,
   textParam,
@@ -165,5 +166,47 @@ describe("nextFilterHref", () => {
     const p = new URLSearchParams(href!.split("?")[1]);
     expect(p.get("location")).toBe("xyz");
     expect(p.get("q")).toBe("pla");
+  });
+});
+
+/**
+ * GH #1141 (Codex P2). `parseFilterParams` cannot answer "did the URL actually
+ * say anything about this key?" — it returns the fallback either way, which is
+ * right for a fresh visit and wrong for a key backed by a persisted preference.
+ * Clicking the header link while filtered navigates to a bare route; treating
+ * the fallback as an instruction there reset the user's saved sort AND had the
+ * persist effect overwrite storage with it.
+ */
+describe("presentFilterKeys", () => {
+  it("is empty for a bare query string — the case that caused the regression", () => {
+    expect(presentFilterKeys("", SPEC).size).toBe(0);
+    // ...while parse still hands back a full, defaulted state. Both are
+    // correct; conflating them is what destroyed the stored preference.
+    expect(parseFilterParams("", SPEC).quick).toBe("all");
+  });
+
+  it("reports a param present even when its value equals the fallback", () => {
+    // `?quick=all` is an explicit instruction, not silence — a shared link
+    // that pins the default has to override a persisted non-default.
+    const present = presentFilterKeys("quick=all&oos=0&q=", SPEC);
+    expect(present.has("quick")).toBe(true);
+    expect(present.has("oos" as never)).toBe(false); // keyed by SPEC key, not param
+    expect(present.has("showOutOfStock")).toBe(true);
+    // `q=` parses to null (textParam trims to empty), so it counts as absent.
+    expect(present.has("search")).toBe(false);
+  });
+
+  it("treats an unparseable value as absent, keeping the persisted preference", () => {
+    // A default the URL never asked for is worse than leaving things alone.
+    expect(presentFilterKeys("quick=bogus&oos=maybe", SPEC).size).toBe(0);
+  });
+
+  it("ignores params outside the spec", () => {
+    // `?location=` rides on printed dry-box QR stickers; it is not ours.
+    expect(presentFilterKeys("location=abc123", SPEC).size).toBe(0);
+  });
+
+  it("accepts a leading ? like the other helpers", () => {
+    expect(presentFilterKeys("?type=PLA", SPEC).has("type")).toBe(true);
   });
 });

--- a/tests/listFilterSpecs.test.ts
+++ b/tests/listFilterSpecs.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  HOME_FILTER_SPEC,
+  HOME_PERSISTED_KEYS,
+  INVENTORY_FILTER_SPEC,
+  INVENTORY_PERSISTED_KEYS,
+} from "@/lib/listFilterSpecs";
+import { serializeFilterParams, type FilterSpec } from "@/lib/listFilterParams";
+
+/**
+ * GH #1141. The two invariants that keep the sticky design honest, and that
+ * nothing else in this repo can check: `vitest.config.ts` runs
+ * `environment: "node"` with no jsdom, so the pages are untestable, which is
+ * exactly why the specs moved into `src/lib`.
+ *
+ * Both failure modes are silent. A persisted key that is not sticky
+ * reintroduces the non-deterministic-shared-link bug for that key alone; a
+ * sticky key whose fallback serializes to empty is un-stuck by the
+ * serializer's own delete branch, with the same result.
+ */
+
+const stickyKeys = (spec: FilterSpec) =>
+  Object.keys(spec)
+    .filter((k) => spec[k].sticky)
+    .sort();
+
+describe("list filter specs", () => {
+  const cases = [
+    { name: "home", spec: HOME_FILTER_SPEC as FilterSpec, persisted: HOME_PERSISTED_KEYS },
+    {
+      name: "inventory",
+      spec: INVENTORY_FILTER_SPEC as FilterSpec,
+      persisted: INVENTORY_PERSISTED_KEYS,
+    },
+  ];
+
+  for (const { name, spec, persisted } of cases) {
+    it(`${name}: every persisted key is sticky, and nothing else is`, () => {
+      // Not "is a subset" — BOTH directions. A persisted key that is not
+      // sticky is the original bug; a sticky key that is not persisted emits
+      // noise into every URL for no reason.
+      expect(stickyKeys(spec)).toEqual([...persisted].sort());
+    });
+
+    it(`${name}: no sticky key's fallback serializes to the empty string`, () => {
+      // The serializer drops a value that serializes to empty, since it is
+      // indistinguishable from absent after a round trip. A sticky key that
+      // hit that branch would be silently un-stuck. None do today — the
+      // fallbacks are enum members and a boolean — but `kind`, `type` and
+      // `vendor` all have `""` fallbacks, so the day one of them becomes a
+      // preference this catches it.
+      for (const key of stickyKeys(spec)) {
+        const entry = spec[key];
+        const raw = entry.serialize ? entry.serialize(entry.fallback) : String(entry.fallback);
+        expect(raw, `${name}.${key}`).not.toBe("");
+      }
+    });
+
+    it(`${name}: a single filter carries every preference explicitly`, () => {
+      // End to end over the REAL spec: this is what makes a shared link mean
+      // the same thing to the sender and the recipient.
+      const state = Object.fromEntries(
+        Object.keys(spec).map((k) => [k, spec[k].fallback]),
+      ) as Record<string, unknown>;
+      state.search = "pla";
+      const params = new URLSearchParams(
+        serializeFilterParams("", spec, state as never),
+      );
+      for (const key of stickyKeys(spec)) {
+        expect(params.has(spec[key].param), `${name}.${key}`).toBe(true);
+      }
+    });
+
+    it(`${name}: an all-default view still serializes bare`, () => {
+      const state = Object.fromEntries(
+        Object.keys(spec).map((k) => [k, spec[k].fallback]),
+      ) as Record<string, unknown>;
+      expect(serializeFilterParams("", spec, state as never)).toBe("");
+    });
+  }
+});
+
+/**
+ * The invariant the key-set comparison above CANNOT catch (Codex P1 review):
+ * `groupBy` is both persisted and sticky, so a writer that forgets to record
+ * the touch passes every test above while silently never persisting — or, the
+ * other way, a URL-derived write laundering into storage.
+ *
+ * Scanning source is ugly and it is what `tests/ipc-contract-parity.test.ts`
+ * already does for the hand-mirrored IPC channels, for the same reason: the
+ * contract spans files with no compile-time link.
+ */
+describe("preference writers record the touch", () => {
+  const SETTERS = ["setGroupBy(", "setSortKey(", "setSortDir(", "setIncludeRetired("];
+
+  for (const file of ["src/app/page.tsx", "src/app/inventory/page.tsx"]) {
+    it(`${file}: every preference setter is a seed or records a touch`, () => {
+      const src = readFileSync(join(process.cwd(), file), "utf8");
+      const lines = src.split("\n");
+      const offenders: string[] = [];
+
+      lines.forEach((line, i) => {
+        if (!SETTERS.some((s) => line.includes(s))) return;
+        // The seed and re-seed adopt URL/persisted values and must NOT record
+        // a touch — that is the whole point of the gate. Both are recognised
+        // by what they PASS, not by proximity: a seeded value always comes out
+        // of the `url` object (`seedFilterState` / `parseFilterParams`), and
+        // the re-seed's keep-current form is a functional update. Proximity
+        // alone was too weak — a long comment between the two pushed a real
+        // seed out of the window.
+        if (line.includes("url.") || line.includes("(cur) =>")) return;
+        // The touch must be in the SAME handler, so the window is tight. A
+        // loose one is worthless: with 12 lines, deleting the `sortDir` touch
+        // still passed because the neighbouring `sortKey` handler's touch was
+        // in range. Every writer here records immediately before its setter,
+        // with at most a comment between.
+        const window = lines.slice(Math.max(0, i - 4), i + 1).join("\n");
+        const key = SETTERS.find((setter) => line.includes(setter))!
+          .slice("set".length, -1);
+        const touch = `prefsTouchedRef.current.add("${key[0].toLowerCase()}${key.slice(1)}")`;
+        if (!window.includes(touch)) {
+          offenders.push(`${file}:${i + 1} ${line.trim()}`);
+        }
+      });
+
+      expect(offenders).toEqual([]);
+    });
+  }
+});

--- a/tests/listFilterSpecs.test.ts
+++ b/tests/listFilterSpecs.test.ts
@@ -84,6 +84,28 @@ describe("list filter specs", () => {
 });
 
 /**
+ * GH #1141 (Codex P2, fourth pass): type and vendor are EXACT keys into
+ * stored data — the schema does not trim them and the APIs compare with $eq —
+ * so their parsers must not editorialize. Pinned on the REAL specs, because
+ * the exactTextParam unit tests alone would stay green if someone swapped an
+ * entry back to the trimming textParam.
+ */
+describe("exact-key params are untrimmed", () => {
+  const entries = [
+    ["home.typeFilter", HOME_FILTER_SPEC.typeFilter],
+    ["home.vendorFilter", HOME_FILTER_SPEC.vendorFilter],
+    ["inventory.type", INVENTORY_FILTER_SPEC.type],
+    ["inventory.vendor", INVENTORY_FILTER_SPEC.vendor],
+  ] as const;
+
+  for (const [label, entry] of entries) {
+    it(`${label} round-trips edge whitespace byte-exact`, () => {
+      expect(entry.parse("PLA "), label).toBe("PLA ");
+    });
+  }
+});
+
+/**
  * The invariant the key-set comparison above CANNOT catch (Codex P1 review):
  * `groupBy` is both persisted and sticky, so a writer that forgets to record
  * the touch passes every test above while silently never persisting — or, the

--- a/tests/listFilterSpecs.test.ts
+++ b/tests/listFilterSpecs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  parseStoredPrefs,
   HOME_FILTER_SPEC,
   HOME_PERSISTED_KEYS,
   INVENTORY_FILTER_SPEC,
@@ -128,4 +129,35 @@ describe("preference writers record the touch", () => {
       expect(offenders).toEqual([]);
     });
   }
+});
+
+/**
+ * GH #1141 (Codex P2). The persist effects parse the stored blob inside a
+ * catch-everything try; a corrupt blob threw at the parse, skipped the
+ * `setItem`, and so was never overwritten — persistence dead until the user
+ * cleared storage by hand. The write path is the one chance to heal, so the
+ * parse must be tolerant there.
+ */
+describe("parseStoredPrefs", () => {
+  it("returns the object for a valid blob", () => {
+    expect(parseStoredPrefs('{"sortKey":"cost"}')).toEqual({ sortKey: "cost" });
+  });
+
+  it("returns {} for absent storage", () => {
+    expect(parseStoredPrefs(null)).toEqual({});
+    expect(parseStoredPrefs("")).toEqual({});
+  });
+
+  it("returns {} for corrupt JSON — the case that killed persistence", () => {
+    expect(parseStoredPrefs("{not json")).toEqual({});
+  });
+
+  it("returns {} for valid JSON that is not a plain object", () => {
+    // Spreading an array would yield index keys, not preferences; a number or
+    // null would spread to nothing but signals the blob is garbage either way.
+    expect(parseStoredPrefs("42")).toEqual({});
+    expect(parseStoredPrefs("null")).toEqual({});
+    expect(parseStoredPrefs('"cost"')).toEqual({});
+    expect(parseStoredPrefs('[{"sortKey":"cost"}]')).toEqual({});
+  });
 });


### PR DESCRIPTION
Fixes #1141.

Filters on the filament list and `/inventory` lived in bare `useState`, so a filtered view could not be shared or bookmarked and a refresh silently dropped you to the unfiltered list. `src/app/page.tsx:198-206` documented this exact gap and deferred it — this is that deferral.

**`replaceState`, not `pushState`** (the decision taken at triage): covers share + bookmark + refresh-survival without making every dropdown change a history entry, which would turn leaving the page into N Back presses.

## Two traps, both verified against a running server

**1. Serialization MERGES, never rebuilds.** `/inventory` accepts `?location=` as a deep link, and that link is encoded into **physically printed dry-box QR stickers** that cannot be reissued. Its consumer waits for the first fetch to resolve, while a URL-writing effect fires on mount — so a serializer that rebuilt the query string would blank the param before anything read it, and every printed label would silently scroll nowhere. `preservesUnknownParams` is the permanent guard.

**2. The home Type/Vendor dropdowns went empty when a filter was seeded.** Their options were derived from the *unfiltered* list response (`page.tsx:351-356`), so they were a side effect of having no filter active; a seeded `?type=PLA` aborts that request (`:325-327`) and the select rendered with only "All types" — invisible AND unclearable. Options now come from the dedicated `/api/filaments/types` + `/vendors` endpoints, as `/inventory` already does.

## Verified in the browser

| check | result |
|---|---|
| `/?type=PLA` seeds the filter and the dropdown | `typeValue=PLA`, **25 options** (was 1) |
| `?location=…&q=pla` on `/inventory` | `location` **preserved**, `q` seeded into the box |
| Edit a filter | URL updates, `history.length` **unchanged** (replaceState) |
| Write goes through Next's patched history | `history.state.__NA === true` |
| Clear the last filter | `?quick=` **removed**, `?sort`/`?dir` preserved, 53 rows |

## Notes

- Allowed values are validated against runtime arrays, with the unions now *derived* from them so the two cannot drift. `?sort=nonsense` falls back rather than putting a control in a state it cannot represent.
- Defaults are omitted, so an unfiltered list has a clean URL and round-tripping is idempotent.
- A shared link's state is not written into the recipient's localStorage — except `includeRetired`, which keeps its existing precedent (`/locations` links here specifically to reveal the retired spools blocking a delete).
- Seeding is post-mount, defaults-then-adopt, per the Codex P2 in `locations/new/page.tsx:28-36`.

Full gate green: 206 files / 4406 tests, plus `tsc`, lint and `electron:typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)