### PR TITLE
fix(sync): heal unreadable tombstones and stop minting new ones (#1152)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -576,6 +576,11 @@ export class SyncService extends EventEmitter {
         // a filaments-only concept. Epoch stamp: LWW-arithmetic-preserving —
         // see the helper's docblock for why NOT `new Date()` and NOT null.
         for (const collectionName of TOMBSTONE_COLLECTIONS) {
+          // Re-checked per iteration (Codex P2): destroy() can flip `aborted`
+          // while an awaited repair is in flight, and the service contract is
+          // that only the operation already in flight may finish — not six
+          // more repairs against a database the user just switched away from.
+          if (this.aborted) break;
           const healed = await repairMalformedTombstones(
             dbHandle.collection(collectionName) as unknown as MinimalTombstoneCollection,
           );

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -24,6 +24,11 @@ import {
   CAUSE_LEAD,
 } from "../src/lib/renameStaging";
 import {
+  repairMalformedTombstones,
+  TOMBSTONE_COLLECTIONS,
+  type MinimalTombstoneCollection,
+} from "../src/lib/malformedTombstones";
+import {
   retombstonePurgedZombies,
   type MinimalZombieCollection,
 } from "../src/lib/purgedZombies";
@@ -561,6 +566,24 @@ export class SyncService extends EventEmitter {
           console.log(
             `[sync] ${side}: re-tombstoned ${zombies} purged zombie filament(s) (GH #1004)`,
           );
+        }
+        // GH #1152: heal unreadable tombstones (the raw-driver `_deletedAt:
+        // ""` shape) on BOTH peers before any copy. The write-site guards
+        // below stop the engine from spreading the value; this removes what
+        // already exists — without it, a peer still carrying the shape
+        // re-copies it forward on the next whole-document LWW transfer. Every
+        // synced collection can hold a tombstone, unlike `_purged`, which is
+        // a filaments-only concept. Epoch stamp: LWW-arithmetic-preserving —
+        // see the helper's docblock for why NOT `new Date()` and NOT null.
+        for (const collectionName of TOMBSTONE_COLLECTIONS) {
+          const healed = await repairMalformedTombstones(
+            dbHandle.collection(collectionName) as unknown as MinimalTombstoneCollection,
+          );
+          if (healed > 0) {
+            console.log(
+              `[sync] ${side}: repaired ${healed} unreadable tombstone(s) in ${collectionName} (GH #1152)`,
+            );
+          }
         }
         // Re-check AFTER the zombie repair (Codex P2). `destroy()` can set
         // `aborted` while that await is in flight, and the trim is a SEPARATE
@@ -1722,13 +1745,37 @@ export class SyncService extends EventEmitter {
             if (localPurged && !remotePurged) {
               await remoteCol.updateOne(
                 { _id: remoteDoc._id },
-                { $set: { _purged: true, _deletedAt: localDoc._deletedAt ?? new Date() } },
+                // GH #1152: `??` passed a raw `_deletedAt: ""` straight
+                // through — the fallback means "stamp a tombstone when there
+                // is not one", and an unreadable value is not one. The purge
+                // tombstone's timestamp never participates in LWW (the purge
+                // branch precedes both delete arms and both-purged is a
+                // no-op), so `new Date()` is inert here and matches
+                // retombstonePurgedZombies' stamp.
+                {
+                  $set: {
+                    _purged: true,
+                    _deletedAt:
+                      SyncService.readTimestamp(localDoc._deletedAt) != null
+                        ? localDoc._deletedAt
+                        : new Date(),
+                  },
+                },
               );
               result.deleted++;
             } else if (!localPurged && remotePurged) {
               await localCol.updateOne(
                 { _id: localDoc._id },
-                { $set: { _purged: true, _deletedAt: remoteDoc._deletedAt ?? new Date() } },
+                // GH #1152 — mirror of the local arm above.
+                {
+                  $set: {
+                    _purged: true,
+                    _deletedAt:
+                      SyncService.readTimestamp(remoteDoc._deletedAt) != null
+                        ? remoteDoc._deletedAt
+                        : new Date(),
+                  },
+                },
               );
               result.deleted++;
             }
@@ -1750,7 +1797,23 @@ export class SyncService extends EventEmitter {
             const localDeletedAt = SyncService.readTimestamp(localDoc._deletedAt) ?? 0;
             const remoteUpdatedAt = SyncService.readUpdatedAt(remoteDoc) ?? 0;
             if (localDeletedAt >= remoteUpdatedAt) {
-              await remoteCol.updateOne({ _id: remoteDoc._id }, { $set: { _deletedAt: localDoc._deletedAt } });
+              // GH #1152: same verbatim-write class as the purge sites, but
+              // the fallback here is EPOCH, not `new Date()` — this tombstone
+              // DOES participate in LWW (the branch above compared it), and it
+              // won with an effective timestamp of 0. Stamping now would
+              // promote it into a fresh delete that beats older live edits on
+              // future cycles; epoch preserves the arithmetic that just ran.
+              await remoteCol.updateOne(
+                { _id: remoteDoc._id },
+                {
+                  $set: {
+                    _deletedAt:
+                      SyncService.readTimestamp(localDoc._deletedAt) != null
+                        ? localDoc._deletedAt
+                        : new Date(0),
+                  },
+                },
+              );
               result.deleted++;
             } else {
               // Remote was updated strictly after local delete — resurrect locally
@@ -1785,7 +1848,18 @@ export class SyncService extends EventEmitter {
             const remoteDeletedAt = SyncService.readTimestamp(remoteDoc._deletedAt) ?? 0;
             const localUpdatedAt = SyncService.readUpdatedAt(localDoc) ?? 0;
             if (remoteDeletedAt >= localUpdatedAt) {
-              await localCol.updateOne({ _id: localDoc._id }, { $set: { _deletedAt: remoteDoc._deletedAt } });
+              // GH #1152 — mirror of the toRemote arm; epoch for the same reason.
+              await localCol.updateOne(
+                { _id: localDoc._id },
+                {
+                  $set: {
+                    _deletedAt:
+                      SyncService.readTimestamp(remoteDoc._deletedAt) != null
+                        ? remoteDoc._deletedAt
+                        : new Date(0),
+                  },
+                },
+              );
               result.deleted++;
             } else {
               const full = await hydrateLocal(localDoc);

--- a/src/lib/malformedTombstones.ts
+++ b/src/lib/malformedTombstones.ts
@@ -80,9 +80,15 @@ export interface MinimalTombstoneCollection {
 export async function repairMalformedTombstones(
   collection: MinimalTombstoneCollection,
 ): Promise<number> {
+  // No `$type: "date"` exclusion (Codex P2): query-form $type matches array
+  // ELEMENTS, so `_deletedAt: [new Date()]` — unreadable to the engine, an
+  // array is nothing readTimestamp understands — would be excluded from the
+  // scan and stay malformed forever. The JS filter below is the single
+  // decision point; the query only bounds the scan to rows that have a
+  // non-null tombstone at all.
   const candidates = await collection
     .find(
-      { _deletedAt: { $exists: true, $nin: [null], $not: { $type: "date" } } },
+      { _deletedAt: { $exists: true, $nin: [null] } },
       { projection: { _deletedAt: 1 } },
     )
     .toArray();
@@ -98,7 +104,13 @@ export async function repairMalformedTombstones(
   const res = await collection.bulkWrite(
     broken.map((d) => ({
       updateOne: {
-        filter: { _id: d._id, _deletedAt: d._deletedAt },
+        // `$eq`, not implicit equality (Codex P2): the observed value sits in
+        // QUERY position, and raw-driver values are explicitly in scope — a
+        // BSON regex placed there implicitly becomes a regex QUERY that never
+        // matches the regex-valued row (the repair would repeat forever), and
+        // an operator-shaped document would change the filter's meaning
+        // entirely. `$eq` compares the observed value as a literal.
+        filter: { _id: d._id, _deletedAt: { $eq: d._deletedAt } },
         update: { $set: { _deletedAt: new Date(0) } },
       },
     })),

--- a/src/lib/malformedTombstones.ts
+++ b/src/lib/malformedTombstones.ts
@@ -80,15 +80,20 @@ export interface MinimalTombstoneCollection {
 export async function repairMalformedTombstones(
   collection: MinimalTombstoneCollection,
 ): Promise<number> {
-  // No `$type: "date"` exclusion (Codex P2): query-form $type matches array
-  // ELEMENTS, so `_deletedAt: [new Date()]` — unreadable to the engine, an
-  // array is nothing readTimestamp understands — would be excluded from the
-  // scan and stay malformed forever. The JS filter below is the single
-  // decision point; the query only bounds the scan to rows that have a
-  // non-null tombstone at all.
+  // `$exists` ONLY (Codex P2, twice — same trap, two operators). Query-form
+  // `$type: "date"` matches array ELEMENTS, so it hid `[new Date()]`; the
+  // `$nin: [null]` that replaced it has the SAME multikey semantics and hid
+  // `[null]` and `[null, "bad"]`. Every value-inspecting query operator
+  // evaluates against elements when the field holds an array, and arrays are
+  // precisely a shape this repair exists to catch — so the server side gets
+  // NO value predicate at all. The JS filter below is the single decision
+  // point (scalar null included: `isReadableTombstone(null)` is true, so an
+  // active row is simply skipped). The cost is fetching one projected field
+  // for every row that has `_deletedAt` at all — these collections are small,
+  // and after two rounds of multikey surprises, correctness over cleverness.
   const candidates = await collection
     .find(
-      { _deletedAt: { $exists: true, $nin: [null] } },
+      { _deletedAt: { $exists: true } },
       { projection: { _deletedAt: 1 } },
     )
     .toArray();

--- a/src/lib/malformedTombstones.ts
+++ b/src/lib/malformedTombstones.ts
@@ -1,0 +1,103 @@
+/**
+ * Repair tombstones the sync engine cannot read — `_deletedAt` values that
+ * `readTimestamp` parses to nothing (GH #1152). The canonical instance is the
+ * raw-driver `_deletedAt: ""`.
+ *
+ * ## Why this shape is uniquely poisonous
+ *
+ * Mongoose cannot produce it (an empty string casts to null on a Date path),
+ * so it only arrives via a raw-driver write — an external tool against a
+ * shared Atlas, a raw import, or the sync engine itself. Once present, it
+ * sits BETWEEN the two classifications the engine uses: OUTSIDE the partial
+ * unique name index (`{_deletedAt: null}` matches null and missing only) yet
+ * DELETED to the sync loop (`_deletedAt != null`). Two #1142 review rounds
+ * each had to defend a different predicate against it; this removes the shape
+ * instead of guarding every reader.
+ *
+ * The write-site guards in `electron/sync-service.ts` stop the ENGINE from
+ * spreading the value; this pass heals what already exists — without it, a
+ * peer that still carries the shape re-copies it forward on the next
+ * whole-document LWW transfer (`stripForTransfer` drops only `_id`/`__v`).
+ *
+ * ## The stamp is EPOCH, and that is a decision, not a default
+ *
+ * `new Date(0)`, because the engine already treats an unreadable tombstone as
+ * time zero (`readTimestamp(x) ?? 0`), so epoch preserves every LWW outcome
+ * exactly: a live peer with any real `updatedAt` still wins and resurrects,
+ * and a both-malformed pair becomes a legal tombstone with unchanged
+ * arithmetic. Stamping `new Date()` would silently PROMOTE the malformed
+ * tombstone into a fresh delete that beats older live edits — trashing a row
+ * the user still has. And normalizing to `null` is explicitly rejected: that
+ * moves the row INTO the partial unique name index mid-pass, where it can
+ * E11000 against an active same-name row — the #1116 zombie failure mode —
+ * and silently resurrects rows in the UI.
+ *
+ * ## What is deliberately left alone
+ *
+ * Anything `readTimestamp` CAN read: real Dates, parseable ISO strings,
+ * finite numbers. The engine tolerates those today, and normalizing them
+ * would CHANGE their LWW arithmetic — the opposite of a repair.
+ *
+ * Idempotent: a repaired row carries a real Date and no longer matches.
+ */
+
+/** Mirrors `SyncService.readTimestamp`'s acceptance, which is the contract:
+ *  repair exactly what that helper cannot read. */
+export function isReadableTombstone(value: unknown): boolean {
+  if (value == null) return true; // null/missing = not a tombstone at all
+  if (value instanceof Date) return !Number.isNaN(value.getTime());
+  if (typeof value === "string") return !Number.isNaN(Date.parse(value));
+  if (typeof value === "number") return !Number.isNaN(value);
+  return false; // objects, booleans — nothing readTimestamp understands
+}
+
+/** The minimal surface the repair needs — injected, like `purgedZombies`,
+ *  because the Electron sync service holds raw driver handles with no
+ *  Mongoose connection to the remote peer. */
+export interface MinimalTombstoneCollection {
+  find(
+    filter: Record<string, unknown>,
+    options: { projection: Record<string, number> },
+  ): { toArray(): Promise<Array<{ _id: unknown; _deletedAt?: unknown }>> };
+  updateMany(
+    filter: Record<string, unknown>,
+    update: Record<string, unknown>,
+  ): Promise<{ modifiedCount?: number } | unknown>;
+}
+
+/**
+ * Stamp every unreadable `_deletedAt` in `collection` to epoch.
+ *
+ * Returns how many rows were repaired, for logging. The candidate query
+ * excludes BSON dates server-side (always readable) and nulls; the JS filter
+ * then keeps only values `readTimestamp` cannot read, so parseable strings
+ * and numbers pass through untouched.
+ */
+export async function repairMalformedTombstones(
+  collection: MinimalTombstoneCollection,
+): Promise<number> {
+  const candidates = await collection
+    .find(
+      { _deletedAt: { $exists: true, $nin: [null], $not: { $type: "date" } } },
+      { projection: { _deletedAt: 1 } },
+    )
+    .toArray();
+  const broken = candidates.filter((d) => !isReadableTombstone(d._deletedAt));
+  if (broken.length === 0) return 0;
+  const res = await collection.updateMany(
+    { _id: { $in: broken.map((d) => d._id) } },
+    { $set: { _deletedAt: new Date(0) } },
+  );
+  return (res as { modifiedCount?: number })?.modifiedCount ?? 0;
+}
+
+/** The collections the sync engine copies — every one can carry a tombstone. */
+export const TOMBSTONE_COLLECTIONS = [
+  "nozzles",
+  "bedtypes",
+  "printers",
+  "locations",
+  "filaments",
+  "printhistories",
+  "sharedcatalogs",
+] as const;

--- a/src/lib/malformedTombstones.ts
+++ b/src/lib/malformedTombstones.ts
@@ -59,9 +59,13 @@ export interface MinimalTombstoneCollection {
     filter: Record<string, unknown>,
     options: { projection: Record<string, number> },
   ): { toArray(): Promise<Array<{ _id: unknown; _deletedAt?: unknown }>> };
-  updateMany(
-    filter: Record<string, unknown>,
-    update: Record<string, unknown>,
+  bulkWrite(
+    operations: Array<{
+      updateOne: {
+        filter: Record<string, unknown>;
+        update: Record<string, unknown>;
+      };
+    }>,
   ): Promise<{ modifiedCount?: number } | unknown>;
 }
 
@@ -84,9 +88,20 @@ export async function repairMalformedTombstones(
     .toArray();
   const broken = candidates.filter((d) => !isReadableTombstone(d._deletedAt));
   if (broken.length === 0) return 0;
-  const res = await collection.updateMany(
-    { _id: { $in: broken.map((d) => d._id) } },
-    { $set: { _deletedAt: new Date(0) } },
+  // CONDITIONAL on the observed value, per row (Codex P1) — the same
+  // observed-state rule every staging write follows. An `_id`-only filter is
+  // a TOCTOU: an API restore or a snapshot replacement landing between the
+  // read above and this write would have its fresh `null` (or valid date)
+  // overwritten with epoch — the repair silently RE-DELETING a row the user
+  // just restored. Filtered on the exact malformed value, a changed row
+  // simply no-matches and the next cycle re-examines it.
+  const res = await collection.bulkWrite(
+    broken.map((d) => ({
+      updateOne: {
+        filter: { _id: d._id, _deletedAt: d._deletedAt },
+        update: { $set: { _deletedAt: new Date(0) } },
+      },
+    })),
   );
   return (res as { modifiedCount?: number })?.modifiedCount ?? 0;
 }

--- a/tests/malformedTombstones.test.ts
+++ b/tests/malformedTombstones.test.ts
@@ -89,7 +89,21 @@ describe("repairMalformedTombstones (GH #1152)", () => {
     expect((await col().findOne({ name: "ArrayDate" }))?._deletedAt).toEqual(new Date(0));
   });
 
-  it("repairs a BSON-regex value — implicit equality would loop forever (Codex P2)", async () => {
+  it("repairs a null-containing array — $nin has the same multikey trap $type did (Codex P2)", async () => {
+    // `$nin: [null]` evaluates against array ELEMENTS, so `[null]` and
+    // `[null, "bad"]` were excluded from the scan while the sync loop still
+    // reads them as deleted and readTimestamp cannot parse them.
+    await col().insertMany([
+      { name: "NullArr", _deletedAt: [null] },
+      { name: "MixedArr", _deletedAt: [null, "bad"] },
+    ]);
+    expect(await repairMalformedTombstones(minimal())).toBe(2);
+    for (const name of ["NullArr", "MixedArr"]) {
+      expect((await col().findOne({ name }))?._deletedAt).toEqual(new Date(0));
+    }
+  });
+
+    it("repairs a BSON-regex value — implicit equality would loop forever (Codex P2)", async () => {
     // In query position a regex is a regex QUERY, which never matches the
     // regex-valued row: the conditional write would no-match every cycle and
     // the row would stay malformed forever. `$eq` compares it as a literal.

--- a/tests/malformedTombstones.test.ts
+++ b/tests/malformedTombstones.test.ts
@@ -81,6 +81,50 @@ describe("repairMalformedTombstones (GH #1152)", () => {
     expect(row?._deletedAt).toBeInstanceOf(Date);
   });
 
+  it("conditions every write on the OBSERVED malformed value (Codex P1)", async () => {
+    // The TOCTOU this pins: an API restore or snapshot replacement landing
+    // between the repair's read and its write must NOT have its fresh value
+    // overwritten — an _id-only filter would silently RE-DELETE a row the
+    // user just restored. A double records what the repair actually sends.
+    const ops: Array<{ updateOne: { filter: Record<string, unknown> } }> = [];
+    const double = {
+      find: () => ({
+        toArray: async () => [
+          { _id: "id1", _deletedAt: "" },
+          { _id: "id2", _deletedAt: "garbage" },
+        ],
+      }),
+      bulkWrite: async (operations: typeof ops) => {
+        ops.push(...operations);
+        return { modifiedCount: operations.length };
+      },
+    };
+    expect(await repairMalformedTombstones(double as never)).toBe(2);
+    expect(ops.map((o) => o.updateOne.filter)).toEqual([
+      { _id: "id1", _deletedAt: "" },
+      { _id: "id2", _deletedAt: "garbage" },
+    ]);
+  });
+
+  it("a row that changed between read and write is left alone", async () => {
+    // The live half of the same contract, against a real collection: seed the
+    // malformed value, then simulate the concurrent restore by changing the
+    // row before the (conditional) write would land. With the observed-value
+    // filter the write no-matches; an _id-only filter would clobber it.
+    await col().insertOne({ name: "Restored", _deletedAt: "" });
+    const real = minimal();
+    const raced: MinimalTombstoneCollection = {
+      find: (f, o) => real.find(f, o),
+      bulkWrite: async (operations) => {
+        // The "restore" lands after the read, before the write.
+        await col().updateOne({ name: "Restored" }, { $set: { _deletedAt: null } });
+        return real.bulkWrite(operations);
+      },
+    };
+    expect(await repairMalformedTombstones(raced)).toBe(0);
+    expect((await col().findOne({ name: "Restored" }))?._deletedAt).toBeNull();
+  });
+
   it("covers every synced collection in the constant", () => {
     expect([...TOMBSTONE_COLLECTIONS].sort()).toEqual(
       [

--- a/tests/malformedTombstones.test.ts
+++ b/tests/malformedTombstones.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import {
+  repairMalformedTombstones,
+  isReadableTombstone,
+  TOMBSTONE_COLLECTIONS,
+  type MinimalTombstoneCollection,
+} from "@/lib/malformedTombstones";
+
+/**
+ * GH #1152. The raw-driver `_deletedAt: ""` shape sits between the engine's
+ * two classifications — outside the partial unique index, yet deleted to the
+ * sync loop — and every reader had to be defended against it separately.
+ * The repair removes the shape; these tests pin what it touches and, just as
+ * load-bearing, what it leaves alone.
+ */
+describe("repairMalformedTombstones (GH #1152)", () => {
+  const col = () => mongoose.connection.collection("bedtypes");
+  const minimal = () => col() as unknown as MinimalTombstoneCollection;
+
+  beforeEach(async () => {
+    await col().deleteMany({});
+  });
+
+  it("stamps a raw _deletedAt:\"\" to EPOCH — the arithmetic-preserving choice", async () => {
+    await col().insertOne({ name: "Broken", _deletedAt: "" });
+    expect(await repairMalformedTombstones(minimal())).toBe(1);
+    const row = await col().findOne({ name: "Broken" });
+    // Epoch, not now: the engine already treated the unreadable value as time
+    // zero (`readTimestamp(x) ?? 0`), so a live peer with any real updatedAt
+    // still wins and resurrects. A fresh date would promote the malformed
+    // tombstone into a delete that beats older live edits.
+    expect(row?._deletedAt).toEqual(new Date(0));
+  });
+
+  it("repairs other unreadable shapes a raw write can produce", async () => {
+    await col().insertMany([
+      { name: "Text", _deletedAt: "not-a-date" },
+      { name: "Obj", _deletedAt: { nested: true } },
+      { name: "Bool", _deletedAt: true },
+    ]);
+    expect(await repairMalformedTombstones(minimal())).toBe(3);
+    for (const name of ["Text", "Obj", "Bool"]) {
+      expect((await col().findOne({ name }))?._deletedAt).toEqual(new Date(0));
+    }
+  });
+
+  it("leaves every readable value alone — repairing those would CHANGE their LWW arithmetic", async () => {
+    const real = new Date("2026-01-02T03:04:05.000Z");
+    await col().insertMany([
+      { name: "Active", _deletedAt: null },
+      { name: "Missing" },
+      { name: "RealDate", _deletedAt: real },
+      { name: "IsoString", _deletedAt: "2026-01-02T03:04:05.000Z" },
+      { name: "EpochNum", _deletedAt: 1735786800000 },
+    ]);
+    expect(await repairMalformedTombstones(minimal())).toBe(0);
+    expect((await col().findOne({ name: "Active" }))?._deletedAt).toBeNull();
+    expect((await col().findOne({ name: "RealDate" }))?._deletedAt).toEqual(real);
+    expect((await col().findOne({ name: "IsoString" }))?._deletedAt).toBe(
+      "2026-01-02T03:04:05.000Z",
+    );
+    expect((await col().findOne({ name: "EpochNum" }))?._deletedAt).toBe(1735786800000);
+  });
+
+  it("is idempotent — a repaired row no longer matches", async () => {
+    await col().insertOne({ name: "Once", _deletedAt: "" });
+    expect(await repairMalformedTombstones(minimal())).toBe(1);
+    expect(await repairMalformedTombstones(minimal())).toBe(0);
+  });
+
+  it("does NOT normalize to null — that would resurrect the row into the unique index", async () => {
+    // The rejected alternative, pinned: null would move the row back into the
+    // partial unique name index mid-pass, where it can E11000 against an
+    // active same-name row — the #1116 zombie failure mode — and silently
+    // resurrect rows in the UI.
+    await col().insertOne({ name: "StaysDead", _deletedAt: "" });
+    await repairMalformedTombstones(minimal());
+    const row = await col().findOne({ name: "StaysDead" });
+    expect(row?._deletedAt).not.toBeNull();
+    expect(row?._deletedAt).toBeInstanceOf(Date);
+  });
+
+  it("covers every synced collection in the constant", () => {
+    expect([...TOMBSTONE_COLLECTIONS].sort()).toEqual(
+      [
+        "bedtypes",
+        "filaments",
+        "locations",
+        "nozzles",
+        "printers",
+        "printhistories",
+        "sharedcatalogs",
+      ].sort(),
+    );
+  });
+});
+
+describe("isReadableTombstone mirrors readTimestamp's acceptance", () => {
+  it("accepts what the engine can read", () => {
+    expect(isReadableTombstone(null)).toBe(true);
+    expect(isReadableTombstone(undefined)).toBe(true);
+    expect(isReadableTombstone(new Date())).toBe(true);
+    expect(isReadableTombstone("2026-01-01")).toBe(true);
+    expect(isReadableTombstone(0)).toBe(true); // epoch number is legitimate (GH #317)
+  });
+
+  it("rejects what the engine cannot", () => {
+    expect(isReadableTombstone("")).toBe(false);
+    expect(isReadableTombstone("garbage")).toBe(false);
+    expect(isReadableTombstone(NaN)).toBe(false);
+    expect(isReadableTombstone(new Date(NaN))).toBe(false);
+    expect(isReadableTombstone({})).toBe(false);
+    expect(isReadableTombstone(true)).toBe(false);
+  });
+});

--- a/tests/malformedTombstones.test.ts
+++ b/tests/malformedTombstones.test.ts
@@ -81,6 +81,25 @@ describe("repairMalformedTombstones (GH #1152)", () => {
     expect(row?._deletedAt).toBeInstanceOf(Date);
   });
 
+  it("repairs a date-containing ARRAY — query-form $type would have hidden it (Codex P2)", async () => {
+    // `$type: "date"` matches array ELEMENTS, so a `$not` exclusion dropped
+    // `[new Date()]` from the scan while the engine still cannot read it.
+    await col().insertOne({ name: "ArrayDate", _deletedAt: [new Date()] });
+    expect(await repairMalformedTombstones(minimal())).toBe(1);
+    expect((await col().findOne({ name: "ArrayDate" }))?._deletedAt).toEqual(new Date(0));
+  });
+
+  it("repairs a BSON-regex value — implicit equality would loop forever (Codex P2)", async () => {
+    // In query position a regex is a regex QUERY, which never matches the
+    // regex-valued row: the conditional write would no-match every cycle and
+    // the row would stay malformed forever. `$eq` compares it as a literal.
+    await col().insertOne({ name: "RegexVal", _deletedAt: /not-a-date/ });
+    expect(await repairMalformedTombstones(minimal())).toBe(1);
+    expect((await col().findOne({ name: "RegexVal" }))?._deletedAt).toEqual(new Date(0));
+    // And it stays repaired — the loop-forever shape is the regression.
+    expect(await repairMalformedTombstones(minimal())).toBe(0);
+  });
+
   it("conditions every write on the OBSERVED malformed value (Codex P1)", async () => {
     // The TOCTOU this pins: an API restore or snapshot replacement landing
     // between the repair's read and its write must NOT have its fresh value
@@ -100,9 +119,12 @@ describe("repairMalformedTombstones (GH #1152)", () => {
       },
     };
     expect(await repairMalformedTombstones(double as never)).toBe(2);
+    // `$eq` wrapping is part of the contract: it is what keeps a BSON regex
+    // or operator-shaped observed value a LITERAL rather than live query
+    // syntax (the second Codex P2 on this file).
     expect(ops.map((o) => o.updateOne.filter)).toEqual([
-      { _id: "id1", _deletedAt: "" },
-      { _id: "id2", _deletedAt: "garbage" },
+      { _id: "id1", _deletedAt: { $eq: "" } },
+      { _id: "id2", _deletedAt: { $eq: "garbage" } },
     ]);
   });
 

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1320,6 +1320,74 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
   });
 
+  describe("unreadable tombstones are healed and never spread (GH #1152)", () => {
+    /**
+     * The raw-driver `_deletedAt: ""` shape sits between the engine's two
+     * classifications — outside the partial unique index yet deleted to the
+     * loop — and it used to be SELF-PROPAGATING: the purge branch's `??`
+     * passed it through verbatim, and stripForTransfer drops only _id/__v so
+     * every whole-doc LWW copy carried it to the other peer. The cycle-start
+     * repair heals both sides; the write-site guards stop the engine from
+     * minting new instances.
+     */
+    it("heals a raw _deletedAt:\"\" on both peers at cycle start", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+
+      // Paired at equal timestamps so the loop itself copies nothing — what
+      // changes must be the repair, not a copy.
+      await localDb.collection("bedtypes").insertOne(
+        { name: "Ghost", material: "PEI", syncId: "mt-a", _deletedAt: "", createdAt: older, updatedAt: older },
+      );
+      await remoteDb.collection("bedtypes").insertOne(
+        { name: "Ghost", material: "PEI", syncId: "mt-a", _deletedAt: "", createdAt: older, updatedAt: older },
+      );
+
+      sync = makeSync();
+      await sync.sync();
+
+      for (const db of [localDb, remoteDb]) {
+        const row = await db.collection("bedtypes").findOne({ syncId: "mt-a" });
+        // EPOCH, not now: the engine already treated the unreadable value as
+        // time zero, so epoch preserves every LWW outcome — a live peer with
+        // a real updatedAt still wins and resurrects on a later cycle.
+        expect(row?._deletedAt).toBeInstanceOf(Date);
+        expect((row?._deletedAt as Date).getTime()).toBe(0);
+      }
+    });
+
+    it("a purge over an unreadable tombstone stamps a real Date on the peer", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+
+      // Purged locally with the malformed tombstone; the remote pair is a
+      // live row the purge branch will tombstone. Seed the local side with a
+      // shape the cycle-start repair has already... no — the repair heals it
+      // first, which is the point: by the time the purge branch runs, the
+      // value it propagates is readable. This test pins the COMPOSED
+      // behaviour: no "" ever reaches the remote.
+      await localDb.collection("filaments").insertOne(
+        { name: "PurgedGhost", vendor: "V", type: "PLA", syncId: "mt-p", instanceId: "mt-p-1",
+          _purged: true, _deletedAt: "", createdAt: older, updatedAt: older },
+      );
+      await remoteDb.collection("filaments").insertOne(
+        { name: "PurgedGhost", vendor: "V", type: "PLA", syncId: "mt-p", instanceId: "mt-p-2",
+          _deletedAt: null, createdAt: older, updatedAt: older },
+      );
+
+      sync = makeSync();
+      await sync.sync();
+
+      const remote = await remoteDb.collection("filaments").findOne({ syncId: "mt-p" });
+      expect(remote?._purged).toBe(true);
+      expect(remote?._deletedAt).toBeInstanceOf(Date);
+      const local = await localDb.collection("filaments").findOne({ syncId: "mt-p" });
+      expect(local?._deletedAt).toBeInstanceOf(Date);
+    });
+  });
+
   describe("purge zombies are repaired on BOTH peers before the trim (GH #1116)", () => {
     /**
      * A zombie (`_purged: true` with `_deletedAt: null`) is ACTIVE as far as


### PR DESCRIPTION
Fixes #1152.

A raw-driver `_deletedAt: ""` sits between the engine's two classifications — **outside** the partial unique index (`{_deletedAt: null}` matches null and missing only) yet **deleted** to the sync loop (`!= null`) — and it was self-propagating: the purge branch's `??` passed it through verbatim, and `stripForTransfer` drops only `_id`/`__v`, so every whole-document LWW copy carried it to the other peer. Two #1142 review rounds each defended a different predicate against this shape; this PR removes the shape instead of guarding every reader.

## Two halves

**Write-site guards** — both purge arms and both delete-propagation arms consult `readTimestamp` and substitute a real Date for anything it cannot read. The stamps deliberately differ:
- purge sites: `new Date()` — the purge tombstone's timestamp never participates in LWW (the purge branch precedes both delete arms; both-purged is a no-op), and the stamp matches `retombstonePurgedZombies`;
- delete-propagation sites: **epoch** — this tombstone *does* participate and just won with an effective timestamp of zero. Stamping now would promote it into a fresh delete that beats older live edits on future cycles.

**Cycle-start repair** — pure `repairMalformedTombstones` (injected minimal-collection shape, like `purgedZombies`) runs on both peers over all seven synced collections and stamps every unreadable tombstone to epoch, the arithmetic-preserving choice: the engine already read the value as time zero, so a live peer with any real `updatedAt` still wins and resurrects.

## What is deliberately left alone

- Anything `readTimestamp` **can** read (real Dates, parseable strings, finite numbers including `0` — GH #317): normalizing those would *change* their LWW arithmetic.
- Normalizing to `null` is explicitly rejected **and pinned by a test**: that moves the row back into the partial unique name index mid-pass, where it can E11000 against an active same-name row — the #1116 zombie failure mode — and silently resurrects rows in the UI.

## Verification

Failing-before: both integration cases fail on the old code with the literal `""` surviving on both peers (cycle-start heal; purge-over-malformed composition). 8 pure cases pin the decision table — repair set, leave-alone set, idempotence, epoch-not-null. Coverage gate green: 211 files / 4551 tests. Rebased on main post-#1156/#1157; affected suites re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)