### PR TITLE
fix(sync): stage a contended rename instead of deadlocking on it (#1142)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -14,6 +14,10 @@ import {
   type MinimalTrimDb,
 } from "../src/lib/trimEntityNames";
 import {
+  isStagingPlaceholder,
+  placeholderFor,
+} from "../src/lib/renameStaging";
+import {
   retombstonePurgedZombies,
   type MinimalZombieCollection,
 } from "../src/lib/purgedZombies";
@@ -59,6 +63,22 @@ export function isDuplicateKeyError(err: unknown): boolean {
   if (e.code !== 11000) return false;
   if (!e.keyPattern || typeof e.keyPattern !== "object") return false;
   return Object.prototype.hasOwnProperty.call(e.keyPattern, "syncId");
+}
+
+/**
+ * A duplicate-key violation on the unique `name` index (GH #1142).
+ *
+ * Distinct from `isDuplicateKeyError`, which deliberately matches only
+ * `syncId` — that one means "another process already inserted this row", a
+ * benign race. A `name` violation means two DIFFERENT records want one name,
+ * which needs the staging path rather than a shrug.
+ */
+export function isNameDuplicateKeyError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: number; keyPattern?: Record<string, unknown> };
+  if (e.code !== 11000) return false;
+  if (!e.keyPattern || typeof e.keyPattern !== "object") return false;
+  return Object.prototype.hasOwnProperty.call(e.keyPattern, "name");
 }
 
 /**
@@ -155,6 +175,13 @@ interface SyncResult {
    * not resolve.
    */
   error?: string | null;
+  /**
+   * GH #1142: rows whose name could not be applied because a row this pass is
+   * NOT moving already holds it. Reported rather than forced — writing anyway
+   * would clobber a record the user still wants. Non-fatal for the collection
+   * by itself; see the paired/unpaired split where this is consumed.
+   */
+  nameConflicts?: number;
 }
 
 /**
@@ -1151,6 +1178,84 @@ export class SyncService extends EventEmitter {
       );
     };
 
+    // ── GH #1142: stage a contended rename instead of deadlocking ────────
+    //
+    // Every entity collection has a partial-unique `name` index, and this loop
+    // writes each row's whole document straight at the target with no
+    // awareness that the name it is about to write is currently held by a
+    // DIFFERENT row the same pass is about to move. Three shapes:
+    //
+    //   cycle  — local A="X" B="Y", remote A="Y" B="X". No ordering works;
+    //            reversing only changes which row fails.
+    //   chain  — A wants the name B is about to vacate.
+    //   unsat  — two rows genuinely want one name and neither is moving.
+    //
+    // The failure is permanent, not transient: it repeats every cycle, and via
+    // `trySync` a failure in `locations` cascade-skips filaments and print
+    // history, so one swapped pair stalls most of sync.
+    //
+    // Handled REACTIVELY rather than by a pre-pass, deliberately: a pre-pass
+    // would have to recompute every row's LWW outcome before the loop, which
+    // means a second copy of the decision logic that can drift from the real
+    // one. Here the real write is attempted, and only an actual name collision
+    // triggers staging — so the healthy path is untouched and there is no
+    // second decision to keep in step.
+    const stagedRenames: { col: typeof localCol; id: ObjectId; originalName: string }[] = [];
+    const stagingNonce = new ObjectId().toHexString().slice(-8);
+
+    /**
+     * Run a write that sets `name`; on a name collision, move the blocking row
+     * aside and retry ONCE.
+     *
+     * Staging is only legitimate when the blocker is itself in this pass's
+     * write set — then its own write lands its real name moments later. A
+     * blocker that isn't moving is the unsatisfiable case: report it and leave
+     * both peers alone rather than clobbering a record the user still wants.
+     */
+    const writeWithRenameStaging = async (
+      col: typeof localCol,
+      targetId: ObjectId,
+      desiredName: unknown,
+      write: () => Promise<unknown>,
+    ): Promise<boolean> => {
+      try {
+        await write();
+        return true;
+      } catch (err) {
+        if (!isNameDuplicateKeyError(err) || typeof desiredName !== "string") throw err;
+
+        const blocker = await col.findOne(
+          { name: desiredName, _deletedAt: null },
+          { projection: { _id: 1, syncId: 1, name: 1 } },
+        );
+        if (!blocker || String(blocker._id) === String(targetId)) throw err;
+
+        // Only a row this pass is going to write can be moved aside.
+        const blockerSyncId = typeof blocker.syncId === "string" ? blocker.syncId : null;
+        if (!blockerSyncId || !pairedSyncIds.has(blockerSyncId)) {
+          result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+          console.warn(
+            `[sync] ${collectionName}: cannot apply name ${JSON.stringify(desiredName)} — ` +
+              `held by a row this pass is not moving. Rename one of them.`,
+          );
+          return false;
+        }
+
+        const placeholder = placeholderFor(String(blocker._id), stagingNonce);
+        await col.updateOne({ _id: blocker._id }, { $set: { name: placeholder } });
+        // Remember it so an unsettled placeholder can be restored below — a
+        // row left named `__sync-staging-…` is visible in the UI and worse
+        // than the collision we were avoiding.
+        stagedRenames.push({
+          col,
+          id: blocker._id as ObjectId,
+          originalName: typeof blocker.name === "string" ? blocker.name : desiredName,
+        });
+        await write();
+        return true;
+      }
+    };
+
     const result: SyncResult = { collection: collectionName, pushed: 0, pulled: 0, updated: 0, deleted: 0 };
 
     // Process all unique syncIds from both sides — BOTH-SIDES ROWS FIRST.
@@ -1172,6 +1277,18 @@ export class SyncService extends EventEmitter {
       (localBySyncId.has(syncId) && remoteBySyncId.has(syncId) ? paired : unpaired).push(syncId);
     }
     const allSyncIds = pairedOnly ? paired : [...paired, ...unpaired];
+    // GH #1142: only a PAIRED row can be moved aside.
+    //
+    // "In this pass" is not enough, and the difference is load-bearing. An
+    // unpaired row is either remote-only (pulled to local — nothing writes its
+    // name on the remote) or local-only (inserted into remote — it isn't there
+    // to block anything yet). Either way no write on THIS target will give it
+    // a real name, so a placeholder put on it can never settle: it would be
+    // stranded as `__sync-staging-…`, visible in the UI, and if its original
+    // name were meanwhile taken by the row it made way for, unrecoverable.
+    //
+    // A paired row is exactly the case where the target IS written this pass.
+    const pairedSyncIds = new Set(paired);
     const heldBack = pairedOnly ? unpaired.length : 0;
     if (heldBack > 0) {
       console.warn(
@@ -1285,8 +1402,14 @@ export class SyncService extends EventEmitter {
               // then freezes the divergence forever. `transformed` is the
               // stripped source (no _id/__v), so replaceOne keeps the target
               // _id. Targeted flag $sets above stay $set (they mutate one key).
-              await localCol.replaceOne({ _id: localDoc._id }, { ...transformed, _deletedAt: null });
-              result.pulled++;
+              // GH #1142: a resurrect sets a name too, and can contend.
+              if (
+                await writeWithRenameStaging(localCol, localDoc._id as ObjectId, transformed.name, () =>
+                  localCol.replaceOne({ _id: localDoc._id }, { ...transformed, _deletedAt: null }),
+                )
+              ) {
+                result.pulled++;
+              }
             }
           }
           continue;
@@ -1307,8 +1430,14 @@ export class SyncService extends EventEmitter {
               const transformed = transformDoc ? transformDoc(doc, "toRemote", targetSpoolIds) : doc;
               // GH #1004 F3: replaceOne so a whole-doc copy also drops fields
               // the source no longer carries (see the toLocal branch above).
-              await remoteCol.replaceOne({ _id: remoteDoc._id }, { ...transformed, _deletedAt: null });
-              result.pushed++;
+              // GH #1142: see the toLocal resurrect above.
+              if (
+                await writeWithRenameStaging(remoteCol, remoteDoc._id as ObjectId, transformed.name, () =>
+                  remoteCol.replaceOne({ _id: remoteDoc._id }, { ...transformed, _deletedAt: null }),
+                )
+              ) {
+                result.pushed++;
+              }
             }
           }
           continue;
@@ -1329,8 +1458,14 @@ export class SyncService extends EventEmitter {
             const transformed = transformDoc ? transformDoc(doc, "toRemote", targetSpoolIds) : doc;
             // GH #1004 F3: replaceOne so the LWW copy drops fields the source
             // deleted (un-pin $unset flows); $set would freeze the divergence.
-            await remoteCol.replaceOne({ _id: remoteDoc._id }, transformed);
-            result.updated++;
+            // GH #1142: a rename may want a name another row still holds.
+            if (
+              await writeWithRenameStaging(remoteCol, remoteDoc._id as ObjectId, transformed.name, () =>
+                remoteCol.replaceOne({ _id: remoteDoc._id }, transformed),
+              )
+            ) {
+              result.updated++;
+            }
           }
         } else if (remoteTime > localTime) {
           // Remote is newer — pull to local
@@ -1340,11 +1475,52 @@ export class SyncService extends EventEmitter {
             const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(localCol, localDoc._id) : undefined;
             const transformed = transformDoc ? transformDoc(doc, "toLocal", targetSpoolIds) : doc;
             // GH #1004 F3: replaceOne (see the toRemote branch above).
-            await localCol.replaceOne({ _id: localDoc._id }, transformed);
-            result.updated++;
+            // GH #1142: see the toRemote branch above.
+            if (
+              await writeWithRenameStaging(localCol, localDoc._id as ObjectId, transformed.name, () =>
+                localCol.replaceOne({ _id: localDoc._id }, transformed),
+              )
+            ) {
+              result.updated++;
+            }
           }
         }
         // Equal timestamps — no action needed
