### PR TITLE
ci: skip the Electron binary download in the gate (#1155)

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -74,6 +74,16 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Install dependencies
+        # GH #1155: nothing in this gate launches Electron — the tests import
+        # the electron module type-only, electron:typecheck is tsc against the
+        # tarball's .d.ts, and the smoke server is plain node. The ~110 MB
+        # binary electron's postinstall fetches off GitHub's release CDN is
+        # therefore pure flake surface (six 503/fetch-failed reds on
+        # 2026-08-12 alone). install.js honors this env and exits before any
+        # network I/O. release.yml's build legs keep their own un-flagged
+        # `npm ci` — electron-builder needs the real binary THERE.
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
         run: npm ci
 
       - name: Lint
@@ -154,6 +164,16 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Install dependencies
+        # GH #1155: nothing in this gate launches Electron — the tests import
+        # the electron module type-only, electron:typecheck is tsc against the
+        # tarball's .d.ts, and the smoke server is plain node. The ~110 MB
+        # binary electron's postinstall fetches off GitHub's release CDN is
+        # therefore pure flake surface (six 503/fetch-failed reds on
+        # 2026-08-12 alone). install.js honors this env and exits before any
+        # network I/O. release.yml's build legs keep their own un-flagged
+        # `npm ci` — electron-builder needs the real binary THERE.
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
         run: npm ci
 
       - name: Build (standalone)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,16 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Install dependencies
+        # GH #1155: nothing in this gate launches Electron — the tests import
+        # the electron module type-only, electron:typecheck is tsc against the
+        # tarball's .d.ts, and the smoke server is plain node. The ~110 MB
+        # binary electron's postinstall fetches off GitHub's release CDN is
+        # therefore pure flake surface (six 503/fetch-failed reds on
+        # 2026-08-12 alone). install.js honors this env and exits before any
+        # network I/O. release.yml's build legs keep their own un-flagged
+        # `npm ci` — electron-builder needs the real binary THERE.
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
         run: npm ci
 
       - name: Lint
@@ -115,6 +125,16 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
 
       - name: Install dependencies
+        # GH #1155: nothing in this gate launches Electron — the tests import
+        # the electron module type-only, electron:typecheck is tsc against the
+        # tarball's .d.ts, and the smoke server is plain node. The ~110 MB
+        # binary electron's postinstall fetches off GitHub's release CDN is
+        # therefore pure flake surface (six 503/fetch-failed reds on
+        # 2026-08-12 alone). install.js honors this env and exits before any
+        # network I/O. release.yml's build legs keep their own un-flagged
+        # `npm ci` — electron-builder needs the real binary THERE.
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
         run: npm ci
 
       - name: Build (standalone)


### PR DESCRIPTION
Fixes #1155.

The Electron binary download inside `npm ci` felled **six CI runs on 2026-08-12 alone** — 503s and `fetch failed`s from `@electron/get` pulling the ~110 MB linux zip off GitHub's release CDN. Nothing in either gate ever launches Electron: the tests import the module type-only, `electron:typecheck` is tsc against the tarball's `.d.ts`, and the smoke server is plain node.

## Change

Step-level `env: ELECTRON_SKIP_BINARY_DOWNLOAD: "1"` on the four Install steps — the `test` and `smoke` jobs in **both** `test.yml` and `ci-gate.yml`, per the KEEP-IN-SYNC contract the files document. Step-level scoping is deliberate: the flag cannot leak anywhere else, and the mirrored job bodies stay identical.

`install.js` honors the env at line 14 and exits before any network I/O.

## What is deliberately untouched

- `release.yml`'s build legs keep their un-flagged `npm ci` — electron-builder needs the real binary there.
- Every other install path already runs `--ignore-scripts` (release notes step, release-bump, Dockerfile), and the mobile workflows have no electron dependency.
- `ci-gate.yml`'s `tag-version` job has no `npm ci`.

## Validation

- A scratch clone ran the exact gate sequence with the flag set: `npm ci` → `node_modules/electron/dist` **absent** → lint → `tsc --noEmit` → `electron:typecheck` → full vitest (210 files / 4541 tests) → `npm run build`. All green.
- This PR's own CI runs the modified `test.yml`, validating the other half live; the `Install dependencies` step log should show no `@electron/get` download output.
- The `ci-gate.yml` half first executes on the next `v*` tag — its failure mode there would be a deterministic "Electron failed to install correctly", not a flake, so a problem announces itself immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)