### PR TITLE
fix(sync): a stranded placeholder is restored by the next cycle, not by a human (#1153)

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1314,6 +1314,14 @@ export class SyncService extends EventEmitter {
     // row it cannot answer for is reported, never guessed — inventing a name
     // is a product decision this machinery is not allowed to make.
     const sweptConflicts: string[] = [];
+    /** Informational one-cycle HOLD-BACKS (Codex P2) — the window quarantines
+     * over rows holding their real names. Distinct from `sweptConflicts`,
+     * which is for genuine strandings: these carry no name contention, so
+     * they must not ride the nameConflicts channel and earn the false "two
+     * rows want the same name … Rename one of them" preamble. They still
+     * FAIL the collection (dependents must not run over a held-back pair);
+     * they just say the truth. */
+    const sweptHoldbacks: string[] = [];
     /** SyncIds of rows left holding an UNRESOLVED placeholder (Codex P2).
      * Reporting is not enough: the row still entered the row loop, and a user
      * edit bumping its `updatedAt` while stranded made the placeholder the
@@ -1413,6 +1421,11 @@ export class SyncService extends EventEmitter {
               // here too, with the same carve-outs as the young branch. One
               // held-back cycle per drained record over a live row — the
               // entry is gone next cycle, so it cannot recur.
+              // Drain FIRST, then say what actually happened (Codex P2):
+              // the drain can fail, the entry then stays aged, and a notice
+              // claiming clearance would lie every cycle of a persistent
+              // _migrations failure.
+              const cleared = await dequeueRestoreOn(migrations, entry, entry.at);
               if (
                 row &&
                 typeof row.syncId === "string" &&
@@ -1420,12 +1433,14 @@ export class SyncService extends EventEmitter {
                 row._purged !== true
               ) {
                 quarantinedSyncIds.add(row.syncId);
-                sweptConflicts.push(
-                  `${collectionName} ${entry.i} had a pending rename record; held back ` +
-                    `this cycle while it was cleared, and retried on the next.`,
+                sweptHoldbacks.push(
+                  cleared
+                    ? `${collectionName} ${entry.i} had a pending rename record; held back ` +
+                        `this cycle while it was cleared, and retried on the next.`
+                    : `${collectionName} ${entry.i} has a pending rename record that could ` +
+                        `not be cleared; held back and retried on the next cycle.`,
                 );
               }
-              await dequeueRestoreOn(migrations, entry, entry.at);
             } else if (
               row &&
               typeof row.syncId === "string" &&
@@ -1444,7 +1459,7 @@ export class SyncService extends EventEmitter {
               // can appear on them, and quarantining would re-block the
               // tombstone from propagating.
               quarantinedSyncIds.add(row.syncId);
-              sweptConflicts.push(
+              sweptHoldbacks.push(
                 `${collectionName} ${entry.i} is being renamed by another sync ` +
                   `service; held back this cycle and retried on the next.`,
               );
@@ -1680,17 +1695,24 @@ export class SyncService extends EventEmitter {
       migrations: ReturnType<Db["collection"]>,
       entry: RenameStagingRestoreKey,
       observedAt?: Date,
-    ): Promise<void> => {
+    ): Promise<boolean> => {
       const match: Document = { c: entry.c, i: entry.i, o: entry.o, p: entry.p };
       if (observedAt !== undefined) match.at = { $eq: observedAt };
-      await migrations
-        .updateOne(
+      try {
+        await migrations.updateOne(
           { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
           { $pull: { entries: match } as Document },
-        )
-        .catch((err: unknown) => {
-          console.warn(`[sync] ${entry.c}: could not dequeue a staging-restore entry.`, err);
-        });
+        );
+        // An accepted write is a clearance even at zero matches — the entry
+        // is gone either way. Only a REJECTED write is a failure, and the
+        // caller decides what that means: most sites tolerate it (the sweep
+        // re-examines next cycle), but the aged drain's notice must not
+        // claim the record was cleared when it was not (Codex P2).
+        return true;
+      } catch (err) {
+        console.warn(`[sync] ${entry.c}: could not dequeue a staging-restore entry.`, err);
+        return false;
+      }
     };
     await sweepSide(localDb, localCol, remoteCol);
     await sweepSide(remoteDb, remoteCol, localCol);
@@ -2113,6 +2135,10 @@ export class SyncService extends EventEmitter {
     if (sweptConflicts.length > 0) {
       result.nameConflicts = (result.nameConflicts ?? 0) + sweptConflicts.length;
     }
+    // Hold-backs FAIL the collection without the collision preamble — they
+    // carry no name contention, so "Rename one of them" would be a false
+    // diagnosis for a pair that converges by itself next cycle (Codex P2).
+    // Rendered at the end with the other additive messages.
 
     // GH #1142: settle any placeholder whose real write never landed.
     //
@@ -2556,6 +2582,13 @@ export class SyncService extends EventEmitter {
     // not merely count them.
     if (strandedNotices.length > 0) {
       result.error = `${result.error ? `${result.error} ` : ""}${strandedNotices.join(" ")}`;
+    }
+
+    if (sweptHoldbacks.length > 0) {
+      // Informational, additive, and still a FAILURE: dependents must not run
+      // over a held-back pair, but the user must not be told to rename
+      // anything (Codex P2 — these are not collisions).
+      result.error = `${result.error ? `${result.error} ` : ""}${sweptHoldbacks.join(" ")}`;
     }
 
     if (heldBack > 0) {

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1538,8 +1538,15 @@ export class SyncService extends EventEmitter {
           } else if (strandedSyncId) {
             // The conditional restore no-matched — someone moved the row
             // between our read and the write. Unknown state: hold it back
-            // this cycle rather than let a possibly-still-stranded row sync.
+            // this cycle rather than let a possibly-still-stranded row sync —
+            // and SAY so (Codex P2), or trySync reads the collection as
+            // successful and dependents run over the deliberately-skipped
+            // pair. Every quarantine reports; this was the last silent one.
             quarantinedSyncIds.add(strandedSyncId);
+            sweptHoldbacks.push(
+              `${collectionName} ${entry.i} changed while being restored; held back ` +
+                `this cycle and re-examined on the next.`,
+            );
           }
         } catch (err) {
           if (!rowInspected) {

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1450,16 +1450,17 @@ export class SyncService extends EventEmitter {
                 };
               }
             } else if (young) {
-              // Holding, but the entry is fresh — report without touching row
-              // or record; the owning pass (or the next aged sweep) resolves.
+              // Holding, but the entry is fresh — usually a healthy owner
+              // between staging and settlement, resolving in seconds (Codex
+              // P2, round 18: the stranding text told the user to rename a
+              // row the owner was about to fix). A crash-stranded row ages
+              // into the real stranding report at the bound. Touch nothing.
               notice = {
-                hold: false,
-                text: strandedPlaceholderNotice({
-                  collection: collectionName,
-                  id: entry.i,
-                  originalName: entry.o,
-                  placeholderName: entry.p,
-                }),
+                hold: true,
+                text:
+                  `${collectionName} ${entry.i} is mid-rename by another sync service; ` +
+                  `its temporary name is held back this cycle and resolved by the owner ` +
+                  `or the next aged sweep.`,
               };
             } else {
               const taken = await col.findOne(
@@ -1513,14 +1514,15 @@ export class SyncService extends EventEmitter {
           // Post-observation failure: the quarantine already happened at the
           // hoist; only the message remains.
           if (strandedSyncId) {
+            // An I/O failure mid-recovery, not a name collision — the
+            // holdback channel says so; a persistent failure re-reports every
+            // cycle, and the hint names the manual escape.
             notice = {
-              hold: false,
-              text: strandedPlaceholderNotice({
-                collection: collectionName,
-                id: entry.i,
-                originalName: entry.o,
-                placeholderName: entry.p,
-              }),
+              hold: true,
+              text:
+                `${collectionName} ${entry.i} holds the temporary name ${JSON.stringify(entry.p)} ` +
+                `and recovery failed this cycle; held back and retried on the next. ` +
+                `Rename it manually if this persists.`,
             };
           }
           console.warn(`[sync] ${collectionName}: staging-restore sweep failed for ${entry.i}.`, err);
@@ -1580,16 +1582,14 @@ export class SyncService extends EventEmitter {
               isRestoreEntry(e) && e.c === collectionName && e.i === String(stray._id),
           );
           if (lateEntry) {
-            // Enqueued after the snapshot: defer the ACTION to its owner;
-            // the hoisted quarantine already holds the pair.
+            // Enqueued after the snapshot — by definition FRESH, an active
+            // owner mid-pass (Codex P2, round 18's named analog): defer the
+            // ACTION to it, hold the pair, and say mid-flight, not stranded.
             notice = {
-              hold: false,
-              text: strandedPlaceholderNotice({
-                collection: collectionName,
-                id: String(stray._id),
-                originalName: lateEntry.o,
-                placeholderName: lateEntry.p,
-              }),
+              hold: true,
+              text:
+                `${collectionName} ${String(stray._id)} is being renamed by another sync ` +
+                `service; held back this cycle and retried on the next.`,
             };
           } else {
             const peer =
@@ -1649,12 +1649,13 @@ export class SyncService extends EventEmitter {
             }
           }
         } catch (err) {
+          // I/O failure, not a collision — same rule as the queue path's catch.
           notice = {
-            hold: false,
+            hold: true,
             text:
               `${collectionName} ${String(stray._id)} holds the temporary name ` +
-              `${JSON.stringify(stray.name)} and could not be recovered this cycle. ` +
-              `Rename it manually if this persists.`,
+              `${JSON.stringify(stray.name)} and recovery failed this cycle; held back ` +
+              `and retried on the next. Rename it manually if this persists.`,
           };
           console.warn(
             `[sync] ${collectionName}: placeholder backstop failed for ${String(stray._id)}.`,
@@ -2125,9 +2126,12 @@ export class SyncService extends EventEmitter {
     // (the #1142 posture — a reported, recoverable stall beats an invisible
     // one). The notices are already seeded into `strandedNotices` above, so
     // they ride the same rendering as a fresh stranding.
-    if (sweptConflicts.length > 0) {
-      result.nameConflicts = (result.nameConflicts ?? 0) + sweptConflicts.length;
-    }
+    // Sweep strandings are SELF-DESCRIBING and are NOT counted into
+    // nameConflicts (Codex P2, round 18): that counter feeds the "two rows
+    // want the same name … Rename one of them" preamble, which is the row
+    // loop's real-collision diagnosis — false for a placeholder stranding,
+    // whose own notice already says exactly what to do. The notices still
+    // FAIL the collection through the strandedNotices rendering below.
     // Hold-backs FAIL the collection without the collision preamble — they
     // carry no name contention, so "Rename one of them" would be a false
     // diagnosis for a pair that converges by itself next cycle (Codex P2).

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1410,11 +1410,17 @@ export class SyncService extends EventEmitter {
             // RESOLVED BY DELETION: the tombstone must propagate, the name in
             // the trash is cosmetic, and the owner's staging filter
             // (`_deletedAt: null`) can never re-placeholder this row. Drain
-            // once aged; a young entry defers to its owner.
+            // once aged; a young entry defers to its owner. The drain result
+            // is DELIBERATELY unchecked here and in the gone-branch below
+            // (Codex P2, round 21 audited all six sites): these branches
+            // report nothing a failed drain could contradict, the row's own
+            // sync behaviour is already correct, and the entry simply retries
+            // on the next aged cycle (dequeueRestoreOn logs its own warning).
             if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
           } else if (!row) {
             // Gone entirely — nothing to hold; drain once aged (versioned on
-            // the observed stamp: the owner may have re-asserted).
+            // the observed stamp: the owner may have re-asserted). Result
+            // unchecked — same rationale as the tombstone branch above.
             if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
           } else {
             // LIVE row with a pending record — obligation 1, unconditionally.
@@ -1482,13 +1488,21 @@ export class SyncService extends EventEmitter {
                   { _id: row._id, name: entry.p },
                   { $set: { name: entry.o } },
                 );
-                await dequeueRestoreOn(migrations, entry, entry.at);
+                // Same clearance composition as the aged-mismatch branch
+                // (Codex P2, round 21): a restore whose record failed to
+                // drain must SAY so, or the leftover entry's next-cycle
+                // holdback reads as an unexplained new rename.
+                const drain = await dequeueRestoreOn(migrations, entry, entry.at);
+                const cleared = drain.accepted && drain.modified > 0;
                 notice = restored.modifiedCount
                   ? {
                       hold: true,
-                      text:
-                        `${collectionName} ${entry.i} was restored to ${JSON.stringify(entry.o)}; ` +
-                        `held back this cycle and synced on the next.`,
+                      text: cleared
+                        ? `${collectionName} ${entry.i} was restored to ${JSON.stringify(entry.o)}; ` +
+                          `held back this cycle and synced on the next.`
+                        : `${collectionName} ${entry.i} was restored to ${JSON.stringify(entry.o)}, ` +
+                          `but its pending rename record could not be cleared; held back and ` +
+                          `retried on the next cycle.`,
                     }
                   : {
                       hold: true,
@@ -2037,9 +2051,18 @@ export class SyncService extends EventEmitter {
         if (!staged.modifiedCount) {
           // Nothing was written, and settlement never sees this row (it is
           // pushed to `stagedRenames` only below) — so the entry comes out
-          // HERE. A failed dequeue is harmless: the sweep re-examines the row
-          // next cycle, finds no placeholder, and drops the entry itself.
-          await dequeueRestoreOn(sideDb.collection("_migrations"), entry);
+          // HERE. A failed dequeue is NOT silently harmless (Codex P2, round
+          // 21): the young leftover record makes later sweeps hold this pair
+          // back as "being renamed" until it ages out — so name the real
+          // cause now. Owner drains are unversioned: an accepted zero-match
+          // means the entry is already gone, which is clearance too.
+          const drain = await dequeueRestoreOn(sideDb.collection("_migrations"), entry);
+          if (!drain.accepted) {
+            sweptHoldbacks.push(
+              `${collectionName} ${String(blocker._id)} kept its name, but its pending ` +
+                `rename record could not be cleared; held back and retried on the next cycle.`,
+            );
+          }
           result.nameConflicts = (result.nameConflicts ?? 0) + 1;
           console.warn(
             `[sync] ${collectionName}: the row holding ${JSON.stringify(desiredName)} changed ` +
@@ -2178,8 +2201,19 @@ export class SyncService extends EventEmitter {
           );
           if (!row || !isStagingPlaceholder(row.name)) {
             // Its write landed (or a rollback restored it, or a human renamed
-            // it) — no placeholder remains, nothing to recover later.
-            await dequeueRestoreOn(stagedDb.collection("_migrations"), stagedEntry);
+            // it) — no placeholder remains, nothing to recover later. The
+            // drain result MUST be checked (Codex P2, round 21): ignored, a
+            // failed cleanup reported success this cycle while the live
+            // entry made every later cycle fail as "being renamed" — for
+            // fifteen minutes, or forever if _migrations keeps failing.
+            // Unversioned owner drain: accepted zero-match = already gone.
+            const drain = await dequeueRestoreOn(stagedDb.collection("_migrations"), stagedEntry);
+            if (!drain.accepted) {
+              sweptHoldbacks.push(
+                `${collectionName} ${String(staged.id)} settled cleanly, but its pending ` +
+                  `rename record could not be cleared; held back and retried on the next cycle.`,
+              );
+            }
             continue;
           }
           const taken = await staged.col.findOne(
@@ -2218,8 +2252,15 @@ export class SyncService extends EventEmitter {
             { $set: { name: staged.originalName } },
           );
           // Restored, or someone else moved it on — either way no placeholder
-          // remains under this entry's name, so it drains.
-          await dequeueRestoreOn(stagedDb.collection("_migrations"), stagedEntry);
+          // remains under this entry's name, so it drains — checked, same as
+          // the landed-write branch above (Codex P2, round 21).
+          const drain = await dequeueRestoreOn(stagedDb.collection("_migrations"), stagedEntry);
+          if (!drain.accepted) {
+            sweptHoldbacks.push(
+              `${collectionName} ${String(staged.id)} settled cleanly, but its pending ` +
+                `rename record could not be cleared; held back and retried on the next cycle.`,
+            );
+          }
           if (!restored.modifiedCount) continue;
         } catch (settleErr) {
           // SURFACE it (Codex P1). Swallowing left the collection reporting

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1404,6 +1404,27 @@ export class SyncService extends EventEmitter {
             // observed stamp: the owner may have re-asserted since this
             // sweep's snapshot.
             if (!young) {
+              // Draining a dead record does NOT close the window (Codex P1,
+              // the suspension race one branch over): an owner suspended past
+              // the age bound can resume AFTER this read, stage, and pause
+              // again — and coveredIds, built from the snapshot that carried
+              // this entry, keeps the backstop away from the fresh
+              // placeholder. So a live, non-tombstoned row is quarantined
+              // here too, with the same carve-outs as the young branch. One
+              // held-back cycle per drained record over a live row — the
+              // entry is gone next cycle, so it cannot recur.
+              if (
+                row &&
+                typeof row.syncId === "string" &&
+                row._deletedAt == null &&
+                row._purged !== true
+              ) {
+                quarantinedSyncIds.add(row.syncId);
+                sweptConflicts.push(
+                  `${collectionName} ${entry.i} had a pending rename record; held back ` +
+                    `this cycle while it was cleared, and retried on the next.`,
+                );
+              }
               await dequeueRestoreOn(migrations, entry, entry.at);
             } else if (
               row &&

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1330,9 +1330,16 @@ export class SyncService extends EventEmitter {
       peerCol: ReturnType<Db["collection"]>,
     ): Promise<void> => {
       const migrations = db.collection("_migrations");
-      const queueDoc = await migrations
-        .findOne({ _id: RESTORE_QUEUE_ID as unknown as ObjectId })
-        .catch(() => null);
+      // A failed read THROWS (Codex P2, and its sibling one page down): the
+      // sweep's whole contract is "no unresolved placeholder syncs", and a
+      // read converted to an empty result silently waives it — queued
+      // placeholders would go unquarantined into the LWW loop while the
+      // cycle reads green. A throw fails the collection through trySync,
+      // dependents cascade-skip, and the next cycle retries: the same
+      // thrown-failure posture the trim established.
+      const queueDoc = await migrations.findOne({
+        _id: RESTORE_QUEUE_ID as unknown as ObjectId,
+      });
       const rawEntries: unknown[] = Array.isArray(queueDoc?.entries) ? queueDoc.entries : [];
       const entries = rawEntries.filter(isRestoreEntry).filter((e) => e.c === collectionName);
       // Drop malformed entries outright — one bad record must not abort the
@@ -1465,13 +1472,13 @@ export class SyncService extends EventEmitter {
 
       // Grammar backstop. STAGING_PREFIX is `__sync-staging-` — word chars
       // and hyphens only, safe as a literal anchored regex.
+      // Same rule as the queue read above: a failed SCAN is not "no strays".
       const strays = await col
         .find(
           { name: { $regex: `^${STAGING_PREFIX}` } },
           { projection: { name: 1, syncId: 1, _deletedAt: 1, _purged: 1 } },
         )
-        .toArray()
-        .catch(() => [] as Document[]);
+        .toArray();
       for (const stray of strays) {
         // STRICT grammar, not the prefix (Codex P2). The backstop ACTS on
         // recognition alone — it rewrites the name to the peer's, or fails

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1350,23 +1350,54 @@ export class SyncService extends EventEmitter {
 
       const coveredIds = new Set(entries.map((e) => e.i));
       for (const entry of entries) {
-        // AGE GATE (Codex P2): a young entry may belong to a pass that is
-        // alive RIGHT NOW on another service — possibly still between its
-        // enqueue and its staging write, where the row holds the original
-        // name and this sweep would misread the record as resolved and drain
-        // it. Skip anything younger than the bound; only a dead pass's
-        // entries are ours to judge.
-        if (Date.now() - entry.at.getTime() < SWEEP_MIN_AGE_MS) continue;
+        // The AGE GATE defers JUDGMENT, not inspection (Codex P1, second
+        // pass). A young entry may belong to a pass alive on another service
+        // — possibly still between its enqueue and its staging write — so no
+        // young entry may be DRAINED or RESTORED. But a young entry whose row
+        // already HOLDS the recorded placeholder is a live stranding either
+        // way (a settlement-taken row re-reported five minutes later sits
+        // well under the fifteen-minute bound), and skipping it entirely left
+        // its syncId unquarantined: an edit while stranded then let LWW copy
+        // the placeholder to the peer — the exact corruption the quarantine
+        // exists to prevent. So the row is always READ; youth only forbids
+        // the destructive verbs.
+        //
+        // The observed syncId lives OUTSIDE the try (Codex P2): the catch
+        // also receives failures from the taken-lookup and the restore
+        // update, AFTER the row was seen holding its placeholder — and
+        // discarding the observation there let the row enter the loop
+        // unquarantined on precisely the cycles where something is already
+        // wrong.
+        let strandedSyncId: string | null = null;
+        const young = Date.now() - entry.at.getTime() < SWEEP_MIN_AGE_MS;
         try {
           const row = await col.findOne(
             { _id: new ObjectId(entry.i) },
             { projection: { name: 1, syncId: 1 } },
           );
           if (!row || row.name !== entry.p) {
-            // Gone, landed, or human-renamed — nothing to recover. Versioned
-            // on the observed stamp: the owner may have re-asserted since
-            // this sweep's snapshot.
-            await dequeueRestoreOn(migrations, entry, entry.at);
+            // Gone, landed, or human-renamed — nothing to recover. Only an
+            // AGED entry may be drained (young + not-holding is exactly the
+            // enqueue-to-update window), and the drain is versioned on the
+            // observed stamp: the owner may have re-asserted since this
+            // sweep's snapshot.
+            if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
+            continue;
+          }
+          if (typeof row.syncId === "string") strandedSyncId = row.syncId;
+          if (young) {
+            // Holding, but the entry is fresh — quarantine and report without
+            // touching row or record; the owning pass (or the next aged
+            // sweep) resolves it.
+            sweptConflicts.push(
+              strandedPlaceholderNotice({
+                collection: collectionName,
+                id: entry.i,
+                originalName: entry.o,
+                placeholderName: entry.p,
+              }),
+            );
+            if (strandedSyncId) quarantinedSyncIds.add(strandedSyncId);
             continue;
           }
           const taken = await col.findOne(
@@ -1382,7 +1413,7 @@ export class SyncService extends EventEmitter {
                 placeholderName: entry.p,
               }),
             );
-            if (typeof row.syncId === "string") quarantinedSyncIds.add(row.syncId);
+            if (strandedSyncId) quarantinedSyncIds.add(strandedSyncId);
             continue; // keep queued — retried next cycle
           }
           const restored = await col.updateOne(
@@ -1394,10 +1425,27 @@ export class SyncService extends EventEmitter {
             console.log(
               `[sync] ${collectionName}: restored ${JSON.stringify(entry.o)} onto ${entry.i} (GH #1153)`,
             );
+          } else if (strandedSyncId) {
+            // The conditional restore no-matched — someone moved the row
+            // between our read and the write. Unknown state: hold it back
+            // this cycle rather than let a possibly-still-stranded row sync.
+            quarantinedSyncIds.add(strandedSyncId);
           }
         } catch (err) {
           // Keep the entry; next cycle retries. One bad row must not abort
-          // the collection's sweep.
+          // the collection's sweep — but a row OBSERVED holding its
+          // placeholder must not sync just because a later step failed.
+          if (strandedSyncId) {
+            quarantinedSyncIds.add(strandedSyncId);
+            sweptConflicts.push(
+              strandedPlaceholderNotice({
+                collection: collectionName,
+                id: entry.i,
+                originalName: entry.o,
+                placeholderName: entry.p,
+              }),
+            );
+          }
           console.warn(`[sync] ${collectionName}: staging-restore sweep failed for ${entry.i}.`, err);
         }
       }
@@ -1488,6 +1536,9 @@ export class SyncService extends EventEmitter {
             );
           }
         } catch (err) {
+          // Same rule as the queue path's catch: a row recognized as a
+          // generated placeholder must not sync because a later step failed.
+          if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
           console.warn(
             `[sync] ${collectionName}: placeholder backstop failed for ${String(stray._id)}.`,
             err,

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1347,10 +1347,16 @@ export class SyncService extends EventEmitter {
       for (const bad of rawEntries.filter(
         (e) => !isRestoreEntry(e) && (e as RenameStagingRestoreEntry)?.c === collectionName,
       )) {
+        // `$eq`, the literal-safety rule in $pull position (Codex P2): a bare
+        // document operand is a MATCH CONDITION, so a malformed subset like
+        // `{c: "bedtypes"}` would pull every valid entry for the collection
+        // along with itself — discarding the authoritative original names and
+        // demoting their rows to the peer-name backstop. `$eq` removes only
+        // elements wholly equal to the malformed value.
         await migrations
           .updateOne(
             { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
-            { $pull: { entries: bad } as Document },
+            { $pull: { entries: { $eq: bad } } as Document },
           )
           .catch(() => {});
       }

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1425,7 +1425,8 @@ export class SyncService extends EventEmitter {
               // the drain can fail, the entry then stays aged, and a notice
               // claiming clearance would lie every cycle of a persistent
               // _migrations failure.
-              const cleared = await dequeueRestoreOn(migrations, entry, entry.at);
+              const drain = await dequeueRestoreOn(migrations, entry, entry.at);
+              const cleared = drain.accepted && drain.modified > 0;
               if (
                 row &&
                 typeof row.syncId === "string" &&
@@ -1520,6 +1521,20 @@ export class SyncService extends EventEmitter {
             console.log(
               `[sync] ${collectionName}: restored ${JSON.stringify(entry.o)} onto ${entry.i} (GH #1153)`,
             );
+            // Quarantine even on SUCCESS (Codex P1) — the last branch that
+            // did not, and the window is the same as everywhere else: another
+            // service can enqueue and stage this very row between this
+            // restore and the slim reads, with coveredIds (built from OUR
+            // snapshot) blinding the backstop. The rule is now uniform: every
+            // queue entry over a live row holds its pair for the cycle. The
+            // restored name syncs on the next one.
+            if (strandedSyncId) {
+              quarantinedSyncIds.add(strandedSyncId);
+              sweptHoldbacks.push(
+                `${collectionName} ${entry.i} was restored to ${JSON.stringify(entry.o)}; ` +
+                  `held back this cycle and synced on the next.`,
+              );
+            }
           } else if (strandedSyncId) {
             // The conditional restore no-matched — someone moved the row
             // between our read and the write. Unknown state: hold it back
@@ -1695,23 +1710,25 @@ export class SyncService extends EventEmitter {
       migrations: ReturnType<Db["collection"]>,
       entry: RenameStagingRestoreKey,
       observedAt?: Date,
-    ): Promise<boolean> => {
+    ): Promise<{ accepted: boolean; modified: number }> => {
       const match: Document = { c: entry.c, i: entry.i, o: entry.o, p: entry.p };
       if (observedAt !== undefined) match.at = { $eq: observedAt };
       try {
-        await migrations.updateOne(
+        const res = await migrations.updateOne(
           { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
           { $pull: { entries: match } as Document },
         );
-        // An accepted write is a clearance even at zero matches — the entry
-        // is gone either way. Only a REJECTED write is a failure, and the
-        // caller decides what that means: most sites tolerate it (the sweep
-        // re-examines next cycle), but the aged drain's notice must not
-        // claim the record was cleared when it was not (Codex P2).
-        return true;
+        // Acceptance and effect are DIFFERENT facts (Codex P2). For the
+        // owner's unversioned drains, an accepted zero-match means the entry
+        // is already gone — clearance either way. For the sweep's VERSIONED
+        // drain, an accepted zero-match can mean a re-asserted twin with a
+        // fresh stamp survived the pull — the record is still queued, and a
+        // notice claiming clearance would lie. The caller composes its claim
+        // from `modified`, not from acceptance.
+        return { accepted: true, modified: res.modifiedCount ?? 0 };
       } catch (err) {
         console.warn(`[sync] ${entry.c}: could not dequeue a staging-restore entry.`, err);
-        return false;
+        return { accepted: false, modified: 0 };
       }
     };
     await sweepSide(localDb, localCol, remoteCol);

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -48,12 +48,36 @@ interface LegacyTransitEntry {
  * Lives in the `_migrations` doc `_id: "renameStagingRestores"` on the SAME
  * database as the staged row (each DB's queue describes its own rows).
  * c=collection, i=String(_id), o=originalName, p=placeholderName. */
-interface RenameStagingRestoreEntry {
+interface RenameStagingRestoreKey {
   c: string;
   i: string;
   o: string;
   p: string;
 }
+
+interface RenameStagingRestoreEntry extends RenameStagingRestoreKey {
+  /** Enqueue time. The sweep refuses to touch entries younger than
+   * `SWEEP_MIN_AGE_MS` — see that constant for the two races this closes. */
+  at: Date;
+}
+
+/**
+ * How old a restore entry must be before another pass's sweep may act on it
+ * (GH #1153, Codex P2). Two services can share one database — the desktop
+ * client and a Docker instance against the same Atlas is the documented
+ * GH #439 reality — and an entry is durable BEFORE its row is staged. In that
+ * enqueue-to-update window the row still holds its original name, so a
+ * concurrent sweep read the record as resolved and DRAINED it; the owning
+ * pass then staged and could crash without the durable record this queue
+ * exists to guarantee. The same blindness let a sweep restore a placeholder
+ * an active pass was still using. Age is the discriminator: a pass's own
+ * staging-to-settlement span is seconds, so an entry older than this bound
+ * belongs to a DEAD pass. Fifteen minutes dwarfs both any plausible pass and
+ * cross-service clock skew (the stamp is written by one service's clock and
+ * compared by another's); the cost is that a genuine stranding waits one
+ * bound before healing — it already waited at least a full cycle.
+ */
+const SWEEP_MIN_AGE_MS = 15 * 60 * 1000;
 
 const RESTORE_QUEUE_ID = "renameStagingRestores";
 
@@ -69,7 +93,9 @@ function isRestoreEntry(value: unknown): value is RenameStagingRestoreEntry {
     typeof e.o === "string" &&
     e.o !== "" &&
     typeof e.p === "string" &&
-    isStagingPlaceholder(e.p)
+    isStagingPlaceholder(e.p) &&
+    e.at instanceof Date &&
+    !Number.isNaN(e.at.getTime())
   );
 }
 
@@ -1285,6 +1311,13 @@ export class SyncService extends EventEmitter {
 
       const coveredIds = new Set(entries.map((e) => e.i));
       for (const entry of entries) {
+        // AGE GATE (Codex P2): a young entry may belong to a pass that is
+        // alive RIGHT NOW on another service — possibly still between its
+        // enqueue and its staging write, where the row holds the original
+        // name and this sweep would misread the record as resolved and drain
+        // it. Skip anything younger than the bound; only a dead pass's
+        // entries are ours to judge.
+        if (Date.now() - entry.at.getTime() < SWEEP_MIN_AGE_MS) continue;
         try {
           const row = await col.findOne(
             { _id: new ObjectId(entry.i) },
@@ -1336,6 +1369,28 @@ export class SyncService extends EventEmitter {
       for (const stray of strays) {
         if (coveredIds.has(String(stray._id))) continue; // queue already handled it
         try {
+          // FRESH re-check (Codex P2): the queue snapshot above predates this
+          // find, and enqueue-before-stage means any placeholder minted since
+          // then already has a durable entry — owned by a live pass the
+          // backstop must not race. The residual window is the milliseconds
+          // between an enqueue landing and this read observing it; even
+          // there, the backstop's conditional update only touches a row
+          // still holding the placeholder, so the worst case is the owning
+          // pass's retry colliding and REPORTING — never silent loss.
+          const nowCovered = await migrations.findOne(
+            { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
+            { projection: { entries: 1 } },
+          );
+          const freshEntries: unknown[] = Array.isArray(nowCovered?.entries)
+            ? nowCovered.entries
+            : [];
+          if (
+            freshEntries.some(
+              (e) => isRestoreEntry(e) && e.i === String(stray._id),
+            )
+          ) {
+            continue;
+          }
           const peer =
             typeof stray.syncId === "string"
               ? await peerCol.findOne({ syncId: stray.syncId }, { projection: { name: 1 } })
@@ -1385,7 +1440,7 @@ export class SyncService extends EventEmitter {
     /** `$pull` one entry from an already-resolved migrations collection. */
     const dequeueRestoreOn = async (
       migrations: ReturnType<Db["collection"]>,
-      entry: RenameStagingRestoreEntry,
+      entry: RenameStagingRestoreKey,
     ): Promise<void> => {
       await migrations
         .updateOne(
@@ -1692,6 +1747,7 @@ export class SyncService extends EventEmitter {
           i: String(blocker._id),
           o: blockerName,
           p: placeholder,
+          at: new Date(),
         };
         const sideDb = col === remoteCol ? remoteDb : localDb;
         try {
@@ -1806,7 +1862,10 @@ export class SyncService extends EventEmitter {
         // and is the one place that knows how each ended. The entry stays
         // queued ONLY on `taken` and on the catch below, which are exactly
         // the strandings the next cycle's sweep exists to retry.
-        const stagedEntry: RenameStagingRestoreEntry = {
+        // A KEY, not a full entry: the dequeue matcher matches on {c,i,o,p}
+        // (query subset semantics), and settlement does not know — and does
+        // not need — the enqueue timestamp.
+        const stagedEntry: RenameStagingRestoreKey = {
           c: collectionName,
           i: String(staged.id),
           o: staged.originalName,

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1353,8 +1353,10 @@ export class SyncService extends EventEmitter {
             { projection: { name: 1 } },
           );
           if (!row || row.name !== entry.p) {
-            // Gone, landed, or human-renamed — nothing to recover.
-            await dequeueRestoreOn(migrations, entry);
+            // Gone, landed, or human-renamed — nothing to recover. Versioned
+            // on the observed stamp: the owner may have re-asserted since
+            // this sweep's snapshot.
+            await dequeueRestoreOn(migrations, entry, entry.at);
             continue;
           }
           const taken = await col.findOne(
@@ -1376,7 +1378,7 @@ export class SyncService extends EventEmitter {
             { _id: row._id, name: entry.p },
             { $set: { name: entry.o } },
           );
-          await dequeueRestoreOn(migrations, entry);
+          await dequeueRestoreOn(migrations, entry, entry.at);
           if (restored.modifiedCount) {
             console.log(
               `[sync] ${collectionName}: restored ${JSON.stringify(entry.o)} onto ${entry.i} (GH #1153)`,
@@ -1424,7 +1426,12 @@ export class SyncService extends EventEmitter {
             : [];
           if (
             freshEntries.some(
-              (e) => isRestoreEntry(e) && e.i === String(stray._id),
+              // Scoped to THIS collection (Codex P2) — _id uniqueness is
+              // per-collection, so an entry for a same-id row in a DIFFERENT
+              // collection must not mask this stray's backstop, potentially
+              // forever when that entry is retained for a taken name. The
+              // `coveredIds` snapshot above already scopes this way.
+              (e) => isRestoreEntry(e) && e.c === collectionName && e.i === String(stray._id),
             )
           ) {
             continue;
@@ -1475,15 +1482,29 @@ export class SyncService extends EventEmitter {
         }
       }
     };
-    /** `$pull` one entry from an already-resolved migrations collection. */
+    /** `$pull` one entry from an already-resolved migrations collection.
+     *
+     * Two drain modes, and the asymmetry is the point (Codex P2):
+     *  - the OWNER (settlement, the zero-match branch) drains by KEY alone —
+     *    it owns the row's fate, and the re-assert may have refreshed the
+     *    stamp it never tracked, so a versioned drain would leak the entry;
+     *  - a SWEEPER passes the `at` it OBSERVED, versioning the drain against
+     *    an in-flight re-assert: it judged a snapshot, and the owner may have
+     *    staged and re-stamped between that snapshot and this $pull — an
+     *    unversioned drain would remove the FRESH record and leave a later
+     *    owner crash with a placeholder and no authoritative original name.
+     *    `$eq` keeps the observed value literal, per this module's rule. */
     const dequeueRestoreOn = async (
       migrations: ReturnType<Db["collection"]>,
       entry: RenameStagingRestoreKey,
+      observedAt?: Date,
     ): Promise<void> => {
+      const match: Document = { c: entry.c, i: entry.i, o: entry.o, p: entry.p };
+      if (observedAt !== undefined) match.at = { $eq: observedAt };
       await migrations
         .updateOne(
           { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
-          { $pull: { entries: { c: entry.c, i: entry.i, o: entry.o, p: entry.p } } as Document },
+          { $pull: { entries: match } as Document },
         )
         .catch((err: unknown) => {
           console.warn(`[sync] ${entry.c}: could not dequeue a staging-restore entry.`, err);

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1314,6 +1314,16 @@ export class SyncService extends EventEmitter {
     // row it cannot answer for is reported, never guessed — inventing a name
     // is a product decision this machinery is not allowed to make.
     const sweptConflicts: string[] = [];
+    /** SyncIds of rows left holding an UNRESOLVED placeholder (Codex P2).
+     * Reporting is not enough: the row still entered the row loop, and a user
+     * edit bumping its `updatedAt` while stranded made the placeholder the
+     * LWW winner — copying `__sync-staging-…` over the peer's legitimate
+     * name. A stranded row is QUARANTINED from this cycle's transfer instead:
+     * its syncId is skipped entirely (both directions — copying the peer's
+     * side inward is equally wrong while the local truth is a placeholder),
+     * and the pair converges on the first cycle after the placeholder
+     * resolves. */
+    const quarantinedSyncIds = new Set<string>();
     const sweepSide = async (
       db: Db,
       col: ReturnType<Db["collection"]>,
@@ -1350,7 +1360,7 @@ export class SyncService extends EventEmitter {
         try {
           const row = await col.findOne(
             { _id: new ObjectId(entry.i) },
-            { projection: { name: 1 } },
+            { projection: { name: 1, syncId: 1 } },
           );
           if (!row || row.name !== entry.p) {
             // Gone, landed, or human-renamed — nothing to recover. Versioned
@@ -1372,6 +1382,7 @@ export class SyncService extends EventEmitter {
                 placeholderName: entry.p,
               }),
             );
+            if (typeof row.syncId === "string") quarantinedSyncIds.add(row.syncId);
             continue; // keep queued — retried next cycle
           }
           const restored = await col.updateOne(
@@ -1447,6 +1458,7 @@ export class SyncService extends EventEmitter {
                 `${JSON.stringify(stray.name)} and its original name could not be determined. ` +
                 `Rename it manually.`,
             );
+            if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
             continue;
           }
           const taken = await col.findOne(
@@ -1462,6 +1474,7 @@ export class SyncService extends EventEmitter {
                 placeholderName: String(stray.name),
               }),
             );
+            if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
             continue;
           }
           const healed = await col.updateOne(
@@ -2071,6 +2084,14 @@ export class SyncService extends EventEmitter {
     // Wrapped so SETTLEMENT ALWAYS RUNS (Codex P1) — see the note above it.
     try {
       for (const syncId of allSyncIds) {
+        // GH #1153 (Codex P2): a row the sweep left holding an unresolved
+        // placeholder is excluded from transfer this cycle — see the
+        // quarantine set's docblock. Marked processed anyway, so a blocker
+        // check treats it as "no write coming", which is the truth.
+        if (quarantinedSyncIds.has(syncId)) {
+          processedSyncIds.add(syncId);
+          continue;
+        }
         // Marked at the TOP, not the bottom: the body is full of `continue`s
         // and a trailing add would be skipped by every one of them. Including
         // the CURRENT id is harmless — `syncId` is unique per collection, so

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1531,16 +1531,33 @@ export class SyncService extends EventEmitter {
           const freshEntries: unknown[] = Array.isArray(nowCovered?.entries)
             ? nowCovered.entries
             : [];
-          if (
-            freshEntries.some(
-              // Scoped to THIS collection (Codex P2) — _id uniqueness is
-              // per-collection, so an entry for a same-id row in a DIFFERENT
-              // collection must not mask this stray's backstop, potentially
-              // forever when that entry is retained for a taken name. The
-              // `coveredIds` snapshot above already scopes this way.
-              (e) => isRestoreEntry(e) && e.c === collectionName && e.i === String(stray._id),
-            )
-          ) {
+          const lateEntry = freshEntries.find(
+            // Scoped to THIS collection (Codex P2) — _id uniqueness is
+            // per-collection, so an entry for a same-id row in a DIFFERENT
+            // collection must not mask this stray's backstop, potentially
+            // forever when that entry is retained for a taken name. The
+            // `coveredIds` snapshot above already scopes this way.
+            (e): e is RenameStagingRestoreEntry =>
+              isRestoreEntry(e) && e.c === collectionName && e.i === String(stray._id),
+          );
+          if (lateEntry) {
+            // A LATE entry — enqueued after this sweep's snapshot, so it never
+            // passed through the entries loop and neither protection path saw
+            // it (Codex P1). Deferring the ACTION to its owner is right; but
+            // the row currently holds a generated placeholder, and if that
+            // owner pauses or crashes while an edit makes the row the LWW
+            // winner, the slim reads just below would carry the placeholder
+            // to the peer. Same treatment as the queue path's young-holding
+            // branch: quarantine and report, touch nothing.
+            if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
+            sweptConflicts.push(
+              strandedPlaceholderNotice({
+                collection: collectionName,
+                id: String(stray._id),
+                originalName: lateEntry.o,
+                placeholderName: lateEntry.p,
+              }),
+            );
             continue;
           }
           const peer =

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -15,6 +15,8 @@ import {
 } from "../src/lib/trimEntityNames";
 import {
   isStagingPlaceholder,
+  placeholderRestoreTarget,
+  STAGING_PREFIX,
   placeholderFor,
   planRenameStaging,
   pendingRenameCanFreeName,
@@ -39,6 +41,36 @@ interface LegacyTransitEntry {
   u: unknown;
   p: unknown;
   r: unknown[] | null;
+}
+
+/** GH #1153: one durable staging-restore record — written BEFORE a row is
+ * moved aside, so a later cycle can put it back no matter how this one ends.
+ * Lives in the `_migrations` doc `_id: "renameStagingRestores"` on the SAME
+ * database as the staged row (each DB's queue describes its own rows).
+ * c=collection, i=String(_id), o=originalName, p=placeholderName. */
+interface RenameStagingRestoreEntry {
+  c: string;
+  i: string;
+  o: string;
+  p: string;
+}
+
+const RESTORE_QUEUE_ID = "renameStagingRestores";
+
+/** Structural validation for queue entries read back from disk — a malformed
+ * entry is dropped rather than allowed to abort its collection's sweep. */
+function isRestoreEntry(value: unknown): value is RenameStagingRestoreEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const e = value as Record<string, unknown>;
+  return (
+    typeof e.c === "string" &&
+    typeof e.i === "string" &&
+    ObjectId.isValid(e.i) &&
+    typeof e.o === "string" &&
+    e.o !== "" &&
+    typeof e.p === "string" &&
+    isStagingPlaceholder(e.p)
+  );
 }
 
 /**
@@ -1203,6 +1235,170 @@ export class SyncService extends EventEmitter {
     // reopen the GH #511 egress problem — that was about pulling full bodies
     // (base64 photoDataUrl blobs, unbounded usageHistory[], calibrations[])
     // for every row on every cycle, which the hydrate helpers still avoid.
+    // ── GH #1153: sweep leftover placeholders BEFORE the pass reads names ──
+    //
+    // Three histories leave a row named `__sync-staging-…` past its own cycle:
+    // settlement's `taken` branch, settlement's catch, and a process death
+    // between staging and settlement. The durable queue written at staging
+    // time carries the original name; this sweep restores it once the name is
+    // free again — BEFORE the slim reads below, so a restored name
+    // participates in this pass's LWW graph and staging plan rather than the
+    // placeholder doing so.
+    //
+    // A stranding that STILL cannot be restored (name permanently taken) is
+    // counted and named every cycle, and — per the #1142 posture, "a
+    // reported, recoverable stall beats an invisible one" — fails the
+    // collection below, cascade-skipping its dependents until a human
+    // renames one of the two rows.
+    //
+    // The GRAMMAR BACKSTOP covers rows with no queue entry (pre-#1153
+    // strandings, and placeholders a pre-#1142 copy propagated to the other
+    // peer): the restore target is derived from the syncId-paired peer's
+    // name, which is what the staged row's own write would have delivered.
+    // `placeholderRestoreTarget` (pure, tested) owns that decision table; a
+    // row it cannot answer for is reported, never guessed — inventing a name
+    // is a product decision this machinery is not allowed to make.
+    const sweptConflicts: string[] = [];
+    const sweepSide = async (
+      db: Db,
+      col: ReturnType<Db["collection"]>,
+      peerCol: ReturnType<Db["collection"]>,
+    ): Promise<void> => {
+      const migrations = db.collection("_migrations");
+      const queueDoc = await migrations
+        .findOne({ _id: RESTORE_QUEUE_ID as unknown as ObjectId })
+        .catch(() => null);
+      const rawEntries: unknown[] = Array.isArray(queueDoc?.entries) ? queueDoc.entries : [];
+      const entries = rawEntries.filter(isRestoreEntry).filter((e) => e.c === collectionName);
+      // Drop malformed entries outright — one bad record must not abort the
+      // sweep, and it can never become restorable.
+      for (const bad of rawEntries.filter(
+        (e) => !isRestoreEntry(e) && (e as RenameStagingRestoreEntry)?.c === collectionName,
+      )) {
+        await migrations
+          .updateOne(
+            { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
+            { $pull: { entries: bad } as Document },
+          )
+          .catch(() => {});
+      }
+
+      const coveredIds = new Set(entries.map((e) => e.i));
+      for (const entry of entries) {
+        try {
+          const row = await col.findOne(
+            { _id: new ObjectId(entry.i) },
+            { projection: { name: 1 } },
+          );
+          if (!row || row.name !== entry.p) {
+            // Gone, landed, or human-renamed — nothing to recover.
+            await dequeueRestoreOn(migrations, entry);
+            continue;
+          }
+          const taken = await col.findOne(
+            { name: entry.o, _deletedAt: null, _id: { $ne: row._id } },
+            { projection: { _id: 1 } },
+          );
+          if (taken) {
+            sweptConflicts.push(
+              strandedPlaceholderNotice({
+                collection: collectionName,
+                id: entry.i,
+                originalName: entry.o,
+                placeholderName: entry.p,
+              }),
+            );
+            continue; // keep queued — retried next cycle
+          }
+          const restored = await col.updateOne(
+            { _id: row._id, name: entry.p },
+            { $set: { name: entry.o } },
+          );
+          await dequeueRestoreOn(migrations, entry);
+          if (restored.modifiedCount) {
+            console.log(
+              `[sync] ${collectionName}: restored ${JSON.stringify(entry.o)} onto ${entry.i} (GH #1153)`,
+            );
+          }
+        } catch (err) {
+          // Keep the entry; next cycle retries. One bad row must not abort
+          // the collection's sweep.
+          console.warn(`[sync] ${collectionName}: staging-restore sweep failed for ${entry.i}.`, err);
+        }
+      }
+
+      // Grammar backstop. STAGING_PREFIX is `__sync-staging-` — word chars
+      // and hyphens only, safe as a literal anchored regex.
+      const strays = await col
+        .find({ name: { $regex: `^${STAGING_PREFIX}` } }, { projection: { name: 1, syncId: 1 } })
+        .toArray()
+        .catch(() => [] as Document[]);
+      for (const stray of strays) {
+        if (coveredIds.has(String(stray._id))) continue; // queue already handled it
+        try {
+          const peer =
+            typeof stray.syncId === "string"
+              ? await peerCol.findOne({ syncId: stray.syncId }, { projection: { name: 1 } })
+              : null;
+          const target = placeholderRestoreTarget(stray.name, null, peer?.name);
+          if (target === null) {
+            sweptConflicts.push(
+              `${collectionName} ${String(stray._id)} holds the temporary name ` +
+                `${JSON.stringify(stray.name)} and its original name could not be determined. ` +
+                `Rename it manually.`,
+            );
+            continue;
+          }
+          const taken = await col.findOne(
+            { name: target, _deletedAt: null, _id: { $ne: stray._id } },
+            { projection: { _id: 1 } },
+          );
+          if (taken) {
+            sweptConflicts.push(
+              strandedPlaceholderNotice({
+                collection: collectionName,
+                id: String(stray._id),
+                originalName: target,
+                placeholderName: String(stray.name),
+              }),
+            );
+            continue;
+          }
+          const healed = await col.updateOne(
+            { _id: stray._id, name: stray.name },
+            { $set: { name: target } },
+          );
+          if (healed.modifiedCount) {
+            console.log(
+              `[sync] ${collectionName}: adopted the peer name ${JSON.stringify(target)} onto ` +
+                `${String(stray._id)} (GH #1153 backstop)`,
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[sync] ${collectionName}: placeholder backstop failed for ${String(stray._id)}.`,
+            err,
+          );
+        }
+      }
+    };
+    /** `$pull` one entry from an already-resolved migrations collection. */
+    const dequeueRestoreOn = async (
+      migrations: ReturnType<Db["collection"]>,
+      entry: RenameStagingRestoreEntry,
+    ): Promise<void> => {
+      await migrations
+        .updateOne(
+          { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
+          { $pull: { entries: { c: entry.c, i: entry.i, o: entry.o, p: entry.p } } as Document },
+        )
+        .catch((err: unknown) => {
+          console.warn(`[sync] ${entry.c}: could not dequeue a staging-restore entry.`, err);
+        });
+    };
+    await sweepSide(localDb, localCol, remoteCol);
+    await sweepSide(remoteDb, remoteCol, localCol);
+
     const SLIM_PROJECTION = { syncId: 1, _deletedAt: 1, _purged: 1, updatedAt: 1, name: 1 };
     const localDocs = await localCol.find({}, { projection: SLIM_PROJECTION }).toArray();
     const remoteDocs = await remoteCol.find({}, { projection: SLIM_PROJECTION }).toArray();
@@ -1269,7 +1465,7 @@ export class SyncService extends EventEmitter {
       placeholderName: string;
     }[] = [];
     /** Rows this pass left holding a placeholder, for the result message. */
-    const strandedNotices: string[] = [];
+    const strandedNotices: string[] = [...sweptConflicts];
     /**
      * SyncIds whose loop iteration has started (and, since iterations are
      * sequential, has finished for every id but the current one). The one
@@ -1482,6 +1678,38 @@ export class SyncService extends EventEmitter {
           return refuseStaging();
         }
 
+        // DURABLE RECORD FIRST (GH #1153) — the same
+        // observation-before-destructive-write ordering the #1021 runner uses.
+        // Settlement can restore a placeholder only while the pass that staged
+        // it is alive; a crash, a thrown cycle, or a taken name used to leave
+        // the row named `__sync-staging-…` with the original name existing
+        // NOWHERE durable. The queue entry is what a later cycle's sweep
+        // restores from. If the enqueue itself fails, staging is refused —
+        // a reported name conflict beats an unrecoverable placeholder.
+        const placeholder = placeholderFor(String(blocker._id), stagingNonce);
+        const entry: RenameStagingRestoreEntry = {
+          c: collectionName,
+          i: String(blocker._id),
+          o: blockerName,
+          p: placeholder,
+        };
+        const sideDb = col === remoteCol ? remoteDb : localDb;
+        try {
+          await sideDb
+            .collection("_migrations")
+            .updateOne(
+              { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
+              { $push: { entries: entry } as Document },
+              { upsert: true },
+            );
+        } catch (enqueueErr) {
+          console.error(
+            `[sync] ${collectionName}: could not record the staging-restore entry; refusing to stage.`,
+            enqueueErr,
+          );
+          return refuseStaging();
+        }
+
         // CONDITIONAL on what was observed (Codex P1). Between the findOne and
         // this update another app or syncer can rename or delete the blocker;
         // an `_id`-only filter would overwrite that concurrent change with a
@@ -1489,12 +1717,16 @@ export class SyncService extends EventEmitter {
         // released, and cleanup could never restore the original because it is
         // now occupied. A zero-match means the world moved — report rather
         // than force.
-        const placeholder = placeholderFor(String(blocker._id), stagingNonce);
         const staged = await col.updateOne(
           { _id: blocker._id, name: blockerName, _deletedAt: null },
           { $set: { name: placeholder } },
         );
         if (!staged.modifiedCount) {
+          // Nothing was written, and settlement never sees this row (it is
+          // pushed to `stagedRenames` only below) — so the entry comes out
+          // HERE. A failed dequeue is harmless: the sweep re-examines the row
+          // next cycle, finds no placeholder, and drops the entry itself.
+          await dequeueRestoreOn(sideDb.collection("_migrations"), entry);
           result.nameConflicts = (result.nameConflicts ?? 0) + 1;
           console.warn(
             `[sync] ${collectionName}: the row holding ${JSON.stringify(desiredName)} changed ` +
@@ -1542,6 +1774,13 @@ export class SyncService extends EventEmitter {
     };
 
     const result: SyncResult = { collection: collectionName, pushed: 0, pulled: 0, updated: 0, deleted: 0 };
+    // GH #1153: a stranding the sweep could not restore FAILS the collection
+    // (the #1142 posture — a reported, recoverable stall beats an invisible
+    // one). The notices are already seeded into `strandedNotices` above, so
+    // they ride the same rendering as a fresh stranding.
+    if (sweptConflicts.length > 0) {
+      result.nameConflicts = (result.nameConflicts ?? 0) + sweptConflicts.length;
+    }
 
     // GH #1142: settle any placeholder whose real write never landed.
     //
@@ -1562,12 +1801,29 @@ export class SyncService extends EventEmitter {
       // Drained, so a second call cannot re-report or re-restore.
       const pending = stagedRenames.splice(0, stagedRenames.length);
       for (const staged of pending) {
+        // GH #1153: settlement is where the durable queue drains for every
+        // resolved outcome — it visits every staged row on every exit path
+        // and is the one place that knows how each ended. The entry stays
+        // queued ONLY on `taken` and on the catch below, which are exactly
+        // the strandings the next cycle's sweep exists to retry.
+        const stagedEntry: RenameStagingRestoreEntry = {
+          c: collectionName,
+          i: String(staged.id),
+          o: staged.originalName,
+          p: staged.placeholderName,
+        };
+        const stagedDb = staged.col === remoteCol ? remoteDb : localDb;
         try {
           const row = await staged.col.findOne(
             { _id: staged.id },
             { projection: { name: 1 } },
           );
-          if (!row || !isStagingPlaceholder(row.name)) continue; // its write landed
+          if (!row || !isStagingPlaceholder(row.name)) {
+            // Its write landed (or a rollback restored it, or a human renamed
+            // it) — no placeholder remains, nothing to recover later.
+            await dequeueRestoreOn(stagedDb.collection("_migrations"), stagedEntry);
+            continue;
+          }
           const taken = await staged.col.findOne(
             { name: staged.originalName, _deletedAt: null, _id: { $ne: staged.id } },
             { projection: { _id: 1 } },
@@ -1603,7 +1859,10 @@ export class SyncService extends EventEmitter {
             { _id: staged.id, name: staged.placeholderName },
             { $set: { name: staged.originalName } },
           );
-          if (!restored.modifiedCount) continue; // someone else moved it on
+          // Restored, or someone else moved it on — either way no placeholder
+          // remains under this entry's name, so it drains.
+          await dequeueRestoreOn(stagedDb.collection("_migrations"), stagedEntry);
+          if (!restored.modifiedCount) continue;
         } catch (settleErr) {
           // SURFACE it (Codex P1). Swallowing left the collection reporting
           // success with a placeholder still stored, and nothing scans for stale

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1403,7 +1403,31 @@ export class SyncService extends EventEmitter {
             // enqueue-to-update window), and the drain is versioned on the
             // observed stamp: the owner may have re-asserted since this
             // sweep's snapshot.
-            if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
+            if (!young) {
+              await dequeueRestoreOn(migrations, entry, entry.at);
+            } else if (
+              row &&
+              typeof row.syncId === "string" &&
+              row._deletedAt == null &&
+              row._purged !== true
+            ) {
+              // A YOUNG entry quarantines its pair through the whole staging
+              // window (Codex P1), not only once the placeholder is visible:
+              // the owner can stage BETWEEN this read and the slim reads
+              // below, at which point coveredIds blinds the backstop and the
+              // fresh placeholder would ride LWW to the peer. Held back one
+              // cycle and reported honestly — this row is not stranded, its
+              // owner is mid-flight (or crashed pre-stage, which the aged
+              // sweep resolves). Tombstoned rows are exempt: the owner's
+              // staging filter requires `_deletedAt: null`, so no placeholder
+              // can appear on them, and quarantining would re-block the
+              // tombstone from propagating.
+              quarantinedSyncIds.add(row.syncId);
+              sweptConflicts.push(
+                `${collectionName} ${entry.i} is being renamed by another sync ` +
+                  `service; held back this cycle and retried on the next.`,
+              );
+            }
             continue;
           }
           // RESOLVED BY DELETION (Codex P2): a user may deal with a stranded

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1382,12 +1382,21 @@ export class SyncService extends EventEmitter {
         // unquarantined on precisely the cycles where something is already
         // wrong.
         let strandedSyncId: string | null = null;
+        /** Did the row read itself succeed? An entry whose row could not even
+         * be INSPECTED cannot be quarantined (no syncId was observed) while
+         * `coveredIds` keeps the backstop away from it too — so nothing can
+         * make the safety promise for it, and the collection must fail
+         * (Codex P2, the read-failure posture one more level down). Distinct
+         * from a row observed WITHOUT a syncId: that row never enters the LWW
+         * maps and cannot spread, so continuing is safe there. */
+        let rowInspected = false;
         const young = Date.now() - entry.at.getTime() < SWEEP_MIN_AGE_MS;
         try {
           const row = await col.findOne(
             { _id: new ObjectId(entry.i) },
             { projection: { name: 1, syncId: 1, _deletedAt: 1, _purged: 1 } },
           );
+          rowInspected = true;
           if (!row || row.name !== entry.p) {
             // Gone, landed, or human-renamed — nothing to recover. Only an
             // AGED entry may be drained (young + not-holding is exactly the
@@ -1458,6 +1467,13 @@ export class SyncService extends EventEmitter {
             quarantinedSyncIds.add(strandedSyncId);
           }
         } catch (err) {
+          if (!rowInspected) {
+            // The row read itself failed: nothing observed, nothing
+            // quarantinable, backstop blinded by coveredIds. The sweep cannot
+            // make its promise for this collection — fail it, like every
+            // other failed read here.
+            throw err;
+          }
           // Keep the entry; next cycle retries. One bad row must not abort
           // the collection's sweep — but a row OBSERVED holding its
           // placeholder must not sync just because a later step failed.

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -14,6 +14,7 @@ import {
   type MinimalTrimDb,
 } from "../src/lib/trimEntityNames";
 import {
+  isGeneratedPlaceholder,
   isStagingPlaceholder,
   placeholderRestoreTarget,
   STAGING_PREFIX,
@@ -1367,6 +1368,15 @@ export class SyncService extends EventEmitter {
         .toArray()
         .catch(() => [] as Document[]);
       for (const stray of strays) {
+        // STRICT grammar, not the prefix (Codex P2). The backstop ACTS on
+        // recognition alone — it rewrites the name to the peer's, or fails
+        // the collection every cycle when it cannot — and entity names are
+        // free-form: a user's own `__sync-staging-custom` matched the prefix
+        // find above and would have been silently renamed to its peer's
+        // value. Only the complete generated shape (8-hex nonce, 24-hex id)
+        // is treated as an artifact; anything else is presumed a user's name
+        // and left entirely alone — not even reported.
+        if (!isGeneratedPlaceholder(stray.name)) continue;
         if (coveredIds.has(String(stray._id))) continue; // queue already handled it
         try {
           // FRESH re-check (Codex P2): the queue snapshot above predates this
@@ -1790,6 +1800,41 @@ export class SyncService extends EventEmitter {
           );
           return false;
         }
+        // RE-ASSERT the record now that the placeholder actually EXISTS
+        // (Codex P2). Age alone cannot distinguish a dead pass from a
+        // SUSPENDED one: a laptop sleeping fifteen minutes between the
+        // enqueue above and this point lets another service's sweep read the
+        // aged entry against a row still holding its original name, judge it
+        // resolved, and drain it — after which this resumed pass would stage
+        // without the durable protection the queue exists to give. So the
+        // record is refreshed the moment the vulnerable state begins: drop
+        // any surviving copy, push a fresh one stamped NOW, which also
+        // restarts the sweep's age window at the moment it matters. A crash
+        // between the two writes leaves a placeholder with no record — the
+        // grammar backstop's case, covered. A refresh failure is logged and
+        // tolerated: the subsequent copy write shares the same connection
+        // and will surface the real problem itself.
+        try {
+          await sideDb
+            .collection("_migrations")
+            .updateOne(
+              { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
+              { $pull: { entries: { c: entry.c, i: entry.i, o: entry.o, p: entry.p } } as Document },
+            );
+          await sideDb
+            .collection("_migrations")
+            .updateOne(
+              { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
+              { $push: { entries: { ...entry, at: new Date() } } as Document },
+              { upsert: true },
+            );
+        } catch (refreshErr) {
+          console.warn(
+            `[sync] ${collectionName}: could not refresh the staging-restore entry for ${entry.i}.`,
+            refreshErr,
+          );
+        }
+
         // Remember it so an unsettled placeholder can be restored below — a
         // row left named `__sync-staging-…` is visible in the UI and worse
         // than the collision we were avoiding.

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -2533,9 +2533,14 @@ export class SyncService extends EventEmitter {
     } catch (loopErr) {
       await settleStagedRenames();
       // `trySync` discards this result object and keeps only the message, so
-      // on THIS path the stranding has to ride the error instead.
-      if (strandedNotices.length > 0) {
-        throw withStrandingNotice(loopErr, strandedNotices.join(" "));
+      // on THIS path everything has to ride the error instead — BOTH channels
+      // (Codex P2, round 20): the hold-backs render only in the post-loop
+      // block this throw never reaches, so carrying strandings alone dropped
+      // a quarantined pair's report whenever an unrelated transfer threw
+      // later in the same cycle.
+      const carried = [...strandedNotices, ...sweptHoldbacks];
+      if (carried.length > 0) {
+        throw withStrandingNotice(loopErr, carried.join(" "));
       }
       throw loopErr;
     }

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1373,7 +1373,7 @@ export class SyncService extends EventEmitter {
         try {
           const row = await col.findOne(
             { _id: new ObjectId(entry.i) },
-            { projection: { name: 1, syncId: 1 } },
+            { projection: { name: 1, syncId: 1, _deletedAt: 1, _purged: 1 } },
           );
           if (!row || row.name !== entry.p) {
             // Gone, landed, or human-renamed — nothing to recover. Only an
@@ -1381,6 +1381,19 @@ export class SyncService extends EventEmitter {
             // enqueue-to-update window), and the drain is versioned on the
             // observed stamp: the owner may have re-asserted since this
             // sweep's snapshot.
+            if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
+            continue;
+          }
+          // RESOLVED BY DELETION (Codex P2): a user may deal with a stranded
+          // row by trashing or purging it. The name no longer needs
+          // restoration — a tombstoned row is outside the partial index, and
+          // a placeholder name in the trash is cosmetic — and quarantining it
+          // would block the one thing that still matters: the TOMBSTONE
+          // propagating to the peer. So: never quarantine, never restore,
+          // never report; drain the entry once aged (a young entry defers to
+          // its owner, as everywhere else). The loop's own predicates decide
+          // tombstoned-ness, per the #1146 rule.
+          if (row._deletedAt != null || row._purged === true) {
             if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
             continue;
           }
@@ -1453,7 +1466,10 @@ export class SyncService extends EventEmitter {
       // Grammar backstop. STAGING_PREFIX is `__sync-staging-` — word chars
       // and hyphens only, safe as a literal anchored regex.
       const strays = await col
-        .find({ name: { $regex: `^${STAGING_PREFIX}` } }, { projection: { name: 1, syncId: 1 } })
+        .find(
+          { name: { $regex: `^${STAGING_PREFIX}` } },
+          { projection: { name: 1, syncId: 1, _deletedAt: 1, _purged: 1 } },
+        )
         .toArray()
         .catch(() => [] as Document[]);
       for (const stray of strays) {
@@ -1466,6 +1482,9 @@ export class SyncService extends EventEmitter {
         // is treated as an artifact; anything else is presumed a user's name
         // and left entirely alone — not even reported.
         if (!isGeneratedPlaceholder(stray.name)) continue;
+        // Tombstoned = resolved by deletion — same rule as the queue path:
+        // let the tombstone sync; the name in the trash is cosmetic.
+        if (stray._deletedAt != null || stray._purged === true) continue;
         if (coveredIds.has(String(stray._id))) continue; // queue already handled it
         try {
           // FRESH re-check (Codex P2): the queue snapshot above predates this
@@ -1536,9 +1555,17 @@ export class SyncService extends EventEmitter {
             );
           }
         } catch (err) {
-          // Same rule as the queue path's catch: a row recognized as a
-          // generated placeholder must not sync because a later step failed.
+          // Same rule as the queue path's catch (Codex P2, both halves): a
+          // row recognized as a generated placeholder must not sync because a
+          // later step failed — and the failure must reach the USER, not just
+          // the console, or the cycle reads green while the placeholder
+          // stands indefinitely.
           if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
+          sweptConflicts.push(
+            `${collectionName} ${String(stray._id)} holds the temporary name ` +
+              `${JSON.stringify(stray.name)} and could not be recovered this cycle. ` +
+              `Rename it manually if this persists.`,
+          );
           console.warn(
             `[sync] ${collectionName}: placeholder backstop failed for ${String(stray._id)}.`,
             err,

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1371,207 +1371,170 @@ export class SyncService extends EventEmitter {
 
       const coveredIds = new Set(entries.map((e) => e.i));
       for (const entry of entries) {
-        // The AGE GATE defers JUDGMENT, not inspection (Codex P1, second
-        // pass). A young entry may belong to a pass alive on another service
-        // — possibly still between its enqueue and its staging write — so no
-        // young entry may be DRAINED or RESTORED. But a young entry whose row
-        // already HOLDS the recorded placeholder is a live stranding either
-        // way (a settlement-taken row re-reported five minutes later sits
-        // well under the fifteen-minute bound), and skipping it entirely left
-        // its syncId unquarantined: an edit while stranded then let LWW copy
-        // the placeholder to the peer — the exact corruption the quarantine
-        // exists to prevent. So the row is always READ; youth only forbids
-        // the destructive verbs.
-        //
-        // The observed syncId lives OUTSIDE the try (Codex P2): the catch
-        // also receives failures from the taken-lookup and the restore
-        // update, AFTER the row was seen holding its placeholder — and
-        // discarding the observation there let the row enter the loop
-        // unquarantined on precisely the cycles where something is already
-        // wrong.
+        // STRUCTURE, not discipline (Codex P1 ×7 — rounds 4 through 17 of
+        // this PR each found one more branch that forgot an obligation).
+        // The two obligations are therefore HOISTED so a branch cannot skip
+        // them:
+        //   1. QUARANTINE at recognition — any live observed row with a
+        //      pending record holds its pair for the cycle, whatever the
+        //      branch then does (restore, drain, defer, fail). The window is
+        //      the argument everywhere: between this read and the slim
+        //      reads, another service can stage this row, and coveredIds
+        //      blinds the backstop to it.
+        //   2. ONE notice per touched row, pushed at a single site after the
+        //      branch logic. Branches only choose the TEXT and channel; a
+        //      branch that forgets gets the generic fallback, never silence.
+        // Branches are an if/else chain with no `continue`, so control
+        // always reaches the central push. Carve-outs stay where they were:
+        // tombstoned rows pass through untouched (their deletion must
+        // propagate; the owner's staging filter can never re-placeholder
+        // them), and a vanished row has nothing to hold.
         let strandedSyncId: string | null = null;
-        /** Did the row read itself succeed? An entry whose row could not even
-         * be INSPECTED cannot be quarantined (no syncId was observed) while
-         * `coveredIds` keeps the backstop away from it too — so nothing can
-         * make the safety promise for it, and the collection must fail
-         * (Codex P2, the read-failure posture one more level down). Distinct
-         * from a row observed WITHOUT a syncId: that row never enters the LWW
-         * maps and cannot spread, so continuing is safe there. */
+        /** Did the row read itself succeed? An entry whose row could not be
+         * INSPECTED cannot be quarantined while coveredIds keeps the
+         * backstop away — nothing can make the safety promise, so the
+         * collection must fail. Distinct from a row observed WITHOUT a
+         * syncId: that row never enters the LWW maps and cannot spread. */
         let rowInspected = false;
         const young = Date.now() - entry.at.getTime() < SWEEP_MIN_AGE_MS;
+        /** The branch's message: channel + text. Null only for rows the
+         * sweep deliberately does not touch (gone / tombstoned). */
+        let notice: { hold: boolean; text: string } | null = null;
         try {
           const row = await col.findOne(
             { _id: new ObjectId(entry.i) },
             { projection: { name: 1, syncId: 1, _deletedAt: 1, _purged: 1 } },
           );
           rowInspected = true;
-          if (!row || row.name !== entry.p) {
-            // Gone, landed, or human-renamed — nothing to recover. Only an
-            // AGED entry may be drained (young + not-holding is exactly the
-            // enqueue-to-update window), and the drain is versioned on the
-            // observed stamp: the owner may have re-asserted since this
-            // sweep's snapshot.
-            if (!young) {
-              // Draining a dead record does NOT close the window (Codex P1,
-              // the suspension race one branch over): an owner suspended past
-              // the age bound can resume AFTER this read, stage, and pause
-              // again — and coveredIds, built from the snapshot that carried
-              // this entry, keeps the backstop away from the fresh
-              // placeholder. So a live, non-tombstoned row is quarantined
-              // here too, with the same carve-outs as the young branch. One
-              // held-back cycle per drained record over a live row — the
-              // entry is gone next cycle, so it cannot recur.
-              // Drain FIRST, then say what actually happened (Codex P2):
-              // the drain can fail, the entry then stays aged, and a notice
-              // claiming clearance would lie every cycle of a persistent
-              // _migrations failure.
-              const drain = await dequeueRestoreOn(migrations, entry, entry.at);
-              const cleared = drain.accepted && drain.modified > 0;
-              if (
-                row &&
-                typeof row.syncId === "string" &&
-                row._deletedAt == null &&
-                row._purged !== true
-              ) {
-                quarantinedSyncIds.add(row.syncId);
-                sweptHoldbacks.push(
-                  cleared
-                    ? `${collectionName} ${entry.i} had a pending rename record; held back ` +
-                        `this cycle while it was cleared, and retried on the next.`
-                    : `${collectionName} ${entry.i} has a pending rename record that could ` +
-                        `not be cleared; held back and retried on the next cycle.`,
-                );
-              }
-            } else if (
-              row &&
-              typeof row.syncId === "string" &&
-              row._deletedAt == null &&
-              row._purged !== true
-            ) {
-              // A YOUNG entry quarantines its pair through the whole staging
-              // window (Codex P1), not only once the placeholder is visible:
-              // the owner can stage BETWEEN this read and the slim reads
-              // below, at which point coveredIds blinds the backstop and the
-              // fresh placeholder would ride LWW to the peer. Held back one
-              // cycle and reported honestly — this row is not stranded, its
-              // owner is mid-flight (or crashed pre-stage, which the aged
-              // sweep resolves). Tombstoned rows are exempt: the owner's
-              // staging filter requires `_deletedAt: null`, so no placeholder
-              // can appear on them, and quarantining would re-block the
-              // tombstone from propagating.
-              quarantinedSyncIds.add(row.syncId);
-              sweptHoldbacks.push(
-                `${collectionName} ${entry.i} is being renamed by another sync ` +
-                  `service; held back this cycle and retried on the next.`,
-              );
-            }
-            continue;
-          }
-          // RESOLVED BY DELETION (Codex P2): a user may deal with a stranded
-          // row by trashing or purging it. The name no longer needs
-          // restoration — a tombstoned row is outside the partial index, and
-          // a placeholder name in the trash is cosmetic — and quarantining it
-          // would block the one thing that still matters: the TOMBSTONE
-          // propagating to the peer. So: never quarantine, never restore,
-          // never report; drain the entry once aged (a young entry defers to
-          // its owner, as everywhere else). The loop's own predicates decide
-          // tombstoned-ness, per the #1146 rule.
-          if (row._deletedAt != null || row._purged === true) {
+          if (row && (row._deletedAt != null || row._purged === true)) {
+            // RESOLVED BY DELETION: the tombstone must propagate, the name in
+            // the trash is cosmetic, and the owner's staging filter
+            // (`_deletedAt: null`) can never re-placeholder this row. Drain
+            // once aged; a young entry defers to its owner.
             if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
-            continue;
-          }
-          if (typeof row.syncId === "string") strandedSyncId = row.syncId;
-          if (young) {
-            // Holding, but the entry is fresh — quarantine and report without
-            // touching row or record; the owning pass (or the next aged
-            // sweep) resolves it.
-            sweptConflicts.push(
-              strandedPlaceholderNotice({
-                collection: collectionName,
-                id: entry.i,
-                originalName: entry.o,
-                placeholderName: entry.p,
-              }),
-            );
-            if (strandedSyncId) quarantinedSyncIds.add(strandedSyncId);
-            continue;
-          }
-          const taken = await col.findOne(
-            { name: entry.o, _deletedAt: null, _id: { $ne: row._id } },
-            { projection: { _id: 1 } },
-          );
-          if (taken) {
-            sweptConflicts.push(
-              strandedPlaceholderNotice({
-                collection: collectionName,
-                id: entry.i,
-                originalName: entry.o,
-                placeholderName: entry.p,
-              }),
-            );
-            if (strandedSyncId) quarantinedSyncIds.add(strandedSyncId);
-            continue; // keep queued — retried next cycle
-          }
-          const restored = await col.updateOne(
-            { _id: row._id, name: entry.p },
-            { $set: { name: entry.o } },
-          );
-          await dequeueRestoreOn(migrations, entry, entry.at);
-          if (restored.modifiedCount) {
-            console.log(
-              `[sync] ${collectionName}: restored ${JSON.stringify(entry.o)} onto ${entry.i} (GH #1153)`,
-            );
-            // Quarantine even on SUCCESS (Codex P1) — the last branch that
-            // did not, and the window is the same as everywhere else: another
-            // service can enqueue and stage this very row between this
-            // restore and the slim reads, with coveredIds (built from OUR
-            // snapshot) blinding the backstop. The rule is now uniform: every
-            // queue entry over a live row holds its pair for the cycle. The
-            // restored name syncs on the next one.
-            if (strandedSyncId) {
-              quarantinedSyncIds.add(strandedSyncId);
-              sweptHoldbacks.push(
-                `${collectionName} ${entry.i} was restored to ${JSON.stringify(entry.o)}; ` +
-                  `held back this cycle and synced on the next.`,
-              );
+          } else if (!row) {
+            // Gone entirely — nothing to hold; drain once aged (versioned on
+            // the observed stamp: the owner may have re-asserted).
+            if (!young) await dequeueRestoreOn(migrations, entry, entry.at);
+          } else {
+            // LIVE row with a pending record — obligation 1, unconditionally.
+            if (typeof row.syncId === "string") {
+              strandedSyncId = row.syncId;
+              quarantinedSyncIds.add(row.syncId);
             }
-          } else if (strandedSyncId) {
-            // The conditional restore no-matched — someone moved the row
-            // between our read and the write. Unknown state: hold it back
-            // this cycle rather than let a possibly-still-stranded row sync —
-            // and SAY so (Codex P2), or trySync reads the collection as
-            // successful and dependents run over the deliberately-skipped
-            // pair. Every quarantine reports; this was the last silent one.
-            quarantinedSyncIds.add(strandedSyncId);
-            sweptHoldbacks.push(
-              `${collectionName} ${entry.i} changed while being restored; held back ` +
-                `this cycle and re-examined on the next.`,
-            );
+            if (row.name !== entry.p) {
+              // Not holding the placeholder: the enqueue-to-stage window, or
+              // a landed/human-fixed row under a stale record.
+              if (!young) {
+                // Drain FIRST, then say what actually happened: the drain can
+                // fail, and a notice claiming clearance would lie every cycle
+                // of a persistent _migrations failure. `modified`, not
+                // acceptance, is the clearance signal — a re-asserted twin
+                // survives a versioned pull as an accepted zero-match.
+                const drain = await dequeueRestoreOn(migrations, entry, entry.at);
+                const cleared = drain.accepted && drain.modified > 0;
+                notice = {
+                  hold: true,
+                  text: cleared
+                    ? `${collectionName} ${entry.i} had a pending rename record; held back ` +
+                      `this cycle while it was cleared, and retried on the next.`
+                    : `${collectionName} ${entry.i} has a pending rename record that could ` +
+                      `not be cleared; held back and retried on the next cycle.`,
+                };
+              } else {
+                notice = {
+                  hold: true,
+                  text:
+                    `${collectionName} ${entry.i} is being renamed by another sync ` +
+                    `service; held back this cycle and retried on the next.`,
+                };
+              }
+            } else if (young) {
+              // Holding, but the entry is fresh — report without touching row
+              // or record; the owning pass (or the next aged sweep) resolves.
+              notice = {
+                hold: false,
+                text: strandedPlaceholderNotice({
+                  collection: collectionName,
+                  id: entry.i,
+                  originalName: entry.o,
+                  placeholderName: entry.p,
+                }),
+              };
+            } else {
+              const taken = await col.findOne(
+                { name: entry.o, _deletedAt: null, _id: { $ne: row._id } },
+                { projection: { _id: 1 } },
+              );
+              if (taken) {
+                notice = {
+                  hold: false,
+                  text: strandedPlaceholderNotice({
+                    collection: collectionName,
+                    id: entry.i,
+                    originalName: entry.o,
+                    placeholderName: entry.p,
+                  }),
+                };
+              } else {
+                const restored = await col.updateOne(
+                  { _id: row._id, name: entry.p },
+                  { $set: { name: entry.o } },
+                );
+                await dequeueRestoreOn(migrations, entry, entry.at);
+                notice = restored.modifiedCount
+                  ? {
+                      hold: true,
+                      text:
+                        `${collectionName} ${entry.i} was restored to ${JSON.stringify(entry.o)}; ` +
+                        `held back this cycle and synced on the next.`,
+                    }
+                  : {
+                      hold: true,
+                      text:
+                        `${collectionName} ${entry.i} changed while being restored; held back ` +
+                        `this cycle and re-examined on the next.`,
+                    };
+                if (restored.modifiedCount) {
+                  console.log(
+                    `[sync] ${collectionName}: restored ${JSON.stringify(entry.o)} onto ${entry.i} (GH #1153)`,
+                  );
+                }
+              }
+            }
           }
         } catch (err) {
           if (!rowInspected) {
             // The row read itself failed: nothing observed, nothing
-            // quarantinable, backstop blinded by coveredIds. The sweep cannot
-            // make its promise for this collection — fail it, like every
-            // other failed read here.
+            // quarantinable, backstop blinded by coveredIds. Fail the
+            // collection, like every other failed read here.
             throw err;
           }
-          // Keep the entry; next cycle retries. One bad row must not abort
-          // the collection's sweep — but a row OBSERVED holding its
-          // placeholder must not sync just because a later step failed.
+          // Post-observation failure: the quarantine already happened at the
+          // hoist; only the message remains.
           if (strandedSyncId) {
-            quarantinedSyncIds.add(strandedSyncId);
-            sweptConflicts.push(
-              strandedPlaceholderNotice({
+            notice = {
+              hold: false,
+              text: strandedPlaceholderNotice({
                 collection: collectionName,
                 id: entry.i,
                 originalName: entry.o,
                 placeholderName: entry.p,
               }),
-            );
+            };
           }
           console.warn(`[sync] ${collectionName}: staging-restore sweep failed for ${entry.i}.`, err);
         }
+        // Obligation 2 — the single push site. The fallback fires only if a
+        // future branch quarantines and assigns nothing: degraded to a
+        // generic message rather than silence.
+        if (strandedSyncId && !notice) {
+          notice = {
+            hold: true,
+            text: `${collectionName} ${entry.i} was held back this cycle by placeholder recovery.`,
+          };
+        }
+        if (notice) (notice.hold ? sweptHoldbacks : sweptConflicts).push(notice.text);
       }
 
       // Grammar backstop. STAGING_PREFIX is `__sync-staging-` — word chars
@@ -1584,28 +1547,26 @@ export class SyncService extends EventEmitter {
         )
         .toArray();
       for (const stray of strays) {
-        // STRICT grammar, not the prefix (Codex P2). The backstop ACTS on
-        // recognition alone — it rewrites the name to the peer's, or fails
-        // the collection every cycle when it cannot — and entity names are
-        // free-form: a user's own `__sync-staging-custom` matched the prefix
-        // find above and would have been silently renamed to its peer's
-        // value. Only the complete generated shape (8-hex nonce, 24-hex id)
-        // is treated as an artifact; anything else is presumed a user's name
-        // and left entirely alone — not even reported.
+        // STRICT grammar, not the prefix: the backstop ACTS on recognition,
+        // and entity names are free-form — a user's own `__sync-staging-custom`
+        // must be left entirely alone, not even reported.
         if (!isGeneratedPlaceholder(stray.name)) continue;
-        // Tombstoned = resolved by deletion — same rule as the queue path:
-        // let the tombstone sync; the name in the trash is cosmetic.
+        // Tombstoned = resolved by deletion — let the tombstone sync.
         if (stray._deletedAt != null || stray._purged === true) continue;
         if (coveredIds.has(String(stray._id))) continue; // queue already handled it
+        // Same hoisted structure as the queue path (Codex P1 ×7, including
+        // the backstop's own restore attempt): a recognized live stray holds
+        // its pair for the cycle no matter which branch runs — another
+        // service can enqueue and stage this row after the re-check below,
+        // or replace a just-healed name, and coveredIds/the finished scan
+        // would never look again this pass. One notice per stray, one push
+        // site, generic fallback over silence.
+        if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
+        let notice: { hold: boolean; text: string } | null = null;
         try {
-          // FRESH re-check (Codex P2): the queue snapshot above predates this
-          // find, and enqueue-before-stage means any placeholder minted since
-          // then already has a durable entry — owned by a live pass the
-          // backstop must not race. The residual window is the milliseconds
-          // between an enqueue landing and this read observing it; even
-          // there, the backstop's conditional update only touches a row
-          // still holding the placeholder, so the worst case is the owning
-          // pass's retry colliding and REPORTING — never silent loss.
+          // FRESH re-check: enqueue-before-stage means any placeholder minted
+          // after the sweep's snapshot already has a durable entry — owned by
+          // a live pass whose ACTION the backstop must defer to.
           const nowCovered = await migrations.findOne(
             { _id: RESTORE_QUEUE_ID as unknown as ObjectId },
             { projection: { entries: 1 } },
@@ -1614,91 +1575,99 @@ export class SyncService extends EventEmitter {
             ? nowCovered.entries
             : [];
           const lateEntry = freshEntries.find(
-            // Scoped to THIS collection (Codex P2) — _id uniqueness is
-            // per-collection, so an entry for a same-id row in a DIFFERENT
-            // collection must not mask this stray's backstop, potentially
-            // forever when that entry is retained for a taken name. The
-            // `coveredIds` snapshot above already scopes this way.
+            // Scoped to THIS collection — _id uniqueness is per-collection.
             (e): e is RenameStagingRestoreEntry =>
               isRestoreEntry(e) && e.c === collectionName && e.i === String(stray._id),
           );
           if (lateEntry) {
-            // A LATE entry — enqueued after this sweep's snapshot, so it never
-            // passed through the entries loop and neither protection path saw
-            // it (Codex P1). Deferring the ACTION to its owner is right; but
-            // the row currently holds a generated placeholder, and if that
-            // owner pauses or crashes while an edit makes the row the LWW
-            // winner, the slim reads just below would carry the placeholder
-            // to the peer. Same treatment as the queue path's young-holding
-            // branch: quarantine and report, touch nothing.
-            if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
-            sweptConflicts.push(
-              strandedPlaceholderNotice({
+            // Enqueued after the snapshot: defer the ACTION to its owner;
+            // the hoisted quarantine already holds the pair.
+            notice = {
+              hold: false,
+              text: strandedPlaceholderNotice({
                 collection: collectionName,
                 id: String(stray._id),
                 originalName: lateEntry.o,
                 placeholderName: lateEntry.p,
               }),
-            );
-            continue;
-          }
-          const peer =
-            typeof stray.syncId === "string"
-              ? await peerCol.findOne({ syncId: stray.syncId }, { projection: { name: 1 } })
-              : null;
-          const target = placeholderRestoreTarget(stray.name, null, peer?.name);
-          if (target === null) {
-            sweptConflicts.push(
-              `${collectionName} ${String(stray._id)} holds the temporary name ` +
-                `${JSON.stringify(stray.name)} and its original name could not be determined. ` +
-                `Rename it manually.`,
-            );
-            if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
-            continue;
-          }
-          const taken = await col.findOne(
-            { name: target, _deletedAt: null, _id: { $ne: stray._id } },
-            { projection: { _id: 1 } },
-          );
-          if (taken) {
-            sweptConflicts.push(
-              strandedPlaceholderNotice({
-                collection: collectionName,
-                id: String(stray._id),
-                originalName: target,
-                placeholderName: String(stray.name),
-              }),
-            );
-            if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
-            continue;
-          }
-          const healed = await col.updateOne(
-            { _id: stray._id, name: stray.name },
-            { $set: { name: target } },
-          );
-          if (healed.modifiedCount) {
-            console.log(
-              `[sync] ${collectionName}: adopted the peer name ${JSON.stringify(target)} onto ` +
-                `${String(stray._id)} (GH #1153 backstop)`,
-            );
+            };
+          } else {
+            const peer =
+              typeof stray.syncId === "string"
+                ? await peerCol.findOne({ syncId: stray.syncId }, { projection: { name: 1 } })
+                : null;
+            const target = placeholderRestoreTarget(stray.name, null, peer?.name);
+            if (target === null) {
+              notice = {
+                hold: false,
+                text:
+                  `${collectionName} ${String(stray._id)} holds the temporary name ` +
+                  `${JSON.stringify(stray.name)} and its original name could not be determined. ` +
+                  `Rename it manually.`,
+              };
+            } else {
+              const taken = await col.findOne(
+                { name: target, _deletedAt: null, _id: { $ne: stray._id } },
+                { projection: { _id: 1 } },
+              );
+              if (taken) {
+                notice = {
+                  hold: false,
+                  text: strandedPlaceholderNotice({
+                    collection: collectionName,
+                    id: String(stray._id),
+                    originalName: target,
+                    placeholderName: String(stray.name),
+                  }),
+                };
+              } else {
+                const healed = await col.updateOne(
+                  { _id: stray._id, name: stray.name },
+                  { $set: { name: target } },
+                );
+                notice = healed.modifiedCount
+                  ? {
+                      hold: true,
+                      text:
+                        `${collectionName} ${String(stray._id)} adopted the name ` +
+                        `${JSON.stringify(target)} from its peer; held back this cycle and ` +
+                        `synced on the next.`,
+                    }
+                  : {
+                      hold: true,
+                      text:
+                        `${collectionName} ${String(stray._id)} changed while being healed; ` +
+                        `held back this cycle and re-examined on the next.`,
+                    };
+                if (healed.modifiedCount) {
+                  console.log(
+                    `[sync] ${collectionName}: adopted the peer name ${JSON.stringify(target)} onto ` +
+                      `${String(stray._id)} (GH #1153 backstop)`,
+                  );
+                }
+              }
+            }
           }
         } catch (err) {
-          // Same rule as the queue path's catch (Codex P2, both halves): a
-          // row recognized as a generated placeholder must not sync because a
-          // later step failed — and the failure must reach the USER, not just
-          // the console, or the cycle reads green while the placeholder
-          // stands indefinitely.
-          if (typeof stray.syncId === "string") quarantinedSyncIds.add(stray.syncId);
-          sweptConflicts.push(
-            `${collectionName} ${String(stray._id)} holds the temporary name ` +
+          notice = {
+            hold: false,
+            text:
+              `${collectionName} ${String(stray._id)} holds the temporary name ` +
               `${JSON.stringify(stray.name)} and could not be recovered this cycle. ` +
               `Rename it manually if this persists.`,
-          );
+          };
           console.warn(
             `[sync] ${collectionName}: placeholder backstop failed for ${String(stray._id)}.`,
             err,
           );
         }
+        if (!notice) {
+          notice = {
+            hold: true,
+            text: `${collectionName} ${String(stray._id)} was held back this cycle by placeholder recovery.`,
+          };
+        }
+        (notice.hold ? sweptHoldbacks : sweptConflicts).push(notice.text);
       }
     };
     /** `$pull` one entry from an already-resolved migrations collection.

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -96,9 +96,39 @@ export function placeholderFor(id: string, nonce: string): string {
   return `${STAGING_PREFIX}${nonce}-${id}`;
 }
 
-/** Is this a placeholder left over from a previous (crashed) pass? */
+/** Is this a placeholder left over from a previous (crashed) pass?
+ *
+ * PREFIX match — deliberately loose, for call sites where a false positive is
+ * CONSERVATIVE: refusing to transfer a placeholder-looking name, or treating
+ * a row as possibly-staged. A site that takes DESTRUCTIVE action on the
+ * strength of the name alone must use `isGeneratedPlaceholder` instead —
+ * names are free-form strings, and a user may legitimately (if unwisely) name
+ * a row `__sync-staging-custom`. */
 export function isStagingPlaceholder(name: unknown): boolean {
   return typeof name === "string" && name.startsWith(STAGING_PREFIX);
+}
+
+/**
+ * Does this name match the COMPLETE generated placeholder grammar —
+ * `__sync-staging-<8 hex nonce>-<24 hex ObjectId>` — not merely the prefix?
+ * (GH #1153, Codex P2.)
+ *
+ * The sweep's grammar backstop ACTS on rows it recognizes: it rewrites the
+ * name to the peer's, or fails the collection every cycle when it cannot.
+ * Entity names are free-form, so a prefix match alone would let a user's own
+ * `__sync-staging-custom` be silently renamed to its peer's value — data
+ * loss by helpfulness. The full grammar (nonce from an ObjectId's tail hex,
+ * id a full ObjectId hex) is not a shape anyone produces by accident.
+ *
+ * Deliberately NOT anchored to the row's own _id: a pre-#1142 LWW copy could
+ * carry a placeholder to the other peer, where the embedded id is the SOURCE
+ * row's — still a genuine artifact, still worth healing.
+ */
+const GENERATED_PLACEHOLDER_RE = new RegExp(
+  `^${STAGING_PREFIX}[0-9a-f]{8}-[0-9a-f]{24}$`,
+);
+export function isGeneratedPlaceholder(name: unknown): boolean {
+  return typeof name === "string" && GENERATED_PLACEHOLDER_RE.test(name);
 }
 
 /**

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -259,6 +259,46 @@ export function pendingRenameCanFreeName(
   return freshSourceName !== blockerCurrentName;
 }
 
+/**
+ * Where should a swept placeholder row be restored to? (GH #1153)
+ *
+ * The sweep meets a row named `__sync-staging-…` on a LATER cycle, when the
+ * pass that staged it — and the in-memory record of its original name — is
+ * gone. Two sources can answer, in strict preference order:
+ *
+ *  1. the DURABLE QUEUE entry written before the row was staged — authoritative,
+ *     it IS the original name;
+ *  2. the syncId-paired PEER row's current name — the staging invariant is that
+ *     a staged row's own write (carrying the peer's name) was expected moments
+ *     later, so the peer's name is what that write would have delivered. Only
+ *     trusted when it is a real, non-placeholder string that actually differs
+ *     from what the row holds now: a placeholder peer means BOTH sides are
+ *     stranded (adopting it would copy the disease, not the cure), and a
+ *     non-string peer answers nothing.
+ *
+ * Returns null when neither source answers — the caller reports and leaves the
+ * row alone, because inventing a name is a product decision this machinery is
+ * not allowed to make. Free-ness on the target side is the CALLER's check: it
+ * is a live index question, not a naming one.
+ */
+export function placeholderRestoreTarget(
+  currentName: unknown,
+  queuedOriginalName: string | null,
+  peerName: unknown,
+): string | null {
+  if (!isStagingPlaceholder(currentName)) return null; // nothing to restore
+  if (queuedOriginalName !== null && queuedOriginalName !== "") return queuedOriginalName;
+  if (
+    typeof peerName === "string" &&
+    peerName !== "" &&
+    !isStagingPlaceholder(peerName) &&
+    peerName !== currentName
+  ) {
+    return peerName;
+  }
+  return null;
+}
+
 /** Facts about a row left holding a staging placeholder. */
 export interface StrandedPlaceholder {
   collection: string;

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -6,6 +6,7 @@ import {
   strandedPlaceholderNotice,
   withStrandingNotice,
   pendingRenameCanFreeName,
+  placeholderRestoreTarget,
   strandingNoticeOf,
   STAGING_PREFIX,
   type RenameIntent,
@@ -319,5 +320,41 @@ describe("stranded placeholder reporting", () => {
     }
     // ...including a lookalike whose key holds the wrong type.
     expect(strandingNoticeOf({ strandingNotice: 42 })).toBeNull();
+  });
+});
+
+/**
+ * GH #1153: where a swept placeholder row is restored to. Preference order is
+ * strict — the durable queue entry IS the original name; the syncId-paired
+ * peer's name is what the staged row's own write would have delivered and is
+ * only trusted when it is a real, non-placeholder string. Null means REPORT:
+ * inventing a name is a product decision this machinery may not make.
+ */
+describe("placeholderRestoreTarget", () => {
+  const ph = `${STAGING_PREFIX}abc123-64b7f0000000000000000001`;
+
+  it("prefers the queued original name over everything", () => {
+    expect(placeholderRestoreTarget(ph, "Textured PEI", "Peer Name")).toBe("Textured PEI");
+  });
+
+  it("adopts the peer name when no queue entry exists", () => {
+    expect(placeholderRestoreTarget(ph, null, "Textured PEI")).toBe("Textured PEI");
+  });
+
+  it("refuses a peer that is itself a placeholder — both sides are stranded", () => {
+    // Adopting it would copy the disease, not the cure.
+    expect(placeholderRestoreTarget(ph, null, `${STAGING_PREFIX}zzz-64b7f0000000000000000002`)).toBeNull();
+  });
+
+  it("answers null when neither source can", () => {
+    expect(placeholderRestoreTarget(ph, null, null)).toBeNull();
+    expect(placeholderRestoreTarget(ph, null, undefined)).toBeNull();
+    expect(placeholderRestoreTarget(ph, null, 42)).toBeNull();
+    expect(placeholderRestoreTarget(ph, null, "")).toBeNull();
+    expect(placeholderRestoreTarget(ph, "", "")).toBeNull();
+  });
+
+  it("does nothing for a row that is not holding a placeholder", () => {
+    expect(placeholderRestoreTarget("Textured PEI", "Whatever", "Peer")).toBeNull();
   });
 });

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   planRenameStaging,
   isStagingPlaceholder,
+  isGeneratedPlaceholder,
   placeholderFor,
   strandedPlaceholderNotice,
   withStrandingNotice,
@@ -356,5 +357,29 @@ describe("placeholderRestoreTarget", () => {
 
   it("does nothing for a row that is not holding a placeholder", () => {
     expect(placeholderRestoreTarget("Textured PEI", "Whatever", "Peer")).toBeNull();
+  });
+});
+
+/**
+ * GH #1153 (Codex P2): the backstop ACTS on recognition, so recognition must
+ * be the complete generated grammar — names are free-form, and a prefix match
+ * alone let a user's own `__sync-staging-custom` be silently renamed.
+ */
+describe("isGeneratedPlaceholder", () => {
+  it("accepts exactly what placeholderFor produces", () => {
+    expect(
+      isGeneratedPlaceholder(placeholderFor("64b7f0000000000000000001", "deadbeef")),
+    ).toBe(true);
+  });
+
+  it("rejects a user name that merely carries the prefix", () => {
+    expect(isGeneratedPlaceholder("__sync-staging-custom")).toBe(false);
+    expect(isGeneratedPlaceholder("__sync-staging-")).toBe(false);
+    expect(isGeneratedPlaceholder("__sync-staging-deadbeef-nothexhexhexhexhexhexhex!")).toBe(false);
+    // Wrong widths — a 7-hex nonce or a 23-hex id is not the generator's.
+    expect(isGeneratedPlaceholder("__sync-staging-deadbee-64b7f0000000000000000001")).toBe(false);
+    expect(isGeneratedPlaceholder("__sync-staging-deadbeef-64b7f000000000000000001")).toBe(false);
+    expect(isGeneratedPlaceholder(42)).toBe(false);
+    expect(isGeneratedPlaceholder(null)).toBe(false);
   });
 });

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1320,6 +1320,160 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
   });
 
+  describe("leftover staging placeholders are swept on the next cycle (GH #1153)", () => {
+    const PH = "__sync-staging-deadbeef-";
+    const QUEUE_ID = "renameStagingRestores";
+
+    /**
+     * The crash case: a prior pass staged a row, wrote its durable restore
+     * entry, and died before settlement. The next cycle's sweep restores the
+     * original name from the queue and drains the entry.
+     */
+    it("restores a queued placeholder and drains the entry", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: `${PH}x1`, material: "PEI", syncId: "sw-a", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Shelf A", material: "PEI", syncId: "sw-a", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf A", p: `${PH}x1` }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      const row = await localDb.collection("bedtypes").findOne({ syncId: "sw-a" });
+      expect(row?.name).toBe("Shelf A");
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect(queue?.entries ?? []).toEqual([]);
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+    });
+
+    /**
+     * The taken case: the original name is occupied, so the sweep must NOT
+     * overwrite — it reports (failing the collection, the #1142 posture) and
+     * keeps the entry. Once the occupier is renamed, the NEXT cycle restores.
+     */
+    it("reports a still-taken name every cycle, then restores once it frees", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: `${PH}x2`, material: "PEI", syncId: "sw-b", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      // The occupier — active, holds the original name, NOT movable.
+      await localDb.collection("bedtypes").insertOne({
+        name: "Shelf B", material: "PEI", syncId: "sw-occ", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: `${PH}x2`, material: "PEI", syncId: "sw-b", _deletedAt: null, createdAt: same, updatedAt: same },
+        { name: "Shelf B", material: "PEI", syncId: "sw-occ", _deletedAt: null, createdAt: same, updatedAt: same },
+      ]);
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf B", p: `${PH}x2` }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      const first = await sync.sync();
+      // Reported and FAILED — the placeholder is visible in the UI and the
+      // collection must not read as green around it.
+      expect(first.find((r) => r.collection === "bedtypes")?.error).toMatch(/rename it back manually/i);
+      const kept = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect((kept?.entries ?? []).length).toBe(1);
+
+      // A human renames the occupier; the next cycle heals.
+      await localDb.collection("bedtypes").updateOne(
+        { syncId: "sw-occ" }, { $set: { name: "Shelf B (old)" } },
+      );
+      await remoteDb.collection("bedtypes").updateOne(
+        { syncId: "sw-occ" }, { $set: { name: "Shelf B (old)" } },
+      );
+      sync.destroy(); sync = makeSync();
+      const second = await sync.sync();
+      expect((await localDb.collection("bedtypes").findOne({ syncId: "sw-b" }))?.name).toBe("Shelf B");
+      expect(second.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+    });
+
+    /**
+     * The grammar backstop: a pre-#1153 stranding has NO queue entry, so the
+     * restore target is derived from the syncId-paired peer's name.
+     */
+    it("adopts the peer's name for a queue-less placeholder", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      await localDb.collection("bedtypes").insertOne({
+        name: `${PH}x3`, material: "PEI", syncId: "sw-c", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Drybox 4", material: "PEI", syncId: "sw-c", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+
+      sync = makeSync();
+      await sync.sync();
+
+      expect((await localDb.collection("bedtypes").findOne({ syncId: "sw-c" }))?.name).toBe("Drybox 4");
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+    });
+
+    /**
+     * The human-rename case: the row no longer holds the placeholder, so the
+     * stale entry drains without touching the row.
+     */
+    it("drains a stale entry without touching a row a human already fixed", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: "Hand Fixed", material: "PEI", syncId: "sw-d", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Hand Fixed", material: "PEI", syncId: "sw-d", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Old Name", p: `${PH}x4` }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      await sync.sync();
+
+      expect((await localDb.collection("bedtypes").findOne({ syncId: "sw-d" }))?.name).toBe("Hand Fixed");
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect(queue?.entries ?? []).toEqual([]);
+    });
+  });
+
   describe("purge zombies are repaired on BOTH peers before the trim (GH #1116)", () => {
     /**
      * A zombie (`_purged: true` with `_deletedAt: null`) is ACTIVE as far as

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1517,6 +1517,53 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * The aged-drain window (Codex P1): draining a dead record over a LIVE
+     * row leaves the same resume race the young branch closed — a suspended
+     * owner can stage between the row read and the slim reads, with the
+     * backstop blinded by coveredIds. The drain proceeds, but the pair sits
+     * this one cycle out.
+     */
+    it("holds a live pair back for the cycle that drains its aged record", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      // Live row holding its ORIGINAL name — the LWW winner — with a dead
+      // (aged) record from a pre-stage crash.
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: "Crash Left (edited)", material: "PEI", syncId: "sw-l", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Crash Left", material: "PEI", syncId: "sw-l", _deletedAt: null,
+        createdAt: older, updatedAt: older,
+      });
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Crash Left", p: `${PH}xb`, at: OLD }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      const first = await sync.sync();
+
+      // The record drained, the pair held back one cycle and reported.
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect(queue?.entries ?? []).toEqual([]);
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-l" }))?.name).toBe("Crash Left");
+      expect(first.find((r) => r.collection === "bedtypes")?.error).toMatch(/held back/i);
+
+      // No record left ⇒ the very next cycle converges normally.
+      sync.destroy(); sync = makeSync();
+      const second = await sync.sync();
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-l" }))?.name).toBe(
+        "Crash Left (edited)",
+      );
+      expect(second.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+    });
+
+    /**
      * The multi-writer race (Codex P2): two services share one database, and
      * an entry is durable BEFORE its row is staged. A concurrent sweep that
      * judged a YOUNG entry would misread the enqueue-to-update window — the

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1646,6 +1646,46 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * The young-holding case (Codex P1): youth defers the destructive verbs,
+     * not inspection. A settlement-taken stranding re-observed five minutes
+     * later sits well under the fifteen-minute bound — and skipping it
+     * entirely left its syncId unquarantined, so an edit while stranded let
+     * LWW copy the placeholder to the peer anyway.
+     */
+    it("quarantines a YOUNG entry whose row already holds the placeholder", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      // Edited while stranded — the LWW winner. The entry is FRESH.
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: `${PH}x8`, material: "PEI", syncId: "sw-i", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Shelf E", material: "PEI", syncId: "sw-i", _deletedAt: null,
+        createdAt: older, updatedAt: older,
+      });
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf E2", p: `${PH}x8`, at: new Date() }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      // The peer's name survives, the stranding is reported, and the row and
+      // record are both UNTOUCHED — youth forbids restore and drain alike.
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-i" }))?.name).toBe("Shelf E");
+      expect((await localDb.collection("bedtypes").findOne({ syncId: "sw-i" }))?.name).toBe(`${PH}x8`);
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect((queue?.entries ?? []).length).toBe(1);
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toMatch(/rename it back manually/i);
+    });
+
+    /**
      * The free-form-name case (Codex P2): a user may name a row with the
      * placeholder PREFIX. The backstop must not touch it — not rename it to
      * its peer's value, not report it — because acting on recognition is

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1523,19 +1523,23 @@ describe("SyncService — v1.12 sync expansion", () => {
      * row still holds its original name — as "resolved" and drain the record
      * the owning pass is about to depend on. Age is the discriminator.
      */
-    it("leaves a YOUNG entry alone even when the row looks resolved", async () => {
+    it("holds a YOUNG entry's pair back without touching the record", async () => {
       const localDb = localClient.db("filament-db");
       const remoteDb = remoteClient.db("filament-db");
-      const same = new Date(Date.now() - 60_000);
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
 
-      // The window shape: row holds its ORIGINAL name; the entry is fresh.
+      // The window shape: row holds its ORIGINAL name, the entry is fresh —
+      // and the row is the LWW winner, so pre-quarantine it would have synced
+      // mid-window (Codex P1: the owner can stage between the sweep and the
+      // slim reads, at which point the backstop is blinded by coveredIds).
       const { insertedId } = await localDb.collection("bedtypes").insertOne({
-        name: "Mid Stage", material: "PEI", syncId: "sw-e", _deletedAt: null,
-        createdAt: same, updatedAt: same,
+        name: "Mid Stage (edited)", material: "PEI", syncId: "sw-e", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
       });
       await remoteDb.collection("bedtypes").insertOne({
         name: "Mid Stage", material: "PEI", syncId: "sw-e", _deletedAt: null,
-        createdAt: same, updatedAt: same,
+        createdAt: older, updatedAt: older,
       });
       await localDb.collection("_migrations").updateOne(
         { _id: QUEUE_ID as never },
@@ -1544,12 +1548,15 @@ describe("SyncService — v1.12 sync expansion", () => {
       );
 
       sync = makeSync();
-      await sync.sync();
+      const results = await sync.sync();
 
       // The entry SURVIVES — only a dead pass's entries are the sweep's to
-      // judge, and this one is younger than the bound.
+      // judge — and the PAIR sat the cycle out: the peer keeps its name
+      // despite losing LWW, with the hold-back reported honestly.
       const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect((queue?.entries ?? []).length).toBe(1);
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-e" }))?.name).toBe("Mid Stage");
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toMatch(/held back this cycle/i);
     });
 
     /**

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1732,6 +1732,53 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * The literal $pull (Codex P2): a bare document operand is a MATCH
+     * CONDITION, so dropping a malformed `{c: "bedtypes"}` subset would pull
+     * every valid entry for the collection along with itself.
+     */
+    it("drops a malformed queue entry without taking valid ones with it", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      // A valid stranded entry the sweep must keep judging...
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: `${PH}xa`, material: "PEI", syncId: "sw-k", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: `${PH}xa`, material: "PEI", syncId: "sw-k", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      for (const db of [localDb, remoteDb]) {
+        await db.collection("bedtypes").insertOne({
+          name: "Shelf G", material: "PEI", syncId: "sw-k-occ", _deletedAt: null,
+          createdAt: same, updatedAt: same,
+        });
+      }
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [
+          // ...and a malformed subset that, as a bare $pull operand, would
+          // match the valid entry too.
+          { c: "bedtypes" },
+          { c: "bedtypes", i: String(insertedId), o: "Shelf G", p: `${PH}xa`, at: OLD },
+        ] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      await sync.sync();
+
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      const entries = (queue?.entries ?? []) as Array<Record<string, unknown>>;
+      // The malformed one is gone; the valid one SURVIVES (still stranded —
+      // its original name is taken — so it stays queued for retry).
+      expect(entries.length).toBe(1);
+      expect(entries[0].i).toBe(String(insertedId));
+    });
+
+    /**
      * The free-form-name case (Codex P2): a user may name a row with the
      * placeholder PREFIX. The backstop must not touch it — not rename it to
      * its peer's value, not report it — because acting on recognition is

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1521,7 +1521,7 @@ describe("SyncService — v1.12 sync expansion", () => {
       });
 
       sync = makeSync();
-      await sync.sync();
+      const results = await sync.sync();
 
       expect((await localDb.collection("bedtypes").findOne({ syncId: "sw-c" }))?.name).toBe("Drybox 4");
       for (const db of [localDb, remoteDb]) {
@@ -1529,6 +1529,16 @@ describe("SyncService — v1.12 sync expansion", () => {
           await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
         ).toBe(0);
       }
+      // The healed pair holds this cycle (Codex P1 round 17: another service
+      // can stage the row right after the heal, with the scan finished and
+      // coveredIds blind) — reported as a hold, not a collision — and the
+      // next cycle is clean.
+      const err = results.find((r) => r.collection === "bedtypes")?.error;
+      expect(err).toMatch(/adopted the name/i);
+      expect(err).not.toMatch(/Rename one of them/);
+      sync.destroy(); sync = makeSync();
+      const second = await sync.sync();
+      expect(second.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
     });
 
     /**

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1323,6 +1323,9 @@ describe("SyncService — v1.12 sync expansion", () => {
   describe("leftover staging placeholders are swept on the next cycle (GH #1153)", () => {
     const PH = "__sync-staging-deadbeef-";
     const QUEUE_ID = "renameStagingRestores";
+    /** Older than SWEEP_MIN_AGE_MS — the sweep only judges DEAD passes'
+     *  entries; a young one may belong to a pass alive on another service. */
+    const OLD = new Date(Date.now() - 20 * 60 * 1000);
 
     /**
      * The crash case: a prior pass staged a row, wrote its durable restore
@@ -1344,7 +1347,7 @@ describe("SyncService — v1.12 sync expansion", () => {
       });
       await localDb.collection("_migrations").updateOne(
         { _id: QUEUE_ID as never },
-        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf A", p: `${PH}x1` }] } },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf A", p: `${PH}x1`, at: OLD }] } },
         { upsert: true },
       );
 
@@ -1388,7 +1391,7 @@ describe("SyncService — v1.12 sync expansion", () => {
       ]);
       await localDb.collection("_migrations").updateOne(
         { _id: QUEUE_ID as never },
-        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf B", p: `${PH}x2` }] } },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf B", p: `${PH}x2`, at: OLD }] } },
         { upsert: true },
       );
 
@@ -1443,6 +1446,42 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * The multi-writer race (Codex P2): two services share one database, and
+     * an entry is durable BEFORE its row is staged. A concurrent sweep that
+     * judged a YOUNG entry would misread the enqueue-to-update window — the
+     * row still holds its original name — as "resolved" and drain the record
+     * the owning pass is about to depend on. Age is the discriminator.
+     */
+    it("leaves a YOUNG entry alone even when the row looks resolved", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      // The window shape: row holds its ORIGINAL name; the entry is fresh.
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: "Mid Stage", material: "PEI", syncId: "sw-e", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Mid Stage", material: "PEI", syncId: "sw-e", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Mid Stage", p: `${PH}x5`, at: new Date() }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      await sync.sync();
+
+      // The entry SURVIVES — only a dead pass's entries are the sweep's to
+      // judge, and this one is younger than the bound.
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect((queue?.entries ?? []).length).toBe(1);
+    });
+
+    /**
      * The human-rename case: the row no longer holds the placeholder, so the
      * stale entry drains without touching the row.
      */
@@ -1461,7 +1500,7 @@ describe("SyncService — v1.12 sync expansion", () => {
       });
       await localDb.collection("_migrations").updateOne(
         { _id: QUEUE_ID as never },
-        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Old Name", p: `${PH}x4` }] } },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Old Name", p: `${PH}x4`, at: OLD }] } },
         { upsert: true },
       );
 

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1553,6 +1553,52 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * The versioned drain (Codex P2): a sweeper judges a SNAPSHOT, and the
+     * owner can stage + re-assert between that snapshot and the $pull. The
+     * drain must match the observed stamp, or it removes the FRESH record —
+     * and a later owner crash leaves the placeholder without its
+     * authoritative original name. Simulated at the unit of the race: the
+     * row is mid-window (holds its original name), the entry is OLD at the
+     * sweep's read, and a re-asserted twin with a fresh stamp sits in the
+     * queue — the aged drain must remove only what it observed.
+     */
+    it("drains only the stamp it observed, never a re-asserted entry", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: "Resolved", material: "PEI", syncId: "sw-g", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Resolved", material: "PEI", syncId: "sw-g", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      const fresh = new Date();
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [
+          // The aged entry the sweep will judge resolved (row holds "Resolved",
+          // not the placeholder) and drain...
+          { c: "bedtypes", i: String(insertedId), o: "Resolved", p: `${PH}x6`, at: OLD },
+          // ...and the re-asserted twin — same key, fresh stamp — that must
+          // SURVIVE, exactly as it would mid-race.
+          { c: "bedtypes", i: String(insertedId), o: "Resolved", p: `${PH}x6`, at: fresh },
+        ] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      await sync.sync();
+
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      const entries = (queue?.entries ?? []) as Array<{ at: Date }>;
+      expect(entries.length).toBe(1);
+      expect(entries[0].at.getTime()).toBe(fresh.getTime());
+    });
+
+    /**
      * The free-form-name case (Codex P2): a user may name a row with the
      * placeholder PREFIX. The backstop must not touch it — not rename it to
      * its peer's value, not report it — because acting on recognition is

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1475,7 +1475,10 @@ describe("SyncService — v1.12 sync expansion", () => {
       const first = await sync.sync();
       // Reported and FAILED — the placeholder is visible in the UI and the
       // collection must not read as green around it.
-      expect(first.find((r) => r.collection === "bedtypes")?.error).toMatch(/rename it back manually/i);
+      const firstTakenErr = first.find((r) => r.collection === "bedtypes")?.error;
+      expect(firstTakenErr).toMatch(/rename it back manually/i);
+      // Self-describing stranding, no false collision preamble (round 18).
+      expect(firstTakenErr).not.toMatch(/Rename one of them/);
       const kept = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect((kept?.entries ?? []).length).toBe(1);
 
@@ -1762,13 +1765,20 @@ describe("SyncService — v1.12 sync expansion", () => {
       sync = makeSync();
       const results = await sync.sync();
 
-      // The peer's name survives, the stranding is reported, and the row and
-      // record are both UNTOUCHED — youth forbids restore and drain alike.
+      // The peer's name survives and the row and record are both UNTOUCHED —
+      // youth forbids restore and drain alike. The report is a HOLD, not a
+      // stranding (Codex P2, round 18): this state is usually a healthy owner
+      // between staging and settlement, and telling the user to rename a row
+      // the owner is about to fix was a false prescription. A crash-stranded
+      // row ages into the real stranding text at the bound.
       expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-i" }))?.name).toBe("Shelf E");
       expect((await localDb.collection("bedtypes").findOne({ syncId: "sw-i" }))?.name).toBe(`${PH}x8`);
       const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect((queue?.entries ?? []).length).toBe(1);
-      expect(results.find((r) => r.collection === "bedtypes")?.error).toMatch(/rename it back manually/i);
+      const err = results.find((r) => r.collection === "bedtypes")?.error;
+      expect(err).toMatch(/mid-rename by another sync service/i);
+      expect(err).not.toMatch(/rename it back manually/i);
+      expect(err).not.toMatch(/Rename one of them/);
     });
 
     /**

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1935,6 +1935,128 @@ describe("SyncService — v1.12 sync expansion", () => {
       const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect(queue?.entries ?? []).toEqual([]);
     });
+
+    /** Pin every entries-emptying `$pull` on `_migrations` to a rejection.
+     *  `moderate` is the trick: validation applies only to documents that
+     *  ALREADY satisfy the validator, so the pre-seeded `entries: []` doc is
+     *  non-conforming and every enqueue passes freely — but once an entry
+     *  lands the doc conforms, and any update that would empty it (the
+     *  drains) is rejected. Deterministic, no mocking. */
+    const failEmptyingDrains = async (db: import("mongodb").Db) => {
+      // Upsert, not insert — the doc survives across tests on the shared servers.
+      await db.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [] } },
+        { upsert: true },
+      );
+      await db.command({
+        collMod: "_migrations",
+        validator: { $or: [{ _id: { $ne: QUEUE_ID } }, { "entries.0": { $exists: true } }] },
+        validationLevel: "moderate",
+        validationAction: "error",
+      });
+    };
+    const allowDrains = async (db: import("mongodb").Db) => {
+      await db.command({ collMod: "_migrations", validator: {}, validationLevel: "off" });
+    };
+
+    /**
+     * Codex P2, round 21: settlement drained its queue entry and IGNORED the
+     * result, so a landed rename whose `_migrations` cleanup failed reported
+     * SUCCESS — while the live entry made every later cycle fail as "being
+     * renamed by another sync service", for the age window or forever.
+     * The cycle that leaves the record behind must be the one that says so.
+     */
+    it("reports a settlement whose queue record could not be cleared, then converges", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 60_000);
+      const newer = new Date();
+
+      // The proven swap seed — local newer, so the remote adopts the swap and
+      // the staging (and its queue entry) happens on the REMOTE.
+      await localDb.collection("bedtypes").insertMany([
+        { name: "X", material: "PEI", syncId: "dq-a", _deletedAt: null, createdAt: older, updatedAt: newer },
+        { name: "Y", material: "PEI", syncId: "dq-b", _deletedAt: null, createdAt: older, updatedAt: newer },
+      ]);
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Y", material: "PEI", syncId: "dq-a", _deletedAt: null, createdAt: older, updatedAt: older },
+        { name: "X", material: "PEI", syncId: "dq-b", _deletedAt: null, createdAt: older, updatedAt: older },
+      ]);
+      await failEmptyingDrains(remoteDb);
+
+      try {
+        sync = makeSync();
+        const results = await sync.sync();
+
+        // The swap itself RESOLVED (both writes landed, no placeholder left)…
+        expect((await remoteDb.collection("bedtypes").findOne({ syncId: "dq-a" }))?.name).toBe("X");
+        expect((await remoteDb.collection("bedtypes").findOne({ syncId: "dq-b" }))?.name).toBe("Y");
+        expect(
+          await remoteDb.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+
+        // …but the cycle must NOT report success: the queue record survived.
+        const err = results.find((r) => r.collection === "bedtypes")?.error;
+        expect(err).toMatch(/pending rename record could not be cleared/i);
+        expect(err).not.toMatch(/Rename one of them/);
+        const queue = await remoteDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+        expect((queue?.entries ?? []).length).toBe(1);
+      } finally {
+        await allowDrains(remoteDb);
+      }
+
+      // Age the leftover record past the sweep window; the next cycle's aged
+      // sweep clears it (holding the pair back once more), and the one after
+      // is clean.
+      await remoteDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { "entries.$[].at": OLD } },
+      );
+      sync.destroy(); sync = makeSync();
+      const second = await sync.sync();
+      expect(second.find((r) => r.collection === "bedtypes")?.error).toMatch(
+        /pending rename record/i,
+      );
+      sync.destroy(); sync = makeSync();
+      const third = await sync.sync();
+      expect(third.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+      const drained = await remoteDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect(drained?.entries ?? []).toEqual([]);
+    });
+
+    /**
+     * The sweep's own restore has the same obligation (round 21 class sweep):
+     * a restored placeholder whose record failed to drain must say so, not
+     * claim a clean "synced on the next".
+     */
+    it("says when a swept restore could not clear its record", async () => {
+      const localDb = localClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: `${PH}dq1`, material: "PEI", syncId: "dq-c", _deletedAt: null,
+        createdAt: same, updatedAt: same,
+      });
+      await failEmptyingDrains(localDb);
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $push: { entries: { c: "bedtypes", i: String(insertedId), o: "Shelf Q", p: `${PH}dq1`, at: OLD } } as never },
+      );
+
+      try {
+        sync = makeSync();
+        const results = await sync.sync();
+
+        // Restored — but honestly reported as un-drained.
+        expect((await localDb.collection("bedtypes").findOne({ syncId: "dq-c" }))?.name).toBe("Shelf Q");
+        const err = results.find((r) => r.collection === "bedtypes")?.error;
+        expect(err).toMatch(/was restored to .*but its pending rename record could not be cleared/i);
+        expect(err).not.toMatch(/synced on the next/i);
+      } finally {
+        await allowDrains(localDb);
+      }
+    });
   });
 
   describe("purge zombies are repaired on BOTH peers before the trim (GH #1116)", () => {

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1552,7 +1552,10 @@ describe("SyncService — v1.12 sync expansion", () => {
       const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect(queue?.entries ?? []).toEqual([]);
       expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-l" }))?.name).toBe("Crash Left");
-      expect(first.find((r) => r.collection === "bedtypes")?.error).toMatch(/held back/i);
+      const firstErr = first.find((r) => r.collection === "bedtypes")?.error;
+      expect(firstErr).toMatch(/held back/i);
+      expect(firstErr).toMatch(/was cleared/i); // the drain succeeded, and the notice says so
+      expect(firstErr).not.toMatch(/Rename one of them/);
 
       // No record left ⇒ the very next cycle converges normally.
       sync.destroy(); sync = makeSync();
@@ -1603,7 +1606,11 @@ describe("SyncService — v1.12 sync expansion", () => {
       const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect((queue?.entries ?? []).length).toBe(1);
       expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-e" }))?.name).toBe("Mid Stage");
-      expect(results.find((r) => r.collection === "bedtypes")?.error).toMatch(/held back this cycle/i);
+      const err = results.find((r) => r.collection === "bedtypes")?.error;
+      expect(err).toMatch(/held back this cycle/i);
+      // Informational, not a collision: the "Rename one of them" preamble
+      // would be a false diagnosis for a pair that converges by itself.
+      expect(err).not.toMatch(/Rename one of them/);
     });
 
     /**

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1426,12 +1426,20 @@ describe("SyncService — v1.12 sync expansion", () => {
       expect(row?.name).toBe("Shelf A");
       const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect(queue?.entries ?? []).toEqual([]);
-      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
       for (const db of [localDb, remoteDb]) {
         expect(
           await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
         ).toBe(0);
       }
+      // The restored pair holds back for THIS cycle (the uniform window
+      // rule: every queue entry over a live row quarantines its pair) with
+      // an honest informational notice, then converges on the next.
+      const err = results.find((r) => r.collection === "bedtypes")?.error;
+      expect(err).toMatch(/was restored to/i);
+      expect(err).not.toMatch(/Rename one of them/);
+      sync.destroy(); sync = makeSync();
+      const second = await sync.sync();
+      expect(second.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
     });
 
     /**
@@ -1481,7 +1489,14 @@ describe("SyncService — v1.12 sync expansion", () => {
       sync.destroy(); sync = makeSync();
       const second = await sync.sync();
       expect((await localDb.collection("bedtypes").findOne({ syncId: "sw-b" }))?.name).toBe("Shelf B");
-      expect(second.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+      // The restoring cycle holds the pair back (uniform window rule) with
+      // the informational notice; the THIRD cycle is fully clean.
+      const secondErr = second.find((r) => r.collection === "bedtypes")?.error;
+      expect(secondErr).toMatch(/was restored to/i);
+      expect(secondErr).not.toMatch(/Rename one of them/);
+      sync.destroy(); sync = makeSync();
+      const third = await sync.sync();
+      expect(third.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
     });
 
     /**

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1553,6 +1553,53 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * The quarantine (Codex P2): reporting an unresolved placeholder is not
+     * enough — the row still entered the row loop, and a user edit bumping
+     * its updatedAt while stranded made the placeholder the LWW WINNER,
+     * copying `__sync-staging-…` over the peer's legitimate name. A stranded
+     * row sits out the cycle entirely.
+     */
+    it("does not let an edited stranded row copy its placeholder to the peer", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date();
+
+      // The stranded row was EDITED while stranded — newer than its peer.
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: `${PH}x7`, material: "PEI", syncId: "sw-h", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Shelf D", material: "PEI", syncId: "sw-h", _deletedAt: null,
+        createdAt: older, updatedAt: older,
+      });
+      // The original name is TAKEN, so the sweep cannot restore.
+      for (const db of [localDb, remoteDb]) {
+        await db.collection("bedtypes").insertOne({
+          name: "Shelf D2", material: "PEI", syncId: "sw-h-occ", _deletedAt: null,
+          createdAt: older, updatedAt: older,
+        });
+      }
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf D2", p: `${PH}x7`, at: OLD }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      // The peer's legitimate name SURVIVES — the stranded row sat the cycle
+      // out despite being the LWW winner — and the stranding is reported.
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "sw-h" }))?.name).toBe("Shelf D");
+      expect(
+        await remoteDb.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+      ).toBe(0);
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toMatch(/rename it back manually/i);
+    });
+
+    /**
      * The versioned drain (Codex P2): a sweeper judges a SNAPSHOT, and the
      * owner can stage + re-assert between that snapshot and the $pull. The
      * drain must match the observed stamp, or it removes the FRESH record —

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1686,6 +1686,52 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
 
     /**
+     * Resolved by deletion (Codex P2): a user may deal with a stranded row by
+     * trashing it. The name no longer needs restoring — but quarantining the
+     * pair blocked the one thing that still matters: the tombstone
+     * propagating to the peer, forever.
+     */
+    it("lets a trashed stranded row propagate its tombstone", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const deletedAt = new Date();
+
+      // Stranded (placeholder name, original taken), then TRASHED by the user.
+      const { insertedId } = await localDb.collection("bedtypes").insertOne({
+        name: `${PH}x9`, material: "PEI", syncId: "sw-j", _deletedAt: deletedAt,
+        createdAt: older, updatedAt: older,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Shelf F", material: "PEI", syncId: "sw-j", _deletedAt: null,
+        createdAt: older, updatedAt: older,
+      });
+      // The occupier that made the stranding permanent.
+      for (const db of [localDb, remoteDb]) {
+        await db.collection("bedtypes").insertOne({
+          name: "Shelf F2", material: "PEI", syncId: "sw-j-occ", _deletedAt: null,
+          createdAt: older, updatedAt: older,
+        });
+      }
+      await localDb.collection("_migrations").updateOne(
+        { _id: QUEUE_ID as never },
+        { $set: { entries: [{ c: "bedtypes", i: String(insertedId), o: "Shelf F2", p: `${PH}x9`, at: OLD }] } },
+        { upsert: true },
+      );
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      // The deletion reached the peer, the entry drained, and nothing about
+      // this row failed the collection.
+      const remote = await remoteDb.collection("bedtypes").findOne({ syncId: "sw-j" });
+      expect(remote?._deletedAt).not.toBeNull();
+      const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
+      expect(queue?.entries ?? []).toEqual([]);
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+    });
+
+    /**
      * The free-form-name case (Codex P2): a user may name a row with the
      * placeholder PREFIX. The backstop must not touch it — not rename it to
      * its peer's value, not report it — because acting on recognition is

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1425,8 +1425,11 @@ describe("SyncService — v1.12 sync expansion", () => {
       const remoteDb = remoteClient.db("filament-db");
       const same = new Date(Date.now() - 60_000);
 
+      // A CONFORMING generated shape — the backstop only acts on the full
+      // grammar now, and a propagated placeholder embeds the SOURCE row's id,
+      // which is why the check is not anchored to this row's own _id.
       await localDb.collection("bedtypes").insertOne({
-        name: `${PH}x3`, material: "PEI", syncId: "sw-c", _deletedAt: null,
+        name: "__sync-staging-deadbeef-64b7f0000000000000000001", material: "PEI", syncId: "sw-c", _deletedAt: null,
         createdAt: same, updatedAt: same,
       });
       await remoteDb.collection("bedtypes").insertOne({
@@ -1479,6 +1482,37 @@ describe("SyncService — v1.12 sync expansion", () => {
       // judge, and this one is younger than the bound.
       const queue = await localDb.collection("_migrations").findOne({ _id: QUEUE_ID as never });
       expect((queue?.entries ?? []).length).toBe(1);
+    });
+
+    /**
+     * The free-form-name case (Codex P2): a user may name a row with the
+     * placeholder PREFIX. The backstop must not touch it — not rename it to
+     * its peer's value, not report it — because acting on recognition is
+     * exactly why recognition must be the complete generated grammar.
+     */
+    it("leaves a user's prefix-shaped name entirely alone", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const same = new Date(Date.now() - 60_000);
+
+      // Same name on both peers, paired, equal timestamps: nothing should
+      // move, nothing should be reported.
+      for (const db of [localDb, remoteDb]) {
+        await db.collection("bedtypes").insertOne({
+          name: "__sync-staging-custom", material: "PEI", syncId: "sw-f", _deletedAt: null,
+          createdAt: same, updatedAt: same,
+        });
+      }
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      for (const db of [localDb, remoteDb]) {
+        expect((await db.collection("bedtypes").findOne({ syncId: "sw-f" }))?.name).toBe(
+          "__sync-staging-custom",
+        );
+      }
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
     });
 
     /**

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -348,3 +348,32 @@ describe("isDuplicateKeyError (GH #439, scoped to syncId per Codex on #464)", ()
     expect(isDuplicateKeyError(11000)).toBe(false);
   });
 });
+
+/**
+ * GH #1153 (Codex P2, several rounds of it): a quarantine without a report is
+ * a silently held-back pair under a green cycle — the posture violation the
+ * sweep exists to end, and it was reintroduced three separate times on three
+ * different branches. Pin it structurally: every quarantine site must have a
+ * user-facing notice within its lexical neighborhood.
+ */
+describe("every quarantine reports (source invariant)", () => {
+  it("finds a notice push near each quarantinedSyncIds.add", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync("electron/sync-service.ts", "utf8");
+    const offenders: number[] = [];
+    const re = /quarantinedSyncIds\.add\([^)]*\);/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) {
+      const after = src.slice(m.index + m[0].length, m.index + m[0].length + 500);
+      const before = src.slice(Math.max(0, m.index - 700), m.index);
+      const reports =
+        after.includes("sweptHoldbacks.push") ||
+        after.includes("sweptConflicts.push") ||
+        before.includes("sweptHoldbacks.push") ||
+        before.includes("sweptConflicts.push") ||
+        before.includes("strandedPlaceholderNotice");
+      if (!reports) offenders.push(src.slice(0, m.index).split("\n").length);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -390,4 +390,21 @@ describe("every quarantine reports (source invariant)", () => {
     const fallbacks = src.match(/was held back this cycle by placeholder recovery/g) ?? [];
     expect(fallbacks.length).toBe(2);
   });
+
+  it("the loop catch carries BOTH notice channels onto the thrown error", async () => {
+    // Codex P2, round 20: `trySync` keeps only the thrown message, and the
+    // post-loop rendering never runs on this path — so a catch that carried
+    // `strandedNotices` alone silently dropped every hold-back report for the
+    // cycle whenever an unrelated transfer threw later in the same pass. The
+    // path needs a mid-loop I/O failure, which a real driver cannot produce
+    // deterministically, so the composition is pinned at the source: the
+    // catch block must fold BOTH channels into the carried notice.
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync("electron/sync-service.ts", "utf8");
+
+    const catchStart = src.indexOf("} catch (loopErr) {");
+    expect(catchStart).toBeGreaterThan(-1);
+    const catchBlock = src.slice(catchStart, src.indexOf("throw loopErr;", catchStart));
+    expect(catchBlock).toContain("[...strandedNotices, ...sweptHoldbacks]");
+  });
 });

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -357,21 +357,102 @@ describe("isDuplicateKeyError (GH #439, scoped to syncId per Codex on #464)", ()
  * user-facing notice within its lexical neighborhood.
  */
 describe("every quarantine reports (source invariant)", () => {
-  it("finds a notice push near each quarantinedSyncIds.add", async () => {
+  it("finds a notice push inside each quarantine's own enclosing block", async () => {
     const { readFileSync } = await import("node:fs");
     const src = readFileSync("electron/sync-service.ts", "utf8");
+
+    // A byte-window version of this test accepted a NEIGHBOR branch's notice
+    // (Codex P2) — deleting one branch's push stayed green because the
+    // adjacent branch's push sat inside the window. So the association is
+    // structural: the notice must live in the same innermost `{...}` block
+    // as the quarantine. Brace matching must ignore braces inside comments,
+    // strings, and template literals (the notices themselves contain `${}`),
+    // hence the mini-lexer.
+    type Mode = "code" | "line" | "block" | "single" | "double" | "template";
+    const stack: number[] = [];
+    const blockOf = new Map<number, { open: number; close: number }>();
+    const spans: Array<{ open: number; close: number }> = [];
+    let mode: Mode = "code";
+    const templateDepth: number[] = []; // ${ nesting per template level
+    for (let k = 0; k < src.length; k++) {
+      const ch = src[k];
+      const next = src[k + 1];
+      if (mode === "line") {
+        if (ch === "\n") mode = "code";
+        continue;
+      }
+      if (mode === "block") {
+        if (ch === "*" && next === "/") { mode = "code"; k++; }
+        continue;
+      }
+      if (mode === "single" || mode === "double") {
+        if (ch === "\\") { k++; continue; }
+        if ((mode === "single" && ch === "'") || (mode === "double" && ch === '"')) mode = "code";
+        continue;
+      }
+      if (mode === "template") {
+        if (ch === "\\") { k++; continue; }
+        if (ch === "`") { mode = "code"; continue; }
+        if (ch === "$" && next === "{") {
+          templateDepth.push(1);
+          mode = "code";
+          k++;
+          continue;
+        }
+        continue;
+      }
+      // code
+      if (ch === "/" && next === "/") { mode = "line"; k++; continue; }
+      if (ch === "/" && next === "*") { mode = "block"; k++; continue; }
+      if (ch === "'") { mode = "single"; continue; }
+      if (ch === '"') { mode = "double"; continue; }
+      if (ch === "`") { mode = "template"; continue; }
+      if (ch === "{") {
+        if (templateDepth.length > 0) templateDepth[templateDepth.length - 1]++;
+        stack.push(k);
+        continue;
+      }
+      if (ch === "}") {
+        if (templateDepth.length > 0) {
+          const d = --templateDepth[templateDepth.length - 1];
+          if (d === 0) {
+            // Closing a ${ } — return to the template literal. The ${'s own
+            // brace was consumed without being pushed, so there is nothing to
+            // pop here; popping anyway corrupted the block structure of every
+            // function containing an interpolation (i.e. every notice).
+            templateDepth.pop();
+            mode = "template";
+            continue;
+          }
+        }
+        const open = stack.pop();
+        if (open !== undefined) spans.push({ open, close: k });
+        continue;
+      }
+    }
+    const innermostBlock = (pos: number) => {
+      let best: { open: number; close: number } | null = null;
+      for (const sp of spans) {
+        if (sp.open < pos && pos < sp.close) {
+          if (!best || sp.open > best.open) best = sp;
+        }
+      }
+      return best;
+    };
+    void blockOf;
+
     const offenders: number[] = [];
     const re = /quarantinedSyncIds\.add\([^)]*\);/g;
     let m: RegExpExecArray | null;
     while ((m = re.exec(src)) !== null) {
-      const after = src.slice(m.index + m[0].length, m.index + m[0].length + 500);
-      const before = src.slice(Math.max(0, m.index - 700), m.index);
+      // A braceless guarded add (`if (x) quarantinedSyncIds.add(x);`) belongs
+      // to its PARENT branch block, which the innermost-block lookup already
+      // yields, since the guard introduces no braces.
+      const block = innermostBlock(m.index);
+      const body = block ? src.slice(block.open, block.close) : "";
       const reports =
-        after.includes("sweptHoldbacks.push") ||
-        after.includes("sweptConflicts.push") ||
-        before.includes("sweptHoldbacks.push") ||
-        before.includes("sweptConflicts.push") ||
-        before.includes("strandedPlaceholderNotice");
+        body.includes("sweptHoldbacks.push") ||
+        body.includes("sweptConflicts.push");
       if (!reports) offenders.push(src.slice(0, m.index).split("\n").length);
     }
     expect(offenders).toEqual([]);

--- a/tests/sync-service.test.ts
+++ b/tests/sync-service.test.ts
@@ -357,104 +357,37 @@ describe("isDuplicateKeyError (GH #439, scoped to syncId per Codex on #464)", ()
  * user-facing notice within its lexical neighborhood.
  */
 describe("every quarantine reports (source invariant)", () => {
-  it("finds a notice push inside each quarantine's own enclosing block", async () => {
+  /**
+   * GH #1153, seventeen review rounds of which seven were "one more branch
+   * forgot an obligation". The sweep now HOISTS both obligations — quarantine
+   * at recognition, one central notice push per touched row with a generic
+   * fallback — so a branch structurally cannot skip either. This invariant
+   * pins that shape: any new branch-local `quarantinedSyncIds.add` or push
+   * site is a regression to per-branch discipline, which failed seven times.
+   */
+  it("the sweep has exactly two hoisted quarantine sites and two central pushes", async () => {
     const { readFileSync } = await import("node:fs");
     const src = readFileSync("electron/sync-service.ts", "utf8");
 
-    // A byte-window version of this test accepted a NEIGHBOR branch's notice
-    // (Codex P2) — deleting one branch's push stayed green because the
-    // adjacent branch's push sat inside the window. So the association is
-    // structural: the notice must live in the same innermost `{...}` block
-    // as the quarantine. Brace matching must ignore braces inside comments,
-    // strings, and template literals (the notices themselves contain `${}`),
-    // hence the mini-lexer.
-    type Mode = "code" | "line" | "block" | "single" | "double" | "template";
-    const stack: number[] = [];
-    const blockOf = new Map<number, { open: number; close: number }>();
-    const spans: Array<{ open: number; close: number }> = [];
-    let mode: Mode = "code";
-    const templateDepth: number[] = []; // ${ nesting per template level
-    for (let k = 0; k < src.length; k++) {
-      const ch = src[k];
-      const next = src[k + 1];
-      if (mode === "line") {
-        if (ch === "\n") mode = "code";
-        continue;
-      }
-      if (mode === "block") {
-        if (ch === "*" && next === "/") { mode = "code"; k++; }
-        continue;
-      }
-      if (mode === "single" || mode === "double") {
-        if (ch === "\\") { k++; continue; }
-        if ((mode === "single" && ch === "'") || (mode === "double" && ch === '"')) mode = "code";
-        continue;
-      }
-      if (mode === "template") {
-        if (ch === "\\") { k++; continue; }
-        if (ch === "`") { mode = "code"; continue; }
-        if (ch === "$" && next === "{") {
-          templateDepth.push(1);
-          mode = "code";
-          k++;
-          continue;
-        }
-        continue;
-      }
-      // code
-      if (ch === "/" && next === "/") { mode = "line"; k++; continue; }
-      if (ch === "/" && next === "*") { mode = "block"; k++; continue; }
-      if (ch === "'") { mode = "single"; continue; }
-      if (ch === '"') { mode = "double"; continue; }
-      if (ch === "`") { mode = "template"; continue; }
-      if (ch === "{") {
-        if (templateDepth.length > 0) templateDepth[templateDepth.length - 1]++;
-        stack.push(k);
-        continue;
-      }
-      if (ch === "}") {
-        if (templateDepth.length > 0) {
-          const d = --templateDepth[templateDepth.length - 1];
-          if (d === 0) {
-            // Closing a ${ } — return to the template literal. The ${'s own
-            // brace was consumed without being pushed, so there is nothing to
-            // pop here; popping anyway corrupted the block structure of every
-            // function containing an interpolation (i.e. every notice).
-            templateDepth.pop();
-            mode = "template";
-            continue;
-          }
-        }
-        const open = stack.pop();
-        if (open !== undefined) spans.push({ open, close: k });
-        continue;
-      }
-    }
-    const innermostBlock = (pos: number) => {
-      let best: { open: number; close: number } | null = null;
-      for (const sp of spans) {
-        if (sp.open < pos && pos < sp.close) {
-          if (!best || sp.open > best.open) best = sp;
-        }
-      }
-      return best;
-    };
-    void blockOf;
+    const adds = src.match(/quarantinedSyncIds\.add\(/g) ?? [];
+    expect(adds.length).toBe(2);
 
-    const offenders: number[] = [];
-    const re = /quarantinedSyncIds\.add\([^)]*\);/g;
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(src)) !== null) {
-      // A braceless guarded add (`if (x) quarantinedSyncIds.add(x);`) belongs
-      // to its PARENT branch block, which the innermost-block lookup already
-      // yields, since the guard introduces no braces.
-      const block = innermostBlock(m.index);
-      const body = block ? src.slice(block.open, block.close) : "";
-      const reports =
-        body.includes("sweptHoldbacks.push") ||
-        body.includes("sweptConflicts.push");
-      if (!reports) offenders.push(src.slice(0, m.index).split("\n").length);
-    }
-    expect(offenders).toEqual([]);
+    const centralPushes =
+      src.match(/\(notice\.hold \? sweptHoldbacks : sweptConflicts\)\.push\(notice\.text\);/g) ?? [];
+    expect(centralPushes.length).toBe(2);
+
+    // ZERO direct pushes inside the sweep loops — branches assign `notice`;
+    // only the central ternary sites push. A direct `sweptX.push(` inside a
+    // branch is the regression this invariant exists to block.
+    const sweepRegion = src.slice(
+      src.indexOf("for (const entry of entries)"),
+      src.indexOf("const SLIM_PROJECTION"),
+    );
+    const branchPushes = (sweepRegion.match(/swept(Holdbacks|Conflicts)\.push\(/g) ?? []).length;
+    expect(branchPushes).toBe(0);
+
+    // The silence fallback exists in both loops.
+    const fallbacks = src.match(/was held back this cycle by placeholder recovery/g) ?? [];
+    expect(fallbacks.length).toBe(2);
   });
 });


### PR DESCRIPTION
Fixes #1153.

The staging mechanism restored its own placeholders at the end of each pass, but the original name lived only in that pass's memory — so a settlement `taken`, a settlement throw, or a process death between staging and settlement left the row named `__sync-staging-…` forever: loudly reported (post-#1142), manually recoverable only. This was the one piece of the staging design with no automatic recovery.

## Durable queue

A restore record `{collection, id, originalName, placeholder}` is written to the `_migrations` doc `renameStagingRestores` **before** the row is moved aside — the observation-before-destructive-write ordering the #1021 runner established — on the **same database** as the staged row, so each DB's queue describes its own rows. An enqueue failure refuses the staging outright: a reported name conflict beats an unrecoverable placeholder.

## Drain: two sites, not five

The triage plan called for five dequeue points. It collapsed to two, because settlement already visits every staged row on every exit path and is the one place that knows how each ended: the zero-match branch dequeues (nothing was written, settlement never sees that row), and settlement dequeues on every no-placeholder outcome — landed, rolled back, human-renamed, restored, moved on — keeping the entry **only** on `taken` and its catch, exactly the strandings the sweep exists to retry.

## Sweep

At the top of every `syncCollection` pass, **before the slim reads**, so a restored name participates in the pass's LWW graph and staging plan rather than the placeholder doing so. A still-taken original name is counted and named every cycle and **fails the collection** (the #1142 posture, confirmed as the product call: a reported, recoverable stall beats an invisible one) until a human renames the occupier — after which the next cycle heals without help.

## Grammar backstop

Rows matching the placeholder grammar with **no** queue entry (pre-#1153 strandings; cross-peer propagated placeholders) restore to the syncId-paired peer's name — what the staged row's own write would have delivered. The decision table is the pure, tested `placeholderRestoreTarget`: the queue beats the peer; a peer that is itself a placeholder is refused (both sides stranded — adopting it copies the disease, not the cure); no answer means REPORT, never guess, because inventing a name is a product decision this machinery is not allowed to make (auto-suffixing was considered and rejected in triage).

## Verification

Failing-before: all four integration cases fail on the pre-change code — the placeholder survives, the queue never drains, the backstop never heals. The taken-name case additionally pins the two-cycle story: reported+failed on cycle one, healed on cycle two after the occupier renames. Coverage gate green: 210 files / 4554 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)