+      }
+    }
+
+    // GH #1142: settle any placeholder whose real write never landed.
+    //
+    // A row is moved aside on the expectation that its own write follows
+    // moments later. If that write did not happen — its branch threw, the row
+    // was skipped, the LWW went the other way — it is left named
+    // `__sync-staging-…`, which is VISIBLE in the UI and worse than the
+    // collision being avoided. Restore the original name when it is free
+    // again; if it is not, leave the placeholder and report, because
+    // overwriting the row that took it would destroy real data.
+    for (const staged of stagedRenames) {
+      try {
+        const row = await staged.col.findOne(
+          { _id: staged.id },
+          { projection: { name: 1 } },
+        );
+        if (!row || !isStagingPlaceholder(row.name)) continue; // its write landed
+        const taken = await staged.col.findOne(
+          { name: staged.originalName, _deletedAt: null, _id: { $ne: staged.id } },
+          { projection: { _id: 1 } },
+        );
+        if (taken) {
+          result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+          console.warn(
+            `[sync] ${collectionName}: left a staging placeholder on ${String(staged.id)} — ` +
+              `${JSON.stringify(staged.originalName)} was taken while it was moved aside.`,
+          );
+          continue;
+        }
+        await staged.col.updateOne({ _id: staged.id }, { $set: { name: staged.originalName } });
+      } catch {
+        /* best-effort: the next cycle re-attempts, and the placeholder is
+           recognisable rather than silently wrong */
       }
     }
 

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1393,7 +1393,23 @@ export class SyncService extends EventEmitter {
 
         const blockerSyncId = typeof blocker.syncId === "string" ? blocker.syncId : null;
         const blockerName = typeof blocker.name === "string" ? blocker.name : null;
-        if (!blockerSyncId || !blockerName || !stageableOn(col).has(String(blocker._id))) {
+        if (
+          !blockerSyncId ||
+          !blockerName ||
+          !stageableOn(col).has(String(blocker._id)) ||
+          // The plan is a SNAPSHOT; re-derive its rule from fresh state
+          // (Codex P1). Staging is legitimate only while the blocker's own
+          // rewrite is still PENDING — the plan checked that against
+          // pre-pass names, but by now the blocker's write may have LANDED,
+          // in which case its fresh name IS its final one and nothing will
+          // ever move it again: staging it can never be settled, because the
+          // name settlement would restore is the one this retry is about to
+          // take. The planner's contested-destination refusal closes this
+          // for rows it can SEE; this closes it for requesters it cannot —
+          // a resurrect is not in the intent graph (its LWW writes the
+          // deleted side), yet its E11000 lands in this same catch.
+          desiredNameOn(col, blockerSyncId) === blockerName
+        ) {
           result.nameConflicts = (result.nameConflicts ?? 0) + 1;
           console.warn(
             `[sync] ${collectionName}: cannot apply name ${JSON.stringify(desiredName)} — ` +

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1207,7 +1207,12 @@ export class SyncService extends EventEmitter {
     // one. Here the real write is attempted, and only an actual name collision
     // triggers staging — so the healthy path is untouched and there is no
     // second decision to keep in step.
-    const stagedRenames: { col: typeof localCol; id: ObjectId; originalName: string }[] = [];
+    const stagedRenames: {
+      col: typeof localCol;
+      id: ObjectId;
+      originalName: string;
+      placeholderName: string;
+    }[] = [];
     const stagingNonce = new ObjectId().toHexString().slice(-8);
 
     /**
@@ -1272,7 +1277,13 @@ export class SyncService extends EventEmitter {
       if (cached) return cached;
       const docs = col === remoteCol ? remoteDocs : localDocs;
       const intents = docs
-        .filter((d) => typeof d.name === "string")
+        // ACTIVE rows only (Codex P1). The unique index is partial on
+        // `_deletedAt: null`, so a trashed row named "X" does NOT occupy that
+        // slot — GH #213 name reuse depends on it. Letting one into the graph
+        // made it the "holder" whenever it sorted first, and a trashed row
+        // never vacates, so the fixpoint declared the whole chain immovable
+        // and refused a swap that was perfectly resolvable — every cycle.
+        .filter((d) => !d._deletedAt && typeof d.name === "string")
         .map((d) => {
           const syncId = typeof d.syncId === "string" ? d.syncId : null;
           const desired = syncId ? desiredNameOn(col, syncId) : null;
@@ -1341,7 +1352,12 @@ export class SyncService extends EventEmitter {
         // Remember it so an unsettled placeholder can be restored below — a
         // row left named `__sync-staging-…` is visible in the UI and worse
         // than the collision we were avoiding.
-        stagedRenames.push({ col, id: blocker._id as ObjectId, originalName: blockerName });
+        stagedRenames.push({
+          col,
+          id: blocker._id as ObjectId,
+          originalName: blockerName,
+          placeholderName: placeholder,
+        });
         try {
           await write();
         } catch (retryErr) {
@@ -1607,10 +1623,29 @@ export class SyncService extends EventEmitter {
           );
           continue;
         }
-        await staged.col.updateOne({ _id: staged.id }, { $set: { name: staged.originalName } });
-      } catch {
-        /* best-effort: the next cycle re-attempts, and the placeholder is
-           recognisable rather than silently wrong */
+        // CONDITIONAL on the placeholder we actually put there (Codex P1).
+        // Another app or syncer can write this row between the read above and
+        // here; an `_id`-only filter would overwrite that newer real name with
+        // the old one — and because the concurrent write may already have
+        // copied its `updatedAt`, the peers could end up with different names
+        // at an EQUAL timestamp, which LWW then never repairs.
+        const restored = await staged.col.updateOne(
+          { _id: staged.id, name: staged.placeholderName },
+          { $set: { name: staged.originalName } },
+        );
+        if (!restored.modifiedCount) continue; // someone else moved it on
+      } catch (settleErr) {
+        // SURFACE it (Codex P1). Swallowing left the collection reporting
+        // success with a placeholder still stored, and nothing scans for stale
+        // placeholders on a later cycle — worse, a row staged after its own
+        // write landed shares its source's `updatedAt`, so LWW does no copy
+        // and never repairs it either.
+        result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+        console.error(
+          `[sync] ${collectionName}: could not restore ${JSON.stringify(staged.originalName)} ` +
+            `on ${String(staged.id)}; it still holds a staging placeholder.`,
+          settleErr,
+        );
       }
     }
 

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -16,6 +16,7 @@ import {
 import {
   isStagingPlaceholder,
   placeholderFor,
+  planRenameStaging,
 } from "../src/lib/renameStaging";
 import {
   retombstonePurgedZombies,
@@ -1227,41 +1228,65 @@ export class SyncService extends EventEmitter {
      * owns its original name.
      */
     /**
-     * Will this pass rewrite `syncId`'s NAME on `col`, to something different
-     * from what that row is called there now?
+     * The name this pass will write for `syncId` on `col`, or null when it
+     * writes nothing there.
      *
-     * This is the only condition under which moving the row aside is safe. It
-     * re-derives just the DIRECTION of the LWW decision — the timestamp
-     * comparison — rather than the whole outcome, because that comparison is
-     * small, total, and cheap to keep honest; duplicating the entire branch
-     * tree is what would drift.
-     *
-     * Deliberately conservative. Every branch it cannot prove (a delete, a
-     * resurrect, an equal timestamp, a missing side) answers false, which
-     * downgrades the case to "unsatisfiable, reported" — a visible conflict,
-     * never a stranded placeholder.
+     * Re-derives only the DIRECTION of the LWW decision — a small, total
+     * comparison — rather than the whole branch tree, which is what would
+     * drift. Deliberately conservative: every branch it cannot model (a
+     * delete, a resurrect, an equal timestamp, a missing side) answers null,
+     * which downgrades the case to "unsatisfiable, reported" rather than
+     * risking a stranded placeholder.
      */
-    const willRewriteNameOn = (col: typeof localCol, syncId: string): boolean => {
+    const desiredNameOn = (col: typeof localCol, syncId: string): string | null => {
       const localDoc = localBySyncId.get(syncId);
       const remoteDoc = remoteBySyncId.get(syncId);
-      if (!localDoc || !remoteDoc) return false; // unpaired: nothing writes it here
-
-      // A tombstoned row on either side takes the delete/resurrect branches,
-      // whose outcomes this shortcut does not model.
-      if (localDoc._deletedAt || remoteDoc._deletedAt) return false;
+      if (!localDoc || !remoteDoc) return null; // unpaired: nothing writes it here
+      if (localDoc._deletedAt || remoteDoc._deletedAt) return null;
 
       const localTime = SyncService.readUpdatedAt(localDoc) ?? 0;
       const remoteTime = SyncService.readUpdatedAt(remoteDoc) ?? 0;
-      if (localTime === remoteTime) return false; // equal: no copy at all
+      if (localTime === remoteTime) return null;
 
-      // The copy runs from the newer side to the older one.
-      const source = localTime > remoteTime ? localDoc : remoteDoc;
-      const target = localTime > remoteTime ? remoteDoc : localDoc;
       const targetIsRemote = localTime > remoteTime;
-      if (targetIsRemote !== (col === remoteCol)) return false; // writes the OTHER side
+      if (targetIsRemote !== (col === remoteCol)) return null; // writes the OTHER side
+      const source = targetIsRemote ? localDoc : remoteDoc;
+      return typeof source.name === "string" ? source.name : null;
+    };
 
-      // ...and only if the name actually changes there.
-      return typeof source.name === "string" && source.name !== target.name;
+    /**
+     * Which rows may be moved aside on `col`, computed ONCE per target.
+     *
+     * Delegated to the pure planner because the answer needs the whole rename
+     * GRAPH, not one hop (Codex P1). Checking only that the immediate blocker
+     * will be rewritten strands it whenever its own destination is itself
+     * blocked: with A->B, B->C and C standing still, A takes B's name and B can
+     * then never take C — and settlement cannot restore B, because A owns its
+     * original name. The planner runs unsatisfiability backwards to a fixpoint,
+     * so a blocked far end refuses the whole chain while a true cycle still
+     * resolves.
+     */
+    const stagingPlans = new Map<typeof localCol, Set<string>>();
+    const stageableOn = (col: typeof localCol): Set<string> => {
+      const cached = stagingPlans.get(col);
+      if (cached) return cached;
+      const docs = col === remoteCol ? remoteDocs : localDocs;
+      const intents = docs
+        .filter((d) => typeof d.name === "string")
+        .map((d) => {
+          const syncId = typeof d.syncId === "string" ? d.syncId : null;
+          const desired = syncId ? desiredNameOn(col, syncId) : null;
+          return {
+            id: String(d._id),
+            currentName: d.name as string,
+            desiredName: desired ?? (d.name as string),
+            willWrite: desired !== null,
+          };
+        });
+      const plan = planRenameStaging(intents, stagingNonce);
+      const ids = new Set(plan.staged.map((st) => st.id));
+      stagingPlans.set(col, ids);
+      return ids;
     };
 
     const writeWithRenameStaging = async (
@@ -1284,7 +1309,7 @@ export class SyncService extends EventEmitter {
 
         const blockerSyncId = typeof blocker.syncId === "string" ? blocker.syncId : null;
         const blockerName = typeof blocker.name === "string" ? blocker.name : null;
-        if (!blockerSyncId || !blockerName || !willRewriteNameOn(col, blockerSyncId)) {
+        if (!blockerSyncId || !blockerName || !stageableOn(col).has(String(blocker._id))) {
           result.nameConflicts = (result.nameConflicts ?? 0) + 1;
           console.warn(
             `[sync] ${collectionName}: cannot apply name ${JSON.stringify(desiredName)} — ` +
@@ -1602,6 +1627,25 @@ export class SyncService extends EventEmitter {
     // The counts above stay real — the paired copies DID happen, so a user's
     // rename still propagates and the collection can converge. Only the
     // dependents wait.
+    // GH #1142 (Codex P1): a name conflict has to reach the user.
+    //
+    // Incrementing a counter nothing reads left `trySync` treating the
+    // collection as successful and the cycle reporting `idle`, while a
+    // whole-document update was silently skipped and would fail identically
+    // every cycle — permanent divergence with no signal at all.
+    //
+    // This is deliberately stricter than the paired/unpaired split agreed for
+    // the SWAP case: a swap now RESOLVES, so anything still counted here is
+    // the unsatisfiable kind — a row that will never sync until a human
+    // renames one of the two. Cascade-skipping dependents is over-strict for
+    // that (both rows exist on both peers, so refs still resolve), but a
+    // reported, recoverable stall beats an invisible one.
+    if ((result.nameConflicts ?? 0) > 0 && !result.error) {
+      result.error =
+        `${result.nameConflicts} name conflict(s) could not be applied — two rows want ` +
+        `the same name and neither can give it up. Rename one of them.`;
+    }
+
     if (heldBack > 0) {
       result.error =
         `held back ${heldBack} unpaired record(s) — the trim pass skipped this ` +

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -17,6 +17,7 @@ import {
   isStagingPlaceholder,
   placeholderFor,
   planRenameStaging,
+  pendingRenameCanFreeName,
   strandedPlaceholderNotice,
   withStrandingNotice,
   strandingNoticeOf,
@@ -1393,29 +1394,49 @@ export class SyncService extends EventEmitter {
 
         const blockerSyncId = typeof blocker.syncId === "string" ? blocker.syncId : null;
         const blockerName = typeof blocker.name === "string" ? blocker.name : null;
-        if (
-          !blockerSyncId ||
-          !blockerName ||
-          !stageableOn(col).has(String(blocker._id)) ||
-          // The plan is a SNAPSHOT; re-derive its rule from fresh state
-          // (Codex P1). Staging is legitimate only while the blocker's own
-          // rewrite is still PENDING — the plan checked that against
-          // pre-pass names, but by now the blocker's write may have LANDED,
-          // in which case its fresh name IS its final one and nothing will
-          // ever move it again: staging it can never be settled, because the
-          // name settlement would restore is the one this retry is about to
-          // take. The planner's contested-destination refusal closes this
-          // for rows it can SEE; this closes it for requesters it cannot —
-          // a resurrect is not in the intent graph (its LWW writes the
-          // deleted side), yet its E11000 lands in this same catch.
-          desiredNameOn(col, blockerSyncId) === blockerName
-        ) {
+        const refuseStaging = () => {
           result.nameConflicts = (result.nameConflicts ?? 0) + 1;
           console.warn(
             `[sync] ${collectionName}: cannot apply name ${JSON.stringify(desiredName)} — ` +
               `held by a row this pass will not rewrite on this side. Rename one of them.`,
           );
           return false;
+        };
+        if (!blockerSyncId || !blockerName || !stageableOn(col).has(String(blocker._id))) {
+          return refuseStaging();
+        }
+
+        // The plan is a SNAPSHOT; staging additionally needs FRESH proof that
+        // the blocker's own pending write will rename it away (Codex P1, twice
+        // over). The first version of this check compared the blocker's fresh
+        // name against its SNAPSHOT desired name — half-fresh, and the half
+        // matters: the pending write hydrates the CURRENT source document at
+        // write time, so a source renamed after the snapshot (a user reverting
+        // a name mid-pass) diverges from `desiredNameOn`, and staging was
+        // authorized for a rename that was no longer coming. Settlement could
+        // not restore the placeholder, because the name it would restore had
+        // been taken by the retry this staging enabled.
+        //
+        // So read the SAME document the pending write will hydrate — the
+        // blocker's source-side pair, by the `_id` the snapshot map carries —
+        // and judge against what it says NOW. The decision table (landed
+        // write, no-op rename, mid-pass revert, vanished source, placeholder
+        // contagion) lives in `pendingRenameCanFreeName`, pure and tested.
+        // This also subsumes the previous check: a landed write makes the
+        // fresh source name equal the blocker's fresh name. The planner still
+        // covers what only IT can see (contested destinations, immovable
+        // chains); this covers what only fresh state can.
+        const sourceSnap = (col === remoteCol ? localBySyncId : remoteBySyncId).get(
+          blockerSyncId,
+        );
+        const sourceFresh = sourceSnap
+          ? await (col === remoteCol ? localCol : remoteCol).findOne(
+              { _id: sourceSnap._id },
+              { projection: { name: 1 } },
+            )
+          : null;
+        if (!pendingRenameCanFreeName(sourceFresh?.name, blockerName)) {
+          return refuseStaging();
         }
 
         // CONDITIONAL on what was observed (Codex P1). Between the findOne and

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1249,6 +1249,17 @@ export class SyncService extends EventEmitter {
     }[] = [];
     /** Rows this pass left holding a placeholder, for the result message. */
     const strandedNotices: string[] = [];
+    /**
+     * SyncIds whose loop iteration has started (and, since iterations are
+     * sequential, has finished for every id but the current one). The one
+     * fact about a blocker that neither the plan nor any name can encode
+     * (Codex P1, seventh pass): whether its write is still COMING. Names
+     * cannot, because a third party renaming the target after the iteration
+     * completed breaks the equality that detects a landed write — the fresh
+     * source still differs from the perturbed target, staging looks
+     * legitimate, and no write remains to replace the placeholder.
+     */
+    const processedSyncIds = new Set<string>();
     const stagingNonce = new ObjectId().toHexString().slice(-8);
 
     /**
@@ -1402,7 +1413,18 @@ export class SyncService extends EventEmitter {
           );
           return false;
         };
-        if (!blockerSyncId || !blockerName || !stageableOn(col).has(String(blocker._id))) {
+        if (
+          !blockerSyncId ||
+          !blockerName ||
+          !stageableOn(col).has(String(blocker._id)) ||
+          // The blocker's own iteration must still be AHEAD (Codex P1). Once
+          // it has run, no write remains this pass, and the name checks below
+          // can no longer prove it: a third party renaming the target
+          // afterwards re-opens the gap between fresh source and fresh target
+          // that normally means "rename pending". Set membership is the only
+          // signal that survives arbitrary concurrent renames.
+          processedSyncIds.has(blockerSyncId)
+        ) {
           return refuseStaging();
         }
 
@@ -1616,6 +1638,11 @@ export class SyncService extends EventEmitter {
     // Wrapped so SETTLEMENT ALWAYS RUNS (Codex P1) — see the note above it.
     try {
       for (const syncId of allSyncIds) {
+        // Marked at the TOP, not the bottom: the body is full of `continue`s
+        // and a trailing add would be skipped by every one of them. Including
+        // the CURRENT id is harmless — `syncId` is unique per collection, so
+        // a blocker (a different _id on the same col) can never carry it.
+        processedSyncIds.add(syncId);
         const localDoc = localBySyncId.get(syncId);
         const remoteDoc = remoteBySyncId.get(syncId);
 

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -17,7 +17,10 @@ import {
   isStagingPlaceholder,
   placeholderFor,
   planRenameStaging,
-  strandedPlaceholderMessage,
+  strandedPlaceholderError,
+  strandedPlaceholderNotice,
+  strandingNoticeOf,
+  CAUSE_LEAD,
 } from "../src/lib/renameStaging";
 import {
   retombstonePurgedZombies,
@@ -126,22 +129,51 @@ export function getDbNameFromUri(uri: string): string {
  * `user is not allowed to do action [update] on [db.coll]`) and by code 13
  * (the more reliable signal, but not always populated on every wrapped
  * error path). Either is sufficient. See GH #143.
+ *
+ * ## Composed errors: classify the CAUSE, re-attach the notice (GH #1142)
+ *
+ * Two things break when a caller wraps a driver error in its own Error, which
+ * `strandedPlaceholderError` does:
+ *
+ *  1. `new Error(msg, {cause})` does NOT inherit `code`, so the "more reliable
+ *     signal" above silently disappears — a genuine `code: 13` whose text does
+ *     not match the regex used to produce the hint and now produces nothing.
+ *     So classification reads through `cause` when there is one.
+ *  2. The auth branch REPLACES the whole message, discarding anything the
+ *     caller put in it. Ordering cannot save a composed message — the function
+ *     never reads the original. So a stranding notice is re-attached at the
+ *     END, outside the auth/redact decision, where no present or future
+ *     rewriting branch can drop it.
+ *
+ * The notice is cause-free by construction (see `strandedPlaceholderNotice`),
+ * so re-attaching it cannot itself trip the regex on the next pass.
  */
 export function wrapSyncErrorMessage(err: unknown, dbName: string): string {
-  const message = err instanceof Error ? err.message : "Sync failed";
+  // Classify the CAUSE when the error carries one — that is where the driver's
+  // own message and `code` survive.
+  const cause = err instanceof Error && err.cause !== undefined ? err.cause : err;
+  const message =
+    cause instanceof Error ? cause.message : err instanceof Error ? err.message : "Sync failed";
   const code =
-    err && typeof err === "object" && "code" in err
-      ? (err as { code: unknown }).code
+    cause && typeof cause === "object" && "code" in cause
+      ? (cause as { code: unknown }).code
       : undefined;
 
   const isAuthError =
     /user is not allowed to do action/i.test(message) || code === 13;
 
-  if (isAuthError) {
-    return `The Atlas user in your connection string only has read permission for "${dbName}". Update the user's role to one that includes readWrite (or change the connection string to one that does), then try again. You can re-enter the connection string in Settings → Connection.`;
-  }
+  const body = isAuthError
+    ? `The Atlas user in your connection string only has read permission for "${dbName}". Update the user's role to one that includes readWrite (or change the connection string to one that does), then try again. You can re-enter the connection string in Settings → Connection.`
+    : message;
 
-  return message.replace(/mongodb(\+srv)?:\/\/[^\s]+/g, "mongodb://***");
+  // A stranded row needs manual recovery and is announced exactly once, so it
+  // survives whichever branch ran above.
+  const notice = strandingNoticeOf(err);
+  const full = notice ? `${notice} ${CAUSE_LEAD}${body}` : body;
+
+  // Redact LAST, over the WHOLE string: the notice quotes user-typed entity
+  // names, and the body may carry a connection string.
+  return full.replace(/mongodb(\+srv)?:\/\/[^\s]+/g, "mongodb://***");
 }
 
 export interface SyncStatus {
@@ -1214,6 +1246,8 @@ export class SyncService extends EventEmitter {
       originalName: string;
       placeholderName: string;
     }[] = [];
+    /** Rows this pass left holding a placeholder, for the result message. */
+    const strandedNotices: string[] = [];
     const stagingNonce = new ObjectId().toHexString().slice(-8);
 
     /**
@@ -1239,16 +1273,46 @@ export class SyncService extends EventEmitter {
      *
      * Re-derives only the DIRECTION of the LWW decision — a small, total
      * comparison — rather than the whole branch tree, which is what would
-     * drift. Deliberately conservative: every branch it cannot model (a
-     * delete, a resurrect, an equal timestamp, a missing side) answers null,
+     * drift. Deliberately conservative: every branch it cannot model (a purge,
+     * a delete, a resurrect, an equal timestamp, a missing side) answers null,
      * which downgrades the case to "unsatisfiable, reported" rather than
      * risking a stranded placeholder.
+     *
+     * ## The property this actually has (Codex P1, second pass)
+     *
+     * Not "it mirrors the loop exactly" — it does not, and claiming so is how
+     * the previous version drifted. The true, scoped claim is: FOR A ROW THAT
+     * IS LIVE ON `col` — the only rows `stageableOn` can ask about, since its
+     * filter is the index predicate — the only branch that rewrites the name
+     * is the both-active LWW one. The purge branch writes flags only;
+     * delete-propagation writes `_deletedAt` only; and both resurrect arms
+     * write on the DELETED side, which that same filter excludes.
+     *
+     * The guards below therefore have to use the LOOP's classifications, not
+     * lookalikes: `_purged === true` and `_deletedAt != null`, matching the
+     * `localPurged`/`localDeleted` derivations further down. Truthiness
+     * disagrees with `!= null` on exactly one stored value — the empty string,
+     * which the driver writes verbatim and Mongoose never casts — and there
+     * the loop takes the DELETE branch (resurrecting on the other side) while
+     * the predictor was claiming a rename on this one. The blocker was then
+     * staged for a write that never came, and the fresh `hydrateRemote` read
+     * could copy `__sync-staging-…` to the other peer before settlement ever
+     * noticed.
+     *
+     * The cost of being wrong in the safe direction is one reported cycle: a
+     * delete or purge frees the name in the same pass without renaming, so
+     * treating that pair as a permanent holder stalls the collection once
+     * (and cascade-skips its dependents) before converging cleanly. That is
+     * the trade this function was always making; it is not free.
      */
     const desiredNameOn = (col: typeof localCol, syncId: string): string | null => {
       const localDoc = localBySyncId.get(syncId);
       const remoteDoc = remoteBySyncId.get(syncId);
       if (!localDoc || !remoteDoc) return null; // unpaired: nothing writes it here
-      if (localDoc._deletedAt || remoteDoc._deletedAt) return null;
+      // Purge first, mirroring the loop's branch order — its purge arm is
+      // tested before either delete arm and writes no name at all.
+      if (localDoc._purged === true || remoteDoc._purged === true) return null;
+      if (localDoc._deletedAt != null || remoteDoc._deletedAt != null) return null;
 
       const localTime = SyncService.readUpdatedAt(localDoc) ?? 0;
       const remoteTime = SyncService.readUpdatedAt(remoteDoc) ?? 0;
@@ -1396,16 +1460,13 @@ export class SyncService extends EventEmitter {
               return null;
             });
           if (!rolledBack?.modifiedCount) {
-            throw new Error(
-              strandedPlaceholderMessage({
-                collection: collectionName,
-                id: String(blocker._id),
-                originalName: blockerName,
-                placeholderName: placeholder,
-                cause: retryErr,
-              }),
-              { cause: retryErr },
-            );
+            throw strandedPlaceholderError({
+              collection: collectionName,
+              id: String(blocker._id),
+              originalName: blockerName,
+              placeholderName: placeholder,
+              cause: retryErr,
+            });
           }
           throw retryErr;
         }
@@ -1655,7 +1716,20 @@ export class SyncService extends EventEmitter {
           { projection: { _id: 1 } },
         );
         if (taken) {
+          // NAME the row, do not just count it (Codex P1). This branch and the
+          // catch below are the two REACHABLE producers of a permanent
+          // placeholder — no race, no privilege change — and until now their
+          // only trace was a console line plus a counter whose rendering could
+          // be overwritten entirely (see the `heldBack` note at the end).
           result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+          strandedNotices.push(
+            strandedPlaceholderNotice({
+              collection: collectionName,
+              id: String(staged.id),
+              originalName: staged.originalName,
+              placeholderName: staged.placeholderName,
+            }),
+          );
           console.warn(
             `[sync] ${collectionName}: left a staging placeholder on ${String(staged.id)} — ` +
               `${JSON.stringify(staged.originalName)} was taken while it was moved aside.`,
@@ -1680,6 +1754,14 @@ export class SyncService extends EventEmitter {
         // write landed shares its source's `updatedAt`, so LWW does no copy
         // and never repairs it either.
         result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+        strandedNotices.push(
+          strandedPlaceholderNotice({
+            collection: collectionName,
+            id: String(staged.id),
+            originalName: staged.originalName,
+            placeholderName: staged.placeholderName,
+          }),
+        );
         console.error(
           `[sync] ${collectionName}: could not restore ${JSON.stringify(staged.originalName)} ` +
             `on ${String(staged.id)}; it still holds a staging placeholder.`,
@@ -1719,11 +1801,23 @@ export class SyncService extends EventEmitter {
         `${result.nameConflicts} name conflict(s) could not be applied — two rows want ` +
         `the same name and neither can give it up. Rename one of them.`;
     }
+    // A row left holding `__sync-staging-…` needs a HUMAN, and nothing scans
+    // for stale placeholders on a later cycle — the equal-`updatedAt` case
+    // documented above is never repaired by LWW either. So name the rows, do
+    // not merely count them.
+    if (strandedNotices.length > 0) {
+      result.error = `${result.error ? `${result.error} ` : ""}${strandedNotices.join(" ")}`;
+    }
 
     if (heldBack > 0) {
-      result.error =
+      // APPEND (Codex P1). This used to ASSIGN, so a held-back collection that
+      // also stranded a placeholder reported only the hold-back — and that text
+      // blames the trim pass, sending the user somewhere the actual problem is
+      // not. Both facts are true at once and both need saying.
+      const held =
         `held back ${heldBack} unpaired record(s) — the trim pass skipped this ` +
         `collection, so its names cannot be matched safely yet`;
+      result.error = result.error ? `${result.error} Also: ${held}` : held;
     }
 
     return result;

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -17,6 +17,7 @@ import {
   isStagingPlaceholder,
   placeholderFor,
   planRenameStaging,
+  strandedPlaceholderMessage,
 } from "../src/lib/renameStaging";
 import {
   retombstonePurgedZombies,
@@ -1277,13 +1278,21 @@ export class SyncService extends EventEmitter {
       if (cached) return cached;
       const docs = col === remoteCol ? remoteDocs : localDocs;
       const intents = docs
-        // ACTIVE rows only (Codex P1). The unique index is partial on
+        // INDEXED rows only (Codex P1, twice). The unique index is partial on
         // `_deletedAt: null`, so a trashed row named "X" does NOT occupy that
         // slot — GH #213 name reuse depends on it. Letting one into the graph
         // made it the "holder" whenever it sorted first, and a trashed row
         // never vacates, so the fixpoint declared the whole chain immovable
         // and refused a swap that was perfectly resolvable — every cycle.
-        .filter((d) => !d._deletedAt && typeof d.name === "string")
+        //
+        // The predicate is MongoDB's own, not JS truthiness. `{_deletedAt:
+        // null}` matches null AND missing and nothing else, so a raw
+        // `_deletedAt: ""` — which Mongoose casts to null on a Date path but
+        // the driver stores verbatim, the shape `trimEntityNames` documents at
+        // its own `== null` test — is OUTSIDE the index. `!d._deletedAt` let
+        // that row in as a holder, reintroducing the immovable-chain stall for
+        // a row that could never have blocked the write in the first place.
+        .filter((d) => d._deletedAt == null && typeof d.name === "string")
         .map((d) => {
           const syncId = typeof d.syncId === "string" ? d.syncId : null;
           const desired = syncId ? desiredNameOn(col, syncId) : null;
@@ -1365,13 +1374,17 @@ export class SyncService extends EventEmitter {
           // through `trySync`, so the settlement loop at the end never runs and
           // nothing scans for stale placeholders on a later cycle — the row
           // would keep the temporary name indefinitely.
-          // SURFACE a failed rollback (Codex P2). If the original name was
-          // claimed while this row sat aside, the restore E11000s too — and
-          // discarding that left the blocker permanently named
-          // `__sync-staging-…`, because the throw below exits before
-          // settlement and nothing scans for stale placeholders on a later
-          // cycle. The original error still wins as the cause; this only makes
-          // sure the stranding is not silent.
+          // SURFACE a failed rollback (Codex P2, twice). If the original name
+          // was claimed while this row sat aside, the restore E11000s too, and
+          // the blocker stays permanently named `__sync-staging-…`: the throw
+          // below exits before settlement and nothing scans for stale
+          // placeholders on a later cycle.
+          //
+          // Counting it in `result` was the WRONG channel — the throw leaves
+          // `syncCollection` entirely and `trySync` builds a fresh zero-count
+          // SyncResult carrying only the error, so the counter was discarded on
+          // the one path it existed for. The error MESSAGE is the only thing
+          // that survives to the renderer, so the stranding goes there.
           const rolledBack = await col
             .updateOne({ _id: blocker._id, name: placeholder }, { $set: { name: blockerName } })
             .catch((rollbackErr: unknown) => {
@@ -1383,7 +1396,16 @@ export class SyncService extends EventEmitter {
               return null;
             });
           if (!rolledBack?.modifiedCount) {
-            result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+            throw new Error(
+              strandedPlaceholderMessage({
+                collection: collectionName,
+                id: String(blocker._id),
+                originalName: blockerName,
+                placeholderName: placeholder,
+                cause: retryErr,
+              }),
+              { cause: retryErr },
+            );
           }
           throw retryErr;
         }

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -17,8 +17,8 @@ import {
   isStagingPlaceholder,
   placeholderFor,
   planRenameStaging,
-  strandedPlaceholderError,
   strandedPlaceholderNotice,
+  withStrandingNotice,
   strandingNoticeOf,
   CAUSE_LEAD,
 } from "../src/lib/renameStaging";
@@ -1434,40 +1434,27 @@ export class SyncService extends EventEmitter {
         try {
           await write();
         } catch (retryErr) {
-          // ROLL BACK IMMEDIATELY (Codex P2). A throw here exits syncCollection
-          // through `trySync`, so the settlement loop at the end never runs and
-          // nothing scans for stale placeholders on a later cycle — the row
-          // would keep the temporary name indefinitely.
-          // SURFACE a failed rollback (Codex P2, twice). If the original name
-          // was claimed while this row sat aside, the restore E11000s too, and
-          // the blocker stays permanently named `__sync-staging-…`: the throw
-          // below exits before settlement and nothing scans for stale
-          // placeholders on a later cycle.
+          // ROLL BACK IMMEDIATELY (Codex P2). A throw here used to exit
+          // `syncCollection` through `trySync`, skipping settlement entirely,
+          // so the row would keep the temporary name indefinitely. Settlement
+          // now runs on that path too (see the loop's catch), which makes this
+          // the fast path rather than the only chance.
           //
-          // Counting it in `result` was the WRONG channel — the throw leaves
-          // `syncCollection` entirely and `trySync` builds a fresh zero-count
-          // SyncResult carrying only the error, so the counter was discarded on
-          // the one path it existed for. The error MESSAGE is the only thing
-          // that survives to the renderer, so the stranding goes there.
-          const rolledBack = await col
+          // Deliberately NOT composing a stranding message here. The blocker is
+          // still in `stagedRenames`, and settlement is the SINGLE place that
+          // reports what it could not restore — reporting in both named the
+          // same row twice, and named only this row while a late failure
+          // strands every row moved aside earlier in the pass as well.
+          await col
             .updateOne({ _id: blocker._id, name: placeholder }, { $set: { name: blockerName } })
             .catch((rollbackErr: unknown) => {
               console.error(
                 `[sync] ${collectionName}: could not roll ${String(blocker._id)} back to ` +
-                  `${JSON.stringify(blockerName)}; it still holds a staging placeholder.`,
+                  `${JSON.stringify(blockerName)}; leaving it to settlement.`,
                 rollbackErr,
               );
               return null;
             });
-          if (!rolledBack?.modifiedCount) {
-            throw strandedPlaceholderError({
-              collection: collectionName,
-              id: String(blocker._id),
-              originalName: blockerName,
-              placeholderName: placeholder,
-              cause: retryErr,
-            });
-          }
           throw retryErr;
         }
         return true;
@@ -1475,6 +1462,91 @@ export class SyncService extends EventEmitter {
     };
 
     const result: SyncResult = { collection: collectionName, pushed: 0, pulled: 0, updated: 0, deleted: 0 };
+
+    // GH #1142: settle any placeholder whose real write never landed.
+    //
+    // A row is moved aside on the expectation that its own write follows
+    // moments later. If that write did not happen — its branch threw, the row
+    // was skipped, the LWW went the other way — it is left named
+    // `__sync-staging-…`, which is VISIBLE in the UI and worse than the
+    // collision being avoided. Restore the original name when it is free
+    // again; if it is not, leave the placeholder and report, because
+    // overwriting the row that took it would destroy real data.
+    //
+    // A FUNCTION, called on EVERY exit from the row loop (Codex P1). Inline
+    // after the loop, it was skipped entirely whenever the loop threw — and
+    // `stagedRenames` accumulates ACROSS iterations, so one late failure
+    // abandoned every row moved aside earlier in the pass, silently and with
+    // no later-cycle sweep to catch it.
+    const settleStagedRenames = async (): Promise<void> => {
+      // Drained, so a second call cannot re-report or re-restore.
+      const pending = stagedRenames.splice(0, stagedRenames.length);
+      for (const staged of pending) {
+        try {
+          const row = await staged.col.findOne(
+            { _id: staged.id },
+            { projection: { name: 1 } },
+          );
+          if (!row || !isStagingPlaceholder(row.name)) continue; // its write landed
+          const taken = await staged.col.findOne(
+            { name: staged.originalName, _deletedAt: null, _id: { $ne: staged.id } },
+            { projection: { _id: 1 } },
+          );
+          if (taken) {
+            // NAME the row, do not just count it (Codex P1). This branch and the
+            // catch below are the two REACHABLE producers of a permanent
+            // placeholder — no race, no privilege change — and until now their
+            // only trace was a console line plus a counter whose rendering could
+            // be overwritten entirely (see the `heldBack` note at the end).
+            result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+            strandedNotices.push(
+              strandedPlaceholderNotice({
+                collection: collectionName,
+                id: String(staged.id),
+                originalName: staged.originalName,
+                placeholderName: staged.placeholderName,
+              }),
+            );
+            console.warn(
+              `[sync] ${collectionName}: left a staging placeholder on ${String(staged.id)} — ` +
+                `${JSON.stringify(staged.originalName)} was taken while it was moved aside.`,
+            );
+            continue;
+          }
+          // CONDITIONAL on the placeholder we actually put there (Codex P1).
+          // Another app or syncer can write this row between the read above and
+          // here; an `_id`-only filter would overwrite that newer real name with
+          // the old one — and because the concurrent write may already have
+          // copied its `updatedAt`, the peers could end up with different names
+          // at an EQUAL timestamp, which LWW then never repairs.
+          const restored = await staged.col.updateOne(
+            { _id: staged.id, name: staged.placeholderName },
+            { $set: { name: staged.originalName } },
+          );
+          if (!restored.modifiedCount) continue; // someone else moved it on
+        } catch (settleErr) {
+          // SURFACE it (Codex P1). Swallowing left the collection reporting
+          // success with a placeholder still stored, and nothing scans for stale
+          // placeholders on a later cycle — worse, a row staged after its own
+          // write landed shares its source's `updatedAt`, so LWW does no copy
+          // and never repairs it either.
+          result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+          strandedNotices.push(
+            strandedPlaceholderNotice({
+              collection: collectionName,
+              id: String(staged.id),
+              originalName: staged.originalName,
+              placeholderName: staged.placeholderName,
+            }),
+          );
+          console.error(
+            `[sync] ${collectionName}: could not restore ${JSON.stringify(staged.originalName)} ` +
+              `on ${String(staged.id)}; it still holds a staging placeholder.`,
+            settleErr,
+          );
+        }
+      }
+    };
 
     // Process all unique syncIds from both sides — BOTH-SIDES ROWS FIRST.
     //
@@ -1504,271 +1576,210 @@ export class SyncService extends EventEmitter {
       );
     }
 
-    for (const syncId of allSyncIds) {
-      const localDoc = localBySyncId.get(syncId);
-      const remoteDoc = remoteBySyncId.get(syncId);
+    // Wrapped so SETTLEMENT ALWAYS RUNS (Codex P1) — see the note above it.
+    try {
+      for (const syncId of allSyncIds) {
+        const localDoc = localBySyncId.get(syncId);
+        const remoteDoc = remoteBySyncId.get(syncId);
 
-      if (localDoc && !remoteDoc) {
-        // Local-only: push to remote.
-        //
-        // GH #439: catch E11000 on `syncId` and treat as a no-op. Two
-        // processes pointed at the same Atlas (desktop client + Docker
-        // instance, two desktops sharing an Atlas) can both pass this
-        // "local-only" branch concurrently when their first sync
-        // cycles overlap. The `syncId` unique index is the right place
-        // to serialize them; the loser of the race just observes the
-        // doc already exists. Without this branch the second insert
-        // bubbled up as a collection-level failure in `trySync` and
-        // the whole sync cycle reported "partial".
-        const full = await hydrateLocal(localDoc);
-        if (!full) continue;
-        const doc = this.stripForTransfer(full);
-        const transformed = transformDoc ? transformDoc(doc, "toRemote") : doc;
-        try {
-          await remoteCol.insertOne({ ...transformed, _id: new ObjectId() });
-          result.pushed++;
-        } catch (err: unknown) {
-          if (!isDuplicateKeyError(err)) throw err;
-          // Other process won the race — the doc is already there,
-          // future cycles will see it via the existing-on-both branch.
-        }
-      } else if (!localDoc && remoteDoc) {
-        // Remote-only: pull to local. Same E11000 guard symmetry — a
-        // concurrent sync from another instance could have already
-        // pulled the same doc to a shared local store.
-        const full = await hydrateRemote(remoteDoc);
-        if (!full) continue;
-        const doc = this.stripForTransfer(full);
-        const transformed = transformDoc ? transformDoc(doc, "toLocal") : doc;
-        try {
-          await localCol.insertOne({ ...transformed, _id: new ObjectId() });
-          result.pulled++;
-        } catch (err: unknown) {
-          if (!isDuplicateKeyError(err)) throw err;
-        }
-      } else if (localDoc && remoteDoc) {
-        // Both exist: handle conflicts
-        const localDeleted = localDoc._deletedAt != null;
-        const remoteDeleted = remoteDoc._deletedAt != null;
-        const localPurged = localDoc._purged === true;
-        const remotePurged = remoteDoc._purged === true;
-
-        // `_purged` is the "delete forever" tombstone (see Filament model
-        // doc comment). It's a one-way flag — once set on either peer, it
-        // wins over any other state, including a remote update that
-        // happened after the local purge. Without this branch, a hard
-        // delete on one peer was getting resurrected from the other side
-        // on the next sync cycle (#213).
-        if (localPurged || remotePurged) {
-          if (localPurged && !remotePurged) {
-            await remoteCol.updateOne(
-              { _id: remoteDoc._id },
-              { $set: { _purged: true, _deletedAt: localDoc._deletedAt ?? new Date() } },
-            );
-            result.deleted++;
-          } else if (!localPurged && remotePurged) {
-            await localCol.updateOne(
-              { _id: localDoc._id },
-              { $set: { _purged: true, _deletedAt: remoteDoc._deletedAt ?? new Date() } },
-            );
-            result.deleted++;
+        if (localDoc && !remoteDoc) {
+          // Local-only: push to remote.
+          //
+          // GH #439: catch E11000 on `syncId` and treat as a no-op. Two
+          // processes pointed at the same Atlas (desktop client + Docker
+          // instance, two desktops sharing an Atlas) can both pass this
+          // "local-only" branch concurrently when their first sync
+          // cycles overlap. The `syncId` unique index is the right place
+          // to serialize them; the loser of the race just observes the
+          // doc already exists. Without this branch the second insert
+          // bubbled up as a collection-level failure in `trySync` and
+          // the whole sync cycle reported "partial".
+          const full = await hydrateLocal(localDoc);
+          if (!full) continue;
+          const doc = this.stripForTransfer(full);
+          const transformed = transformDoc ? transformDoc(doc, "toRemote") : doc;
+          try {
+            await remoteCol.insertOne({ ...transformed, _id: new ObjectId() });
+            result.pushed++;
+          } catch (err: unknown) {
+            if (!isDuplicateKeyError(err)) throw err;
+            // Other process won the race — the doc is already there,
+            // future cycles will see it via the existing-on-both branch.
           }
-          // else: both already purged — nothing to do
-          continue;
-        }
+        } else if (!localDoc && remoteDoc) {
+          // Remote-only: pull to local. Same E11000 guard symmetry — a
+          // concurrent sync from another instance could have already
+          // pulled the same doc to a shared local store.
+          const full = await hydrateRemote(remoteDoc);
+          if (!full) continue;
+          const doc = this.stripForTransfer(full);
+          const transformed = transformDoc ? transformDoc(doc, "toLocal") : doc;
+          try {
+            await localCol.insertOne({ ...transformed, _id: new ObjectId() });
+            result.pulled++;
+          } catch (err: unknown) {
+            if (!isDuplicateKeyError(err)) throw err;
+          }
+        } else if (localDoc && remoteDoc) {
+          // Both exist: handle conflicts
+          const localDeleted = localDoc._deletedAt != null;
+          const remoteDeleted = remoteDoc._deletedAt != null;
+          const localPurged = localDoc._purged === true;
+          const remotePurged = remoteDoc._purged === true;
 
-        if (localDeleted && remoteDeleted) {
-          // Both soft-deleted (in trash) — nothing to do
-          continue;
-        }
+          // `_purged` is the "delete forever" tombstone (see Filament model
+          // doc comment). It's a one-way flag — once set on either peer, it
+          // wins over any other state, including a remote update that
+          // happened after the local purge. Without this branch, a hard
+          // delete on one peer was getting resurrected from the other side
+          // on the next sync cycle (#213).
+          if (localPurged || remotePurged) {
+            if (localPurged && !remotePurged) {
+              await remoteCol.updateOne(
+                { _id: remoteDoc._id },
+                { $set: { _purged: true, _deletedAt: localDoc._deletedAt ?? new Date() } },
+              );
+              result.deleted++;
+            } else if (!localPurged && remotePurged) {
+              await localCol.updateOne(
+                { _id: localDoc._id },
+                { $set: { _purged: true, _deletedAt: remoteDoc._deletedAt ?? new Date() } },
+              );
+              result.deleted++;
+            }
+            // else: both already purged — nothing to do
+            continue;
+          }
 
-        if (localDeleted && !remoteDeleted) {
-          // Deleted locally — propagate if the deletion is at least as
-          // recent as the remote update. GH #317: `>=` (not `>`) so the
-          // delete wins on a timestamp tie — an equal-millisecond
-          // delete-right-after-edit must not resurrect the row. NaN-safe
-          // via readTimestamp ?? 0.
-          const localDeletedAt = SyncService.readTimestamp(localDoc._deletedAt) ?? 0;
-          const remoteUpdatedAt = SyncService.readUpdatedAt(remoteDoc) ?? 0;
-          if (localDeletedAt >= remoteUpdatedAt) {
-            await remoteCol.updateOne({ _id: remoteDoc._id }, { $set: { _deletedAt: localDoc._deletedAt } });
-            result.deleted++;
-          } else {
-            // Remote was updated strictly after local delete — resurrect locally
-            const full = await hydrateRemote(remoteDoc);
-            if (full) {
-              const doc = this.stripForTransfer(full);
-              const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(localCol, localDoc._id) : undefined;
-              const transformed = transformDoc ? transformDoc(doc, "toLocal", targetSpoolIds) : doc;
-              // GH #1004 F3: replaceOne, not $set. A whole-doc LWW copy must
-              // also DELETE fields the source no longer has — the $unset
-              // un-pinning flows (#951/#969/#971 un-pin a variant override so
-              // GH #106 inheritance resumes) leave a field absent on the
-              // source; $set can't remove it, and the equal-updatedAt result
-              // then freezes the divergence forever. `transformed` is the
-              // stripped source (no _id/__v), so replaceOne keeps the target
-              // _id. Targeted flag $sets above stay $set (they mutate one key).
-              // GH #1142: a resurrect sets a name too, and can contend.
-              if (
-                await writeWithRenameStaging(localCol, localDoc._id as ObjectId, transformed.name, () =>
-                  localCol.replaceOne({ _id: localDoc._id }, { ...transformed, _deletedAt: null }),
-                )
-              ) {
-                result.pulled++;
+          if (localDeleted && remoteDeleted) {
+            // Both soft-deleted (in trash) — nothing to do
+            continue;
+          }
+
+          if (localDeleted && !remoteDeleted) {
+            // Deleted locally — propagate if the deletion is at least as
+            // recent as the remote update. GH #317: `>=` (not `>`) so the
+            // delete wins on a timestamp tie — an equal-millisecond
+            // delete-right-after-edit must not resurrect the row. NaN-safe
+            // via readTimestamp ?? 0.
+            const localDeletedAt = SyncService.readTimestamp(localDoc._deletedAt) ?? 0;
+            const remoteUpdatedAt = SyncService.readUpdatedAt(remoteDoc) ?? 0;
+            if (localDeletedAt >= remoteUpdatedAt) {
+              await remoteCol.updateOne({ _id: remoteDoc._id }, { $set: { _deletedAt: localDoc._deletedAt } });
+              result.deleted++;
+            } else {
+              // Remote was updated strictly after local delete — resurrect locally
+              const full = await hydrateRemote(remoteDoc);
+              if (full) {
+                const doc = this.stripForTransfer(full);
+                const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(localCol, localDoc._id) : undefined;
+                const transformed = transformDoc ? transformDoc(doc, "toLocal", targetSpoolIds) : doc;
+                // GH #1004 F3: replaceOne, not $set. A whole-doc LWW copy must
+                // also DELETE fields the source no longer has — the $unset
+                // un-pinning flows (#951/#969/#971 un-pin a variant override so
+                // GH #106 inheritance resumes) leave a field absent on the
+                // source; $set can't remove it, and the equal-updatedAt result
+                // then freezes the divergence forever. `transformed` is the
+                // stripped source (no _id/__v), so replaceOne keeps the target
+                // _id. Targeted flag $sets above stay $set (they mutate one key).
+                // GH #1142: a resurrect sets a name too, and can contend.
+                if (
+                  await writeWithRenameStaging(localCol, localDoc._id as ObjectId, transformed.name, () =>
+                    localCol.replaceOne({ _id: localDoc._id }, { ...transformed, _deletedAt: null }),
+                  )
+                ) {
+                  result.pulled++;
+                }
               }
             }
+            continue;
           }
-          continue;
-        }
 
-        if (!localDeleted && remoteDeleted) {
-          // Mirror of the branch above — delete wins on a tie (GH #317).
-          const remoteDeletedAt = SyncService.readTimestamp(remoteDoc._deletedAt) ?? 0;
-          const localUpdatedAt = SyncService.readUpdatedAt(localDoc) ?? 0;
-          if (remoteDeletedAt >= localUpdatedAt) {
-            await localCol.updateOne({ _id: localDoc._id }, { $set: { _deletedAt: remoteDoc._deletedAt } });
-            result.deleted++;
-          } else {
+          if (!localDeleted && remoteDeleted) {
+            // Mirror of the branch above — delete wins on a tie (GH #317).
+            const remoteDeletedAt = SyncService.readTimestamp(remoteDoc._deletedAt) ?? 0;
+            const localUpdatedAt = SyncService.readUpdatedAt(localDoc) ?? 0;
+            if (remoteDeletedAt >= localUpdatedAt) {
+              await localCol.updateOne({ _id: localDoc._id }, { $set: { _deletedAt: remoteDoc._deletedAt } });
+              result.deleted++;
+            } else {
+              const full = await hydrateLocal(localDoc);
+              if (full) {
+                const doc = this.stripForTransfer(full);
+                const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(remoteCol, remoteDoc._id) : undefined;
+                const transformed = transformDoc ? transformDoc(doc, "toRemote", targetSpoolIds) : doc;
+                // GH #1004 F3: replaceOne so a whole-doc copy also drops fields
+                // the source no longer carries (see the toLocal branch above).
+                // GH #1142: see the toLocal resurrect above.
+                if (
+                  await writeWithRenameStaging(remoteCol, remoteDoc._id as ObjectId, transformed.name, () =>
+                    remoteCol.replaceOne({ _id: remoteDoc._id }, { ...transformed, _deletedAt: null }),
+                  )
+                ) {
+                  result.pushed++;
+                }
+              }
+            }
+            continue;
+          }
+
+          // Both active — last-write-wins. GH #317: NaN-safe timestamps so
+          // a doc missing `updatedAt` doesn't stall the merge (it sorts as
+          // epoch 0 rather than making every comparison false).
+          const localTime = SyncService.readUpdatedAt(localDoc) ?? 0;
+          const remoteTime = SyncService.readUpdatedAt(remoteDoc) ?? 0;
+
+          if (localTime > remoteTime) {
+            // Local is newer — push to remote
             const full = await hydrateLocal(localDoc);
             if (full) {
               const doc = this.stripForTransfer(full);
               const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(remoteCol, remoteDoc._id) : undefined;
               const transformed = transformDoc ? transformDoc(doc, "toRemote", targetSpoolIds) : doc;
-              // GH #1004 F3: replaceOne so a whole-doc copy also drops fields
-              // the source no longer carries (see the toLocal branch above).
-              // GH #1142: see the toLocal resurrect above.
+              // GH #1004 F3: replaceOne so the LWW copy drops fields the source
+              // deleted (un-pin $unset flows); $set would freeze the divergence.
+              // GH #1142: a rename may want a name another row still holds.
               if (
                 await writeWithRenameStaging(remoteCol, remoteDoc._id as ObjectId, transformed.name, () =>
-                  remoteCol.replaceOne({ _id: remoteDoc._id }, { ...transformed, _deletedAt: null }),
+                  remoteCol.replaceOne({ _id: remoteDoc._id }, transformed),
                 )
               ) {
-                result.pushed++;
+                result.updated++;
+              }
+            }
+          } else if (remoteTime > localTime) {
+            // Remote is newer — pull to local
+            const full = await hydrateRemote(remoteDoc);
+            if (full) {
+              const doc = this.stripForTransfer(full);
+              const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(localCol, localDoc._id) : undefined;
+              const transformed = transformDoc ? transformDoc(doc, "toLocal", targetSpoolIds) : doc;
+              // GH #1004 F3: replaceOne (see the toRemote branch above).
+              // GH #1142: see the toRemote branch above.
+              if (
+                await writeWithRenameStaging(localCol, localDoc._id as ObjectId, transformed.name, () =>
+                  localCol.replaceOne({ _id: localDoc._id }, transformed),
+                )
+              ) {
+                result.updated++;
               }
             }
           }
-          continue;
+          // Equal timestamps — no action needed
         }
-
-        // Both active — last-write-wins. GH #317: NaN-safe timestamps so
-        // a doc missing `updatedAt` doesn't stall the merge (it sorts as
-        // epoch 0 rather than making every comparison false).
-        const localTime = SyncService.readUpdatedAt(localDoc) ?? 0;
-        const remoteTime = SyncService.readUpdatedAt(remoteDoc) ?? 0;
-
-        if (localTime > remoteTime) {
-          // Local is newer — push to remote
-          const full = await hydrateLocal(localDoc);
-          if (full) {
-            const doc = this.stripForTransfer(full);
-            const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(remoteCol, remoteDoc._id) : undefined;
-            const transformed = transformDoc ? transformDoc(doc, "toRemote", targetSpoolIds) : doc;
-            // GH #1004 F3: replaceOne so the LWW copy drops fields the source
-            // deleted (un-pin $unset flows); $set would freeze the divergence.
-            // GH #1142: a rename may want a name another row still holds.
-            if (
-              await writeWithRenameStaging(remoteCol, remoteDoc._id as ObjectId, transformed.name, () =>
-                remoteCol.replaceOne({ _id: remoteDoc._id }, transformed),
-              )
-            ) {
-              result.updated++;
-            }
-          }
-        } else if (remoteTime > localTime) {
-          // Remote is newer — pull to local
-          const full = await hydrateRemote(remoteDoc);
-          if (full) {
-            const doc = this.stripForTransfer(full);
-            const targetSpoolIds = transformDoc ? await fetchTargetSpoolIds(localCol, localDoc._id) : undefined;
-            const transformed = transformDoc ? transformDoc(doc, "toLocal", targetSpoolIds) : doc;
-            // GH #1004 F3: replaceOne (see the toRemote branch above).
-            // GH #1142: see the toRemote branch above.
-            if (
-              await writeWithRenameStaging(localCol, localDoc._id as ObjectId, transformed.name, () =>
-                localCol.replaceOne({ _id: localDoc._id }, transformed),
-              )
-            ) {
-              result.updated++;
-            }
-          }
-        }
-        // Equal timestamps — no action needed
       }
+
+    } catch (loopErr) {
+      await settleStagedRenames();
+      // `trySync` discards this result object and keeps only the message, so
+      // on THIS path the stranding has to ride the error instead.
+      if (strandedNotices.length > 0) {
+        throw withStrandingNotice(loopErr, strandedNotices.join(" "));
+      }
+      throw loopErr;
     }
 
-    // GH #1142: settle any placeholder whose real write never landed.
-    //
-    // A row is moved aside on the expectation that its own write follows
-    // moments later. If that write did not happen — its branch threw, the row
-    // was skipped, the LWW went the other way — it is left named
-    // `__sync-staging-…`, which is VISIBLE in the UI and worse than the
-    // collision being avoided. Restore the original name when it is free
-    // again; if it is not, leave the placeholder and report, because
-    // overwriting the row that took it would destroy real data.
-    for (const staged of stagedRenames) {
-      try {
-        const row = await staged.col.findOne(
-          { _id: staged.id },
-          { projection: { name: 1 } },
-        );
-        if (!row || !isStagingPlaceholder(row.name)) continue; // its write landed
-        const taken = await staged.col.findOne(
-          { name: staged.originalName, _deletedAt: null, _id: { $ne: staged.id } },
-          { projection: { _id: 1 } },
-        );
-        if (taken) {
-          // NAME the row, do not just count it (Codex P1). This branch and the
-          // catch below are the two REACHABLE producers of a permanent
-          // placeholder — no race, no privilege change — and until now their
-          // only trace was a console line plus a counter whose rendering could
-          // be overwritten entirely (see the `heldBack` note at the end).
-          result.nameConflicts = (result.nameConflicts ?? 0) + 1;
-          strandedNotices.push(
-            strandedPlaceholderNotice({
-              collection: collectionName,
-              id: String(staged.id),
-              originalName: staged.originalName,
-              placeholderName: staged.placeholderName,
-            }),
-          );
-          console.warn(
-            `[sync] ${collectionName}: left a staging placeholder on ${String(staged.id)} — ` +
-              `${JSON.stringify(staged.originalName)} was taken while it was moved aside.`,
-          );
-          continue;
-        }
-        // CONDITIONAL on the placeholder we actually put there (Codex P1).
-        // Another app or syncer can write this row between the read above and
-        // here; an `_id`-only filter would overwrite that newer real name with
-        // the old one — and because the concurrent write may already have
-        // copied its `updatedAt`, the peers could end up with different names
-        // at an EQUAL timestamp, which LWW then never repairs.
-        const restored = await staged.col.updateOne(
-          { _id: staged.id, name: staged.placeholderName },
-          { $set: { name: staged.originalName } },
-        );
-        if (!restored.modifiedCount) continue; // someone else moved it on
-      } catch (settleErr) {
-        // SURFACE it (Codex P1). Swallowing left the collection reporting
-        // success with a placeholder still stored, and nothing scans for stale
-        // placeholders on a later cycle — worse, a row staged after its own
-        // write landed shares its source's `updatedAt`, so LWW does no copy
-        // and never repairs it either.
-        result.nameConflicts = (result.nameConflicts ?? 0) + 1;
-        strandedNotices.push(
-          strandedPlaceholderNotice({
-            collection: collectionName,
-            id: String(staged.id),
-            originalName: staged.originalName,
-            placeholderName: staged.placeholderName,
-          }),
-        );
-        console.error(
-          `[sync] ${collectionName}: could not restore ${JSON.stringify(staged.originalName)} ` +
-            `on ${String(staged.id)}; it still holds a staging placeholder.`,
-          settleErr,
-        );
-      }
-    }
+    await settleStagedRenames();
 
     // GH #1116 (Codex P1): a HELD-BACK collection must read as a FAILED
     // prerequisite, or `trySync` lets its dependents run against a partial

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1141,7 +1141,13 @@ export class SyncService extends EventEmitter {
     // cycle (default every 5 min) just to compare four metadata fields —
     // on an Atlas hybrid install with photo-attached spools that's tens
     // to hundreds of MB of metered egress per cycle.
-    const SLIM_PROJECTION = { syncId: 1, _deletedAt: 1, _purged: 1, updatedAt: 1 };
+    // GH #1142 adds `name`: the rename-staging predicate has to know whether a
+    // blocker's own copy would rewrite its name on THIS side, which means
+    // comparing the two sides' names. It is a short string, so it does not
+    // reopen the GH #511 egress problem — that was about pulling full bodies
+    // (base64 photoDataUrl blobs, unbounded usageHistory[], calibrations[])
+    // for every row on every cycle, which the hydrate helpers still avoid.
+    const SLIM_PROJECTION = { syncId: 1, _deletedAt: 1, _purged: 1, updatedAt: 1, name: 1 };
     const localDocs = await localCol.find({}, { projection: SLIM_PROJECTION }).toArray();
     const remoteDocs = await remoteCol.find({}, { projection: SLIM_PROJECTION }).toArray();
 
@@ -1207,11 +1213,57 @@ export class SyncService extends EventEmitter {
      * Run a write that sets `name`; on a name collision, move the blocking row
      * aside and retry ONCE.
      *
-     * Staging is only legitimate when the blocker is itself in this pass's
-     * write set — then its own write lands its real name moments later. A
-     * blocker that isn't moving is the unsatisfiable case: report it and leave
-     * both peers alone rather than clobbering a record the user still wants.
+     * Staging is legitimate ONLY when the blocker's own LWW outcome writes to
+     * THIS target with a different name — then its real name lands moments
+     * later. Anything else is the unsatisfiable case: report it and leave both
+     * peers alone rather than clobbering a record the user still wants.
+     *
+     * "Paired" is NOT that condition, and the gap is the whole hazard (Codex
+     * P1). A paired row's LWW can copy in the OPPOSITE direction, or do
+     * nothing on an equal timestamp — in either case nothing rewrites its name
+     * on this target, so the placeholder is stranded, and a later copy in the
+     * other direction can propagate `__sync-staging-…` to the other peer. By
+     * then cleanup cannot restore it either, because the row it made way for
+     * owns its original name.
      */
+    /**
+     * Will this pass rewrite `syncId`'s NAME on `col`, to something different
+     * from what that row is called there now?
+     *
+     * This is the only condition under which moving the row aside is safe. It
+     * re-derives just the DIRECTION of the LWW decision — the timestamp
+     * comparison — rather than the whole outcome, because that comparison is
+     * small, total, and cheap to keep honest; duplicating the entire branch
+     * tree is what would drift.
+     *
+     * Deliberately conservative. Every branch it cannot prove (a delete, a
+     * resurrect, an equal timestamp, a missing side) answers false, which
+     * downgrades the case to "unsatisfiable, reported" — a visible conflict,
+     * never a stranded placeholder.
+     */
+    const willRewriteNameOn = (col: typeof localCol, syncId: string): boolean => {
+      const localDoc = localBySyncId.get(syncId);
+      const remoteDoc = remoteBySyncId.get(syncId);
+      if (!localDoc || !remoteDoc) return false; // unpaired: nothing writes it here
+
+      // A tombstoned row on either side takes the delete/resurrect branches,
+      // whose outcomes this shortcut does not model.
+      if (localDoc._deletedAt || remoteDoc._deletedAt) return false;
+
+      const localTime = SyncService.readUpdatedAt(localDoc) ?? 0;
+      const remoteTime = SyncService.readUpdatedAt(remoteDoc) ?? 0;
+      if (localTime === remoteTime) return false; // equal: no copy at all
+
+      // The copy runs from the newer side to the older one.
+      const source = localTime > remoteTime ? localDoc : remoteDoc;
+      const target = localTime > remoteTime ? remoteDoc : localDoc;
+      const targetIsRemote = localTime > remoteTime;
+      if (targetIsRemote !== (col === remoteCol)) return false; // writes the OTHER side
+
+      // ...and only if the name actually changes there.
+      return typeof source.name === "string" && source.name !== target.name;
+    };
+
     const writeWithRenameStaging = async (
       col: typeof localCol,
       targetId: ObjectId,
@@ -1230,28 +1282,53 @@ export class SyncService extends EventEmitter {
         );
         if (!blocker || String(blocker._id) === String(targetId)) throw err;
 
-        // Only a row this pass is going to write can be moved aside.
         const blockerSyncId = typeof blocker.syncId === "string" ? blocker.syncId : null;
-        if (!blockerSyncId || !pairedSyncIds.has(blockerSyncId)) {
+        const blockerName = typeof blocker.name === "string" ? blocker.name : null;
+        if (!blockerSyncId || !blockerName || !willRewriteNameOn(col, blockerSyncId)) {
           result.nameConflicts = (result.nameConflicts ?? 0) + 1;
           console.warn(
             `[sync] ${collectionName}: cannot apply name ${JSON.stringify(desiredName)} — ` +
-              `held by a row this pass is not moving. Rename one of them.`,
+              `held by a row this pass will not rewrite on this side. Rename one of them.`,
           );
           return false;
         }
 
+        // CONDITIONAL on what was observed (Codex P1). Between the findOne and
+        // this update another app or syncer can rename or delete the blocker;
+        // an `_id`-only filter would overwrite that concurrent change with a
+        // placeholder, the retry would then take a name its owner had just
+        // released, and cleanup could never restore the original because it is
+        // now occupied. A zero-match means the world moved — report rather
+        // than force.
         const placeholder = placeholderFor(String(blocker._id), stagingNonce);
-        await col.updateOne({ _id: blocker._id }, { $set: { name: placeholder } });
+        const staged = await col.updateOne(
+          { _id: blocker._id, name: blockerName, _deletedAt: null },
+          { $set: { name: placeholder } },
+        );
+        if (!staged.modifiedCount) {
+          result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+          console.warn(
+            `[sync] ${collectionName}: the row holding ${JSON.stringify(desiredName)} changed ` +
+              `while being moved aside; leaving both rows alone this cycle.`,
+          );
+          return false;
+        }
         // Remember it so an unsettled placeholder can be restored below — a
         // row left named `__sync-staging-…` is visible in the UI and worse
         // than the collision we were avoiding.
-        stagedRenames.push({
-          col,
-          id: blocker._id as ObjectId,
-          originalName: typeof blocker.name === "string" ? blocker.name : desiredName,
-        });
-        await write();
+        stagedRenames.push({ col, id: blocker._id as ObjectId, originalName: blockerName });
+        try {
+          await write();
+        } catch (retryErr) {
+          // ROLL BACK IMMEDIATELY (Codex P2). A throw here exits syncCollection
+          // through `trySync`, so the settlement loop at the end never runs and
+          // nothing scans for stale placeholders on a later cycle — the row
+          // would keep the temporary name indefinitely.
+          await col
+            .updateOne({ _id: blocker._id, name: placeholder }, { $set: { name: blockerName } })
+            .catch(() => {});
+          throw retryErr;
+        }
         return true;
       }
     };
@@ -1277,18 +1354,6 @@ export class SyncService extends EventEmitter {
       (localBySyncId.has(syncId) && remoteBySyncId.has(syncId) ? paired : unpaired).push(syncId);
     }
     const allSyncIds = pairedOnly ? paired : [...paired, ...unpaired];
-    // GH #1142: only a PAIRED row can be moved aside.
-    //
-    // "In this pass" is not enough, and the difference is load-bearing. An
-    // unpaired row is either remote-only (pulled to local — nothing writes its
-    // name on the remote) or local-only (inserted into remote — it isn't there
-    // to block anything yet). Either way no write on THIS target will give it
-    // a real name, so a placeholder put on it can never settle: it would be
-    // stranded as `__sync-staging-…`, visible in the UI, and if its original
-    // name were meanwhile taken by the row it made way for, unrecoverable.
-    //
-    // A paired row is exactly the case where the target IS written this pass.
-    const pairedSyncIds = new Set(paired);
     const heldBack = pairedOnly ? unpaired.length : 0;
     if (heldBack > 0) {
       console.warn(

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1365,9 +1365,26 @@ export class SyncService extends EventEmitter {
           // through `trySync`, so the settlement loop at the end never runs and
           // nothing scans for stale placeholders on a later cycle — the row
           // would keep the temporary name indefinitely.
-          await col
+          // SURFACE a failed rollback (Codex P2). If the original name was
+          // claimed while this row sat aside, the restore E11000s too — and
+          // discarding that left the blocker permanently named
+          // `__sync-staging-…`, because the throw below exits before
+          // settlement and nothing scans for stale placeholders on a later
+          // cycle. The original error still wins as the cause; this only makes
+          // sure the stranding is not silent.
+          const rolledBack = await col
             .updateOne({ _id: blocker._id, name: placeholder }, { $set: { name: blockerName } })
-            .catch(() => {});
+            .catch((rollbackErr: unknown) => {
+              console.error(
+                `[sync] ${collectionName}: could not roll ${String(blocker._id)} back to ` +
+                  `${JSON.stringify(blockerName)}; it still holds a staging placeholder.`,
+                rollbackErr,
+              );
+              return null;
+            });
+          if (!rolledBack?.modifiedCount) {
+            result.nameConflicts = (result.nameConflicts ?? 0) + 1;
+          }
           throw retryErr;
         }
         return true;

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -123,6 +123,43 @@ export function planRenameStaging(
     if (!holderByName.has(row.currentName)) holderByName.set(row.currentName, row);
   }
 
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  /**
+   * Which rows can actually VACATE the name they hold?
+   *
+   * Not just "is it moving" — its own destination has to be reachable too.
+   * Checking one level is insufficient (Codex P1): with A->B, B->C and C
+   * standing still, a one-level check stages B for A, A takes B's name, and
+   * then B cannot take C. Settlement cannot restore B either, because A now
+   * owns its original name — B is stranded as `__sync-staging-…` permanently.
+   *
+   * Unsatisfiability propagates BACKWARDS along the chain, so this is a
+   * fixpoint: start optimistic, then repeatedly knock out any row whose
+   * destination is held by a row that cannot vacate, until nothing changes. A
+   * pure cycle (A<->B) survives — each depends only on the other, and neither
+   * is ever knocked out — which is exactly right, since staging one of them
+   * frees the whole cycle.
+   */
+  const canVacate = new Set<string>();
+  for (const row of rows) {
+    if (row.willWrite && row.desiredName !== row.currentName) canVacate.add(row.id);
+  }
+  for (;;) {
+    let changed = false;
+    for (const id of [...canVacate]) {
+      const row = byId.get(id)!;
+      const holder = holderByName.get(row.desiredName);
+      if (!holder || holder.id === row.id) continue; // destination is free
+      if (!canVacate.has(holder.id)) {
+        // The row occupying our destination will never leave it.
+        canVacate.delete(id);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
   const stagedIds = new Set<string>();
   for (const row of rows) {
     if (!row.willWrite) continue;
@@ -131,10 +168,8 @@ export function planRenameStaging(
     const holder = holderByName.get(row.desiredName);
     if (!holder || holder.id === row.id) continue;
 
-    // The holder is moving too, so getting it out of the way unblocks this
-    // write and the holder's own write will give it its real name.
-    const holderIsMoving = holder.willWrite && holder.desiredName !== holder.currentName;
-    if (holderIsMoving) {
+    // Only move a holder aside when the whole chain behind it terminates.
+    if (canVacate.has(holder.id) && canVacate.has(row.id)) {
       if (!stagedIds.has(holder.id)) {
         stagedIds.add(holder.id);
         staged.push({
@@ -146,9 +181,8 @@ export function planRenameStaging(
       continue;
     }
 
-    // The holder is staying put — or is being written WITHOUT a rename, which
-    // means it is keeping this exact name. Two rows genuinely want one name;
-    // staging cannot help and writing anyway would either E11000 or clobber.
+    // Either the holder is staying put, or its own destination is blocked by
+    // something that is. Staging cannot help; report and write nothing.
     unsatisfiable.push({
       id: row.id,
       desiredName: row.desiredName,

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -237,29 +237,32 @@ export function strandedPlaceholderNotice(info: StrandedPlaceholder): string {
 const STRANDING_KEY = "strandingNotice";
 
 /**
- * Build the error a caller throws when a staged row could NOT be put back.
+ * Attach a stranding notice to an error on its way up.
  *
- * ONE factory rather than "compose a message, then tag it" because those are two
- * steps a later edit can desynchronise, and the resulting failure is silent and
- * identical to the bug this exists to fix. Composing and tagging in the same
- * expression makes an untagged stranding message unrepresentable.
+ * ONE factory rather than "compose a message, then tag it" because those are
+ * two steps a later edit can desynchronise, and the resulting failure is silent
+ * and identical to the bug this exists to fix. Composing and tagging in the
+ * same expression makes an untagged stranding message unrepresentable.
  *
  * The original error rides as `cause`, which matters beyond provenance: it is
  * where a driver error's `code` lives, and `new Error(msg, {cause})` does NOT
  * inherit it — so a consumer that classifies errors by code has to look through
  * `cause`, and can only do that if the cause is attached.
  *
+ * Notices ACCUMULATE. One pass can move several rows aside, and a failure late
+ * in that pass strands all of them at once; reporting only the last would be a
+ * quieter version of reporting none.
+ *
  * A duck-typed string property, not a subclass: `instanceof` fails silently if
  * the module is ever loaded twice, and a silent drop is exactly the failure mode
  * being designed out.
  */
-export function strandedPlaceholderError(
-  info: StrandedPlaceholder & { cause: unknown },
-): Error {
-  const notice = strandedPlaceholderNotice(info);
-  const causeText = info.cause instanceof Error ? info.cause.message : String(info.cause);
-  const err = new Error(`${notice} ${CAUSE_LEAD}${causeText}`, { cause: info.cause });
-  return Object.assign(err, { [STRANDING_KEY]: notice });
+export function withStrandingNotice(cause: unknown, notice: string): Error {
+  const existing = strandingNoticeOf(cause);
+  const combined = existing ? `${existing} ${notice}` : notice;
+  const causeText = cause instanceof Error ? cause.message : String(cause);
+  const err = new Error(`${combined} ${CAUSE_LEAD}${causeText}`, { cause });
+  return Object.assign(err, { [STRANDING_KEY]: combined });
 }
 
 /**

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -145,6 +145,35 @@ export function planRenameStaging(
   for (const row of rows) {
     if (row.willWrite && row.desiredName !== row.currentName) canVacate.add(row.id);
   }
+
+  // A CONTESTED destination poisons every row that desires it (Codex P1).
+  //
+  // Two rows desiring the same name can only happen when the SOURCE holds
+  // duplicate active names — a state the trim pass refuses to index and the
+  // sync continues through paired-only. At most one of them can win the name;
+  // the loser E11000s against the winner, whose write has by then LANDED, so
+  // moving the winner aside can never be settled — its original name is the
+  // contested one, which the loser's retry just took. Concretely: with target
+  // A="X", B="Y", C="Z" and desires A→"Y", B→"X", C→"Y", staging resolved the
+  // A↔B swap and then C collided with the now-final A; the cached plan still
+  // authorized staging A, C took "Y", and settlement could not restore A —
+  // stranded permanently.
+  //
+  // There is no principled winner to pick (write order is incidental), so
+  // every contender is refused: removed from `canVacate` BEFORE the fixpoint,
+  // which also cascades — a row whose destination is held by a contender
+  // cannot rely on it vacating, and is knocked out by the ordinary rule.
+  const desireCount = new Map<string, number>();
+  for (const row of rows) {
+    if (row.willWrite && row.desiredName !== row.currentName) {
+      desireCount.set(row.desiredName, (desireCount.get(row.desiredName) ?? 0) + 1);
+    }
+  }
+  for (const row of rows) {
+    if (canVacate.has(row.id) && (desireCount.get(row.desiredName) ?? 0) > 1) {
+      canVacate.delete(row.id);
+    }
+  }
   for (;;) {
     let changed = false;
     for (const id of [...canVacate]) {

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -193,40 +193,83 @@ export function planRenameStaging(
   return { staged, unsatisfiable };
 }
 
-/**
- * Compose the error a caller throws when a staged row could NOT be put back.
- *
- * Extracted here — pure, and next to the rest of the staging vocabulary —
- * because the failure it describes is a genuine race (the original name has to
- * be claimed by a third party in the window between staging and rollback) and
- * so cannot be induced from a sync test. Testing the message instead of the
- * race at least pins the two decisions that matter: that the stranding leads,
- * and that the cause survives.
- *
- * ## Why the stranding leads and the cause follows
- *
- * `wrapSyncErrorMessage` REPLACES the whole message when it recognises the
- * read-only-Atlas shape (GH #143), so anything appended after an auth-shaped
- * cause is dropped. Between the two, the durable problem has to win: a
- * permissions error recurs on the next cycle and re-tells its own story, while
- * a row left holding a placeholder is announced exactly once.
- *
- * (The conflict should not arise anyway — staging already wrote to this same
- * collection a moment earlier, which proves writes were permitted.)
- */
-export function strandedPlaceholderMessage(input: {
+/** Facts about a row left holding a staging placeholder. */
+export interface StrandedPlaceholder {
   collection: string;
   id: string;
   originalName: string;
   placeholderName: string;
-  cause: unknown;
-}): string {
-  const cause =
-    input.cause instanceof Error ? input.cause.message : String(input.cause);
+}
+
+/**
+ * The lead-in that joins a stranding notice to the failure that caused it.
+ *
+ * Shared so the composer and any consumer that re-attaches the notice after
+ * normalising an error agree on the wording.
+ */
+export const CAUSE_LEAD = "The failure was: ";
+
+/**
+ * The CAUSE-FREE sentence describing a stranded row.
+ *
+ * Cause-free is the load-bearing property, not a style choice. `wrapSyncErrorMessage`
+ * decides whether an error is the read-only-Atlas shape by testing a REGEX over
+ * the message, and it REPLACES the whole string when it matches. Interpolating a
+ * cause into the same string is therefore how the stranding disappears — first
+ * because an auth-shaped cause makes the composed message match, and second
+ * because the notice quotes user-typed entity names, so a row could be named
+ * into matching it. Keeping the notice free of the cause means the notice can be
+ * re-attached AFTER any such decision, and can never be the thing that trips it.
+ *
+ * An earlier version relied on ORDER — stranding first, cause second — which
+ * achieves nothing: the wrapper returns a fresh string and never reads the
+ * original at all.
+ */
+export function strandedPlaceholderNotice(info: StrandedPlaceholder): string {
   return (
-    `${input.collection} ${input.id} was moved aside to free the name ` +
-    `${JSON.stringify(input.originalName)} and could not be restored — it still holds the ` +
-    `temporary name ${JSON.stringify(input.placeholderName)}. Rename it back manually. ` +
-    `The write that failed reported: ${cause}`
+    `${info.collection} ${info.id} was moved aside to free the name ` +
+    `${JSON.stringify(info.originalName)} and could not be restored — it still holds the ` +
+    `temporary name ${JSON.stringify(info.placeholderName)}. Rename it back manually.`
   );
+}
+
+/** Where the notice is stashed on a thrown error, for consumers to recover. */
+const STRANDING_KEY = "strandingNotice";
+
+/**
+ * Build the error a caller throws when a staged row could NOT be put back.
+ *
+ * ONE factory rather than "compose a message, then tag it" because those are two
+ * steps a later edit can desynchronise, and the resulting failure is silent and
+ * identical to the bug this exists to fix. Composing and tagging in the same
+ * expression makes an untagged stranding message unrepresentable.
+ *
+ * The original error rides as `cause`, which matters beyond provenance: it is
+ * where a driver error's `code` lives, and `new Error(msg, {cause})` does NOT
+ * inherit it — so a consumer that classifies errors by code has to look through
+ * `cause`, and can only do that if the cause is attached.
+ *
+ * A duck-typed string property, not a subclass: `instanceof` fails silently if
+ * the module is ever loaded twice, and a silent drop is exactly the failure mode
+ * being designed out.
+ */
+export function strandedPlaceholderError(
+  info: StrandedPlaceholder & { cause: unknown },
+): Error {
+  const notice = strandedPlaceholderNotice(info);
+  const causeText = info.cause instanceof Error ? info.cause.message : String(info.cause);
+  const err = new Error(`${notice} ${CAUSE_LEAD}${causeText}`, { cause: info.cause });
+  return Object.assign(err, { [STRANDING_KEY]: notice });
+}
+
+/**
+ * Recover the cause-free stranding notice from an error, or null.
+ *
+ * Total by design — it is called from a generic catch that has no idea what
+ * threw.
+ */
+export function strandingNoticeOf(err: unknown): string | null {
+  if (typeof err !== "object" || err === null) return null;
+  const value = (err as Record<string, unknown>)[STRANDING_KEY];
+  return typeof value === "string" ? value : null;
 }

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -1,0 +1,160 @@
+/**
+ * Staging contended renames so a hybrid-sync copy can't deadlock on the
+ * unique `name` index (GH #1142).
+ *
+ * ## The problem
+ *
+ * `syncCollection` decides each row's LWW outcome and writes it immediately,
+ * with no awareness that the name it is about to write is currently held by a
+ * DIFFERENT row that the same pass is about to move. Every entity collection
+ * has a partial-unique index on `name`, so the write is rejected outright.
+ *
+ * Three distinct shapes, and only the first was reported:
+ *
+ *   - **Cycle** — local `A="X" B="Y"`, remote `A="Y" B="X"`. Whichever row is
+ *     written first wants a name the other still holds. No ordering fixes it;
+ *     reversing only changes which one fails.
+ *   - **Chain** — `A` wants the name `B` is about to vacate. This one IS
+ *     order-dependent, and the existing paired-before-unpaired ordering
+ *     already resolves some of it, but not when the chain runs the other way.
+ *   - **Unsatisfiable** — two rows genuinely want the same final name, and one
+ *     of them is not moving. No amount of staging helps; it needs a human.
+ *
+ * The failure is permanent, not transient: it repeats every cycle, and via
+ * `trySync`'s dependency chain a failure in `locations` cascade-skips
+ * `filaments` and `printhistories`, so one swapped pair can stall most of sync
+ * indefinitely.
+ *
+ * ## The approach
+ *
+ * Classic unique-value-swap staging. Before the copies, move every CONTENDED
+ * holder to a placeholder name that cannot collide; run the copies, which
+ * write the real names; then settle anything still holding a placeholder.
+ *
+ * This module is the decision half — pure, so the graph reasoning is testable
+ * without two live databases. The caller does the I/O.
+ *
+ * ## Why the placeholder must be settled, not assumed
+ *
+ * A row is moved to a placeholder on the expectation that its own write lands
+ * moments later. If that write does not happen — the copy threw, the process
+ * died, the row was skipped — the row is left named `__sync-staging-…`, which
+ * is visible in the UI and worse than the duplicate we were avoiding. The
+ * caller MUST restore anything unsettled, which is why `planRenameStaging`
+ * returns the original name alongside the placeholder.
+ */
+
+/** A row on the receiving peer, and the name this pass intends to give it. */
+export interface RenameIntent {
+  /** Opaque row identity — the caller's `_id`, stringified. */
+  id: string;
+  /** What the row is called on the target right now. */
+  currentName: string;
+  /**
+   * What this pass will write. Equal to `currentName` for a row that is being
+   * copied without a rename, which still matters: such a row HOLDS its name
+   * and can therefore block someone else.
+   */
+  desiredName: string;
+  /** False for a row that is present but not being written this pass. It can
+   *  still block a name, and it can never be staged out of the way. */
+  willWrite: boolean;
+}
+
+export interface StagedRename {
+  id: string;
+  /** The name to restore if this row's real write never lands. */
+  originalName: string;
+  placeholderName: string;
+}
+
+export interface UnsatisfiableRename {
+  id: string;
+  desiredName: string;
+  /** The row that holds `desiredName` and is not going to give it up. */
+  heldBy: string;
+}
+
+export interface RenameStagingPlan {
+  /** Rows to move to a placeholder BEFORE any copy. */
+  staged: StagedRename[];
+  /** Rows whose desired name cannot be satisfied — report, do not write. */
+  unsatisfiable: UnsatisfiableRename[];
+}
+
+/**
+ * A placeholder that cannot collide with a real name or with another
+ * placeholder.
+ *
+ * The prefix is deliberately conspicuous: if one is ever left behind by a
+ * crash, it should be obvious in the UI what it is and where it came from,
+ * rather than looking like a name the user typed.
+ */
+export const STAGING_PREFIX = "__sync-staging-";
+
+export function placeholderFor(id: string, nonce: string): string {
+  return `${STAGING_PREFIX}${nonce}-${id}`;
+}
+
+/** Is this a placeholder left over from a previous (crashed) pass? */
+export function isStagingPlaceholder(name: unknown): boolean {
+  return typeof name === "string" && name.startsWith(STAGING_PREFIX);
+}
+
+/**
+ * Decide which rows must be moved aside before the copies, and which desired
+ * names cannot be satisfied at all.
+ *
+ * `nonce` makes the placeholders unique per pass so two concurrent syncers
+ * cannot generate the same one.
+ */
+export function planRenameStaging(
+  rows: readonly RenameIntent[],
+  nonce: string,
+): RenameStagingPlan {
+  const staged: StagedRename[] = [];
+  const unsatisfiable: UnsatisfiableRename[] = [];
+
+  // Who currently holds each name on the target. A duplicate current name
+  // shouldn't be possible under the unique index, but if the index is missing
+  // the FIRST holder wins the slot — matching what the index would enforce.
+  const holderByName = new Map<string, RenameIntent>();
+  for (const row of rows) {
+    if (!holderByName.has(row.currentName)) holderByName.set(row.currentName, row);
+  }
+
+  const stagedIds = new Set<string>();
+  for (const row of rows) {
+    if (!row.willWrite) continue;
+    if (row.desiredName === row.currentName) continue;
+
+    const holder = holderByName.get(row.desiredName);
+    if (!holder || holder.id === row.id) continue;
+
+    // The holder is moving too, so getting it out of the way unblocks this
+    // write and the holder's own write will give it its real name.
+    const holderIsMoving = holder.willWrite && holder.desiredName !== holder.currentName;
+    if (holderIsMoving) {
+      if (!stagedIds.has(holder.id)) {
+        stagedIds.add(holder.id);
+        staged.push({
+          id: holder.id,
+          originalName: holder.currentName,
+          placeholderName: placeholderFor(holder.id, nonce),
+        });
+      }
+      continue;
+    }
+
+    // The holder is staying put — or is being written WITHOUT a rename, which
+    // means it is keeping this exact name. Two rows genuinely want one name;
+    // staging cannot help and writing anyway would either E11000 or clobber.
+    unsatisfiable.push({
+      id: row.id,
+      desiredName: row.desiredName,
+      heldBy: holder.id,
+    });
+  }
+
+  return { staged, unsatisfiable };
+}

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -192,3 +192,41 @@ export function planRenameStaging(
 
   return { staged, unsatisfiable };
 }
+
+/**
+ * Compose the error a caller throws when a staged row could NOT be put back.
+ *
+ * Extracted here — pure, and next to the rest of the staging vocabulary —
+ * because the failure it describes is a genuine race (the original name has to
+ * be claimed by a third party in the window between staging and rollback) and
+ * so cannot be induced from a sync test. Testing the message instead of the
+ * race at least pins the two decisions that matter: that the stranding leads,
+ * and that the cause survives.
+ *
+ * ## Why the stranding leads and the cause follows
+ *
+ * `wrapSyncErrorMessage` REPLACES the whole message when it recognises the
+ * read-only-Atlas shape (GH #143), so anything appended after an auth-shaped
+ * cause is dropped. Between the two, the durable problem has to win: a
+ * permissions error recurs on the next cycle and re-tells its own story, while
+ * a row left holding a placeholder is announced exactly once.
+ *
+ * (The conflict should not arise anyway — staging already wrote to this same
+ * collection a moment earlier, which proves writes were permitted.)
+ */
+export function strandedPlaceholderMessage(input: {
+  collection: string;
+  id: string;
+  originalName: string;
+  placeholderName: string;
+  cause: unknown;
+}): string {
+  const cause =
+    input.cause instanceof Error ? input.cause.message : String(input.cause);
+  return (
+    `${input.collection} ${input.id} was moved aside to free the name ` +
+    `${JSON.stringify(input.originalName)} and could not be restored — it still holds the ` +
+    `temporary name ${JSON.stringify(input.placeholderName)}. Rename it back manually. ` +
+    `The write that failed reported: ${cause}`
+  );
+}

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -222,6 +222,43 @@ export function planRenameStaging(
   return { staged, unsatisfiable };
 }
 
+/**
+ * May the blocker be moved aside, given a FRESH read of its source row?
+ *
+ * Staging a blocker is a bet that its own pending write — later in this same
+ * pass — will rename it away, vacating the name for good. The write's body is
+ * hydrated from the source document AT WRITE TIME, so the only honest way to
+ * predict it is to read that same document now (Codex P1, sixth pass — the
+ * previous check compared the blocker's fresh name against its SNAPSHOT
+ * desired name, and a source renamed after the snapshot made the two diverge:
+ * staging was authorized for a rename that was no longer coming, and the
+ * placeholder could never be settled).
+ *
+ * The table, and why each row refuses:
+ *  - not a string: the source is gone or malformed — no rename is provably
+ *    coming, and hydration at write time will skip the copy entirely;
+ *  - equal to the blocker's current name: nothing will move the blocker off
+ *    this name. This one clause covers three distinct histories at once — the
+ *    write already LANDED (it transferred exactly this name), the write is a
+ *    no-op rename, and the source was REVERTED to match after the snapshot;
+ *  - a staging placeholder: the source row is itself moved aside on its own
+ *    side, and the pending write would transfer the placeholder text verbatim
+ *    onto this peer — the propagation this module exists to prevent.
+ *
+ * A residual race remains by construction: the source can change between this
+ * read and the blocker's write, and without transactions that window cannot
+ * be zero. It shrinks from pass-length to the gap between two adjacent
+ * writes, and settlement now names anything that still slips through.
+ */
+export function pendingRenameCanFreeName(
+  freshSourceName: unknown,
+  blockerCurrentName: string,
+): boolean {
+  if (typeof freshSourceName !== "string") return false;
+  if (isStagingPlaceholder(freshSourceName)) return false;
+  return freshSourceName !== blockerCurrentName;
+}
+
 /** Facts about a row left holding a staging placeholder. */
 export interface StrandedPlaceholder {
   collection: string;

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -104,6 +104,46 @@ describe("planRenameStaging", () => {
   it("the nonce separates concurrent passes", () => {
     expect(placeholderFor("a", "n1")).not.toBe(placeholderFor("a", "n2"));
   });
+
+  /**
+   * GH #1142 (Codex P1): a one-level check is not enough. With A->B, B->C and
+   * C standing still, staging B for A lets A take B's name, but B can then
+   * never take C — and settlement cannot restore B, because A owns its
+   * original name. B would be stranded as a placeholder permanently.
+   */
+  it("refuses the whole CHAIN when its far end is blocked", () => {
+    const plan = planRenameStaging(
+      [row("a", "A", "B"), row("b", "B", "C"), row("c", "C", "C", false)],
+      "n1",
+    );
+    // Nothing is moved aside...
+    expect(plan.staged).toEqual([]);
+    // ...and BOTH links are reported, not just the one touching C.
+    expect(plan.unsatisfiable.map((u) => u.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("still resolves a chain whose far end IS free", () => {
+    const plan = planRenameStaging([row("a", "A", "B"), row("b", "B", "C")], "n1");
+    expect(plan.staged.map((s) => s.id)).toEqual(["b"]);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("a pure CYCLE survives the fixpoint", () => {
+    // Each depends only on the other, so neither is ever knocked out —
+    // correct, because staging one frees the whole cycle.
+    const plan = planRenameStaging([row("a", "X", "Y"), row("b", "Y", "X")], "n1");
+    expect(plan.staged.length).toBeGreaterThanOrEqual(1);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("a longer cycle also survives", () => {
+    const plan = planRenameStaging(
+      [row("a", "X", "Y"), row("b", "Y", "Z"), row("c", "Z", "X")],
+      "n1",
+    );
+    expect(plan.staged.length).toBeGreaterThanOrEqual(1);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
 });
 
 describe("isStagingPlaceholder", () => {

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -3,6 +3,7 @@ import {
   planRenameStaging,
   isStagingPlaceholder,
   placeholderFor,
+  strandedPlaceholderMessage,
   STAGING_PREFIX,
   type RenameIntent,
 } from "@/lib/renameStaging";
@@ -153,5 +154,58 @@ describe("isStagingPlaceholder", () => {
     expect(isStagingPlaceholder("")).toBe(false);
     expect(isStagingPlaceholder(null)).toBe(false);
     expect(isStagingPlaceholder(42)).toBe(false);
+  });
+});
+
+/**
+ * The rollback-failed path in `writeWithRenameStaging` is a genuine race — a
+ * third party has to claim the original name in the window between staging and
+ * rollback — so it cannot be induced from a sync test. What CAN be pinned is
+ * the message it hands up, which after GH #1142 (Codex P2, twice) is the only
+ * channel that reaches the user: the throw leaves `syncCollection` entirely and
+ * `trySync` rebuilds a zero-count SyncResult carrying nothing but the error, so
+ * a counter on `result` — the previous attempt — was discarded on the one path
+ * it existed for.
+ */
+describe("strandedPlaceholderMessage", () => {
+  const base = {
+    collection: "bedtypes",
+    id: "64b7f0000000000000000001",
+    originalName: "Textured PEI",
+    placeholderName: "__sync-staging-64b7f0000000000000000001-abc",
+  };
+
+  it("names the row, both names, and what the user has to do", () => {
+    const msg = strandedPlaceholderMessage({ ...base, cause: new Error("E11000 dup key") });
+    expect(msg).toContain("bedtypes 64b7f0000000000000000001");
+    expect(msg).toContain('"Textured PEI"');
+    expect(msg).toContain('"__sync-staging-64b7f0000000000000000001-abc"');
+    expect(msg).toMatch(/rename it back manually/i);
+  });
+
+  it("keeps the underlying failure, so the cause is not lost", () => {
+    expect(
+      strandedPlaceholderMessage({ ...base, cause: new Error("E11000 dup key") }),
+    ).toContain("E11000 dup key");
+  });
+
+  it("leads with the stranding — an auth-shaped cause must not displace it", () => {
+    // `wrapSyncErrorMessage` REPLACES the whole message on the read-only-Atlas
+    // shape (GH #143). Anything after such a cause would be dropped, so the
+    // durable problem has to come first: a permissions error re-tells itself
+    // next cycle, a stranded placeholder is announced exactly once.
+    const msg = strandedPlaceholderMessage({
+      ...base,
+      cause: new Error("user is not allowed to do action [update] on [db.bedtypes]"),
+    });
+    expect(msg.indexOf("bedtypes 64b7f0000000000000000001")).toBeLessThan(
+      msg.indexOf("user is not allowed"),
+    );
+  });
+
+  it("survives a non-Error rejection", () => {
+    expect(strandedPlaceholderMessage({ ...base, cause: "socket hang up" })).toContain(
+      "socket hang up",
+    );
   });
 });

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -79,19 +79,20 @@ describe("planRenameStaging", () => {
     expect(plan.unsatisfiable).toEqual([]);
   });
 
-  it("stages a holder only once even when two rows contend for it", () => {
-    // Both A and C want B's name. B is staged once, not twice — a second
-    // rename would move it off the placeholder the first one recorded.
+  it("refuses BOTH rows contending for one name (Codex P1, fifth pass)", () => {
+    // Both A and C want B's name. An earlier version staged B once and let
+    // "the index reject the loser" — reasoning this test used to ENCODE as
+    // intent. That rejection is exactly what strands the winner: the loser's
+    // E11000 finds the winner as its blocker, the cached plan still authorized
+    // staging it, and settlement could not restore a name the loser's retry
+    // had just taken. There is no principled winner (write order is
+    // incidental), so every contender is refused and B stays put.
     const plan = planRenameStaging(
       [row("a", "P", "B"), row("c", "Q", "B"), row("b", "B", "Z")],
       "n1",
     );
-    expect(plan.staged.map((s) => s.id)).toEqual(["b"]);
-    // The loser is reported rather than silently dropped... or rather: both
-    // wanted B, and only one can have it. The second is NOT unsatisfiable here
-    // because B is genuinely vacating; the index will reject the loser and the
-    // per-row error path reports it.
-    expect(plan.unsatisfiable).toEqual([]);
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable.map((u) => u.id).sort()).toEqual(["a", "c"]);
   });
 
   it("gives every staged row a distinct, recognisable placeholder", () => {
@@ -156,6 +157,54 @@ describe("isStagingPlaceholder", () => {
     expect(isStagingPlaceholder("")).toBe(false);
     expect(isStagingPlaceholder(null)).toBe(false);
     expect(isStagingPlaceholder(42)).toBe(false);
+  });
+});
+
+/**
+ * GH #1142 (Codex P1, fifth pass): a CONTESTED destination — two rows desiring
+ * the same name — must poison the plan, not merely fail one of the writes.
+ *
+ * The state requires the SOURCE to hold duplicate active names, which the trim
+ * pass refuses to index ("resolve them and restart") while the sync continues
+ * paired-only. At most one contender can win; the loser then E11000s against
+ * the WINNER, whose write has landed — and a cached plan that still authorized
+ * staging the winner had it moved aside with no write ever coming, while its
+ * original name was taken by the loser's retry. Settlement cannot restore it:
+ * stranded permanently.
+ */
+describe("planRenameStaging with contested destinations", () => {
+  it("refuses the whole cycle when a third row desires a name inside it", () => {
+    // Codex's exact example: target A="X", B="Y", C="Z"; desires A→Y, B→X,
+    // C→Y. Pre-fix this planned staged=[B, A] and let the A↔B swap resolve —
+    // after which C collided with the now-final A and stranded it.
+    const plan = planRenameStaging(
+      [row("A", "X", "Y"), row("B", "Y", "X"), row("C", "Z", "Y")],
+      "nonce",
+    );
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable.map((u) => u.id).sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("refuses to stage a contender for an UNRELATED requester", () => {
+    // D wants A's current name. A is moving — but A is contesting "Y" with C,
+    // so A may lose the race and never vacate "X". Staging A for D's benefit
+    // gambles a permanent placeholder on write order.
+    const plan = planRenameStaging(
+      [row("A", "X", "Y"), row("C", "Z", "Y"), row("D", "W", "X")],
+      "nonce",
+    );
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable.map((u) => u.id)).toEqual(["D"]);
+  });
+
+  it("still resolves a clean swap next to an uncontested rename", () => {
+    // The refusal must be scoped to the contested name, not the whole pass.
+    const plan = planRenameStaging(
+      [row("A", "X", "Y"), row("B", "Y", "X"), row("E", "P", "Q")],
+      "nonce",
+    );
+    expect(plan.staged.map((s) => s.id).sort()).toEqual(["A", "B"]);
+    expect(plan.unsatisfiable).toEqual([]);
   });
 });
 

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -4,7 +4,7 @@ import {
   isStagingPlaceholder,
   placeholderFor,
   strandedPlaceholderNotice,
-  strandedPlaceholderError,
+  withStrandingNotice,
   strandingNoticeOf,
   STAGING_PREFIX,
   type RenameIntent,
@@ -192,10 +192,10 @@ describe("stranded placeholder reporting", () => {
     // If the cause leaked in here, an auth-shaped one would make the notice
     // itself match wrapSyncErrorMessage's regex on re-attachment, and the
     // stranding would vanish exactly as it did before.
-    const err = strandedPlaceholderError({
-      ...info,
-      cause: new Error("user is not allowed to do action [update] on [db.bedtypes]"),
-    });
+    const err = withStrandingNotice(
+      new Error("user is not allowed to do action [update] on [db.bedtypes]"),
+      strandedPlaceholderNotice(info),
+    );
     expect(strandingNoticeOf(err)).not.toContain("user is not allowed");
     // ...while the composed message still carries both halves.
     expect(err.message).toContain("user is not allowed");
@@ -207,15 +207,24 @@ describe("stranded placeholder reporting", () => {
     // driver error's `code` lives, and `new Error(msg, {cause})` does not
     // inherit it.
     const cause = Object.assign(new Error("Unauthorized"), { code: 13 });
-    const err = strandedPlaceholderError({ ...info, cause });
+    const err = withStrandingNotice(cause, strandedPlaceholderNotice(info));
     expect(err.cause).toBe(cause);
     expect(strandingNoticeOf(err)).toBe(strandedPlaceholderNotice(info));
   });
 
   it("survives a non-Error rejection", () => {
-    expect(strandedPlaceholderError({ ...info, cause: "socket hang up" }).message).toContain(
-      "socket hang up",
-    );
+    expect(
+      withStrandingNotice("socket hang up", strandedPlaceholderNotice(info)).message,
+    ).toContain("socket hang up");
+  });
+
+  it("ACCUMULATES notices — one pass can strand several rows at once", () => {
+    // A failure late in a pass abandons every row moved aside earlier, so
+    // reporting only the last would be a quieter version of reporting none.
+    const first = withStrandingNotice(new Error("boom"), "ROW-A stranded.");
+    const both = withStrandingNotice(first, "ROW-B stranded.");
+    expect(strandingNoticeOf(both)).toBe("ROW-A stranded. ROW-B stranded.");
+    expect(both.cause).toBe(first);
   });
 
   it("reads no notice off anything that is not a tagged error", () => {

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -5,6 +5,7 @@ import {
   placeholderFor,
   strandedPlaceholderNotice,
   withStrandingNotice,
+  pendingRenameCanFreeName,
   strandingNoticeOf,
   STAGING_PREFIX,
   type RenameIntent,
@@ -205,6 +206,42 @@ describe("planRenameStaging with contested destinations", () => {
     );
     expect(plan.staged.map((s) => s.id).sort()).toEqual(["A", "B"]);
     expect(plan.unsatisfiable).toEqual([]);
+  });
+});
+
+/**
+ * GH #1142 (Codex P1, sixth pass): the runtime staging predicate, judged
+ * against a FRESH read of the blocker's source row — the same document its
+ * pending write will hydrate. The mid-pass mutation that makes this matter (a
+ * user reverting a source name between the snapshot and the write) cannot be
+ * induced from the DB harness, so the decision table is pinned here and the
+ * wiring is structural: sync-service passes `sourceFresh?.name` straight in.
+ */
+describe("pendingRenameCanFreeName", () => {
+  it("authorizes when the pending write will genuinely rename the blocker", () => {
+    expect(pendingRenameCanFreeName("Drybox 2", "Drybox 1")).toBe(true);
+  });
+
+  it("refuses when the fresh source name EQUALS the blocker's current name", () => {
+    // One clause, three histories: the write already landed (it transferred
+    // exactly this name), the write is a no-op rename, or the source was
+    // reverted to match after the snapshot. In all three nothing will ever
+    // move the blocker off this name, so a placeholder could not be settled.
+    expect(pendingRenameCanFreeName("Drybox 1", "Drybox 1")).toBe(false);
+  });
+
+  it("refuses when the source is gone or malformed — no rename provably coming", () => {
+    expect(pendingRenameCanFreeName(undefined, "Drybox 1")).toBe(false);
+    expect(pendingRenameCanFreeName(null, "Drybox 1")).toBe(false);
+    expect(pendingRenameCanFreeName(42, "Drybox 1")).toBe(false);
+  });
+
+  it("refuses when the source itself holds a staging placeholder", () => {
+    // The pending write would transfer the placeholder text verbatim onto
+    // this peer — the exact propagation this module exists to prevent.
+    expect(
+      pendingRenameCanFreeName(`${STAGING_PREFIX}abc123-def`, "Drybox 1"),
+    ).toBe(false);
   });
 });
 

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  planRenameStaging,
+  isStagingPlaceholder,
+  placeholderFor,
+  STAGING_PREFIX,
+  type RenameIntent,
+} from "@/lib/renameStaging";
+
+/**
+ * GH #1142. The graph reasoning is here so it can be pinned without two live
+ * databases; `tests/sync-service-expansion.test.ts` covers the wiring.
+ */
+
+const row = (
+  id: string,
+  currentName: string,
+  desiredName: string,
+  willWrite = true,
+): RenameIntent => ({ id, currentName, desiredName, willWrite });
+
+describe("planRenameStaging", () => {
+  it("stages nothing when no write contends for a held name", () => {
+    const plan = planRenameStaging([row("a", "X", "X2"), row("b", "Y", "Y2")], "n1");
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("breaks a CYCLE — the reported swap", () => {
+    // A wants Y (held by B), B wants X (held by A). No ordering works.
+    const plan = planRenameStaging([row("a", "X", "Y"), row("b", "Y", "X")], "n1");
+    // Staging ONE of them is enough: once it holds a placeholder, the other's
+    // write lands, and the staged row's own write then lands too.
+    expect(plan.staged.length).toBeGreaterThanOrEqual(1);
+    expect(plan.unsatisfiable).toEqual([]);
+    for (const s of plan.staged) {
+      expect(isStagingPlaceholder(s.placeholderName)).toBe(true);
+      // The original is carried so the caller can restore it if the real
+      // write never lands.
+      expect(["X", "Y"]).toContain(s.originalName);
+    }
+  });
+
+  it("breaks a CHAIN — A wants the name B is about to vacate", () => {
+    const plan = planRenameStaging([row("a", "A", "B"), row("b", "B", "C")], "n1");
+    expect(plan.staged.map((s) => s.id)).toEqual(["b"]);
+    expect(plan.staged[0].originalName).toBe("B");
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("reports UNSATISFIABLE when the holder is not moving", () => {
+    // B is present and keeping its name; A wants it. Staging cannot help.
+    const plan = planRenameStaging([row("a", "X", "Y"), row("b", "Y", "Y", false)], "n1");
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable).toEqual([{ id: "a", desiredName: "Y", heldBy: "b" }]);
+  });
+
+  it("reports UNSATISFIABLE when the holder is written WITHOUT a rename", () => {
+    // B is being copied but keeps the same name — it is not vacating it.
+    const plan = planRenameStaging([row("a", "X", "Y"), row("b", "Y", "Y", true)], "n1");
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable).toEqual([{ id: "a", desiredName: "Y", heldBy: "b" }]);
+  });
+
+  it("does not stage a row against itself", () => {
+    // A row keeping its own name is not blocking itself.
+    const plan = planRenameStaging([row("a", "X", "X")], "n1");
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("ignores a row that is not being written", () => {
+    const plan = planRenameStaging([row("a", "X", "Y", false), row("b", "Y", "Z")], "n1");
+    // `a` isn't writing, so it needs nothing; `b`'s target Z is free.
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("stages a holder only once even when two rows contend for it", () => {
+    // Both A and C want B's name. B is staged once, not twice — a second
+    // rename would move it off the placeholder the first one recorded.
+    const plan = planRenameStaging(
+      [row("a", "P", "B"), row("c", "Q", "B"), row("b", "B", "Z")],
+      "n1",
+    );
+    expect(plan.staged.map((s) => s.id)).toEqual(["b"]);
+    // The loser is reported rather than silently dropped... or rather: both
+    // wanted B, and only one can have it. The second is NOT unsatisfiable here
+    // because B is genuinely vacating; the index will reject the loser and the
+    // per-row error path reports it.
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("gives every staged row a distinct, recognisable placeholder", () => {
+    const plan = planRenameStaging(
+      [row("a", "X", "Y"), row("b", "Y", "X"), row("c", "Z", "W")],
+      "nonce7",
+    );
+    const names = plan.staged.map((s) => s.placeholderName);
+    expect(new Set(names).size).toBe(names.length);
+    for (const n of names) expect(n.startsWith(STAGING_PREFIX)).toBe(true);
+  });
+
+  it("the nonce separates concurrent passes", () => {
+    expect(placeholderFor("a", "n1")).not.toBe(placeholderFor("a", "n2"));
+  });
+});
+
+describe("isStagingPlaceholder", () => {
+  it("recognises its own output and nothing else", () => {
+    expect(isStagingPlaceholder(placeholderFor("abc", "n1"))).toBe(true);
+    expect(isStagingPlaceholder("Drybox #1")).toBe(false);
+    expect(isStagingPlaceholder("")).toBe(false);
+    expect(isStagingPlaceholder(null)).toBe(false);
+    expect(isStagingPlaceholder(42)).toBe(false);
+  });
+});

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -3,7 +3,9 @@ import {
   planRenameStaging,
   isStagingPlaceholder,
   placeholderFor,
-  strandedPlaceholderMessage,
+  strandedPlaceholderNotice,
+  strandedPlaceholderError,
+  strandingNoticeOf,
   STAGING_PREFIX,
   type RenameIntent,
 } from "@/lib/renameStaging";
@@ -158,17 +160,20 @@ describe("isStagingPlaceholder", () => {
 });
 
 /**
- * The rollback-failed path in `writeWithRenameStaging` is a genuine race — a
- * third party has to claim the original name in the window between staging and
- * rollback — so it cannot be induced from a sync test. What CAN be pinned is
- * the message it hands up, which after GH #1142 (Codex P2, twice) is the only
- * channel that reaches the user: the throw leaves `syncCollection` entirely and
- * `trySync` rebuilds a zero-count SyncResult carrying nothing but the error, so
- * a counter on `result` — the previous attempt — was discarded on the one path
- * it existed for.
+ * GH #1142 (Codex P2, twice). The rollback-failed path is a genuine race — a
+ * third party has to claim the original name between staging and rollback — so
+ * it cannot be induced from a sync test. What CAN be pinned is the structure
+ * that carries it to the user, and the structure is the whole fix: the notice
+ * is CAUSE-FREE so it can be re-attached after `wrapSyncErrorMessage` has
+ * decided what kind of error this is, and the factory composes and tags in one
+ * expression so an untagged stranding message cannot be written.
+ *
+ * `tests/sync-service.test.ts` pins the other half — that the wrapper actually
+ * re-attaches it — which is where the previous attempt failed: it asserted
+ * ORDERING inside a string the wrapper discards wholesale.
  */
-describe("strandedPlaceholderMessage", () => {
-  const base = {
+describe("stranded placeholder reporting", () => {
+  const info = {
     collection: "bedtypes",
     id: "64b7f0000000000000000001",
     originalName: "Textured PEI",
@@ -176,36 +181,48 @@ describe("strandedPlaceholderMessage", () => {
   };
 
   it("names the row, both names, and what the user has to do", () => {
-    const msg = strandedPlaceholderMessage({ ...base, cause: new Error("E11000 dup key") });
-    expect(msg).toContain("bedtypes 64b7f0000000000000000001");
-    expect(msg).toContain('"Textured PEI"');
-    expect(msg).toContain('"__sync-staging-64b7f0000000000000000001-abc"');
-    expect(msg).toMatch(/rename it back manually/i);
+    const notice = strandedPlaceholderNotice(info);
+    expect(notice).toContain("bedtypes 64b7f0000000000000000001");
+    expect(notice).toContain('"Textured PEI"');
+    expect(notice).toContain('"__sync-staging-64b7f0000000000000000001-abc"');
+    expect(notice).toMatch(/rename it back manually/i);
   });
 
-  it("keeps the underlying failure, so the cause is not lost", () => {
-    expect(
-      strandedPlaceholderMessage({ ...base, cause: new Error("E11000 dup key") }),
-    ).toContain("E11000 dup key");
-  });
-
-  it("leads with the stranding — an auth-shaped cause must not displace it", () => {
-    // `wrapSyncErrorMessage` REPLACES the whole message on the read-only-Atlas
-    // shape (GH #143). Anything after such a cause would be dropped, so the
-    // durable problem has to come first: a permissions error re-tells itself
-    // next cycle, a stranded placeholder is announced exactly once.
-    const msg = strandedPlaceholderMessage({
-      ...base,
+  it("keeps the notice free of the cause — the property the wrapper relies on", () => {
+    // If the cause leaked in here, an auth-shaped one would make the notice
+    // itself match wrapSyncErrorMessage's regex on re-attachment, and the
+    // stranding would vanish exactly as it did before.
+    const err = strandedPlaceholderError({
+      ...info,
       cause: new Error("user is not allowed to do action [update] on [db.bedtypes]"),
     });
-    expect(msg.indexOf("bedtypes 64b7f0000000000000000001")).toBeLessThan(
-      msg.indexOf("user is not allowed"),
-    );
+    expect(strandingNoticeOf(err)).not.toContain("user is not allowed");
+    // ...while the composed message still carries both halves.
+    expect(err.message).toContain("user is not allowed");
+    expect(err.message).toContain("bedtypes 64b7f0000000000000000001");
+  });
+
+  it("tags exactly what it composed, and keeps the cause attached", () => {
+    // The cause has to survive as an OBJECT, not just as text: it is where a
+    // driver error's `code` lives, and `new Error(msg, {cause})` does not
+    // inherit it.
+    const cause = Object.assign(new Error("Unauthorized"), { code: 13 });
+    const err = strandedPlaceholderError({ ...info, cause });
+    expect(err.cause).toBe(cause);
+    expect(strandingNoticeOf(err)).toBe(strandedPlaceholderNotice(info));
   });
 
   it("survives a non-Error rejection", () => {
-    expect(strandedPlaceholderMessage({ ...base, cause: "socket hang up" })).toContain(
+    expect(strandedPlaceholderError({ ...info, cause: "socket hang up" }).message).toContain(
       "socket hang up",
     );
+  });
+
+  it("reads no notice off anything that is not a tagged error", () => {
+    for (const value of [null, undefined, "a string", 42, {}, new Error("plain")]) {
+      expect(strandingNoticeOf(value)).toBeNull();
+    }
+    // ...including a lookalike whose key holds the wrong type.
+    expect(strandingNoticeOf({ strandingNotice: 42 })).toBeNull();
   });
 });

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1131,6 +1131,97 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * GH #1142 (Codex P1, third pass): the staging PREDICTOR has to classify
+     * deletion the way the LOOP does, not merely the way the index does.
+     *
+     * `desiredNameOn` used JS truthiness while the loop uses `_deletedAt !=
+     * null`. They disagree on exactly one stored value — the empty string —
+     * and there the loop takes the DELETE branch (resurrecting on the other
+     * side) while the predictor claimed a rename on this one. The blocker got
+     * staged for a write that never came, and the resurrect's fresh
+     * `hydrateRemote` read copied `__sync-staging-…` onto the OTHER peer,
+     * where nothing tracks it and settlement never looks.
+     *
+     * Distinct from the `_deletedAt: ""` case above, which pins the HOLDER
+     * GRAPH: there the ghost is paired at equal timestamps, so `desiredNameOn`
+     * short-circuits before ever reaching the deletion test.
+     *
+     * SEED CONSTRAINTS, all load-bearing:
+     *  - remote B needs a REAL `updatedAt`; at epoch 0 the delete propagates
+     *    instead of resurrecting and the cross-peer half is lost;
+     *  - local B's `_deletedAt` must be the literal `""` — a real Date returns
+     *    null even pre-fix and the test proves nothing;
+     *  - remote B needs `_deletedAt: null` so it is inside the partial index
+     *    and findable as the blocker.
+     */
+    it("will not stage a blocker whose pair is a raw _deletedAt:\"\" row", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Bee", material: "PEI", syncId: "esn-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Zed", material: "PEI", syncId: "esn-b", _deletedAt: "", createdAt: older, updatedAt: newer },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Aye", material: "PEI", syncId: "esn-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Bee", material: "PEI", syncId: "esn-b", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+
+      // NOTHING may hold a placeholder — on either peer. The local one is the
+      // one that used to escape entirely: `stagedRenames` never tracked it, so
+      // no settlement pass could have restored it.
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+      // Both peers keep their seeded names: the case is reported, not forced.
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "esn-a" }))!.name).toBe("Aye");
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "esn-b" }))!.name).toBe("Bee");
+    });
+
+    /**
+     * The same defect through the PURGE branch. The loop's first both-exist
+     * arm fires on `_purged` and writes only the flags — no name — so a paired
+     * row with a purge zombie on one side (`_purged: true` with a live
+     * `_deletedAt`) is just as immovable as a deleted one.
+     *
+     * Seeded on `bedtypes` DELIBERATELY: `retombstonePurgedZombies` repairs
+     * `filaments` only, so a filaments-based test would pass on the migration
+     * rather than on this guard.
+     */
+    it("will not stage a blocker whose pair is a purge zombie", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Pea", material: "PEI", syncId: "pz-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Qew", material: "PEI", syncId: "pz-b", _deletedAt: null, _purged: true, createdAt: older, updatedAt: newer },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Ehh", material: "PEI", syncId: "pz-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Pea", material: "PEI", syncId: "pz-b", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "pz-a" }))!.name).toBe("Ehh");
+    });
+
+    /**
      * The unsatisfiable case: a row this pass is NOT moving already holds the
      * name. Staging cannot help, so it must be reported and BOTH peers left
      * alone — writing anyway would clobber a record the user still wants.

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -898,6 +898,88 @@ describe("SyncService — v1.12 sync expansion", () => {
   // Mongoose then can't find it by name at all, because a String schema
   // setter applies to QUERY values too.
 
+  describe("contended renames are staged, not deadlocked (GH #1142)", () => {
+    /**
+     * The reported repro, verbatim, and it fails on `main`: two rows with the
+     * SAME syncIds on both peers and their names SWAPPED. Whichever paired row
+     * is copied first wants a name the other still holds, the partial-unique
+     * `name` index rejects it, and reversing the order only changes which one
+     * fails — the pair is a cycle.
+     *
+     * It is not transient. It repeats every cycle, and via `trySync` a failure
+     * in a parent collection cascade-skips its dependents, so one swapped pair
+     * stalls most of sync indefinitely.
+     */
+    it("resolves a cross-peer name SWAP instead of erroring forever", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 60_000);
+      const newer = new Date();
+
+      await localDb.collection("bedtypes").insertMany([
+        { name: "X", material: "PEI", syncId: "swap-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Y", material: "PEI", syncId: "swap-b", _deletedAt: null, createdAt: older, updatedAt: newer },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Y", material: "PEI", syncId: "swap-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "X", material: "PEI", syncId: "swap-b", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      // The collection completed instead of aborting on E11000.
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+
+      // Local is newer for both, so the remote adopts the swap...
+      const a = await remoteDb.collection("bedtypes").findOne({ syncId: "swap-a" });
+      const b = await remoteDb.collection("bedtypes").findOne({ syncId: "swap-b" });
+      expect(a!.name).toBe("X");
+      expect(b!.name).toBe("Y");
+
+      // ...and no placeholder was left behind.
+      const leftovers = await remoteDb
+        .collection("bedtypes")
+        .countDocuments({ name: { $regex: "^__sync-staging-" } });
+      expect(leftovers).toBe(0);
+    });
+
+    /**
+     * The unsatisfiable case: a row this pass is NOT moving already holds the
+     * name. Staging cannot help, so it must be reported and BOTH peers left
+     * alone — writing anyway would clobber a record the user still wants.
+     */
+    it("reports an unsatisfiable name conflict without clobbering the holder", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 60_000);
+      const newer = new Date();
+
+      // Local renames its row to "Taken"; the remote already has a DIFFERENT,
+      // unpaired row called "Taken" that this pass will not move.
+      await localDb.collection("bedtypes").insertOne({
+        name: "Taken", material: "PEI", syncId: "unsat-a",
+        _deletedAt: null, createdAt: older, updatedAt: newer,
+      });
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Original", material: "PEI", syncId: "unsat-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Taken", material: "PEI", syncId: "unsat-squatter", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+
+      // The squatter is untouched — that is the point.
+      const squatter = await remoteDb.collection("bedtypes").findOne({ syncId: "unsat-squatter" });
+      expect(squatter!.name).toBe("Taken");
+      // And no placeholder was stranded on it.
+      const leftovers = await remoteDb
+        .collection("bedtypes")
+        .countDocuments({ name: { $regex: "^__sync-staging-" } });
+      expect(leftovers).toBe(0);
+    });
+  });
+
   describe("purge zombies are repaired on BOTH peers before the trim (GH #1116)", () => {
     /**
      * A zombie (`_purged: true` with `_deletedAt: null`) is ACTIVE as far as

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -988,6 +988,50 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * GH #1142 (Codex P1): a TRASHED row must not enter the holder graph.
+     *
+     * The unique index is partial on `_deletedAt: null`, so a trashed row
+     * named "X" does not occupy that slot — GH #213 name reuse depends on it.
+     * Letting one in made it the "holder" whenever it sorted first, and a
+     * trashed row never vacates, so the fixpoint declared the chain immovable
+     * and refused a swap that was perfectly resolvable, every cycle.
+     */
+    it("resolves a swap even when a TRASHED row shares one of the names", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      // A trashed "X" on the remote, inserted FIRST so it sorts ahead of the
+      // active blocker in the holder map.
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "X", material: "PEI", syncId: "tomb-x",
+        _deletedAt: older, createdAt: older, updatedAt: older,
+      });
+      await localDb.collection("bedtypes").insertMany([
+        { name: "X", material: "PEI", syncId: "tswap-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Y", material: "PEI", syncId: "tswap-b", _deletedAt: null, createdAt: older, updatedAt: newer },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Y", material: "PEI", syncId: "tswap-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "X", material: "PEI", syncId: "tswap-b", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+
+      sync = makeSync();
+      const results = await sync.sync();
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+
+      // The swap went through despite the tombstone sharing a name.
+      const a = await remoteDb.collection("bedtypes").findOne({ syncId: "tswap-a" });
+      const b = await remoteDb.collection("bedtypes").findOne({ syncId: "tswap-b" });
+      expect(a!.name).toBe("X");
+      expect(b!.name).toBe("Y");
+      expect(
+        await remoteDb.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+      ).toBe(0);
+    });
+
+    /**
      * GH #1142 (Codex P1): the whole CHAIN has to terminate, not just the
      * first hop. A -> B, B -> C, and C standing still: a one-hop check stages
      * B for A, A takes "B", and B can then never take "C" — settlement cannot

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -988,6 +988,53 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * GH #1142 (Codex P1): the whole CHAIN has to terminate, not just the
+     * first hop. A -> B, B -> C, and C standing still: a one-hop check stages
+     * B for A, A takes "B", and B can then never take "C" — settlement cannot
+     * restore B either, because A owns its original name. B would be left as
+     * `__sync-staging-…` permanently.
+     */
+    it("refuses a rename chain whose far end is immovable", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+      const same = new Date(Date.now() - 60_000);
+
+      // The chain lives on the REMOTE (the target): A wants B's name, B wants
+      // C's, and C never moves. Local names are what gets copied over.
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Bee", material: "PEI", syncId: "ch-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Cee", material: "PEI", syncId: "ch-b", _deletedAt: null, createdAt: older, updatedAt: newer },
+        // Equal timestamps on C, so nothing is copied for it either way; its
+        // local name just has to be distinct here.
+        { name: "Seaside", material: "PEI", syncId: "ch-c", _deletedAt: null, createdAt: older, updatedAt: same },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Aye", material: "PEI", syncId: "ch-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Bee", material: "PEI", syncId: "ch-b", _deletedAt: null, createdAt: older, updatedAt: older },
+        // Equal timestamps: C never moves, so "Cee" is never vacated.
+        { name: "Cee", material: "PEI", syncId: "ch-c", _deletedAt: null, createdAt: older, updatedAt: same },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+
+      // NOTHING was moved aside, so nothing can be stranded.
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+      // B still has its real name on the remote — the one a one-hop check
+      // would have left as a placeholder.
+      const b = await remoteDb.collection("bedtypes").findOne({ syncId: "ch-b" });
+      expect(b!.name).toBe("Bee");
+      const c = await remoteDb.collection("bedtypes").findOne({ syncId: "ch-c" });
+      expect(c!.name).toBe("Cee");
+    });
+
+    /**
      * The unsatisfiable case: a row this pass is NOT moving already holds the
      * name. Staging cannot help, so it must be reported and BOTH peers left
      * alone — writing anyway would clobber a record the user still wants.
@@ -995,31 +1042,40 @@ describe("SyncService — v1.12 sync expansion", () => {
     it("reports an unsatisfiable name conflict without clobbering the holder", async () => {
       const localDb = localClient.db("filament-db");
       const remoteDb = remoteClient.db("filament-db");
-      const older = new Date(Date.now() - 60_000);
+      const older = new Date(Date.now() - 120_000);
       const newer = new Date();
+      const same = new Date(Date.now() - 60_000);
 
-      // Local renames its row to "Taken"; the remote already has a DIFFERENT,
-      // unpaired row called "Taken" that this pass will not move.
-      await localDb.collection("bedtypes").insertOne({
-        name: "Taken", material: "PEI", syncId: "unsat-a",
-        _deletedAt: null, createdAt: older, updatedAt: newer,
-      });
+      // Local A is newer and wants "Taken" on the remote. Remote B holds
+      // "Taken" and is NOT moving — its timestamps match, so no copy happens
+      // for it at all. Both rows are PAIRED, so nothing reaches the insert
+      // path; the only conflict is the one under test.
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Taken", material: "PEI", syncId: "unsat-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Squat", material: "PEI", syncId: "unsat-b", _deletedAt: null, createdAt: older, updatedAt: same },
+      ]);
       await remoteDb.collection("bedtypes").insertMany([
         { name: "Original", material: "PEI", syncId: "unsat-a", _deletedAt: null, createdAt: older, updatedAt: older },
-        { name: "Taken", material: "PEI", syncId: "unsat-squatter", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Taken", material: "PEI", syncId: "unsat-b", _deletedAt: null, createdAt: older, updatedAt: same },
       ]);
 
       sync = makeSync();
-      await sync.sync();
+      const results = await sync.sync();
 
-      // The squatter is untouched — that is the point.
-      const squatter = await remoteDb.collection("bedtypes").findOne({ syncId: "unsat-squatter" });
-      expect(squatter!.name).toBe("Taken");
+      // GH #1142 (Codex P1): it must SURFACE. A counter nothing reads left the
+      // cycle reporting idle while a whole-document update was silently
+      // skipped and would fail identically forever.
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toMatch(/name conflict/i);
+
+      // The immovable holder is untouched — that is the point.
+      const holder = await remoteDb.collection("bedtypes").findOne({ syncId: "unsat-b" });
+      expect(holder!.name).toBe("Taken");
       // And no placeholder was stranded on it.
-      const leftovers = await remoteDb
-        .collection("bedtypes")
-        .countDocuments({ name: { $regex: "^__sync-staging-" } });
-      expect(leftovers).toBe(0);
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
     });
   });
 

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1079,6 +1079,58 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * GH #1142 (Codex P1, second pass): the holder graph must use MONGODB's
+     * predicate, not JS truthiness. `{_deletedAt: null}` matches null AND
+     * missing and nothing else, so a raw `_deletedAt: ""` — Mongoose casts an
+     * empty string to null on a Date path, the driver stores it verbatim, and
+     * `trimEntityNames` documents the same shape at its own `== null` test —
+     * sits OUTSIDE the partial unique index and can never block a write.
+     *
+     * `!d._deletedAt` let such a row in as a holder. Sorted first it won the
+     * name slot, never vacated (nothing is copying it), and the fixpoint then
+     * declared a perfectly resolvable swap immovable — every cycle, forever.
+     */
+    it("ignores a raw _deletedAt:\"\" row, which the partial index does not cover", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+      const same = new Date(Date.now() - 60_000);
+
+      // A pure two-row swap on the remote: A wants B's name and B wants A's.
+      // Resolvable by staging one of them aside.
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Bee", material: "PEI", syncId: "esd-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Aye", material: "PEI", syncId: "esd-b", _deletedAt: null, createdAt: older, updatedAt: newer },
+        // The ghost, paired at equal timestamps so nothing is copied for it —
+        // it exists only to sit in the graph.
+        { name: "Bee", material: "PEI", syncId: "esd-ghost", _deletedAt: "", createdAt: older, updatedAt: same },
+      ]);
+      // Inserted FIRST on the target side so it wins the "Bee" slot in the
+      // holder map — first holder wins, which is what made this bite.
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Bee", material: "PEI", syncId: "esd-ghost", _deletedAt: "", createdAt: older, updatedAt: same },
+        { name: "Aye", material: "PEI", syncId: "esd-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Bee", material: "PEI", syncId: "esd-b", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      // The swap goes through — no conflict reported.
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "esd-a" }))!.name).toBe("Bee");
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "esd-b" }))!.name).toBe("Aye");
+      // The ghost is untouched, and nothing was left holding a placeholder.
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "esd-ghost" }))!.name).toBe("Bee");
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+    });
+
+    /**
      * The unsatisfiable case: a row this pass is NOT moving already holds the
      * name. Staging cannot help, so it must be reported and BOTH peers left
      * alone — writing anyway would clobber a record the user still wants.

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1222,6 +1222,60 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * GH #1142 (Codex P1, fifth pass): a CONTESTED destination must refuse the
+     * whole tangle, because the cached plan cannot follow mid-pass reality.
+     *
+     * The state: the SOURCE holds duplicate active names ("Y" twice), which the
+     * trim refuses to index ("resolve them and restart") while the sync
+     * continues paired-only — so the writes still run against the indexed
+     * target. Pre-fix, the A↔B swap resolved first, C then E11000'd against
+     * the now-final A, and the SNAPSHOT plan still authorized staging A: C
+     * took "Y", and settlement could not restore A because "Y" was occupied.
+     * A stayed `__sync-staging-…` permanently.
+     *
+     * Post-fix nothing is written for the contested tangle at all — three
+     * reported conflicts, both peers byte-identical to the seed. The trim's
+     * own message already tells the user the real remedy (dedupe the source).
+     */
+    it("refuses a contested destination instead of stranding the winner", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      // The source needs duplicate active names, so its unique index (created
+      // by the harness beforeEach) has to go — mirroring the real precondition.
+      await localDb.collection("bedtypes").dropIndex("name_1");
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Y", material: "PEI", syncId: "cd-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "X", material: "PEI", syncId: "cd-b", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Y", material: "PEI", syncId: "cd-c", _deletedAt: null, createdAt: older, updatedAt: newer },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "X", material: "PEI", syncId: "cd-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Y", material: "PEI", syncId: "cd-b", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "Z", material: "PEI", syncId: "cd-c", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      // NOTHING holds a placeholder — the pre-fix outcome was exactly one,
+      // stranded on remote A after C took the name settlement would restore.
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+      // The target is untouched: refused, not half-applied.
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "cd-a" }))!.name).toBe("X");
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "cd-b" }))!.name).toBe("Y");
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "cd-c" }))!.name).toBe("Z");
+      // And it is REPORTED, not silent.
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeTruthy();
+    });
+
+    /**
      * The unsatisfiable case: a row this pass is NOT moving already holds the
      * name. Staging cannot help, so it must be reported and BOTH peers left
      * alone — writing anyway would clobber a record the user still wants.

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -945,6 +945,49 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * GH #1142 (Codex P1). "Paired" was not the right condition either.
+     *
+     * A paired blocker's own LWW can copy in the OPPOSITE direction, so
+     * nothing rewrites its name on THIS target — the placeholder is stranded,
+     * and its later copy the other way can propagate `__sync-staging-…` to the
+     * other peer. Cleanup cannot rescue it by then, because the row it made
+     * way for owns its original name.
+     *
+     * Here local A is newer and wants "X" on the remote, while remote B
+     * currently owns "X" and is NEWER than local B — so B's copy runs
+     * remote -> local and never rewrites B on the remote.
+     */
+    it("refuses to stage a blocker whose copy runs the OTHER way", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      await localDb.collection("bedtypes").insertMany([
+        { name: "X", material: "PEI", syncId: "dir-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Bee", material: "PEI", syncId: "dir-b", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Aye", material: "PEI", syncId: "dir-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        // remote B is NEWER, so B copies remote -> local and keeps "X" here.
+        { name: "X", material: "PEI", syncId: "dir-b", _deletedAt: null, createdAt: older, updatedAt: newer },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+
+      // B keeps its real name on the remote — never staged, never stranded.
+      const b = await remoteDb.collection("bedtypes").findOne({ syncId: "dir-b" });
+      expect(b!.name).toBe("X");
+      // And no placeholder leaked to EITHER peer.
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+    });
+
+    /**
      * The unsatisfiable case: a row this pass is NOT moving already holds the
      * name. Staging cannot help, so it must be reported and BOTH peers left
      * alone — writing anyway would clobber a record the user still wants.

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -4,6 +4,7 @@ import {
   isDuplicateKeyError,
   wrapSyncErrorMessage,
 } from "../electron/sync-service";
+import { strandedPlaceholderError } from "@/lib/renameStaging";
 
 describe("getDbNameFromUri", () => {
   it("extracts db name from a basic mongodb URI with explicit path", () => {
@@ -123,6 +124,114 @@ describe("wrapSyncErrorMessage", () => {
     const wrapped = wrapSyncErrorMessage(err, "filament-db");
     // No rewrite — message passes through (with URI redaction, n/a here)
     expect(wrapped).toBe("network reset while updating filament cache");
+  });
+});
+
+/**
+ * GH #1142 (Codex P2, twice). A stranded row needs a HUMAN — nothing scans for
+ * leftover `__sync-staging-…` names on a later cycle, and the equal-`updatedAt`
+ * case is documented as never repaired by LWW — so the one announcement has to
+ * survive whatever else the wrapper decides about the error.
+ *
+ * The previous attempt tried to achieve that by ORDERING the composed message.
+ * It cannot work: the auth branch RETURNS a fresh string and never reads the
+ * original, so both orderings lose equally. These cases pin the structural
+ * property instead, and the first two FAIL on that design.
+ */
+describe("wrapSyncErrorMessage + a stranded placeholder", () => {
+  const info = {
+    collection: "bedtypes",
+    id: "64b7f0000000000000000001",
+    originalName: "Textured PEI",
+    placeholderName: "__sync-staging-64b7f0000000000000000001-abc",
+  };
+  const expectStranding = (wrapped: string) => {
+    expect(wrapped).toContain("bedtypes 64b7f0000000000000000001");
+    expect(wrapped).toContain('"Textured PEI"');
+    expect(wrapped).toContain('"__sync-staging-64b7f0000000000000000001-abc"');
+    expect(wrapped).toMatch(/rename it back manually/i);
+  };
+
+  it("keeps BOTH the stranding and the Atlas hint when the cause is auth-shaped", () => {
+    const wrapped = wrapSyncErrorMessage(
+      strandedPlaceholderError({
+        ...info,
+        cause: Object.assign(
+          new Error("user is not allowed to do action [update] on [prod-db.bedtypes]"),
+          { code: 13 },
+        ),
+      }),
+      "prod-db",
+    );
+    expectStranding(wrapped);
+    expect(wrapped).toContain('only has read permission for "prod-db"');
+    expect(wrapped).toContain("readWrite");
+  });
+
+  it("still recognises code 13 through the wrapper — a composed Error inherits no code", () => {
+    // The inverse gap, and the more damaging half: `new Error(msg, {cause})`
+    // does not copy `code`, so classifying the OUTER error threw away the
+    // signal the docblock calls the reliable one. A fix that merely appends the
+    // notice inside the auth branch passes the case above and fails this one.
+    const wrapped = wrapSyncErrorMessage(
+      strandedPlaceholderError({
+        ...info,
+        cause: Object.assign(new Error("Unauthorized"), { code: 13 }),
+      }),
+      "prod-db",
+    );
+    expectStranding(wrapped);
+    expect(wrapped).toContain('only has read permission for "prod-db"');
+  });
+
+  it("keeps the stranding and the driver text when the cause is not auth", () => {
+    const wrapped = wrapSyncErrorMessage(
+      strandedPlaceholderError({
+        ...info,
+        cause: new Error('E11000 duplicate key error index: name_1 dup key: { name: "Textured PEI" }'),
+      }),
+      "prod-db",
+    );
+    expectStranding(wrapped);
+    expect(wrapped).toContain("E11000");
+    expect(wrapped).not.toContain("only has read permission");
+  });
+
+  it("redacts a connection string in the cause without losing the stranding", () => {
+    // Redaction has to run over the FINAL string: the notice is concatenated
+    // after the branch decision, so redacting only the body would leave a
+    // future notice-borne URI in the clear.
+    const wrapped = wrapSyncErrorMessage(
+      strandedPlaceholderError({
+        ...info,
+        cause: new Error("connect failed to mongodb+srv://user:secret@cluster.mongodb.net/db"),
+      }),
+      "prod-db",
+    );
+    expectStranding(wrapped);
+    expect(wrapped).toContain("mongodb://***");
+    expect(wrapped).not.toContain("secret");
+  });
+
+  it("keeps a non-Error cause's text rather than collapsing it", () => {
+    // Guards the recursion trap: re-entering the wrapper with the cause would
+    // turn a string cause into "Sync failed".
+    const wrapped = wrapSyncErrorMessage(
+      strandedPlaceholderError({ ...info, cause: "socket hang up" }),
+      "prod-db",
+    );
+    expectStranding(wrapped);
+    expect(wrapped).toContain("socket hang up");
+  });
+
+  it("leaves an ordinary auth error exactly as GH #143 specified", () => {
+    const wrapped = wrapSyncErrorMessage(
+      new Error("user is not allowed to do action [update] on [prod-db.bedtypes]"),
+      "prod-db",
+    );
+    expect(wrapped).toContain('only has read permission for "prod-db"');
+    expect(wrapped).not.toContain("staging");
+    expect(wrapped).not.toMatch(/rename it back manually/i);
   });
 });
 

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -4,7 +4,7 @@ import {
   isDuplicateKeyError,
   wrapSyncErrorMessage,
 } from "../electron/sync-service";
-import { strandedPlaceholderError } from "@/lib/renameStaging";
+import { strandedPlaceholderNotice, withStrandingNotice } from "@/lib/renameStaging";
 
 describe("getDbNameFromUri", () => {
   it("extracts db name from a basic mongodb URI with explicit path", () => {
@@ -151,16 +151,17 @@ describe("wrapSyncErrorMessage + a stranded placeholder", () => {
     expect(wrapped).toContain('"__sync-staging-64b7f0000000000000000001-abc"');
     expect(wrapped).toMatch(/rename it back manually/i);
   };
+  /** Exactly what the settlement path hands up: the row's notice, the real
+   *  failure as `cause`. */
+  const stranded = (cause: unknown) =>
+    withStrandingNotice(cause, strandedPlaceholderNotice(info));
 
   it("keeps BOTH the stranding and the Atlas hint when the cause is auth-shaped", () => {
     const wrapped = wrapSyncErrorMessage(
-      strandedPlaceholderError({
-        ...info,
-        cause: Object.assign(
+      stranded(Object.assign(
           new Error("user is not allowed to do action [update] on [prod-db.bedtypes]"),
           { code: 13 },
-        ),
-      }),
+        )),
       "prod-db",
     );
     expectStranding(wrapped);
@@ -174,10 +175,7 @@ describe("wrapSyncErrorMessage + a stranded placeholder", () => {
     // signal the docblock calls the reliable one. A fix that merely appends the
     // notice inside the auth branch passes the case above and fails this one.
     const wrapped = wrapSyncErrorMessage(
-      strandedPlaceholderError({
-        ...info,
-        cause: Object.assign(new Error("Unauthorized"), { code: 13 }),
-      }),
+      stranded(Object.assign(new Error("Unauthorized"), { code: 13 })),
       "prod-db",
     );
     expectStranding(wrapped);
@@ -186,10 +184,7 @@ describe("wrapSyncErrorMessage + a stranded placeholder", () => {
 
   it("keeps the stranding and the driver text when the cause is not auth", () => {
     const wrapped = wrapSyncErrorMessage(
-      strandedPlaceholderError({
-        ...info,
-        cause: new Error('E11000 duplicate key error index: name_1 dup key: { name: "Textured PEI" }'),
-      }),
+      stranded(new Error('E11000 duplicate key error index: name_1 dup key: { name: "Textured PEI" }')),
       "prod-db",
     );
     expectStranding(wrapped);
@@ -202,10 +197,7 @@ describe("wrapSyncErrorMessage + a stranded placeholder", () => {
     // after the branch decision, so redacting only the body would leave a
     // future notice-borne URI in the clear.
     const wrapped = wrapSyncErrorMessage(
-      strandedPlaceholderError({
-        ...info,
-        cause: new Error("connect failed to mongodb+srv://user:secret@cluster.mongodb.net/db"),
-      }),
+      stranded(new Error("connect failed to mongodb+srv://user:secret@cluster.mongodb.net/db")),
       "prod-db",
     );
     expectStranding(wrapped);
@@ -217,7 +209,7 @@ describe("wrapSyncErrorMessage + a stranded placeholder", () => {
     // Guards the recursion trap: re-entering the wrapper with the cause would
     // turn a string cause into "Sync failed".
     const wrapped = wrapSyncErrorMessage(
-      strandedPlaceholderError({ ...info, cause: "socket hang up" }),
+      stranded("socket hang up"),
       "prod-db",
     );
     expectStranding(wrapped);


### PR DESCRIPTION
Fixes #1142.

`syncCollection` wrote each row's whole document at the target with no awareness that the name it was about to write was held by a **different row the same pass was about to move**. The partial-unique `name` index rejected it, every cycle, and via `trySync` a failure in `locations` cascade-skipped filaments and print history — so one swapped pair stalled most of sync indefinitely.

The test runs **the issue's verbatim repro**, which fails on `main`.

## Three shapes, only one reported

| | shape | fixed by |
|---|---|---|
| cycle | local `A="X" B="Y"`, remote `A="Y" B="X"` — no ordering works | staging |
| chain | `A` wants the name `B` is about to vacate | staging |
| unsatisfiable | two rows genuinely want one name, neither moving | reported, both peers left alone |

## Reactive, not a pre-pass

A pre-pass would have to recompute every row's LWW outcome before the loop — a second copy of the decision logic that can drift from the real one. Here the real write is attempted and only an actual collision triggers staging, so the healthy path is untouched.

## Only a PAIRED row may be staged — this is the subtle part

"In this pass" is not sufficient. An unpaired row is either remote-only (pulled to local, so nothing writes its name on the remote) or local-only (not there to block anything yet) — either way **no write on that target would ever give it a real name**, so a placeholder on it could never settle. It would strand `__sync-staging-…` in the UI, and if its original name had meanwhile been taken by the row it made way for, unrecoverably.

My first version staged any row in the pass, and the unsatisfiable test caught it clobbering an innocent squatter. Both halves are pinned by tests that fail when reverted individually — I checked them separately.

## Also

- **`isNameDuplicateKeyError`** — the existing `isDuplicateKeyError` deliberately matches only `syncId` ("another process inserted this row", benign). A `name` violation is a different thing and got its own predicate rather than widening that one.
- **Placeholders are settled** at the end of the pass: original name restored when free, loud warning when not.
- The graph reasoning is a pure `src/lib/renameStaging.ts` (11 unit tests) so it is testable without two live databases.

Full gate green: 206 files / 4403 tests, plus `tsc`, lint and `electron:typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)