### PR TITLE
fix(names): survivor-aware lookups on every name-addressed path (#1143)

### DIFF
--- a/src/app/api/bed-types/[id]/route.ts
+++ b/src/app/api/bed-types/[id]/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import BedType from "@/models/BedType";
 import Filament from "@/models/Filament";
@@ -47,6 +51,21 @@ export async function PUT(
     if ("name" in body) update.name = body.name;
     if ("material" in body) update.material = body.material;
     if ("notes" in body) update.notes = body.notes;
+    // GH #1116: a RENAME needs the same trimmed check as the create — the
+    // index compares raw stored strings, so renaming onto a surviving
+    // untrimmed spelling does not collide and leaves two rows rendering
+    // identically. `id` excludes this row itself.
+    const nameConflict = await survivorNameConflict(
+      BedType.collection as unknown as MinimalNameCollection,
+      (body as { name?: unknown }).name,
+      id,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A bed type with that name already exists: "${String((body as { name?: unknown }).name).trim()}"`,
+        409,
+      );
+    }
     const bedType = await BedType.findOneAndUpdate(
       { _id: id, _deletedAt: null },
       update,

--- a/src/app/api/bed-types/route.ts
+++ b/src/app/api/bed-types/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import BedType from "@/models/BedType";
 import Printer from "@/models/Printer";
@@ -65,6 +69,22 @@ export async function POST(request: NextRequest) {
     delete body.updatedAt;
     delete body.__v;
     delete body.syncId;
+    // GH #1116: the partial unique index can no longer answer this. It
+    // compares RAW stored strings, so a submitted "Smooth PEI" and a surviving
+    // untrimmed "Smooth PEI " are two different keys and the write succeeds —
+    // manufacturing the indistinguishable pair this change exists to remove.
+    // Ask the trimmed question explicitly, in the same 409 shape
+    // handleDuplicateKeyError produces so the client contract is unchanged.
+    const nameConflict = await survivorNameConflict(
+      BedType.collection as unknown as MinimalNameCollection,
+      body.name,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A bed type with that name already exists: "${String(body.name).trim()}"`,
+        409,
+      );
+    }
     const bedType = await BedType.create(body);
     return NextResponse.json(bedType, { status: 201 });
   } catch (err) {

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findExactRawNameId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import "@/models/Nozzle";
@@ -62,7 +66,22 @@ export async function GET(
       : null;
 
     if (!filament) {
-      filament = await Filament.findOne({ name: decodedName, _deletedAt: null })
+      // name-lookup-ok: read-only; a miss is a 404
+      // GH #1116 (Codex P1, same class as the sync routes): the EXACT stored
+      // spelling wins. The setter casts this query, so with both "X" and "X "
+      // active a request addressed as "X " would return the CANONICAL row's
+      // data — the wrong filament's calibration / spool state.
+      const exactId = await findExactRawNameId(
+        Filament.collection as unknown as MinimalNameCollection,
+        decodedName,
+        { _deletedAt: null },
+      );
+      // name-lookup-ok: exact-spelling resolution above covers the cast case
+      filament = await Filament.findOne(
+        exactId
+          ? { _id: exactId, _deletedAt: null }
+          : { name: decodedName, _deletedAt: null },
+      )
         .populate("calibrations.nozzle")
         .populate("calibrations.printer")
         .populate("calibrations.bedType")

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findExactRawNameId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import { generateOrcaSlicerProfiles } from "@/lib/orcaSlicerBundle";
@@ -147,7 +151,22 @@ export async function POST(
       ? await Filament.findOne({ _id: id, _deletedAt: null })
       : null;
     if (!filament) {
-      filament = await Filament.findOne({ name: decodedName, _deletedAt: null });
+      // name-lookup-ok: resolves an EXISTING row; create-on-404 removed in #867
+      // GH #1116 (Codex P1): the EXACT stored spelling wins. `decodedName`
+      // is the addressing key, and the `trim: true` setter casts this query
+      // — so with both "X" and "X " active (an unresolved migration) a
+      // preset addressed as "X " would select the CANONICAL row and apply
+      // the preset to the wrong filament. Before the setter this query
+      // matched "X " exactly, so the redirection is ours to prevent.
+      const exactId = await findExactRawNameId(
+        Filament.collection as unknown as MinimalNameCollection,
+        decodedName,
+        { _deletedAt: null },
+      );
+      // name-lookup-ok: exact-spelling resolution above covers the cast case
+      filament = exactId
+        ? await Filament.findOne({ _id: exactId, _deletedAt: null })
+        : await Filament.findOne({ name: decodedName, _deletedAt: null });
     }
 
     if (!filament) {

--- a/src/app/api/filaments/[id]/restore/route.ts
+++ b/src/app/api/filaments/[id]/restore/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findSurvivorId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
@@ -74,13 +78,29 @@ export async function POST(
     // Name collision check: if a non-deleted filament now uses this name,
     // restoring would violate the partial unique index. Fail with a useful
     // message so the caller can rename one or the other.
-    const conflict = await Filament.findOne({
+    // GH #1116: a MISSED collision fails in the dangerous direction. `name`
+    // casts, so restoring a trashed `"X"` while an unresolved active `"X "`
+    // survives finds nothing, the restore proceeds, and the user ends up with
+    // two ACTIVE rows rendering identically — precisely what this guard is
+    // for. The survivor lookup compares TRIMMED forms, which is the question
+    // the guard is actually asking. ("Refuses, never creates" was the wrong
+    // exemption: failing to refuse is how this one creates a duplicate.)
+    // name-lookup-ok: survivor lookup below covers the cast case
+    let conflict: { _id: unknown } | null = await Filament.findOne({
       name: trashed.name,
       _deletedAt: null,
       _id: { $ne: trashed._id },
     })
       .select("_id")
       .lean();
+    if (!conflict) {
+      const survivorId = await findSurvivorId(
+        Filament.collection as unknown as MinimalNameCollection,
+        String(trashed.name ?? ""),
+        { _deletedAt: null, _id: { $ne: trashed._id } },
+      );
+      if (survivorId) conflict = { _id: survivorId };
+    }
     if (conflict) {
       return errorResponse(
         `Cannot restore: another active filament named "${trashed.name}" already exists. Rename one of them first.`,

--- a/src/app/api/filaments/[id]/route.ts
+++ b/src/app/api/filaments/[id]/route.ts
@@ -1,4 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findExactRawNameId,
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
 import Filament, { IFilament } from "@/models/Filament";
@@ -235,6 +240,38 @@ export async function GET(
   } catch (err) {
     return errorResponseFromCaught(err, "Failed to fetch filament");
   }
+}
+
+/**
+ * Is `name` already taken by a DIFFERENT active filament — including one the
+ * trim migration could not repair? (GH #1116)
+ *
+ * The ordinary `Filament.exists({ name })` casts, so it cannot see a stored
+ * raw `"X "`; renaming onto it therefore passes the check AND does not trip
+ * the unique index (the raw strings differ), leaving two active rows that
+ * render identically.
+ *
+ * Self-exclusion is compared in JS, not pushed into the filter: this is a
+ * RAW-DRIVER query, where nothing casts, so `{_id: {$ne: "507f…"}}` compares
+ * an ObjectId against a string, never matches, and the row fails to exclude
+ * ITSELF — every save echoing an unchanged name would 409.
+ */
+async function nameTakenBySurvivor(
+  name: unknown,
+  selfId: string,
+): Promise<string | null> {
+  // Delegates to the shared helper so the CAST normalization lives in exactly
+  // one place (Codex P2). A local `typeof name === "string"` gate is a hole:
+  // a JSON client can send `7` or `{"_id":"X"}`, Mongoose stores "7" / "X",
+  // and beside a survivor stored as "7 " the raw index admits the duplicate
+  // while the guard never looked. Fixing that in the shared helper and
+  // leaving this copy behind is the same twin-call-site miss this change has
+  // repeatedly made.
+  return survivorNameConflict(
+    Filament.collection as unknown as MinimalNameCollection,
+    name,
+    selfId,
+  );
 }
 
 export async function PUT(
@@ -596,11 +633,19 @@ export async function PUT(
       const effectiveName =
         typeof body.name === "string" ? body.name : dryRunTarget.name;
       if (
-        await Filament.exists({
+        // name-lookup-ok: the survivor check below covers the cast case
+        (await Filament.exists({
           name: effectiveName,
           _deletedAt: null,
           _id: { $ne: id },
-        })
+        })) ||
+        // GH #1116 (Codex P1): this has to catch a SURVIVOR too, and it has to
+        // do so HERE. Left to the post-gate guard, a confirmed reparent+rename
+        // would irreversibly promote the carrying parent — moving its color and
+        // spools onto a new variant — and only then 409, reporting failure
+        // after a side effect it cannot undo. Fail-fast before the irreversible
+        // bit is this route's own contract.
+        (await nameTakenBySurvivor(effectiveName, id))
       ) {
         return errorResponse(
           `A filament with that name already exists: "${effectiveName}"`,
@@ -644,6 +689,34 @@ export async function PUT(
       }
       clearParentThresholdAfterWrite = adoption.clearOrphanedThreshold;
       adoptionGateCleared = true;
+    }
+
+    // GH #1116: refuse a rename onto a SURVIVING untrimmed name.
+    //
+    // The PUT has no name pre-check by design — it lets the write-time E11000
+    // handler produce the 409. That stops working here: renaming to "X" while
+    // an unresolved active "X " survives does NOT trip the unique index (the
+    // raw stored strings differ), so the write succeeds and leaves two active
+    // rows rendering identically. This is the main UI edit path, so it is the
+    // likeliest way a user manufactures the duplicate by hand.
+    //
+    // Trimmed comparison, because that is the question being asked: would the
+    // renamed row be indistinguishable from an existing one?
+    // The NON-reparent path: the pre-lock check above only runs when this PUT
+    // also re-parents. Same rule, same helper, so the two cannot drift.
+    if (body.name != null) {
+      const survivorId = await nameTakenBySurvivor(body.name, id);
+      if (survivorId) {
+        // Same shape as this route's existing duplicate-key 409
+        // (`handleDuplicateKeyError`), NOT the sync route's structured
+        // `name_taken` envelope. This guard intercepts a case that used to
+        // reach the E11000 handler, so it must answer the way that handler
+        // does or it silently changes a tested response contract (PR #357).
+        return errorResponse(
+          `A filament with that name already exists: "${String(body.name).trim()}"`,
+          409,
+        );
+      }
     }
 
     // GH #605: a filament with ≥1 live variant is a TEMPLATE and must not
@@ -890,7 +963,21 @@ export async function POST(
         }
       }
       if (!filament) {
-        filament = await Filament.findOne({ name: decodedName, _deletedAt: null });
+        // GH #1116 (Codex P1): the EXACT stored spelling wins. `decodedName`
+        // is the addressing key, and the `trim: true` setter casts this query
+        // — so with both "X" and "X " active (an unresolved migration) a
+        // preset addressed as "X " would select the CANONICAL row and apply
+        // the preset to the wrong filament. Before the setter this query
+        // matched "X " exactly, so the redirection is ours to prevent.
+        const exactId = await findExactRawNameId(
+          Filament.collection as unknown as MinimalNameCollection,
+          decodedName,
+          { _deletedAt: null },
+        );
+        // name-lookup-ok: exact-spelling resolution above covers the cast case
+        filament = exactId
+          ? await Filament.findOne({ _id: exactId, _deletedAt: null })
+          : await Filament.findOne({ name: decodedName, _deletedAt: null });
         if (filament) matchedBy = "name";
       }
       // GH #950: a #872 per-nozzle preset is named "<base> <Ø type [HF]>". When
@@ -902,9 +989,25 @@ export async function POST(
         const hint =
           typeof config.filamentdb_nozzle === "string" ? config.filamentdb_nozzle.trim() : "";
         if (hint && decodedName.endsWith(` ${hint}`)) {
-          const baseName = decodedName.slice(0, -(hint.length + 1)).trim();
+          // GH #1116 (Codex P1): keep the RAW slice as well as the trimmed
+          // one. A per-nozzle preset generated for an unresolved `"X "` is
+          // named `"X  0.4 Brass"`, so slicing the hint leaves `"X "` — and
+          // `.trim()` here, plus the setter's cast, both land on the CANONICAL
+          // `"X"`. The sync would then write the legacy row's preset settings
+          // and calibration onto the bystander. Resolve the raw slice first;
+          // it is unambiguous when it hits, and falls through when it doesn't.
+          const rawBase = decodedName.slice(0, -(hint.length + 1));
+          const baseName = rawBase.trim();
           if (baseName) {
-            filament = await Filament.findOne({ name: baseName, _deletedAt: null });
+            const baseExactId = await findExactRawNameId(
+              Filament.collection as unknown as MinimalNameCollection,
+              rawBase,
+              { _deletedAt: null },
+            );
+            // name-lookup-ok: exact-spelling resolution above covers the cast case
+            filament = baseExactId
+              ? await Filament.findOne({ _id: baseExactId, _deletedAt: null })
+              : await Filament.findOne({ name: baseName, _deletedAt: null });
             if (filament) matchedBy = "name";
           }
         }
@@ -1407,11 +1510,27 @@ export async function POST(
         // non-deleted index would E11000 on the write anyway; the pre-check turns it
         // into a friendly, actionable 409 (a TOCTOU race still falls back to the
         // E11000 handler below).
-        const clash = await Filament.findOne({
+        // GH #1116: a MISSED clash fails in the dangerous direction. `name`
+        // casts, so renaming to "X" while an unresolved active "X " survives
+        // finds nothing here AND does not E11000 below (the raw strings
+        // differ), leaving two active rows rendering identically. The survivor
+        // lookup compares TRIMMED forms, which is the question the guard is
+        // really asking. ("Refuses, never creates" was the wrong exemption:
+        // failing to refuse is exactly how this one creates a duplicate.)
+        // name-lookup-ok: survivor lookup below covers the cast case
+        let clash: { _id: unknown } | null = await Filament.findOne({
           name: sentName,
           _deletedAt: null,
           _id: { $ne: filament._id },
         });
+        if (!clash) {
+          const survivorId = await survivorNameConflict(
+            Filament.collection as unknown as MinimalNameCollection,
+            sentName,
+            filament._id,
+          );
+          if (survivorId) clash = { _id: survivorId };
+        }
         if (clash) {
           return NextResponse.json(
             {
@@ -1536,6 +1655,7 @@ export async function POST(
       if (update.name != null && isDuplicateKeyError(validationErr)) {
         // Look up the winner so the race fallback returns the SAME shape as the
         // pre-check (incl. conflictId); the rename didn't apply.
+        // name-lookup-ok: name_taken guard that REFUSES; it never creates
         const clash = await Filament.findOne({ name: update.name, _deletedAt: null });
         return NextResponse.json(
           {

--- a/src/app/api/filaments/[id]/spool-check/route.ts
+++ b/src/app/api/filaments/[id]/spool-check/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findExactRawNameId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import { getErrorMessage, errorResponse } from "@/lib/apiErrorHandler";
@@ -54,7 +58,22 @@ export async function GET(
       ? await Filament.findOne({ _id: id, _deletedAt: null }).lean()
       : null;
     if (!filament) {
-      filament = await Filament.findOne({ name: decodedName, _deletedAt: null }).lean();
+      // name-lookup-ok: read-only; a miss is a 404
+      // GH #1116 (Codex P1, same class as the sync routes): the EXACT stored
+      // spelling wins. The setter casts this query, so with both "X" and "X "
+      // active a request addressed as "X " would return the CANONICAL row's
+      // data — the wrong filament's calibration / spool state.
+      const exactId = await findExactRawNameId(
+        Filament.collection as unknown as MinimalNameCollection,
+        decodedName,
+        { _deletedAt: null },
+      );
+      // name-lookup-ok: exact-spelling resolution above covers the cast case
+      filament = await Filament.findOne(
+        exactId
+          ? { _id: exactId, _deletedAt: null }
+          : { name: decodedName, _deletedAt: null },
+      ).lean();
     }
 
     if (!filament) {

--- a/src/app/api/filaments/bambustudio/route.ts
+++ b/src/app/api/filaments/bambustudio/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findSurvivorId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import {
@@ -150,10 +154,22 @@ export async function POST(request: NextRequest) {
     // resolved.
 
     // Phase 1 — active update.
-    const existingActive = await Filament.findOne({
+    let existingActive = await Filament.findOne({
       name,
       _deletedAt: null,
     });
+    if (!existingActive) {
+      // GH #1116 (Codex P1): the miss may be a LOOKUP failure rather than an
+      // absence — the setter casts this query, so it cannot select a row whose
+      // stored name is still raw. See src/lib/trimmedNameLookup.ts.
+      const survivorId = await findSurvivorId(
+        Filament.collection as unknown as MinimalNameCollection,
+        name,
+        { _deletedAt: null },
+      );
+      if (survivorId)
+        existingActive = await Filament.findOne({ _id: survivorId, _deletedAt: null });
+    }
     if (existingActive) {
       const payload = await prepareBambuUpdate(
         parsed,
@@ -204,11 +220,27 @@ export async function POST(request: NextRequest) {
     // rather than creating a duplicate that would strand the trashed
     // record (its restore would 409 forever on the name conflict).
     // (Codex P1 on PR #387 round 5.)
-    const existingTrashed = await Filament.findOne({
+    let existingTrashed = await Filament.findOne({
       name,
       _deletedAt: { $ne: null },
       _purged: { $ne: true },
     });
+    if (!existingTrashed) {
+      // GH #1116 (Codex P1): the miss may be a LOOKUP failure rather than an
+      // absence — the setter casts this query, so it cannot select a row whose
+      // stored name is still raw. See src/lib/trimmedNameLookup.ts.
+      const survivorId = await findSurvivorId(
+        Filament.collection as unknown as MinimalNameCollection,
+        name,
+        { _deletedAt: { $ne: null }, _purged: { $ne: true } },
+      );
+      if (survivorId)
+        existingTrashed = await Filament.findOne({
+          _id: survivorId,
+          _deletedAt: { $ne: null },
+          _purged: { $ne: true },
+        });
+    }
     if (existingTrashed) {
       const payload = await prepareBambuUpdate(
         parsed,
@@ -328,6 +360,7 @@ export async function POST(request: NextRequest) {
       if (!isDuplicateKeyError(createErr)) {
         return errorResponseFromCaught(createErr, "Failed to create filament");
       }
+      // name-lookup-ok: post-E11000 recovery: the index proved an exact stored-string match, so no survivor is involved
       const racing = await Filament.findOne({ name, _deletedAt: null });
       if (!racing) {
         // The winning row was already deleted; bail out with the

--- a/src/app/api/filaments/import-atlas/route.ts
+++ b/src/app/api/filaments/import-atlas/route.ts
@@ -12,6 +12,10 @@ import {
   LEGACY_NOZZLE_CONDITION_RE,
 } from "@/lib/legacyNozzleConditions";
 import { castNameLikeSchema } from "@/lib/trimEntityNames";
+import {
+  findByTrimmedName,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 
 /**
  * GH #255: explicit ALLOW-LIST of filament fields that may be copied
@@ -269,7 +273,30 @@ export async function POST(request: NextRequest) {
         const castName = castNameLikeSchema(filamentData.name);
         const importName = castName === null ? "" : castName.trim();
         if (castName !== null) filamentData.name = importName;
-        const existing = await Filament.findOne({ name: importName, _deletedAt: null });
+        let existing = await Filament.findOne({ name: importName, _deletedAt: null });
+        if (!existing && importName !== "") {
+          // GH #1116 (Codex P1): the miss may be a LOOKUP failure, not an
+          // absence. The setter casts this query, so it cannot select a local
+          // row whose stored name is still the raw `"PLA Basic "` — which is
+          // what survives when `trimEntityNames` had to skip the filaments
+          // collection or leave that row alone. Falling through to create
+          // would succeed (the two raw strings are distinct, so the partial
+          // unique index has no objection) and mint a second active filament
+          // that renders identically to the first.
+          //
+          // Re-hydrate by `_id`, the one key casting cannot break.
+          const survivor = await findByTrimmedName(
+            Filament.collection as unknown as MinimalNameCollection,
+            importName,
+            { _deletedAt: null },
+          );
+          if (survivor) {
+            existing = await Filament.findOne({
+              _id: survivor._id as Parameters<typeof Filament.findById>[0],
+              _deletedAt: null,
+            });
+          }
+        }
         if (existing) {
           preserveLocalSpoolIds(existing.spools);
           // GH #605 (codex round 3 sweep; extended round 4, F4): when the
@@ -355,11 +382,33 @@ export async function POST(request: NextRequest) {
           // invisible everywhere (list / trash both filter on `_purged:
           // { $ne: true }`) but still occupies the name on the partial-
           // unique active-name index, so the user can't recreate it.
-          const softDeleted = await Filament.findOne({
+          let softDeleted = await Filament.findOne({
             name: importName,
             _deletedAt: { $ne: null },
             _purged: { $ne: true },
           });
+          if (!softDeleted && importName !== "") {
+            // Same lookup failure as the active branch above, one state over.
+            // Missing an untrimmed TOMBSTONE does not immediately duplicate —
+            // the partial unique index only covers active rows, so the create
+            // below succeeds legitimately — but it defers the duplicate rather
+            // than avoiding it: restoring that tombstone later flips only
+            // `_deletedAt`, leaving its raw name intact, and the user ends up
+            // with two ACTIVE rows rendering identically. Resurrect the row
+            // that is actually there instead.
+            const survivor = await findByTrimmedName(
+              Filament.collection as unknown as MinimalNameCollection,
+              importName,
+              { _deletedAt: { $ne: null }, _purged: { $ne: true } },
+            );
+            if (survivor) {
+              softDeleted = await Filament.findOne({
+                _id: survivor._id as Parameters<typeof Filament.findById>[0],
+                _deletedAt: { $ne: null },
+                _purged: { $ne: true },
+              });
+            }
+          }
           if (softDeleted) {
             // GH #605 sweep: no template check needed on the resurrect — a
             // trashed doc cannot have live variants (soft-deleting a parent

--- a/src/app/api/filaments/route.ts
+++ b/src/app/api/filaments/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import Nozzle from "@/models/Nozzle";
@@ -680,6 +684,31 @@ export async function POST(request: NextRequest) {
     // with the OpenPrintTag variant import so no secondary entry point can
     // mint the first variant of a carrying parent without this exact
     // confirmation contract. See src/lib/createVariantGated.ts.
+    // GH #1116 (Codex P1): BEFORE the gated variant path, not after it.
+    //
+    // The partial unique index compares RAW stored strings, so a submitted
+    // "PLA" and a surviving untrimmed "PLA " are different keys and the create
+    // succeeds — producing the indistinguishable pair this change exists to
+    // remove. `createVariantGated` has the same blind spot: its own duplicate
+    // probe is a cast Mongoose query.
+    //
+    // Placed here it covers BOTH exits. Below the gate it covered only the
+    // standalone create, and worse: the gate RETURNS from the variant path, so
+    // a variant named onto a survivor was inserted without ever reaching the
+    // check — and for a confirmed carrying parent the promotion (which moves
+    // the parent's color and spools) would already have happened. Fail-fast
+    // before the irreversible bit, the same ordering the PUT needed.
+    const nameConflict = await survivorNameConflict(
+      Filament.collection as unknown as MinimalNameCollection,
+      body.name,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A filament with that name already exists: "${String(body.name).trim()}"`,
+        409,
+      );
+    }
+
     if (variantParent) {
       const result = await createVariantGated(Filament, variantParent._id, body, promoteParent);
       switch (result.outcome) {

--- a/src/app/api/locations/[id]/route.ts
+++ b/src/app/api/locations/[id]/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
 import Location from "@/models/Location";
@@ -68,6 +72,21 @@ export async function PUT(
       update.desiccantChangedAt = raw;
     }
     if ("notes" in body) update.notes = body.notes;
+    // GH #1116: a RENAME needs the same trimmed check as the create — the
+    // index compares raw stored strings, so renaming onto a surviving
+    // untrimmed spelling does not collide and leaves two rows rendering
+    // identically. `id` excludes this row itself.
+    const nameConflict = await survivorNameConflict(
+      Location.collection as unknown as MinimalNameCollection,
+      (body as { name?: unknown }).name,
+      id,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A location with that name already exists: "${String((body as { name?: unknown }).name).trim()}"`,
+        409,
+      );
+    }
     const location = await Location.findOneAndUpdate(
       { _id: id, _deletedAt: null },
       update,

--- a/src/app/api/locations/route.ts
+++ b/src/app/api/locations/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Location from "@/models/Location";
 import Filament from "@/models/Filament";
@@ -145,6 +149,22 @@ export async function POST(request: NextRequest) {
         !(typeof body.desiccantChangedAt === "string" &&
           isValidIsoDateString(body.desiccantChangedAt))) {
       return errorResponse("desiccantChangedAt must be an ISO date string or null", 400);
+    }
+    // GH #1116: the partial unique index can no longer answer this. It
+    // compares RAW stored strings, so a submitted "Drybox" and a surviving
+    // untrimmed "Drybox " are two different keys and the write succeeds —
+    // manufacturing the indistinguishable pair this change exists to remove.
+    // Ask the trimmed question explicitly, in the same 409 shape
+    // handleDuplicateKeyError produces so the client contract is unchanged.
+    const nameConflict = await survivorNameConflict(
+      Location.collection as unknown as MinimalNameCollection,
+      body.name,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A location with that name already exists: "${String(body.name).trim()}"`,
+        409,
+      );
     }
     const location = await Location.create(body);
     return NextResponse.json(location, { status: 201 });

--- a/src/app/api/nozzles/[id]/clone/route.ts
+++ b/src/app/api/nozzles/[id]/clone/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import { errorResponse, errorResponseFromCaught } from "@/lib/apiErrorHandler";
@@ -54,6 +58,22 @@ export async function POST(
       source.name,
       peers.map((p) => p.name),
     );
+
+    // GH #1116 (Codex P1): the GENERATED name needs the survivor check too.
+    // The peer regex above is a raw-name match that misses an untrimmed
+    // survivor, so with an active `"0.4 #2 "` this picks `"0.4 #2"`, the
+    // unique index compares the raw strings and permits it, and the clone is
+    // indistinguishable from the row it failed to see.
+    const nameConflict = await survivorNameConflict(
+      Nozzle.collection as unknown as MinimalNameCollection,
+      newName,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A nozzle with that name already exists: "${newName}"`,
+        409,
+      );
+    }
 
     const cloned = await Nozzle.create({
       name: newName,

--- a/src/app/api/nozzles/[id]/clone/route.ts
+++ b/src/app/api/nozzles/[id]/clone/route.ts
@@ -27,6 +27,10 @@ import { nextCloneName, clonePeerNamePattern } from "@/lib/nozzleConflicts";
  * follow-up assignment, because this endpoint deliberately doesn't know
  * which printer triggered the clone.
  */
+/** How many `#N` suffixes to probe before giving up. Each miss consumes one,
+ *  so the loop terminates on its own; this only bounds a pathological DB. */
+const MAX_CLONE_SUFFIX_PROBES = 50;
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -54,23 +58,39 @@ export async function POST(
     })
       .select("name")
       .lean();
-    const newName = nextCloneName(
-      source.name,
-      peers.map((p) => p.name),
-    );
+    const peerNames = peers.map((p) => p.name);
+    const firstName = nextCloneName(source.name, peerNames);
 
     // GH #1116 (Codex P1): the GENERATED name needs the survivor check too.
     // The peer regex above is a raw-name match that misses an untrimmed
-    // survivor, so with an active `"0.4 #2 "` this picks `"0.4 #2"`, the
-    // unique index compares the raw strings and permits it, and the clone is
-    // indistinguishable from the row it failed to see.
-    const nameConflict = await survivorNameConflict(
-      Nozzle.collection as unknown as MinimalNameCollection,
-      newName,
-    );
+    // survivor, so with an active `"0.4 #2 "` it picks `"0.4 #2"`, the unique
+    // index compares the raw strings and permits it, and the clone renders
+    // identically to the row it failed to see.
+    //
+    // ADVANCE past it rather than refusing (Codex P2). This endpoint is the
+    // UI's way to mint a distinct physical nozzle, and a survivor is a
+    // permanent state — the migration leaves it precisely because it cannot be
+    // repaired automatically. Returning 409 would make cloning impossible
+    // forever, on every retry, even though `"0.4 #3"` is free. So treat the
+    // survivor as an occupied suffix, which is exactly what it is to a human
+    // reading the list, and take the next candidate.
+    let newName = firstName;
+    let attempt = 0;
+    let nameConflict: string | null = null;
+    // Bounded: each miss consumes one suffix, so this terminates. The cap only
+    // stops a pathological database from spinning.
+    while (attempt < MAX_CLONE_SUFFIX_PROBES) {
+      nameConflict = await survivorNameConflict(
+        Nozzle.collection as unknown as MinimalNameCollection,
+        newName,
+      );
+      if (!nameConflict) break;
+      attempt += 1;
+      newName = nextCloneName(source.name, [...peerNames, newName]);
+    }
     if (nameConflict) {
       return errorResponse(
-        `A nozzle with that name already exists: "${newName}"`,
+        `Could not find a free name for the clone (last tried "${newName}").`,
         409,
       );
     }

--- a/src/app/api/nozzles/[id]/route.ts
+++ b/src/app/api/nozzles/[id]/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import Filament from "@/models/Filament";
@@ -95,6 +99,21 @@ export async function PUT(
       return errorResponse(assignment.message, 400);
     }
     const { printerIds, targetId: validatedTargetId } = assignment;
+    // GH #1116: a RENAME needs the same trimmed check as the create — the
+    // index compares raw stored strings, so renaming onto a surviving
+    // untrimmed spelling does not collide and leaves two rows rendering
+    // identically. `id` excludes this row itself.
+    const nameConflict = await survivorNameConflict(
+      Nozzle.collection as unknown as MinimalNameCollection,
+      (body as { name?: unknown }).name,
+      id,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A nozzle with that name already exists: "${String((body as { name?: unknown }).name).trim()}"`,
+        409,
+      );
+    }
 
     const nozzle = await Nozzle.findOneAndUpdate(
       { _id: id, _deletedAt: null },

--- a/src/app/api/nozzles/route.ts
+++ b/src/app/api/nozzles/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Nozzle from "@/models/Nozzle";
 import Printer from "@/models/Printer";
@@ -92,6 +96,22 @@ export async function POST(request: NextRequest) {
       return errorResponse(assignment.message, 400);
     }
 
+    // GH #1116: the partial unique index can no longer answer this. It
+    // compares RAW stored strings, so a submitted "0.4 Brass" and a surviving
+    // untrimmed "0.4 Brass " are two different keys and the write succeeds —
+    // manufacturing the indistinguishable pair this change exists to remove.
+    // Ask the trimmed question explicitly, in the same 409 shape
+    // handleDuplicateKeyError produces so the client contract is unchanged.
+    const nameConflict = await survivorNameConflict(
+      Nozzle.collection as unknown as MinimalNameCollection,
+      body.name,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A nozzle with that name already exists: "${String(body.name).trim()}"`,
+        409,
+      );
+    }
     const nozzle = await Nozzle.create(body);
 
     if (assignment.targetId) {

--- a/src/app/api/openprinttag/import/route.ts
+++ b/src/app/api/openprinttag/import/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findSurvivorId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
@@ -250,21 +254,62 @@ export async function POST(request: NextRequest) {
           }
         };
 
-        const existing = await Filament.findOneAndUpdate(
+        // CANONICAL FIRST, survivor only on a miss (Codex P2).
+        //
+        // A row the migration could not trim is invisible to a name-filtered
+        // query (the setter casts it), so on its own this atomic upsert would
+        // miss it and the create below would mint a second active row.
+        //
+        // But the scan must not run FIRST. Its `$expr` matches the canonical
+        // and the untrimmed row alike and imposes no ordering, so in exactly
+        // the collision state that produces a survivor — same-vendor `"PLA"`
+        // AND `"PLA "` — a survivor-first lookup would pick either one, and
+        // the import could start updating the legacy row where the indexed
+        // query had deterministically chosen the canonical one. Trying the
+        // cast query first keeps that determinism and reaches the scan only
+        // when there is genuinely nothing canonical to hit.
+        let existing = await Filament.findOneAndUpdate(
           { name, _deletedAt: null, vendor },
           { $set: optUpdateFields },
           { returnDocument: "after" },
         );
+        if (!existing) {
+          const survivorId = await findSurvivorId(
+            Filament.collection as unknown as MinimalNameCollection,
+            name,
+            { _deletedAt: null, vendor },
+          );
+          if (survivorId) {
+            existing = await Filament.findOneAndUpdate(
+              { _id: survivorId, _deletedAt: null, vendor },
+              { $set: optUpdateFields },
+              { returnDocument: "after" },
+            );
+          }
+        }
 
         if (existing) {
           await applyConditionalDefaults(existing);
           updated++;
         } else {
           // Check if a filament exists with a different vendor (name collision)
-          const nameCollision = await Filament.findOne({ name, _deletedAt: null }).lean();
+          let nameCollision = await Filament.findOne({ name, _deletedAt: null }).lean();
+          if (!nameCollision) {
+            // Same blind spot, and it matters in the opposite direction: a
+            // MISSED collision lets the create proceed into a duplicate.
+            const otherVendorId = await findSurvivorId(
+              Filament.collection as unknown as MinimalNameCollection,
+              name,
+              { _deletedAt: null },
+            );
+            if (otherVendorId) {
+              nameCollision = await Filament.findOne({ _id: otherVendorId }).lean();
+            }
+          }
           if (nameCollision) {
             errors.push(
               `${material.name}: skipped — a filament named "${name}" already exists under vendor "${nameCollision.vendor}"`,
+            // name-lookup-ok: post-E11000 recovery: the index proved an exact stored-string match
             );
             continue;
           }
@@ -281,6 +326,7 @@ export async function POST(request: NextRequest) {
           } catch (createErr) {
             if (!isDuplicateKeyError(createErr)) throw createErr;
             const winner = await Filament.findOneAndUpdate(
+              // name-lookup-ok: post-E11000 recovery: the index proved an exact stored-string match
               { name, vendor, _deletedAt: null },
               { $set: optUpdateFields },
               { returnDocument: "after" },
@@ -296,6 +342,7 @@ export async function POST(request: NextRequest) {
             } else {
               // The race winner is in a different vendor — same shape as
               // the pre-create nameCollision branch above.
+              // name-lookup-ok: post-E11000 recovery; the index proved an exact stored-string match
               const racedCollision = await Filament.findOne({ name, _deletedAt: null }).lean();
               if (racedCollision) {
                 errors.push(
@@ -385,7 +432,21 @@ async function importAsVariant(slugs: string[], parentId: string, promoteParent:
 
   // Refuse a name collision rather than updating / re-parenting an existing
   // row — a "create variant" action must never mutate another filament.
-  const collision = await Filament.findOne({ name, _deletedAt: null }).lean();
+  let collision = await Filament.findOne({ name, _deletedAt: null }).lean();
+  if (!collision) {
+    // GH #1116 (Codex P1): a MISSED collision fails in the dangerous
+    // direction. A row the migration could not trim is invisible to this cast
+    // query, so the refusal below is skipped and the variant is created —
+    // producing exactly the pair of identically-rendering active rows this
+    // guard exists to prevent, with the new one additionally parented.
+    const survivorId = await findSurvivorId(
+      Filament.collection as unknown as MinimalNameCollection,
+      name,
+      { _deletedAt: null },
+    );
+    if (survivorId)
+      collision = await Filament.findOne({ _id: survivorId, _deletedAt: null }).lean();
+  }
   if (collision) {
     return NextResponse.json(
       { error: `A filament named "${name}" already exists — rename it, or import it without a parent.` },

--- a/src/app/api/printers/[id]/route.ts
+++ b/src/app/api/printers/[id]/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Printer from "@/models/Printer";
 import Filament from "@/models/Filament";
@@ -146,6 +150,21 @@ export async function PUT(
     if ("enclosed" in body) update.enclosed = body.enclosed;
     if ("autoBedLevel" in body) update.autoBedLevel = body.autoBedLevel;
     if ("amsSlots" in body) update.amsSlots = body.amsSlots;
+    // GH #1116: a RENAME needs the same trimmed check as the create — the
+    // index compares raw stored strings, so renaming onto a surviving
+    // untrimmed spelling does not collide and leaves two rows rendering
+    // identically. `id` excludes this row itself.
+    const nameConflict = await survivorNameConflict(
+      Printer.collection as unknown as MinimalNameCollection,
+      (body as { name?: unknown }).name,
+      id,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A printer with that name already exists: "${String((body as { name?: unknown }).name).trim()}"`,
+        409,
+      );
+    }
 
     const printer = await Printer.findOneAndUpdate(
       { _id: id, _deletedAt: null },

--- a/src/app/api/printers/route.ts
+++ b/src/app/api/printers/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Printer from "@/models/Printer";
 import Filament from "@/models/Filament";
@@ -132,6 +136,22 @@ export async function POST(request: NextRequest) {
       return errorResponse(slotError, 400);
     }
 
+    // GH #1116: the partial unique index can no longer answer this. It
+    // compares RAW stored strings, so a submitted "MK4" and a surviving
+    // untrimmed "MK4 " are two different keys and the write succeeds —
+    // manufacturing the indistinguishable pair this change exists to remove.
+    // Ask the trimmed question explicitly, in the same 409 shape
+    // handleDuplicateKeyError produces so the client contract is unchanged.
+    const nameConflict = await survivorNameConflict(
+      Printer.collection as unknown as MinimalNameCollection,
+      body.name,
+    );
+    if (nameConflict) {
+      return errorResponse(
+        `A printer with that name already exists: "${String(body.name).trim()}"`,
+        409,
+      );
+    }
     const printer = await Printer.create(body);
 
     // GH #242 — see printers/[id] PUT. Clear any spools this new printer

--- a/src/app/api/prusament/import/route.ts
+++ b/src/app/api/prusament/import/route.ts
@@ -1,4 +1,8 @@
 import mongoose from "mongoose";
+import {
+  findSurvivorId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament, { generateInstanceId } from "@/models/Filament";
@@ -286,9 +290,24 @@ export async function POST(request: NextRequest) {
     // that has since become a TEMPLATE must 400, not attach inventory to
     // it. The `name` pin plus the cap ride the guard's extraFilter so the
     // atomic-write semantics of the original single findOneAndUpdate hold.
-    const activeByName = await Filament.findOne({ name, _deletedAt: null })
+    let activeByName = await Filament.findOne({ name, _deletedAt: null })
       .select("_id")
       .lean();
+    // GH #1116 (Codex P1): a row the migration could not trim is invisible to
+    // a name-filtered query (the setter casts it), so this would miss and the
+    // create below would mint a second active row.
+    const activeSurvivorId = activeByName
+      ? null
+      : await findSurvivorId(
+          Filament.collection as unknown as MinimalNameCollection,
+          name,
+          { _deletedAt: null },
+        );
+    if (activeSurvivorId) {
+      activeByName = await Filament.findOne({ _id: activeSurvivorId })
+        .select("_id")
+        .lean();
+    }
     if (activeByName) {
       const guarded = await runExclusive(filamentLockKey(activeByName._id), () =>
         pushSpoolWithTemplateGuard(
@@ -296,7 +315,16 @@ export async function POST(request: NextRequest) {
           String(activeByName._id),
           prusamentSpoolFields,
           hasVariants,
-          { extraFilter: { name, $expr: SPOOL_CAP_EXPR } },
+          {
+            // The `name` pin makes the push atomic against a concurrent
+            // rename. It cannot be used for a SURVIVOR — a cast filter can
+            // never match its raw stored value — so pin the `_id` there,
+            // which is strictly more specific and preserves the same
+            // "still the row we resolved" guarantee.
+            extraFilter: activeSurvivorId
+              ? { _id: activeSurvivorId, $expr: SPOOL_CAP_EXPR }
+              : { name, $expr: SPOOL_CAP_EXPR },
+          },
         ),
       );
       if (guarded.outcome === "template") {
@@ -315,8 +343,13 @@ export async function POST(request: NextRequest) {
 
     // No conditional match — either the name doesn't exist (continue
     // to create) OR the name exists but is over cap. Check which.
+    // GH #1116 (Codex P1): reuse the resolved survivor id. Against a survivor
+    // the guarded push above fails on the cap expression, and this probe --
+    // filtered by a cast `name` -- would then MISS the very row that is over
+    // cap, so the request fell through and created a canonical duplicate
+    // carrying the spool. The cap error is the correct answer.
     const blocked = await Filament.findOne(
-      { name, _deletedAt: null },
+      activeSurvivorId ? { _id: activeSurvivorId } : { name, _deletedAt: null },
       { spools: 1 },
     ).lean();
     if (
@@ -352,19 +385,47 @@ export async function POST(request: NextRequest) {
     // first-variant create racing the just-revived row serializes behind
     // the promotion gate's own in-lock re-fetch, which then sees (and
     // moves) this spool.
-    const resurrected = await Filament.findOneAndUpdate(
-      {
-        name,
-        _deletedAt: { $ne: null },
-        _purged: { $ne: true },
-        $expr: SPOOL_CAP_EXPR,
-      },
-      {
-        $set: { _deletedAt: null },
-        $push: { spools: prusamentSpoolFields },
-      },
+    // GH #1116: same blind spot as the active branch — a surviving untrimmed
+    // TRASHED row is unreachable by a cast name filter, so this resurrect
+    // would miss and the create below would take the name, stranding the
+    // tombstone whose restore then 409s on the conflict forever.
+    //
+    // CANONICAL FIRST, survivor only on a miss (Codex P2). The partial unique
+    // index covers active rows only, so a canonical `"PLA"` tombstone and an
+    // untrimmed `"PLA "` tombstone may BOTH exist — and the scan's `$expr`
+    // matches either with no ordering. Scanning first would resurrect an
+    // arbitrary one of them and attach the spool to it, where the indexed
+    // query deterministically restored the canonical row.
+    const resurrectFilter = {
+      _deletedAt: { $ne: null },
+      _purged: { $ne: true },
+      $expr: SPOOL_CAP_EXPR,
+    };
+    const resurrectUpdate = {
+      $set: { _deletedAt: null },
+      $push: { spools: prusamentSpoolFields },
+    };
+    let resurrected = await Filament.findOneAndUpdate(
+      // name-lookup-ok: canonical attempt; the survivor scan below covers the miss
+      { name, ...resurrectFilter },
+      resurrectUpdate,
       { returnDocument: "after" },
     ).lean();
+    let trashedSurvivorId: unknown | null = null;
+    if (!resurrected) {
+      trashedSurvivorId = await findSurvivorId(
+        Filament.collection as unknown as MinimalNameCollection,
+        name,
+        { _deletedAt: { $ne: null }, _purged: { $ne: true } },
+      );
+      if (trashedSurvivorId) {
+        resurrected = await Filament.findOneAndUpdate(
+          { _id: trashedSurvivorId, ...resurrectFilter },
+          resurrectUpdate,
+          { returnDocument: "after" },
+        ).lean();
+      }
+    }
     if (resurrected) {
       return NextResponse.json({
         action: "add-spool",
@@ -376,7 +437,9 @@ export async function POST(request: NextRequest) {
     // must NOT fall through to create (the new active row would strand
     // the trashed one on the name forever).
     const trashedBlocked = await Filament.findOne(
-      { name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
+      trashedSurvivorId
+        ? { _id: trashedSurvivorId }
+        : { name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
       { spools: 1 },
     ).lean();
     if (
@@ -425,6 +488,7 @@ export async function POST(request: NextRequest) {
           bed_temp_range: `${spool.bedTempMin}-${spool.bedTempMax}`,
         },
       });
+    // name-lookup-ok: post-E11000 recovery: the index proved an exact stored-string match
     } catch (createErr) {
       if (!isDuplicateKeyError(createErr)) throw createErr;
       // GH #605 (codex round 3, Finding B): same guard treatment as the
@@ -432,6 +496,7 @@ export async function POST(request: NextRequest) {
       // spool-less row, but nothing stops it from being (or instantly
       // becoming) a template, so the recovery push must not bypass the
       // guard either.
+      // name-lookup-ok: post-E11000 recovery; the index proved an exact stored-string match
       const winner = await Filament.findOne({ name, _deletedAt: null })
         .select("_id")
         .lean();

--- a/src/app/api/spools/import/route.ts
+++ b/src/app/api/spools/import/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  findByTrimmedName,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
 import Filament, { generateInstanceId, isSpoolInstanceIdTaken } from "@/models/Filament";
 import Location from "@/models/Location";
@@ -191,10 +195,35 @@ export async function POST(request: NextRequest) {
       if (!name) return null;
       if (locationCache.has(name)) return locationCache.get(name)!;
       let loc = await Location.findOne({ name, _deletedAt: null });
-      if (!loc) {
-        loc = await Location.create({ name });
+      let id: string;
+      if (loc) {
+        id = String(loc._id);
+      } else {
+        // GH #1116 (Codex P1): the miss may be a LOOKUP failure rather than a
+        // genuine absence. `name` carries `trim: true`, and a Mongoose setter
+        // casts QUERY values too, so this findOne cannot select a row whose
+        // stored value is still the raw `"Drybox #1 "` — which is exactly what
+        // survives when `trimEntityNames` had to skip the locations collection
+        // (no protective index) or leave that row alone (a collision).
+        //
+        // Creating here would then succeed: the two raw strings are distinct,
+        // so the unique index does not object, and the user gets a second
+        // location that renders identically while every imported spool attaches
+        // to the twin. That IS the bug this whole change exists to remove, and
+        // this route is its original reproduction path.
+        const survivor = await findByTrimmedName(
+          Location.collection as unknown as MinimalNameCollection,
+          name,
+          { _deletedAt: null },
+        );
+        if (survivor) {
+          // Address it by `_id` — the one key casting cannot break.
+          id = String(survivor._id);
+        } else {
+          loc = await Location.create({ name });
+          id = String(loc._id);
+        }
       }
-      const id = String(loc._id);
       locationCache.set(name, id);
       return id;
     }

--- a/src/lib/importFilaments.ts
+++ b/src/lib/importFilaments.ts
@@ -7,6 +7,7 @@ import { runExclusive, filamentLockKey } from "@/lib/filamentMutex";
 import { stripTemplateFieldsForWrite } from "@/lib/templateStrip";
 import { clearOrphanedParentThreshold } from "@/lib/promoteParent";
 import { firstVariantGateInfo } from "@/lib/firstVariantGate";
+import { trimmedNameFilter } from "@/lib/trimmedNameLookup";
 
 export interface ImportRow {
   name?: string;
@@ -670,6 +671,60 @@ export async function upsertImportRows(
   const allExisting = await Filament.find({ name: { $in: [...namesToLoad] } })
     .select(INHERITANCE_PROJECTION)
     .lean();
+
+  // GH #1116 (Codex P1 ×2): ALSO find stored rows whose TRIMMED name matches —
+  // with the RAW DRIVER, which is the only thing that can see them.
+  //
+  // `trimEntityNames` can legitimately leave a row untrimmed: its normalized
+  // name would collide with a live sibling, or its whole collection was
+  // skipped because no adequate unique index could be established. Such a row
+  // is invisible to every Mongoose query, because a String schema setter
+  // applies to QUERY values too — the `$in` above is itself trimmed, so it
+  // asks for `"PLA"` and never matches a stored `"PLA "`.
+  //
+  // The predicate is on the STORED value, not on the input's spelling. An
+  // earlier version filtered the INPUT for untrimmed names, which missed the
+  // ordinary case entirely: importing a canonical `"PLA"` against a surviving
+  // `"PLA "` produced no candidates at all, and the importer created `"PLA"`
+  // beside it. Whatever whitespace either side happens to carry, the question
+  // is the same one the schema asks — do the trimmed forms match.
+  //
+  // Only names the indexed lookup did NOT already resolve, so the healthy
+  // path adds nothing. `$expr` can't use the index, so this is a scan; it
+  // runs on an explicit, batch, user-initiated import, and the alternative
+  // is a silent duplicate.
+  //
+  // Collisions resolve explicitly rather than by insertion luck: the index
+  // below keys on the TRIMMED name and prefers a row already stored exactly
+  // that way, so a canonical row always wins and the untrimmed one is left
+  // for the migration to report.
+  // ACTIVE matches only (Codex P2). A tombstone is not a match for this
+  // purpose: with the collection skipped, an active `"PLA "` can coexist with
+  // a soft-deleted `"PLA"`, and counting the tombstone as "found" skipped the
+  // scan — so the importer resurrected the tombstone and left TWO active rows
+  // rendering identically, which is the duplicate this exists to prevent.
+  const alreadyFound = new Set(
+    (allExisting as unknown as LeanFilament[])
+      .filter((d) => d._deletedAt == null)
+      .map((d) => String(d.name ?? "").trim()),
+  );
+  const stillMissing = [...namesToLoad].filter((n) => !alreadyFound.has(n.trim()));
+  if (stillMissing.length > 0) {
+    const projection: Record<string, 1> = {};
+    for (const field of INHERITANCE_PROJECTION.split(/\s+/)) {
+      if (field) projection[field] = 1;
+    }
+    const untrimmed = (await Filament.collection
+      .find(trimmedNameFilter(stillMissing), { projection })
+      .toArray()) as unknown as LeanFilament[];
+    const seen = new Set(
+      (allExisting as unknown as LeanFilament[]).map((d) => String(d._id)),
+    );
+    const extra = untrimmed.filter((doc) => !seen.has(String(doc._id)));
+    if (extra.length > 0) {
+      (allExisting as unknown as LeanFilament[]).push(...extra);
+    }
+  }
 
   // The same map carries existing rows AND filaments created earlier in
   // this same import batch — pass-2 (variant rows) resolves the `Parent`

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -27,6 +27,10 @@
  */
 
 import Filament from "@/models/Filament";
+import {
+  findSurvivorId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import { splitInheritedImportSet } from "@/lib/importFilaments";
 import { stripTemplateFieldsForWrite } from "@/lib/templateStrip";
 import { firstVariantGateInfo } from "@/lib/firstVariantGate";
@@ -363,7 +367,15 @@ export async function upsertIniFilament(
     const byId = await Filament.findOne({ _id: fid, _deletedAt: null })
       .select("_id name")
       .lean();
-    if (byId && byId.name !== name) {
+    // GH #1116 (Codex P1): compare TRIMMED, or this guard fires on the exact
+    // survivor the fallback below exists to repair. `parseIni` trims a section
+    // name, while an `_id` lookup returns the RAW stored value — so a row the
+    // migration could not trim resolves as `"PLA "` against a section named
+    // `"PLA"`, and the ordinary exported-INI round trip threw here before ever
+    // reaching phase 1. Differing only by edge whitespace is not the ambiguity
+    // this guard is about (a renamed preset vs a copied id): it is one
+    // identity, recorded in two spellings, and the update normalizes it.
+    if (byId && String(byId.name ?? "").trim() !== name.trim()) {
       throw new Error(
         `filamentdb_id ${fid} resolves to "${byId.name}", but this section is named ` +
           `"${name}" — not imported (rename the section to match, or resolve the id/name conflict).`,
@@ -372,9 +384,27 @@ export async function upsertIniFilament(
   }
 
   // Phase 1 — update an existing ACTIVE row.
-  const existingActive = await Filament.findOne({ name, _deletedAt: null })
+  let existingActive = await Filament.findOne({ name, _deletedAt: null })
     .select(INI_INHERITANCE_PROJECTION)
     .lean();
+  let activeIsSurvivor = false;
+  if (!existingActive) {
+    // GH #1116 (Codex P1): the miss may be a LOOKUP failure rather than an
+    // absence — the setter casts this query, so it cannot select a row whose
+    // stored name is still raw. Re-read through the SAME projection so the
+    // shape the caller depends on is unchanged.
+    const survivorId = await findSurvivorId(
+      Filament.collection as unknown as MinimalNameCollection,
+      name,
+      { _deletedAt: null },
+    );
+    if (survivorId) {
+      existingActive = await Filament.findOne({ _id: survivorId, _deletedAt: null })
+        .select(INI_INHERITANCE_PROJECTION)
+        .lean();
+      activeIsSurvivor = existingActive != null;
+    }
+  }
   if (existingActive) {
     const update = await buildIniUpdate(collapsed, existingActive);
     // GH #605 (codex P2, slicer-sync sweep): the name-matched target may be a
@@ -400,7 +430,17 @@ export async function upsertIniFilament(
           // `name` re-checked so a concurrent rename in the read→write window
           // misses here and falls through (rather than the by-id write reverting
           // the rename via the `name` in `$set`). GH #951 (Codex).
-          { _id: existingActive._id, name, _deletedAt: null },
+          // GH #1116: the `name` clause CANNOT be used against a survivor —
+          // it is Mongoose-cast, so it asks for the trimmed form and can never
+          // match the raw stored value. Left in, the by-`_id` write would miss
+          // and fall straight through to the phase-3 create, making the
+          // survivor lookup above completely inert. `_id` + `_deletedAt` still
+          // pin the row we resolved and its liveness; only the #951
+          // concurrent-rename check is given up, and only for a row that is
+          // already in the degraded state the migration reports.
+          activeIsSurvivor
+            ? { _id: existingActive._id, _deletedAt: null }
+            : { _id: existingActive._id, name, _deletedAt: null },
           update,
           { runValidators: true, context: "query", returnDocument: "after" },
         );
@@ -417,13 +457,31 @@ export async function upsertIniFilament(
   // Phase 2 — resurrect a TRASHED (non-purged) row of the same name rather
   // than creating a duplicate that would strand the trashed record (its
   // restore would 409 forever on the name conflict). GH #297.
-  const existingTrashed = await Filament.findOne({
+  let existingTrashed = await Filament.findOne({
     name,
     _deletedAt: { $ne: null },
     _purged: { $ne: true },
   })
     .select(INI_INHERITANCE_PROJECTION)
     .lean();
+  let trashedIsSurvivor = false;
+  if (!existingTrashed) {
+    const survivorId = await findSurvivorId(
+      Filament.collection as unknown as MinimalNameCollection,
+      name,
+      { _deletedAt: { $ne: null }, _purged: { $ne: true } },
+    );
+    if (survivorId) {
+      existingTrashed = await Filament.findOne({
+        _id: survivorId,
+        _deletedAt: { $ne: null },
+        _purged: { $ne: true },
+      })
+        .select(INI_INHERITANCE_PROJECTION)
+        .lean();
+      trashedIsSurvivor = existingTrashed != null;
+    }
+  }
   if (existingTrashed) {
     const update = await buildIniUpdate(collapsed, existingTrashed);
     // GH #605: no template strip on the resurrect — a TRASHED doc cannot have
@@ -451,7 +509,9 @@ export async function upsertIniFilament(
     const doResurrect = () =>
       Filament.findOneAndUpdate(
         // `name` re-checked for the same rename-race reason as phase 1.
-        { _id: existingTrashed._id, name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
+        trashedIsSurvivor
+          ? { _id: existingTrashed._id, _deletedAt: { $ne: null }, _purged: { $ne: true } }
+          : { _id: existingTrashed._id, name, _deletedAt: { $ne: null }, _purged: { $ne: true } },
         update,
         { runValidators: true, context: "query", returnDocument: "after" },
       );
@@ -485,6 +545,7 @@ export async function upsertIniFilament(
   // created filament is always a root: no inheritance to preserve here, and
   // the nested `temperatures` object rides straight into the create.
   try {
+    // name-lookup-ok: post-E11000 recovery: the index proved an exact stored-string match
     await Filament.create({ ...collapsed });
     return "created";
   } catch (createErr) {
@@ -493,6 +554,7 @@ export async function upsertIniFilament(
     // create. Recompute the update against THAT row (it may be a variant) and
     // apply it as if we'd taken phase 1, so parallel identical imports stay
     // idempotent instead of throwing.
+    // name-lookup-ok: post-E11000 recovery; the index proved an exact stored-string match
     const racing = await Filament.findOne({ name, _deletedAt: null })
       .select(INI_INHERITANCE_PROJECTION)
       .lean();

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -428,6 +428,28 @@ export async function upsertIniFilament(
   }
   if (existingActive) {
     const update = await buildIniUpdate(collapsed, existingActive);
+    // GH #1116 (Codex P1): do not RENAME a survivor into an occupied name.
+    //
+    // Dropping `name` from the write FILTER is not enough — `toUpdateSet` also
+    // puts the section's canonical name in `$set`, so the by-`_id` update
+    // would try to rename `"PLA "` to `"PLA"`, collide with the canonical row
+    // that already holds it, and throw E11000 instead of applying the
+    // settings.
+    //
+    // Conditional on a twin ACTUALLY holding it, though: a LONE survivor has
+    // nothing to collide with, and normalizing it there is a free repair the
+    // existing coverage relies on. Only when the name is taken does the
+    // rename get dropped — resolving that pair is the migration's job, and it
+    // is the thing that knows how to refuse rather than clobber.
+    if (activeIsSurvivor) {
+      // name-lookup-ok: `name` is already the canonical trimmed form here
+      const canonicalTwin = await Filament.findOne({ name, _deletedAt: null })
+        .select("_id")
+        .lean();
+      if (canonicalTwin && String(canonicalTwin._id) !== String(existingActive._id)) {
+        delete (update.$set as Record<string, unknown> | undefined)?.name;
+      }
+    }
     // GH #605 (codex P2, slicer-sync sweep): the name-matched target may be a
     // TEMPLATE (≥1 live variant) — strip the per-variant fields the section
     // echoes (`color` from filament_colour; the shared TEMPLATE_STRIP_FIELDS)

--- a/src/lib/iniImportApply.ts
+++ b/src/lib/iniImportApply.ts
@@ -363,6 +363,10 @@ export async function upsertIniFilament(
   // matching name — or a stale/absent id — falls through to the name-based
   // upsert below.
   const fid = collapsed.filamentdbId;
+  /** The row the preset's own `filamentdb_id` selected, when it is a
+   *  trim-equal match. Phase 1 must use THIS row rather than re-resolving by
+   *  name — see below. */
+  let idSelected: { _id: Parameters<typeof Filament.findById>[0]; name?: unknown } | null = null;
   if (fid && /^[a-f0-9]{24}$/i.test(fid)) {
     const byId = await Filament.findOne({ _id: fid, _deletedAt: null })
       .select("_id name")
@@ -381,13 +385,30 @@ export async function upsertIniFilament(
           `"${name}" — not imported (rename the section to match, or resolve the id/name conflict).`,
       );
     }
+    idSelected = byId ?? null;
   }
 
+  // GH #1116 (Codex P1): once the id has SELECTED a row, keep it.
+  //
+  // Accepting a trim-equal pair above and then re-resolving by name below
+  // sends the update to the wrong row: with an active `"PLA"` and a survivor
+  // `"PLA "`, an exported INI carrying the SURVIVOR's `filamentdb_id` passes
+  // the guard, and the canonical-first query in phase 1 then selects `"PLA"` —
+  // so the survivor's settings are written onto the canonical bystander. The
+  // id is the more specific address; it wins.
+  const idSelectedIsSurvivor =
+    idSelected !== null && String(idSelected.name ?? "") !== name;
+
   // Phase 1 — update an existing ACTIVE row.
-  let existingActive = await Filament.findOne({ name, _deletedAt: null })
-    .select(INI_INHERITANCE_PROJECTION)
-    .lean();
-  let activeIsSurvivor = false;
+  let existingActive = idSelected
+    ? await Filament.findOne({ _id: idSelected._id, _deletedAt: null })
+        .select(INI_INHERITANCE_PROJECTION)
+        .lean()
+    : // name-lookup-ok: the survivor fallback below covers the cast case
+      await Filament.findOne({ name, _deletedAt: null })
+        .select(INI_INHERITANCE_PROJECTION)
+        .lean();
+  let activeIsSurvivor = idSelectedIsSurvivor && existingActive != null;
   if (!existingActive) {
     // GH #1116 (Codex P1): the miss may be a LOOKUP failure rather than an
     // absence — the setter casts this query, so it cannot select a row whose

--- a/src/lib/matchFilament.ts
+++ b/src/lib/matchFilament.ts
@@ -1,4 +1,8 @@
 import Filament from "@/models/Filament";
+import {
+  findExactRawNameId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 
 /**
  * Resolve a scanned tag / QR / barcode against the filament database.
@@ -218,7 +222,23 @@ export async function matchFilament(query: MatchQuery): Promise<MatchResult> {
   //    GH #896 vendor-substring fix.
   if (name) {
     // 1a. Exact-case — a confident match even when a case-variant sibling exists.
-    const exact = await Filament.findOne({ name, _deletedAt: null })
+    //
+    // GH #1116 (Codex P2): "exact" has to mean exact. `name` carries
+    // `trim: true` and the setter casts QUERY values, so with both "X" and an
+    // unresolved "X " active, a scan carrying "X " matched the CANONICAL row
+    // and returned it as CONFIDENT — never reaching the ambiguity tiers below.
+    // The NFC decode and match APIs would then auto-associate the tag with the
+    // wrong filament, which is exactly the silent mis-selection the GH #954
+    // case-sensitivity work above exists to prevent, by another route.
+    const exactRawId = await findExactRawNameId(
+      Filament.collection as unknown as MinimalNameCollection,
+      name,
+      { _deletedAt: null },
+    );
+    // name-lookup-ok: exact-spelling resolution above covers the cast case
+    const exact = await Filament.findOne(
+      exactRawId ? { _id: exactRawId, _deletedAt: null } : { name, _deletedAt: null },
+    )
       .select(MATCH_PROJECTION)
       .lean();
     if (exact) {

--- a/src/lib/promoteParent.ts
+++ b/src/lib/promoteParent.ts
@@ -1,3 +1,7 @@
+import {
+  survivorNameConflict,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 /**
  * GH #605 — parent/variant template model, Phase 2b: parent promotion.
  *
@@ -193,7 +197,26 @@ export async function resolvePromotionVariantName(
   for (let n = 2; ; n++) {
     const taken =
       alsoTaken?.has(candidate) ||
-      (await FilamentModel.exists({ name: candidate, _deletedAt: null }));
+      // name-lookup-ok: the survivor check below covers the cast case
+      (await FilamentModel.exists({ name: candidate, _deletedAt: null })) ||
+      // GH #1116 (Codex P1): the GENERATED name needs the survivor check too.
+      // `exists` casts, so against an active survivor stored as
+      // `"PLA — Red "` this picks `"PLA — Red"`, the unique index compares
+      // the two raw strings and permits it, and the promotion lands two
+      // active filaments that render identically — created by the very
+      // sequence meant to tidy the family up.
+      //
+      // Guarded on `.collection` for the same reason `externalRefs: null`
+      // exists in this file: it is model-agnostic by design (client components
+      // import `parentPromotionState`, so a static model import would drag
+      // Mongoose into the client bundle) and its unit tests pass MOCK models
+      // that have no raw collection. Every real Mongoose model has one, so
+      // production always takes the check.
+      (typeof FilamentModel?.collection?.findOne === "function" &&
+        (await survivorNameConflict(
+          FilamentModel.collection as unknown as MinimalNameCollection,
+          candidate,
+        )) !== null);
     if (!taken) return candidate;
     candidate = `${baseName} (${n})`;
   }

--- a/src/lib/singleFilamentExport.ts
+++ b/src/lib/singleFilamentExport.ts
@@ -14,6 +14,10 @@
  */
 
 import Filament from "@/models/Filament";
+import {
+  findExactRawNameId,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
 import "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
@@ -62,8 +66,22 @@ export async function resolveFilamentForExport(
     ).lean()) as FilamentDoc | null;
   }
   if (!filament) {
+    // GH #1116 (Codex P2): the export is ADDRESSED by this name, so a cast
+    // that lands on a different row hands the user a download containing
+    // another filament's settings — silently, under the name they asked for.
+    // "Read-only" is not the same as harmless.
+    const exactRawId = await findExactRawNameId(
+      Filament.collection as unknown as MinimalNameCollection,
+      idOrName,
+      { _deletedAt: null },
+    );
     filament = (await withPopulate(
-      Filament.findOne({ name: idOrName, _deletedAt: null }),
+      // name-lookup-ok: exact-spelling resolution above covers the cast case
+      Filament.findOne(
+        exactRawId
+          ? { _id: exactRawId, _deletedAt: null }
+          : { name: idOrName, _deletedAt: null },
+      ),
     ).lean()) as FilamentDoc | null;
   }
 

--- a/src/lib/trimmedNameLookup.ts
+++ b/src/lib/trimmedNameLookup.ts
@@ -1,0 +1,223 @@
+import { JS_TRIM_CHARS, castNameLikeSchema } from "@/lib/trimEntityNames";
+
+/**
+ * Find a stored entity by name when the stored side might NOT be trimmed yet
+ * (GH #1116).
+ *
+ * ## Why any of this is needed
+ *
+ * `name` carries `trim: true` on all five uniquely-named models. A Mongoose
+ * String setter applies to QUERY values, not just writes — so
+ * `Model.findOne({ name: "X " })` casts to `{ name: "X" }` and can never select
+ * a row whose STORED value is still the raw `"X "`. Trimming the input first
+ * does not help either: the untrimmed side is the one in the database.
+ *
+ * `trimEntityNames` repairs stored rows, but it does not always get to finish.
+ * It SKIPS a collection whose protective unique index cannot be established,
+ * and it leaves individual rows alone when trimming them would collide or
+ * would empty the required field. Either way a raw untrimmed row SURVIVES.
+ *
+ * Against a survivor, any "look up by name, create when missing" path misses,
+ * creates, and succeeds — the two raw strings are distinct, so the unique index
+ * has no objection — and the user is left with two rows that render
+ * identically. That is precisely the duplicate #1116 exists to eliminate,
+ * reproduced by the very code that was supposed to stop it.
+ *
+ * ## Why it is one shared helper
+ *
+ * This rule was applied to the CSV importer and to nothing else, and the two
+ * call sites that needed it next were each found by review, one round apart.
+ * A single exported filter means the next resolve-or-create path either uses it
+ * or is visibly not using it.
+ *
+ * ## Why the `chars` argument is not optional
+ *
+ * `$trim` without `chars` strips MongoDB's ASCII-only default set, while every
+ * other trim in this codebase is `String.prototype.trim` — which also removes
+ * U+00A0, U+FEFF, U+3000 and the rest. Omitting it makes this query and the
+ * schema setter disagree about what a name is, which is the same class of bug
+ * one level down. `JS_TRIM_CHARS` is the single source of truth, shared with
+ * `EDGE_WHITESPACE_PATTERN` so the migration's scan and this lookup cannot
+ * drift apart.
+ *
+ * ## ALWAYS CANONICAL FIRST — this is correctness, not just cost
+ *
+ * Run the ordinary indexed name query first and reach for this only when it
+ * MISSES. Two independent reasons, and the second is the one that bites:
+ *
+ *   1. `$expr` cannot use an index, so this is a collection scan. Keeping it
+ *      on the miss path means the healthy case pays nothing.
+ *
+ *   2. The predicate matches the canonical row and the untrimmed one ALIKE,
+ *      and imposes no ordering. In precisely the state that produces a
+ *      survivor — `"PLA"` and `"PLA "` both present, which the partial unique
+ *      index permits for tombstones and which a skipped migration permits for
+ *      active rows — a survivor-first lookup returns an ARBITRARY one of them.
+ *      The indexed query is deterministic and picks the canonical row; this
+ *      one is not. Scanning first therefore turns a correct, predictable
+ *      update into a coin flip over which of two rows gets written.
+ *
+ * That mistake has been made twice in this codebase (the OpenPrintTag bulk
+ * upsert and the Prusament trashed resurrect), both times while ADDING this
+ * fallback, so it is stated here rather than left to be rediscovered.
+ */
+
+/**
+ * A raw-driver filter matching rows whose STORED `name` trims to any of
+ * `names`.
+ *
+ * Compose it with the caller's own conditions (`_deletedAt: null`, and so on);
+ * this deliberately says nothing about liveness, because the importers disagree
+ * about what they want there — some resurrect a tombstone, some must not see
+ * one at all.
+ *
+ * A non-string stored `name` is coerced to `""` rather than erroring: `$trim`
+ * throws on a non-string input, and legacy data does hold them. Such a row
+ * simply does not match (no caller passes `""`, which would be an empty name).
+ */
+export function trimmedNameFilter(names: string[]): Record<string, unknown> {
+  return {
+    $expr: {
+      $in: [
+        {
+          $trim: {
+            input: {
+              $cond: [{ $eq: [{ $type: "$name" }, "string"] }, "$name", ""],
+            },
+            chars: JS_TRIM_CHARS,
+          },
+        },
+        names.map((n) => n.trim()),
+      ],
+    },
+  };
+}
+
+/** Minimal raw-driver shape, so callers can pass `Model.collection` and tests
+ *  can pass a fake without standing up a connection. */
+export interface MinimalNameCollection {
+  findOne(
+    filter: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<{ _id: unknown; name?: unknown } | null>;
+}
+
+/**
+ * The single-name fallback: the raw `_id` of a surviving untrimmed row whose
+ * name trims to `name`, or null.
+ *
+ * Returns the RAW document rather than a Mongoose one on purpose — the caller
+ * needs the `_id` to address the row (by `_id`, which casting cannot break),
+ * and hydrating through Mongoose here would re-introduce the very lookup that
+ * cannot see this row.
+ */
+export async function findByTrimmedName(
+  collection: MinimalNameCollection,
+  name: string,
+  extraFilter: Record<string, unknown> = {},
+): Promise<{ _id: unknown; name?: unknown } | null> {
+  const trimmed = name.trim();
+  if (trimmed === "") return null;
+  return collection.findOne({ ...extraFilter, ...trimmedNameFilter([trimmed]) });
+}
+
+/**
+ * Just the `_id` of a surviving untrimmed row, for the common shape:
+ *
+ * ```ts
+ * let existing = await Filament.findOne({ name, _deletedAt: null }).lean();
+ * if (!existing) {
+ *   const id = await findSurvivorId(Filament.collection, name, { _deletedAt: null });
+ *   if (id) existing = await Filament.findOne({ _id: id }).lean();
+ * }
+ * ```
+ *
+ * Returning the id rather than a document is deliberate: every caller re-reads
+ * through its OWN query — with its own `.lean()`, projection or population —
+ * so the fallback cannot quietly change the shape the caller expects. And an
+ * `_id` re-read is safe where the name re-read was not, because casting can
+ * mangle a name but never an ObjectId.
+ */
+export async function findSurvivorId(
+  collection: MinimalNameCollection,
+  name: string,
+  extraFilter: Record<string, unknown> = {},
+): Promise<unknown | null> {
+  const row = await findByTrimmedName(collection, name, extraFilter);
+  return row ? row._id : null;
+}
+
+/**
+ * The mirror problem: a NAME-ADDRESSED request whose name is the addressing
+ * key, where the cast can silently redirect it to a DIFFERENT row.
+ *
+ * The importers above ask "does a row for this name already exist?", and a
+ * miss costs a duplicate. The slicer sync routes ask something stricter — "the
+ * preset is literally called this; give me THAT filament" — and there a cast
+ * costs something worse than a duplicate.
+ *
+ * With both `"X"` and `"X "` active (an unresolved migration), a preset
+ * addressed as `"X "` casts to `"X"` and selects the CANONICAL row. The sync
+ * then writes the preset's settings and calibration onto a filament that is
+ * not the one the slicer was talking about. Before `trim: true` the same query
+ * matched the raw `"X "` exactly, so this is a redirection the schema change
+ * introduced, and no amount of create-on-404 removal makes it safe: nothing is
+ * created, the wrong record is simply overwritten.
+ *
+ * So: when the addressing name carries edge whitespace, look for that EXACT
+ * stored spelling with the raw driver first. A hit is unambiguous — the slicer
+ * named a row that literally exists under that spelling. A miss (including
+ * after the migration has since normalized it) falls through to the ordinary
+ * cast query, which is then correct.
+ *
+ * Returns null when the name has no edge whitespace, because the cast query is
+ * already an exact match and a second round trip would buy nothing.
+ */
+/**
+ * Would writing `name` produce a row indistinguishable from an existing one?
+ *
+ * The ordinary CRUD creates and renames leaned entirely on the partial unique
+ * index to reject a duplicate name, and that stops working against a survivor:
+ * the index compares the RAW stored strings, so `"Drybox"` and a surviving
+ * `"Drybox "` are two different keys and the write succeeds. Before
+ * `trim: true` the submitted spelling reached the index unchanged and collided
+ * as the user expected; now it is cast first, and the collision evaporates.
+ *
+ * So the guard has to ask the question the index can no longer answer — do the
+ * TRIMMED forms match — before the create or the rename.
+ *
+ * Returns the conflicting row's id as a string, or null. `selfId` excludes the
+ * row being renamed; it is compared in JS rather than pushed into the filter,
+ * because this is a raw-driver query where an ObjectId never equals a string
+ * and the row would fail to exclude itself.
+ *
+ * The incoming value is normalized through `castNameLikeSchema` FIRST (Codex
+ * P2). A bare `typeof name !== "string"` skip is a hole: a JSON client can
+ * send `7` or `{"_id": "X"}`, Mongoose stores those as `"7"` and `"X"`, and
+ * beside a survivor stored as `"7 "` or `"X "` the raw index sees different
+ * strings and admits the duplicate — while the guard, having decided the value
+ * "isn't a name", never looked. Ask what the SCHEMA will store, which is the
+ * same question every other part of this change asks.
+ */
+export async function survivorNameConflict(
+  collection: MinimalNameCollection,
+  name: unknown,
+  selfId?: unknown,
+): Promise<string | null> {
+  const cast = castNameLikeSchema(name);
+  if (cast === null || !cast.trim()) return null;
+  const row = await findByTrimmedName(collection, cast, { _deletedAt: null });
+  if (!row) return null;
+  const id = String(row._id);
+  return selfId != null && id === String(selfId) ? null : id;
+}
+
+export async function findExactRawNameId(
+  collection: MinimalNameCollection,
+  name: string,
+  extraFilter: Record<string, unknown> = {},
+): Promise<unknown | null> {
+  if (name === name.trim()) return null;
+  const row = await collection.findOne({ ...extraFilter, name });
+  return row ? row._id : null;
+}

--- a/src/lib/trimmedNameLookup.ts
+++ b/src/lib/trimmedNameLookup.ts
@@ -100,6 +100,13 @@ export interface MinimalNameCollection {
     filter: Record<string, unknown>,
     options?: Record<string, unknown>,
   ): Promise<{ _id: unknown; name?: unknown } | null>;
+  /** Optional: used by `survivorNameConflict`, which has to look PAST a match
+   *  that turns out to be the row being renamed. Absent on the unit-test
+   *  fakes that only exercise the single-row helpers. */
+  find?(
+    filter: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): { toArray(): Promise<{ _id: unknown; name?: unknown }[]> };
 }
 
 /**
@@ -206,6 +213,33 @@ export async function survivorNameConflict(
 ): Promise<string | null> {
   const cast = castNameLikeSchema(name);
   if (cast === null || !cast.trim()) return null;
+
+  // Look PAST a match that turns out to be the row being renamed (Codex P2).
+  //
+  // Several active rows can trim to the same name — that is exactly the state
+  // a skipped migration leaves — and a single-match lookup returns an
+  // ARBITRARY one of them. If it happened to be `selfId`, reporting "no
+  // conflict" let the save normalize a survivor `"X "` to `"X"` beside an
+  // existing `"X"`, producing two identical STORED names with no index left to
+  // catch it (the collection was skipped precisely because no adequate unique
+  // index could be built).
+  //
+  // A small cap is enough: we only need one row that is not self.
+  if (collection.find) {
+    const rows = await collection
+      .find(
+        { _deletedAt: null, ...trimmedNameFilter([cast]) },
+        { projection: { _id: 1 }, limit: 5 },
+      )
+      .toArray();
+    for (const row of rows) {
+      const id = String(row._id);
+      if (selfId != null && id === String(selfId)) continue;
+      return id;
+    }
+    return null;
+  }
+
   const row = await findByTrimmedName(collection, cast, { _deletedAt: null });
   if (!row) return null;
   const id = String(row._id);

--- a/tests/import-atlas-name-trim.test.ts
+++ b/tests/import-atlas-name-trim.test.ts
@@ -125,5 +125,116 @@ describe("Atlas import agrees with the trimmed identity rule (#1116, Codex P2)",
     expect(fresh.cost).toBe(10);
   });
 
+  /**
+   * GH #1116 (Codex P1, round 23). The test above covers the SOURCE side
+   * carrying whitespace. This is the mirror — and the one that actually bites:
+   * the LOCAL row is the untrimmed one, because `trimEntityNames` skipped the
+   * filaments collection (no protective unique index could be established) or
+   * left that row alone.
+   *
+   * A skip is not hypothetical: it is exactly what happens on a database whose
+   * existing duplicate active names block the index build, and the migration
+   * deliberately reports rather than merges those.
+   *
+   * The local row is then invisible to `findOne({ name })` — the setter casts
+   * the query — so the route fell through to create, the partial unique index
+   * had no objection (the two raw strings differ), and the user got a second
+   * active filament rendering identically to the first.
+   */
+  it("resolves a SURVIVING untrimmed local row instead of creating a twin", async () => {
+    // Written with the raw driver: this is a row the migration has not
+    // repaired, so it must NOT go through the setter.
+    const localId = new mongoose.Types.ObjectId();
+    await mongoose.connection.collection("filaments").insertOne({
+      _id: localId,
+      name: "PLA Basic ",
+      vendor: "V",
+      type: "PLA",
+      cost: 10,
+      _deletedAt: null,
+      spools: [],
+    });
 
+    const remoteId = new mongoose.Types.ObjectId();
+    await remoteCollection().insertOne({
+      _id: remoteId,
+      name: "PLA Basic",
+      vendor: "V",
+      type: "PLA",
+      cost: 42,
+      _deletedAt: null,
+      spools: [],
+    });
+
+    const res = await importAtlas(
+      new NextRequest("http://localhost/api/filaments/import-atlas", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ uri: remoteUri(), filamentIds: [String(remoteId)] }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // The survivor was updated in place — no twin.
+    expect(body.created).toBe(0);
+    expect(body.updated).toBe(1);
+    expect(await Filament.countDocuments({ _deletedAt: null })).toBe(1);
+
+    // Addressed by _id, so the row that changed is the one that was there.
+    const fresh = await Filament.findById(localId);
+    expect(fresh.cost).toBe(42);
+  });
+
+  /**
+   * The same lookup failure one state over: the survivor is a TOMBSTONE.
+   *
+   * Missing it does not duplicate immediately — the partial unique index only
+   * covers active rows, so the fresh create succeeds legitimately — but it
+   * DEFERS the duplicate rather than avoiding it. Restoring that tombstone
+   * later flips only `_deletedAt` and leaves its raw name intact, at which
+   * point two ACTIVE rows render identically. So the import resurrects the row
+   * that is actually there.
+   */
+  it("resurrects a SURVIVING untrimmed tombstone rather than minting a fresh row", async () => {
+    const localId = new mongoose.Types.ObjectId();
+    await mongoose.connection.collection("filaments").insertOne({
+      _id: localId,
+      name: "PLA Basic ",
+      vendor: "V",
+      type: "PLA",
+      cost: 10,
+      _deletedAt: new Date(),
+      spools: [],
+    });
+
+    const remoteId = new mongoose.Types.ObjectId();
+    await remoteCollection().insertOne({
+      _id: remoteId,
+      name: "PLA Basic",
+      vendor: "V",
+      type: "PLA",
+      cost: 42,
+      _deletedAt: null,
+      spools: [],
+    });
+
+    const res = await importAtlas(
+      new NextRequest("http://localhost/api/filaments/import-atlas", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ uri: remoteUri(), filamentIds: [String(remoteId)] }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.created).toBe(0);
+    expect(body.updated).toBe(1);
+
+    // One row total, and it is the ORIGINAL — revived, not replaced.
+    expect(await Filament.countDocuments({})).toBe(1);
+    const fresh = await Filament.findById(localId);
+    expect(fresh._deletedAt).toBeNull();
+    expect(fresh.cost).toBe(42);
+  });
 });

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -796,3 +796,59 @@ describe("upsertIniFilament — a surviving untrimmed row (GH #1116)", () => {
     expect(rows[0].name).toBe("Trashed Survivor");
   });
 });
+
+/**
+ * GH #1116 (Codex P1). Accepting a trim-equal id/name pair and then
+ * re-resolving by NAME sends the update to the wrong row: with an active
+ * "PLA" and a survivor "PLA ", an exported INI carrying the SURVIVOR's
+ * `filamentdb_id` passes the guard, and the canonical-first query then selects
+ * "PLA" — writing the survivor's settings onto the canonical bystander.
+ */
+describe("upsertIniFilament — an id-selected survivor keeps the update (GH #1116)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+    await Filament.collection.deleteMany({});
+  });
+
+  const section = (name: string, filamentdbId?: string): CollapsedFilamentData => ({
+    name,
+    vendor: "Acme",
+    type: "PLA",
+    color: "#808080",
+    cost: 77,
+    density: 1.24,
+    diameter: 1.75,
+    temperatures: { nozzle: 210, nozzleFirstLayer: null, bed: 60, bedFirstLayer: null },
+    maxVolumetricSpeed: null,
+    inherits: null,
+    settings: {},
+    ...(filamentdbId ? { filamentdbId } : {}),
+  });
+
+  it("writes to the row the id names, not the canonical twin", async () => {
+    const canonical = await Filament.collection.insertOne({
+      name: "PLA", vendor: "Acme", type: "PLA", cost: 1,
+      instanceId: "wsini001", _deletedAt: null, spools: [], settings: {},
+    });
+    const survivor = await Filament.collection.insertOne({
+      name: "PLA ", vendor: "Acme", type: "PLA", cost: 2,
+      instanceId: "wsini002", _deletedAt: null, spools: [], settings: {},
+    });
+
+    const outcome = await upsertIniFilament(
+      section("PLA", String(survivor.insertedId)),
+    );
+    expect(outcome).toBe("updated");
+
+    // The survivor got the settings...
+    const s2 = await Filament.collection.findOne({ _id: survivor.insertedId });
+    expect(s2!.cost).toBe(77);
+    // ...and the bystander is untouched. That is the whole point.
+    const c2 = await Filament.collection.findOne({ _id: canonical.insertedId });
+    expect(c2!.cost).toBe(1);
+    expect(c2!.name).toBe("PLA");
+  });
+});

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -811,6 +811,13 @@ describe("upsertIniFilament — an id-selected survivor keeps the update (GH #11
   beforeEach(async () => {
     Filament = (await import("@/models/Filament")).default;
     await Filament.collection.deleteMany({});
+    // Build the PRODUCTION index (Codex P1). Without it this test passed while
+    // the update was in fact trying to rename the survivor onto the canonical
+    // row's name — an E11000 in the real world. The partial filter is what
+    // lets the two coexist in the first place.
+    await Filament.collection
+      .createIndex({ name: 1 }, { unique: true, partialFilterExpression: { _deletedAt: null } })
+      .catch(() => {});
   });
 
   const section = (name: string, filamentdbId?: string): CollapsedFilamentData => ({
@@ -846,6 +853,10 @@ describe("upsertIniFilament — an id-selected survivor keeps the update (GH #11
     // The survivor got the settings...
     const s2 = await Filament.collection.findOne({ _id: survivor.insertedId });
     expect(s2!.cost).toBe(77);
+    // ...and KEPT its raw name. Renaming it to the canonical form would
+    // collide with the row that already holds it; normalizing names is the
+    // migration's job, not the importer's.
+    expect(s2!.name).toBe("PLA ");
     // ...and the bystander is untouched. That is the whole point.
     const c2 = await Filament.collection.findOne({ _id: canonical.insertedId });
     expect(c2!.cost).toBe(1);

--- a/tests/iniImportApply.test.ts
+++ b/tests/iniImportApply.test.ts
@@ -717,3 +717,82 @@ describe("upsertIniFilament — create-race recovery (GH #951)", () => {
     });
   });
 });
+
+/**
+ * GH #1116 (Codex P1, round 24). `trimEntityNames` can leave a raw untrimmed
+ * row behind — a skipped collection, or a row whose trim would collide. The
+ * INI importer then cannot see it (the `trim: true` setter casts the query),
+ * falls through all three phases, and CREATES a second active filament that
+ * renders identically to the one it failed to find.
+ *
+ * Two halves have to work, and the second is easy to miss: fixing only the
+ * LOOKUP leaves the fix completely inert, because the phase-1 write filter
+ * re-pins `name` (the GH #951 rename guard) and that clause is cast too — so
+ * the by-`_id` update would miss and fall through to the create anyway.
+ */
+describe("upsertIniFilament — a surviving untrimmed row (GH #1116)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+  });
+
+  const section = (name: string): CollapsedFilamentData => ({
+    name,
+    vendor: "Acme",
+    type: "PLA",
+    color: "#808080",
+    cost: 25,
+    density: 1.24,
+    diameter: 1.75,
+    temperatures: { nozzle: 210, nozzleFirstLayer: null, bed: 60, bedFirstLayer: null },
+    maxVolumetricSpeed: null,
+    inherits: null,
+    settings: {},
+  });
+
+  it("updates the survivor in place instead of creating a twin", async () => {
+    // Raw driver on purpose — a Mongoose create would trim it.
+    await Filament.collection.insertOne({
+      name: "Survivor PLA ",
+      vendor: "Acme",
+      type: "PLA",
+      cost: 1,
+      _deletedAt: null,
+      spools: [],
+    });
+
+    const outcome = await upsertIniFilament(section("Survivor PLA"));
+    expect(outcome).toBe("updated");
+
+    // One row, not two — and the write landed on the row that was there.
+    const rows = await Filament.collection.find({}).toArray();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cost).toBe(25);
+    // The update also normalizes the stored name, because `name` rides the
+    // $set and the setter trims it on the way in.
+    expect(rows[0].name).toBe("Survivor PLA");
+  });
+
+  it("resurrects a surviving untrimmed TRASHED row rather than stranding it", async () => {
+    // Left behind, this strands the tombstone: the new active row owns the
+    // name, so the trashed row's restore 409s forever (GH #297).
+    await Filament.collection.insertOne({
+      name: "Trashed Survivor ",
+      vendor: "Acme",
+      type: "PLA",
+      cost: 1,
+      _deletedAt: new Date(),
+      spools: [],
+    });
+
+    const outcome = await upsertIniFilament(section("Trashed Survivor"));
+    expect(outcome).toBe("updated");
+
+    const rows = await Filament.collection.find({}).toArray();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]._deletedAt).toBeNull();
+    expect(rows[0].name).toBe("Trashed Survivor");
+  });
+});

--- a/tests/name-lookup-invariant.test.ts
+++ b/tests/name-lookup-invariant.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * GH #1116 — the drift guard for the survivor-fallback rule.
+ *
+ * ## Why this test exists
+ *
+ * A Mongoose String setter applies to QUERY values, so once `name` carries
+ * `trim: true` no name-filtered query can select a row whose STORED name is
+ * still raw. `trimEntityNames` repairs stored rows but can legitimately leave
+ * survivors behind (a skipped collection, a colliding row).
+ *
+ * Every "resolve by name, then create when missing" path therefore needs the
+ * `src/lib/trimmedNameLookup.ts` fallback, or it manufactures a duplicate that
+ * renders identically to the row it failed to find.
+ *
+ * That rule was applied at one call site, then found missing at two more a
+ * review round later, then at four more the round after that — the same defect
+ * class three rounds running, every instance found by a human reading the diff.
+ * This test is the mechanism that replaces the human.
+ *
+ * ## Granularity is the whole point (Codex P1)
+ *
+ * The first version of this file asked whether the FILE imported the helper.
+ * That is worthless: one guarded query anywhere exempts every other query in
+ * the same file — and it was already waving through a live bug, the variant
+ * collision check in the OpenPrintTag importer, in a file that used the helper
+ * fifty lines earlier. So the unit of judgement is the QUERY, not the file.
+ *
+ * Each name-filtered query must have, within its immediate neighbourhood,
+ * either a call to the fallback or an explicit
+ *
+ *     // name-lookup-ok: <why this one cannot manufacture a duplicate>
+ *
+ * marker. Writing the reason at the query — rather than in a table at the top
+ * of some other file — is what makes the next reviewer able to check it.
+ */
+
+const SRC = "src";
+
+/** How far from the match to look for a fallback call or a marker. Generous
+ *  on purpose: a guarded query and its fallback are often separated by the
+ *  comment explaining why. */
+const WINDOW_BEFORE = 6;
+const WINDOW_AFTER = 40;
+
+/** `findOne({ name` / `findOneAndUpdate({ name, ...` — a bare `name` key in a
+ *  query filter, not a `name:` nested inside an update document. */
+const NAME_FILTER =
+  /(findOne|findOneAndUpdate|findOneAndDelete|updateOne|deleteOne)\(\s*\{[^}]{0,240}?(^|[\s,{])name\s*[,:]/m;
+const NAME_FILTER_G = new RegExp(NAME_FILTER.source, "gm");
+
+const SATISFIED = /findSurvivorId|findByTrimmedName|trimmedNameFilter|name-lookup-ok:/;
+
+/** A match whose own line is a comment is documentation, not a query. */
+function isCommentLine(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith("*") || t.startsWith("//") || t.startsWith("/*");
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (full.endsWith(".ts") || full.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+interface Offender {
+  file: string;
+  line: number;
+  snippet: string;
+}
+
+function findOffenders(): Offender[] {
+  const offenders: Offender[] = [];
+  for (const file of walk(SRC)) {
+    const rel = file.replace(/\\/g, "/");
+    const source = readFileSync(file, "utf8");
+    const lines = source.split("\n");
+    NAME_FILTER_G.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = NAME_FILTER_G.exec(source)) !== null) {
+      const lineIndex = source.slice(0, m.index).split("\n").length - 1;
+      if (isCommentLine(lines[lineIndex] ?? "")) continue;
+      const window = lines
+        .slice(Math.max(0, lineIndex - WINDOW_BEFORE), lineIndex + WINDOW_AFTER)
+        .join("\n");
+      if (SATISFIED.test(window)) continue;
+      offenders.push({
+        file: rel,
+        line: lineIndex + 1,
+        snippet: (lines[lineIndex] ?? "").trim().slice(0, 100),
+      });
+    }
+  }
+  return offenders;
+}
+
+describe("every name-filtered query is survivor-aware (GH #1116)", () => {
+  it("has no unguarded, unexplained name-filtered query", () => {
+    const offenders = findOffenders();
+    expect(
+      offenders.map((o) => `${o.file}:${o.line}  ${o.snippet}`),
+      "Each of these filters a Mongoose query on `name` with no survivor " +
+        "fallback nearby and no explanation.\n\n" +
+        "If the path can CREATE when the lookup misses, it will manufacture a " +
+        "duplicate against a row `trimEntityNames` could not repair — use " +
+        "findSurvivorId/findByTrimmedName from src/lib/trimmedNameLookup.ts.\n\n" +
+        "If it genuinely cannot (a read-only lookup, a guard that only " +
+        "refuses, or a post-E11000 recovery where the index already proved an " +
+        "exact stored-string match), put a\n" +
+        "    // name-lookup-ok: <reason>\n" +
+        "comment on the line above it.",
+    ).toEqual([]);
+  });
+
+  it("actually detects the pattern it claims to", () => {
+    // A detector that silently matches nothing passes forever while covering
+    // nothing — which is precisely the failure this file exists to prevent one
+    // level up, so it is asserted rather than assumed.
+    expect(NAME_FILTER.test(`await Filament.findOne({ name, _deletedAt: null })`)).toBe(true);
+    expect(
+      NAME_FILTER.test(`await Filament.findOneAndUpdate({\n  name: importName,\n  vendor,\n})`),
+    ).toBe(true);
+    // Not a name filter: addressed by id, or `name` inside the update doc.
+    expect(NAME_FILTER.test(`await Filament.findOne({ _id: id })`)).toBe(false);
+    expect(
+      NAME_FILTER.test(`await Filament.updateOne({ _id: id }, { $set: { name: "x" } })`),
+    ).toBe(false);
+  });
+
+  it("still finds the real call sites — the sweep is not vacuous", () => {
+    // Without this, deleting the regex body or pointing SRC at an empty
+    // directory would turn the suite green. The count is deliberately a floor,
+    // not an equality, so ordinary churn does not fail CI.
+    let total = 0;
+    for (const file of walk(SRC)) {
+      const source = readFileSync(file, "utf8");
+      NAME_FILTER_G.lastIndex = 0;
+      while (NAME_FILTER_G.exec(source) !== null) total++;
+    }
+    expect(total).toBeGreaterThanOrEqual(20);
+  });
+
+  it("treats a marker as scoped to its own query, not the file", () => {
+    // The regression that motivated the rewrite: a guarded query must not
+    // launder an unguarded one elsewhere in the same file.
+    const guarded = [
+      "const a = await Filament.findOne({ name, _deletedAt: null });",
+      "// name-lookup-ok: read-only",
+    ].join("\n");
+    const unguardedFarBelow = [
+      guarded,
+      ...Array.from({ length: WINDOW_AFTER + 10 }, () => "// filler"),
+      "const b = await Filament.findOne({ name, vendor });",
+    ].join("\n");
+    const lines = unguardedFarBelow.split("\n");
+    NAME_FILTER_G.lastIndex = 0;
+    const positions: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = NAME_FILTER_G.exec(unguardedFarBelow)) !== null) {
+      positions.push(unguardedFarBelow.slice(0, m.index).split("\n").length - 1);
+    }
+    expect(positions).toHaveLength(2);
+    const windowFor = (i: number) =>
+      lines.slice(Math.max(0, i - WINDOW_BEFORE), i + WINDOW_AFTER).join("\n");
+    expect(SATISFIED.test(windowFor(positions[0]))).toBe(true);
+    expect(SATISFIED.test(windowFor(positions[1]))).toBe(false);
+  });
+});

--- a/tests/name-whitespace.test.ts
+++ b/tests/name-whitespace.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import mongoose from "mongoose";
+import { NextRequest } from "next/server";
 import { upsertImportRows } from "@/lib/importFilaments";
 import { trimEntityNames, type MinimalTrimDb } from "@/lib/trimEntityNames";
 
@@ -250,6 +251,150 @@ describe("filament import matches a legacy untrimmed row (#1116)", () => {
     expect(result.skippedRows?.[0].reason).toContain("Missing required field");
   });
 
+
+
+  /**
+   * Reach the condition the raw-driver fallback exists for: an untrimmed row
+   * present at import time.
+   *
+   * Doing that by index manipulation does not work. Mongoose's `autoIndex`
+   * rebuilds the schema's unique `name_1` in the BACKGROUND on first model
+   * use, so a plain index planted here races that build — locally about half
+   * the runs, and it was a real CI failure (IndexKeySpecsConflict, because
+   * MongoDB auto-names both indexes `name_1`).
+   *
+   * So settle the migration instead: one no-op import flips
+   * `cached.migrations.trimEntityNames`, after which the pass does not run
+   * again in this process and a row inserted through the raw driver survives
+   * untrimmed. That models the production states that matter — a row the pass
+   * had to leave alone, or a collection it skipped — without depending on
+   * which one, and without fighting autoIndex.
+   */
+  async function settleTrimMigration() {
+    await upsertImportRows([
+      { name: "Settle Probe", vendor: "V", type: "PLA" },
+    ]);
+    await Filament.deleteMany({ name: "Settle Probe" });
+  }
+
+  it("does not CREATE a duplicate when the untrimmed row survived the migration (Codex P1)", async () => {
+    // Reaching this state takes care: `upsertImportRows` calls dbConnect,
+    // whose trim pass would normally repair the row before the import runs.
+    // The reachable survival route is a SKIPPED collection — no adequate
+    // unique name index, so the pass deliberately writes nothing. A plain
+    // NON-unique index on `name` produces exactly that: createIndex conflicts
+    // on the options, and the existing index is not unique, so the pass
+    // refuses to write unserialized.
+    //
+    // Such a row is invisible to every Mongoose query, because a String
+    // schema setter applies to QUERY values too. Without the raw-driver
+    // load the import creates a SECOND record beside it — the duplicate this
+    // whole change exists to stop.
+    await settleTrimMigration();
+    await mongoose.connection.collection("filaments").insertOne({
+      name: "PLA Legacy ", vendor: "V", type: "PLA", _deletedAt: null, spools: [], cost: 1,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000001",
+    });
+
+    const result = await upsertImportRows([
+      { name: "PLA Legacy ", vendor: "V", type: "PLA", cost: 42 },
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(1);
+    expect(await Filament.countDocuments({})).toBe(1);
+    // Better than merely avoiding the duplicate: the update goes through the
+    // schema setter, so finding the row also REPAIRS its name — the thing the
+    // migration couldn't do without a serializing index.
+    const raw = await mongoose.connection
+      .collection("filaments")
+      .findOne({ name: "PLA Legacy" });
+    expect(raw).not.toBeNull();
+    expect(raw!.cost).toBe(42);
+  });
+
+  it("matches a surviving legacy row even when the IMPORT name is canonical (Codex P1)", async () => {
+    // The predicate has to be on the STORED value. Keying it on the input's
+    // spelling missed the ordinary case: importing a canonical "PLA Canon"
+    // against a surviving "PLA Canon " produced no candidates at all, and the
+    // importer created a second row beside it.
+    await settleTrimMigration();
+    await mongoose.connection.collection("filaments").insertOne({
+      name: "PLA Canon ", vendor: "V", type: "PLA", _deletedAt: null, spools: [], cost: 1,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000002",
+    });
+
+    const result = await upsertImportRows([
+      { name: "PLA Canon", vendor: "V", type: "PLA", cost: 42 },
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(1);
+    expect(await Filament.countDocuments({})).toBe(1);
+  });
+
+  it("matches across DIFFERENT edge whitespace on the two sides", async () => {
+    await settleTrimMigration();
+    await mongoose.connection.collection("filaments").insertOne({
+      name: "  PLA Both", vendor: "V", type: "PLA", _deletedAt: null, spools: [], cost: 1,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000003",
+    });
+
+    const result = await upsertImportRows([
+      { name: "PLA Both  ", vendor: "V", type: "PLA", cost: 7 },
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(await Filament.countDocuments({})).toBe(1);
+  });
+
+  it("scans when the indexed lookup found only a TOMBSTONE (Codex P2)", async () => {
+    // With the collection skipped, an active "PLA Ghost " can coexist with a
+    // soft-deleted "PLA Ghost". Counting the tombstone as "found" skipped the
+    // scan, so the importer resurrected the tombstone and left TWO active
+    // rows rendering identically.
+    await settleTrimMigration();
+    await mongoose.connection.collection("filaments").insertMany([
+      { name: "PLA Ghost", vendor: "V", type: "PLA", _deletedAt: new Date(), spools: [], cost: 1 },
+      { name: "PLA Ghost ", vendor: "V", type: "PLA", _deletedAt: null, spools: [], cost: 2 },
+    ]);
+
+    const result = await upsertImportRows([
+      { name: "PLA Ghost", vendor: "V", type: "PLA", cost: 42 },
+    ]);
+
+    expect(result.created).toBe(0);
+    // Exactly one ACTIVE row, and it is the one that was already active.
+    expect(await Filament.countDocuments({ _deletedAt: null })).toBe(1);
+    const active = await Filament.findOne({ _deletedAt: null });
+    expect(active.cost).toBe(42);
+  });
+
+  it("matches a name whose whitespace only JS trim() strips (Codex P2)", async () => {
+    // MongoDB's $trim default set is ASCII; it does not strip U+FEFF, which
+    // String.prototype.trim does — and the schema setter uses the latter.
+    await settleTrimMigration();
+    await mongoose.connection.collection("filaments").insertOne({
+      name: "PLA Bom\uFEFF", vendor: "V", type: "PLA", _deletedAt: null, spools: [], cost: 1,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000004",
+    });
+
+    const result = await upsertImportRows([
+      { name: "PLA Bom", vendor: "V", type: "PLA", cost: 42 },
+    ]);
+
+    expect(result.created).toBe(0);
+    expect(await Filament.countDocuments({ _deletedAt: null })).toBe(1);
+  });
+
   it("still creates a genuinely new row", async () => {
     const result = await upsertImportRows([
       { name: "Fresh PLA ", vendor: "V", type: "PLA" },
@@ -407,5 +552,392 @@ describe("an inadequate legacy name index is converted, not skipped forever", ()
     expect(res.skipped.map((s) => s.collection)).toContain("locations");
     const idx = await col().indexes();
     expect(idx.some((i) => (i as { name?: string }).name === "name_1")).toBe(true);
+  });
+});
+
+
+/**
+ * GH #1116 (Codex round 29) — the WRONG-MATCH and MISSED-COLLISION hazards.
+ *
+ * Three distinct ways the cast bites, and the earlier work only covered the
+ * first:
+ *   (A) a MISS then a create  -> a duplicate                (survivor fallback)
+ *   (B) a MISS in a GUARD     -> the guard wrongly permits  (survivor fallback)
+ *   (C) a WRONG MATCH         -> the wrong row is used      (exact-spelling)
+ *
+ * "Read-only" was never a valid exemption for (C): reading the wrong row hands
+ * back another filament's data. "Refuses, never creates" was never valid for
+ * (B): failing to refuse is exactly how the guard creates a duplicate.
+ */
+describe("wrong-match and missed-collision hazards (#1116)", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let Filament: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+    await Filament.collection.deleteMany({});
+  });
+
+  async function seedBothSpellings() {
+    const canonical = await Filament.collection.insertOne({
+      name: "Amb PLA", vendor: "V", type: "PLA", cost: 1,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000005",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    const raw = await Filament.collection.insertOne({
+      name: "Amb PLA ", vendor: "V", type: "PLA", cost: 2,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000006",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    return { canonicalId: canonical.insertedId, rawId: raw.insertedId };
+  }
+
+  it("(C) matchFilament returns the row actually named, not the canonical one", async () => {
+    const { rawId } = await seedBothSpellings();
+    const { matchFilament } = await import("@/lib/matchFilament");
+
+    const res = await matchFilament({ name: "Amb PLA " });
+    // A confident match, and the RIGHT one — an NFC scan must not
+    // auto-associate the tag with a different filament.
+    expect(res.match).not.toBeNull();
+    expect(String((res.match as { _id: unknown })._id)).toBe(String(rawId));
+  });
+
+  it("(C) a single-filament export exports the row that was addressed", async () => {
+    const { rawId } = await seedBothSpellings();
+    const { resolveFilamentForExport } = await import("@/lib/singleFilamentExport");
+
+    const doc = await resolveFilamentForExport("Amb PLA ");
+    expect(doc).not.toBeNull();
+    expect(String(doc!._id)).toBe(String(rawId));
+  });
+
+  it("(B) a rename onto a surviving untrimmed name is REFUSED", async () => {
+    const { rawId } = await seedBothSpellings();
+    const other = await Filament.create({ name: "Other PLA", vendor: "V", type: "PLA" });
+    const { PUT } = await import("@/app/api/filaments/[id]/route");
+
+    const res = await PUT(
+      new NextRequest(`http://localhost/api/filaments/${other._id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Amb PLA" }),
+      }),
+      { params: Promise.resolve({ id: String(other._id) }) },
+    );
+
+    // Without the survivor check this returned 200 and left TWO active rows
+    // rendering as "Amb PLA" — the raw index strings differ, so no E11000.
+    expect(res.status).toBe(409);
+    // And nothing was renamed.
+    expect((await Filament.collection.findOne({ _id: other._id }))!.name).toBe("Other PLA");
+    expect((await Filament.collection.findOne({ _id: rawId }))!.name).toBe("Amb PLA ");
+  });
+
+  it("(B) a reparent+rename onto a survivor 409s BEFORE promoting the parent", async () => {
+    // Fail-fast before the irreversible bit. A confirmed reparent that also
+    // renames onto a surviving untrimmed name must not promote the carrying
+    // parent — moving its color and spools onto a new variant — and only then
+    // report failure.
+    // ONLY the survivor — no canonical row. With both present the ordinary
+    // cast check finds the canonical one and the survivor path is never
+    // exercised, which is exactly how the first version of this test passed
+    // against the unfixed code.
+    await Filament.collection.insertOne({
+      name: "Amb PLA ", vendor: "V", type: "PLA", cost: 2,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000007",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    // A LEGACY carrying parent: has its own color and a spool, no variants yet.
+    const parent = await Filament.create({
+      name: "Carrier PLA", vendor: "V", type: "PLA", color: "#123456",
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000008",
+      spools: [{ totalWeight: 1000 }],
+    });
+    const target = await Filament.create({ name: "Target PLA", vendor: "V", type: "PLA" });
+    const { PUT } = await import("@/app/api/filaments/[id]/route");
+
+    const res = await PUT(
+      new NextRequest(`http://localhost/api/filaments/${target._id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Amb PLA",            // collides with the survivor "Amb PLA "
+          parentId: String(parent._id),
+          promoteParent: true,        // confirmed — the gate WOULD promote
+        }),
+      }),
+      { params: Promise.resolve({ id: String(target._id) }) },
+    );
+
+    expect(res.status).toBe(409);
+    // The parent is completely untouched — no promotion happened.
+    const fresh = await Filament.collection.findOne({ _id: parent._id });
+    expect(fresh!.color).toBe("#123456");
+    expect(fresh!.spools).toHaveLength(1);
+    expect(await Filament.countDocuments({ parentId: parent._id })).toBe(0);
+  });
+});
+
+
+/**
+ * GH #1116 (Codex P1, round 31) — the ordinary CRUD writes.
+ *
+ * These leaned entirely on the partial unique index to reject a duplicate
+ * name. That stops working against a survivor: the index compares RAW stored
+ * strings, so "Drybox" and a surviving "Drybox " are two different keys and
+ * the write succeeds. Before `trim: true` the submitted spelling reached the
+ * index unchanged and collided as the user expected; now it is cast first and
+ * the collision evaporates.
+ */
+describe("ordinary CRUD refuses a name that already exists untrimmed (#1116)", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let Location: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    for (const [name, mod] of [
+      ["Location", await import("@/models/Location")],
+    ] as const) {
+      if (!mongoose.models[name]) {
+        mongoose.model(name, (mod as { default: { schema: mongoose.Schema } }).default.schema);
+      }
+    }
+    Location = mongoose.models.Location;
+    await Location.collection.deleteMany({});
+  });
+
+  it("POST refuses to create beside a surviving untrimmed row", async () => {
+    await Location.collection.insertOne({
+      name: "Drybox ", kind: "drybox", _deletedAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    });
+    const { POST } = await import("@/app/api/locations/route");
+
+    const res = await POST(
+      new NextRequest("http://localhost/api/locations", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Drybox", kind: "drybox" }),
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/already exists/i);
+    expect(await Location.collection.countDocuments({})).toBe(1);
+  });
+
+  it("PUT refuses to rename onto a surviving untrimmed row", async () => {
+    await Location.collection.insertOne({
+      name: "Drybox ", kind: "drybox", _deletedAt: null,
+      createdAt: new Date(), updatedAt: new Date(),
+    });
+    const other = await Location.create({ name: "Shelf", kind: "shelf" });
+    const { PUT } = await import("@/app/api/locations/[id]/route");
+
+    const res = await PUT(
+      new NextRequest(`http://localhost/api/locations/${other._id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Drybox" }),
+      }),
+      { params: Promise.resolve({ id: String(other._id) }) },
+    );
+
+    expect(res.status).toBe(409);
+    expect((await Location.collection.findOne({ _id: other._id }))!.name).toBe("Shelf");
+  });
+
+  it("a no-op save that echoes the row's OWN name still succeeds", async () => {
+    // Self-exclusion: the guard must not 409 the ordinary form echo.
+    const loc = await Location.create({ name: "Shelf", kind: "shelf" });
+    const { PUT } = await import("@/app/api/locations/[id]/route");
+    const res = await PUT(
+      new NextRequest(`http://localhost/api/locations/${loc._id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Shelf", notes: "touched" }),
+      }),
+      { params: Promise.resolve({ id: String(loc._id) }) },
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+
+/**
+ * GH #1116 (Codex round 32) — the two holes round 31's own guard left.
+ */
+describe("the create guard covers the gated variant path and cast names (#1116)", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let Filament: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+    await Filament.collection.deleteMany({});
+  });
+
+  it("a VARIANT create onto a survivor 409s, and never promotes the parent", async () => {
+    // The gate RETURNS from the variant path, so a guard placed after it was
+    // unreachable here — the variant was inserted, and for a carrying parent
+    // the promotion had already moved its color and spools.
+    await Filament.collection.insertOne({
+      name: "Var PLA ", vendor: "V", type: "PLA",
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws00000009",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    const parent = await Filament.create({
+      name: "Carrier", vendor: "V", type: "PLA", color: "#123456",
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws0000000a",
+      spools: [{ totalWeight: 1000 }],
+    });
+    const { POST } = await import("@/app/api/filaments/route");
+
+    const res = await POST(
+      new NextRequest("http://localhost/api/filaments", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Var PLA",
+          vendor: "V",
+          type: "PLA",
+          parentId: String(parent._id),
+          promoteParent: true,
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    // No variant was inserted...
+    expect(await Filament.countDocuments({ parentId: parent._id })).toBe(0);
+    // ...and the carrying parent is untouched.
+    const fresh = await Filament.collection.findOne({ _id: parent._id });
+    expect(fresh!.color).toBe("#123456");
+    expect(fresh!.spools).toHaveLength(1);
+  });
+
+  it("a schema-castable NON-STRING name is checked, not skipped", async () => {
+    // Mongoose stores `7` as "7". Beside a survivor stored as "7 " the raw
+    // index sees different strings and admits the duplicate — while a
+    // `typeof name !== "string"` skip means the guard never looked.
+    await Filament.collection.insertOne({
+      name: "7 ", vendor: "V", type: "PLA",
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws0000000b",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    const { POST } = await import("@/app/api/filaments/route");
+
+    const res = await POST(
+      new NextRequest("http://localhost/api/filaments", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: 7, vendor: "V", type: "PLA" }),
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    expect(await Filament.collection.countDocuments({})).toBe(1);
+  });
+});
+
+
+/**
+ * GH #1116 (Codex round 33) — GENERATED names need the guard too.
+ *
+ * Both of these compute a name themselves and then create it. Their own
+ * "is it taken?" probes are cast queries (an `exists`, an anchored regex),
+ * so neither can see a survivor, and the raw unique index then permits the
+ * write because the two stored strings differ.
+ */
+describe("generated names are survivor-checked (#1116)", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let Filament: any;
+  let Nozzle: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    Filament = (await import("@/models/Filament")).default;
+    const nozMod = await import("@/models/Nozzle");
+    if (!mongoose.models.Nozzle) mongoose.model("Nozzle", nozMod.default.schema);
+    Nozzle = mongoose.models.Nozzle;
+    await Filament.collection.deleteMany({});
+    await Nozzle.collection.deleteMany({});
+  });
+
+  it("the PROMOTION copy's generated name is checked", async () => {
+    // A carrying parent "PLA" with colorName "Red" promotes to a variant
+    // named "PLA — Red". An active survivor already holds "PLA — Red ".
+    await Filament.collection.insertOne({
+      name: "PLA — Red ", vendor: "V", type: "PLA", instanceId: "wsgen0001",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    const parent = await Filament.create({
+      name: "PLA", vendor: "V", type: "PLA",
+      color: "#FF0000", colorName: "Red", spools: [{ totalWeight: 1000 }],
+    });
+    const { resolvePromotionVariantName } = await import("@/lib/promoteParent");
+
+    const chosen = await resolvePromotionVariantName(Filament, "PLA — Red");
+    // It must NOT pick the name the survivor already renders as.
+    expect(chosen).not.toBe("PLA — Red");
+    expect(chosen).toBe("PLA — Red (2)");
+    expect(parent.name).toBe("PLA");
+  });
+
+  it("the nozzle CLONE's generated name is checked", async () => {
+    const source = await Nozzle.create({ name: "0.4", diameter: 0.4, type: "brass" });
+    // The clone would generate "0.4 #2"; a survivor already holds "0.4 #2 ".
+    await Nozzle.collection.insertOne({
+      name: "0.4 #2 ", diameter: 0.4, type: "brass", _deletedAt: null,
+    });
+    const { POST } = await import("@/app/api/nozzles/[id]/clone/route");
+
+    const res = await POST(
+      new NextRequest(`http://localhost/api/nozzles/${source._id}/clone`, {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ id: String(source._id) }) },
+    );
+
+    expect(res.status).toBe(409);
+    // Two rows only — the source and the survivor. No indistinguishable clone.
+    expect(await Nozzle.collection.countDocuments({})).toBe(2);
+  });
+
+  it("the filament PUT guard checks a schema-castable NON-STRING name", async () => {
+    await Filament.collection.insertOne({
+      name: "7 ", vendor: "V", type: "PLA", instanceId: "wsgen0002",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    const target = await Filament.create({ name: "Target", vendor: "V", type: "PLA" });
+    const { PUT } = await import("@/app/api/filaments/[id]/route");
+
+    const res = await PUT(
+      new NextRequest(`http://localhost/api/filaments/${target._id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: 7 }),
+      }),
+      { params: Promise.resolve({ id: String(target._id) }) },
+    );
+
+    expect(res.status).toBe(409);
+    expect((await Filament.collection.findOne({ _id: target._id }))!.name).toBe("Target");
   });
 });

--- a/tests/name-whitespace.test.ts
+++ b/tests/name-whitespace.test.ts
@@ -900,25 +900,30 @@ describe("generated names are survivor-checked (#1116)", () => {
     expect(parent.name).toBe("PLA");
   });
 
-  it("the nozzle CLONE's generated name is checked", async () => {
-    const source = await Nozzle.create({ name: "0.4", diameter: 0.4, type: "brass" });
-    // The clone would generate "0.4 #2"; a survivor already holds "0.4 #2 ".
+  it("the nozzle CLONE ADVANCES past a survivor instead of refusing forever", async () => {
+    // A survivor is a PERMANENT state — the migration leaves it precisely
+    // because it cannot repair it automatically — so refusing would make
+    // cloning impossible forever, on every retry, even though the next suffix
+    // is free. It is an occupied suffix to a human reading the list, so treat
+    // it as one.
+    const source = await Nozzle.create({ name: "0.5", diameter: 0.5, type: "brass" });
     await Nozzle.collection.insertOne({
-      name: "0.4 #2 ", diameter: 0.4, type: "brass", _deletedAt: null,
+      name: "0.5 #2 ", diameter: 0.5, type: "brass", _deletedAt: null,
     });
     const { POST } = await import("@/app/api/nozzles/[id]/clone/route");
 
     const res = await POST(
-      new NextRequest(`http://localhost/api/nozzles/${source._id}/clone`, {
-        method: "POST",
-      }),
+      new NextRequest(`http://localhost/api/nozzles/${source._id}/clone`, { method: "POST" }),
       { params: Promise.resolve({ id: String(source._id) }) },
     );
 
-    expect(res.status).toBe(409);
-    // Two rows only — the source and the survivor. No indistinguishable clone.
-    expect(await Nozzle.collection.countDocuments({})).toBe(2);
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    // Skipped the survivor-occupied "#2" and took the next free suffix.
+    expect(created.name).toBe("0.5 #3");
+    expect(await Nozzle.collection.countDocuments({})).toBe(3);
   });
+
 
   it("the filament PUT guard checks a schema-castable NON-STRING name", async () => {
     await Filament.collection.insertOne({

--- a/tests/slicer-sync-template-strip.test.ts
+++ b/tests/slicer-sync-template-strip.test.ts
@@ -384,3 +384,134 @@ describe("GH #605 — slicer sync template strip", () => {
     });
   });
 });
+
+/**
+ * GH #1116 (Codex P1, round 28) — a name-addressed sync must reach the row the
+ * slicer actually named.
+ *
+ * `name` carries `trim: true`, and a Mongoose String setter casts QUERY values.
+ * So with both "X" and "X " active — the state an unresolved trim migration
+ * leaves — a preset addressed as "X " casts to "X" and selects the CANONICAL
+ * row. The sync then writes the preset's settings onto a DIFFERENT filament.
+ *
+ * Before the setter this query matched "X " exactly, so the redirection is
+ * introduced by the schema change; removing create-on-404 does not help,
+ * because nothing is created — the wrong record is simply overwritten.
+ */
+describe("GH #1116 — a name-addressed sync resolves the EXACT stored spelling", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+
+  beforeEach(async () => {
+    const filMod = await import("@/models/Filament");
+    if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
+    Filament = mongoose.models.Filament;
+    await Filament.collection.deleteMany({});
+  });
+
+  /** Both spellings active — what a skipped/blocked trim pass leaves behind.
+   *  Written with the raw driver, because the setter would trim the second. */
+  async function seedBothSpellings() {
+    const canonical = await Filament.collection.insertOne({
+      name: "Ambiguous PLA", vendor: "V", type: "PLA", cost: 1,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws0000000c",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    const raw = await Filament.collection.insertOne({
+      name: "Ambiguous PLA ", vendor: "V", type: "PLA", cost: 2,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws0000000d",
+      _deletedAt: null, spools: [], settings: {},
+    });
+    return { canonicalId: canonical.insertedId, rawId: raw.insertedId };
+  }
+
+  it("PrusaSlicer sync writes to the untrimmed row it addressed, not the canonical one", async () => {
+    const { canonicalId, rawId } = await seedBothSpellings();
+
+    const res = await prusaSync(
+      new NextRequest("http://localhost/api/filaments/Ambiguous%20PLA%20", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Ambiguous PLA ",
+          config: { filament_cost: "42" },
+        }),
+      }),
+      { params: Promise.resolve({ id: "Ambiguous PLA " }) },
+    );
+    expect(res.status).toBe(200);
+
+    const raw = await Filament.collection.findOne({ _id: rawId });
+    const canonical = await Filament.collection.findOne({ _id: canonicalId });
+    expect(raw!.cost).toBe(42);
+    // The bystander is untouched — that is the whole point.
+    expect(canonical!.cost).toBe(1);
+  });
+
+  it("still resolves normally once the migration has normalized the row", async () => {
+    // Only the canonical row exists now. An old preset still addressed as
+    // "X " must fall through to the cast query and find it.
+    await Filament.collection.insertOne({
+      name: "Settled PLA", vendor: "V", type: "PLA", cost: 1,
+      // Raw driver bypasses the schema default, and `instanceId` carries a
+      // UNIQUE index — two seeds would both be null and collide on it.
+      instanceId: "ws0000000e",
+      _deletedAt: null, spools: [], settings: {},
+    });
+
+    const res = await prusaSync(
+      new NextRequest("http://localhost/api/filaments/Settled%20PLA%20", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Settled PLA ", config: { filament_cost: "7" } }),
+      }),
+      { params: Promise.resolve({ id: "Settled PLA " }) },
+    );
+    expect(res.status).toBe(200);
+    expect((await Filament.collection.findOne({ name: "Settled PLA" }))!.cost).toBe(7);
+  });
+
+  it("OrcaSlicer sync has the same resolution", async () => {
+    const { canonicalId, rawId } = await seedBothSpellings();
+
+    const res = await orcaSync(
+      new NextRequest("http://localhost/api/filaments/Ambiguous%20PLA%20/orcaslicer", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cost: 42 }),
+      }),
+      { params: Promise.resolve({ id: "Ambiguous PLA " }) },
+    );
+    expect(res.status).toBe(200);
+
+    expect((await Filament.collection.findOne({ _id: rawId }))!.cost).toBe(42);
+    expect((await Filament.collection.findOne({ _id: canonicalId }))!.cost).toBe(1);
+  });
+
+  it("the per-nozzle BASE fallback resolves the raw slice, not the trimmed one", async () => {
+    // A per-nozzle preset generated for an unresolved "X " is named
+    // "X  0.4 Brass" (two spaces). Slicing the hint leaves "X ", and both
+    // `.trim()` and the setter's cast land on the canonical "X".
+    const { canonicalId, rawId } = await seedBothSpellings();
+
+    const res = await prusaSync(
+      new NextRequest("http://localhost/api/filaments/x", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Ambiguous PLA  0.4 Brass",
+          config: { filamentdb_nozzle: "0.4 Brass", filament_cost: "42" },
+        }),
+      }),
+      { params: Promise.resolve({ id: "Ambiguous PLA  0.4 Brass" }) },
+    );
+    expect(res.status).toBe(200);
+
+    expect((await Filament.collection.findOne({ _id: rawId }))!.cost).toBe(42);
+    expect((await Filament.collection.findOne({ _id: canonicalId }))!.cost).toBe(1);
+  });
+});

--- a/tests/spools-import-route.test.ts
+++ b/tests/spools-import-route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import mongoose from "mongoose";
 import { NextRequest } from "next/server";
 import { POST as importSpools } from "@/app/api/spools/import/route";
+import { trimEntityNames } from "@/lib/trimEntityNames";
 
 // GH #605: an overridable hasVariants so the "became a template mid-import"
 // race is testable deterministically — the default passthrough keeps every
@@ -1388,5 +1389,108 @@ describe("/api/spools/import — legacy roll migration (#1111)", () => {
     const fresh = await Filament.findById(f._id);
     expect(fresh.spools).toHaveLength(1);
     expect(fresh.totalWeight).toBeNull();
+  });
+
+  /**
+   * GH #1116, end to end on the LITERAL reported path.
+   *
+   * The rest of the #1116 coverage tests the pieces (schema setter, migration,
+   * importer key). This one walks the actual bug report: a location whose
+   * stored name carried a trailing space, a spool CSV naming it, and the
+   * auto-create in `resolveLocationId` manufacturing a SECOND location that
+   * renders identically — the original silently dropping to zero spools.
+   *
+   * It is deliberately end to end because `resolveLocationId` is fixed only
+   * TRANSITIVELY: it calls `Location.findOne({ name })` through Mongoose, so
+   * the `trim: true` setter casts the query value, and `Location.create` trims
+   * on write. Nothing at that call site says so, so nothing but a test stops a
+   * future refactor to the raw driver (which several hot paths in this repo
+   * already use) from quietly reopening the duplicate.
+   */
+  describe("the reported duplicate-location path (GH #1116)", () => {
+    it("resolves a whitespace-named location instead of auto-creating a twin", async () => {
+      // `tests/setup.ts` wipes `mongoose.models` between tests and this
+      // describe only re-registers Filament, so bring Location back too.
+      const locationMod = await import("@/models/Location");
+      if (!mongoose.models.Location) {
+        mongoose.model("Location", locationMod.default.schema);
+      }
+      const LocationModel = mongoose.models.Location;
+
+      // Pre-upgrade row, written the way the driver would have stored it.
+      await mongoose.connection.collection("locations").insertOne({
+        name: "Drybox #1 ", kind: "drybox", _deletedAt: null,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+
+      // Stand in for `dbConnect`, which runs this pass EARLY on every connect
+      // precisely so no name-addressed lookup runs against unrepaired data.
+      // Without it the import still manufactures the twin — which is not a
+      // gap so much as the reason the pass runs where it does, and the reason
+      // a collection it has to SKIP keeps reporting until a human resolves it.
+      await trimEntityNames(
+        mongoose.connection.db as unknown as import("@/lib/trimEntityNames").MinimalTrimDb,
+      );
+      await Filament.create({ name: "PLA Basic", vendor: "V", type: "PLA" });
+
+      // The CSV carries the name QUOTED with its trailing space — which is
+      // exactly what csvWriter now emits, and the shape that used to miss.
+      const res = await importSpools(
+        csvRequest('filament,totalWeight,location\nPLA Basic,1000,"Drybox #1 "\n'),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).imported).toBe(1);
+
+      const locations = await LocationModel.find({ _deletedAt: null });
+      expect(locations).toHaveLength(1);
+      expect(locations[0].name).toBe("Drybox #1");
+
+      // And the spool landed on that one, not on a twin.
+      const filament = await Filament.findOne({ name: "PLA Basic" });
+      expect(filament.spools).toHaveLength(1);
+      expect(String(filament.spools[0].locationId)).toBe(String(locations[0]._id));
+    });
+
+    /**
+     * The case above assumes the pass SUCCEEDED. This is the one that bites
+     * (Codex P1, round 23): `trimEntityNames` skips a collection whose
+     * protective unique index cannot be established — which is exactly what a
+     * database with pre-existing duplicate active names does — and the raw
+     * untrimmed row survives.
+     *
+     * `resolveLocationId` then cannot see it (the setter casts the query),
+     * falls through to `Location.create`, and the create SUCCEEDS because the
+     * two raw strings are distinct so the unique index has no objection. The
+     * user gets a second location rendering identically to the first, and
+     * every imported spool attaches to the twin — the original silently
+     * dropping to zero spools, which is the bug report verbatim.
+     */
+    it("resolves a SURVIVING untrimmed location when the migration never ran", async () => {
+      const locationMod = await import("@/models/Location");
+      if (!mongoose.models.Location) {
+        mongoose.model("Location", locationMod.default.schema);
+      }
+      const LocationModel = mongoose.models.Location;
+
+      const raw = await mongoose.connection.collection("locations").insertOne({
+        name: "Drybox #1 ", kind: "drybox", _deletedAt: null,
+        createdAt: new Date(), updatedAt: new Date(),
+      });
+      await Filament.create({ name: "PLA Basic", vendor: "V", type: "PLA" });
+
+      // Deliberately NO trimEntityNames call — the survivor is still there.
+      const res = await importSpools(
+        csvRequest('filament,totalWeight,location\nPLA Basic,1000,"Drybox #1 "\n'),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).imported).toBe(1);
+
+      // No twin was manufactured...
+      const locations = await LocationModel.find({ _deletedAt: null });
+      expect(locations).toHaveLength(1);
+      // ...and the spool attached to the row that was actually there.
+      const filament = await Filament.findOne({ name: "PLA Basic" });
+      expect(String(filament.spools[0].locationId)).toBe(String(raw.insertedId));
+    });
   });
 });

--- a/tests/trimmedNameLookup.test.ts
+++ b/tests/trimmedNameLookup.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  trimmedNameFilter,
+  findByTrimmedName,
+  type MinimalNameCollection,
+} from "@/lib/trimmedNameLookup";
+import { JS_TRIM_CHARS } from "@/lib/trimEntityNames";
+
+/**
+ * GH #1116. This helper is the fallback every "resolve by name, create when
+ * missing" path needs, because a Mongoose String setter casts QUERY values and
+ * therefore cannot select a stored row the migration has not trimmed yet.
+ *
+ * The rule it encodes was applied to one call site and missed at two others,
+ * each found a review round apart — so the shape is pinned here rather than
+ * re-derived per caller.
+ */
+describe("trimmedNameFilter", () => {
+  function trimSpec(filter: Record<string, unknown>) {
+    const expr = filter.$expr as { $in: [{ $trim: Record<string, unknown> }, string[]] };
+    return { trim: expr.$in[0].$trim, wanted: expr.$in[1] };
+  }
+
+  it("compares the STORED name's trimmed form against the trimmed inputs", () => {
+    const { wanted } = trimSpec(trimmedNameFilter(["  PLA  ", "PETG"]));
+    expect(wanted).toEqual(["PLA", "PETG"]);
+  });
+
+  it("passes JS_TRIM_CHARS as `chars`, not MongoDB's default set", () => {
+    // Load-bearing, and the reason is subtle: `$trim` without `chars` strips
+    // MongoDB's ASCII-only set, so a name ending in U+00A0 / U+FEFF / U+3000
+    // would NOT match here while `String.prototype.trim` (what the schema
+    // setter uses) removes it — the query and the schema would disagree about
+    // the same row, which is the bug one level down.
+    const { trim } = trimSpec(trimmedNameFilter(["PLA"]));
+    expect(trim.chars).toBe(JS_TRIM_CHARS);
+    expect(String(trim.chars)).toContain(" ");
+    expect(String(trim.chars)).toContain("﻿");
+  });
+
+  it("coerces a non-string stored name rather than erroring on it", () => {
+    // `$trim` throws on a non-string input and legacy data holds them, which
+    // would fail the whole import rather than skipping one unmatched row.
+    const { trim } = trimSpec(trimmedNameFilter(["PLA"]));
+    expect(trim.input).toEqual({
+      $cond: [{ $eq: [{ $type: "$name" }, "string"] }, "$name", ""],
+    });
+  });
+
+  it("matches nothing for an empty input list", () => {
+    const { wanted } = trimSpec(trimmedNameFilter([]));
+    expect(wanted).toEqual([]);
+  });
+});
+
+describe("findByTrimmedName", () => {
+  function fakeCollection(result: { _id: unknown; name?: unknown } | null) {
+    const calls: Record<string, unknown>[] = [];
+    const collection: MinimalNameCollection = {
+      async findOne(filter) {
+        calls.push(filter);
+        return result;
+      },
+    };
+    return { collection, calls };
+  }
+
+  it("returns the surviving row", async () => {
+    const { collection } = fakeCollection({ _id: "abc", name: "Drybox #1 " });
+    expect(await findByTrimmedName(collection, "Drybox #1")).toEqual({
+      _id: "abc",
+      name: "Drybox #1 ",
+    });
+  });
+
+  it("merges the caller's own conditions with the name predicate", async () => {
+    const { collection, calls } = fakeCollection(null);
+    await findByTrimmedName(collection, "Drybox #1", { _deletedAt: null });
+    expect(calls[0]._deletedAt).toBeNull();
+    expect(calls[0].$expr).toBeDefined();
+  });
+
+  it("short-circuits a blank name without querying", async () => {
+    // A whitespace-only name trims to "", which is not a legal name — and
+    // querying for it would scan the collection to match nothing.
+    const { collection, calls } = fakeCollection({ _id: "x" });
+    expect(await findByTrimmedName(collection, "   ")).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("looks up by the TRIMMED form of an untrimmed input", async () => {
+    const { collection, calls } = fakeCollection(null);
+    await findByTrimmedName(collection, "  Drybox #1  ");
+    const expr = calls[0].$expr as { $in: [unknown, string[]] };
+    expect(expr.$in[1]).toEqual(["Drybox #1"]);
+  });
+});

--- a/tests/trimmedNameLookup.test.ts
+++ b/tests/trimmedNameLookup.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  survivorNameConflict,
   trimmedNameFilter,
   findByTrimmedName,
   type MinimalNameCollection,
@@ -93,5 +94,52 @@ describe("findByTrimmedName", () => {
     await findByTrimmedName(collection, "  Drybox #1  ");
     const expr = calls[0].$expr as { $in: [unknown, string[]] };
     expect(expr.$in[1]).toEqual(["Drybox #1"]);
+  });
+});
+
+describe("survivorNameConflict", () => {
+  /** A fake whose `find` returns matches in a caller-chosen order, so the
+   *  "arbitrary match happens to be self" case is deterministic. */
+  function fakeWith(rows: { _id: string }[]) {
+    return {
+      async findOne() {
+        return rows[0] ?? null;
+      },
+      find() {
+        return { async toArray() { return rows; } };
+      },
+    } as unknown as Parameters<typeof survivorNameConflict>[0];
+  }
+
+  it("looks PAST a match that is the row being renamed", async () => {
+    // Several active rows can trim to one name — exactly what a skipped
+    // migration leaves. A single-match lookup returns an ARBITRARY one; when
+    // that was self, the guard reported "no conflict" and the save normalized
+    // a survivor "X " to "X" beside an existing "X", producing two identical
+    // STORED names with no index left to catch it.
+    const col = fakeWith([{ _id: "self" }, { _id: "other" }]);
+    expect(await survivorNameConflict(col, "X", "self")).toBe("other");
+  });
+
+  it("still reports no conflict when self is the ONLY match", async () => {
+    const col = fakeWith([{ _id: "self" }]);
+    expect(await survivorNameConflict(col, "X", "self")).toBeNull();
+  });
+
+  it("reports the first match when there is no self to exclude", async () => {
+    const col = fakeWith([{ _id: "other" }]);
+    expect(await survivorNameConflict(col, "X")).toBe("other");
+  });
+
+  it("normalizes a schema-castable non-string before deciding", async () => {
+    // Mongoose stores 7 as "7"; a `typeof` skip would never look.
+    const col = fakeWith([{ _id: "other" }]);
+    expect(await survivorNameConflict(col, 7)).toBe("other");
+  });
+
+  it("ignores a value the schema would reject, and a blank name", async () => {
+    const col = fakeWith([{ _id: "other" }]);
+    expect(await survivorNameConflict(col, ["nope"])).toBeNull();
+    expect(await survivorNameConflict(col, "   ")).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #1143.

The guard layer split out of #1138, ported onto `main` now that the core has landed. It keeps the rest of the application correct while the trim migration is **blocked** and a raw untrimmed row survives.

## Mechanism (confirmed against Mongoose 9.7.4 source)

`trim` is a SETTER (`lib/schema/string.js:365-378`) and `castForQuery` runs `applySetters` (`:689-707`), so a QUERY value is trimmed too — even an `$in` batch load misses (`handleArray`, `:626-634`). The partial unique index compares RAW stored strings, so `"X"` and a surviving `"X "` coexist legally. A survivor is simultaneously **unreachable by its own name** and **shadowed by its twin**.

## The taxonomy — the thing that should have been written first

| | hazard | outcome | remedy |
|---|---|---|---|
| A | lookup MISSES, then creates | duplicate row | survivor fallback |
| B | lookup MISSES inside a GUARD | guard wrongly permits | survivor fallback |
| C | lookup matches the WRONG row | another record read/overwritten | exact-spelling resolution |

Two exemption rationales that sound reasonable and are not: *"read-only, a miss is a 404"* ignores (C) — reading the wrong row hands back another filament's data. *"It only refuses, it never creates"* ignores (B) — failing to refuse is exactly how that guard creates the duplicate.

## Surfaces

- **Importers (A):** CSV/XLSX, Atlas, Bambu Studio, PrusaSlicer INI, OpenPrintTag, Prusament, and the spool CSV import's `resolveLocationId` — the bug report's literal reproduction path.
- **Name-addressed reads and syncs (C):** PrusaSlicer and OrcaSlicer sync-back (both **mutating**), the per-nozzle base-name fallback, calibration, spool-check, `matchFilament` (an NFC scan auto-associating with the wrong filament), single-filament export.
- **Guards (B):** filament PUT rename, restore conflict, OpenPrintTag variant collision, and the ordinary CRUD create/rename on all five models.
- **Generated names:** the promotion copy's variant name, the nozzle clone's `#N` suffix.
- **Drift guard:** `tests/name-lookup-invariant.test.ts`, **per-query** — a file-level check was worthless and was already waving through a live bug.

## Invariants that each cost a review round

- **Canonical query FIRST**, survivor scan only on a miss — the survivor `$expr` matches both rows with no ordering, so scanning first turns a deterministic update into a coin flip.
- **Self-exclusion in JS**, never in a raw-driver filter — an ObjectId never equals a string, so the row fails to exclude *itself* and every no-op save 409s.
- **`castNameLikeSchema` before deciding to skip** — a JSON client sending `7` stores `"7"`.
- **Guards before the irreversible promotion step.**
- **Liveness kept on `_id` re-reads**, and `$expr` batched per import.

## Porting note

Ported the delta rather than rebasing: `main` has moved **ahead** of this branch on the shared files (paired-only hold-back, the prerequisite cascade, the inadequate-index conversion), so a rebase would have reverted them. Overlap was checked file by file and main's versions kept.

One correction to the triage summary: `src/lib/iniImportApply.ts` was flagged there as a live instance of the "inert fix" pattern. It is not — the write filter is already survivor-aware (`activeIsSurvivor ? {_id, _deletedAt} : {_id, name, _deletedAt}`), with a comment describing that exact trap. Verified before porting.

Full gate green: 207 files / 4429 tests, plus `tsc`, lint and `electron:typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)