### PR TITLE
fix(sync): a resurrect can stage its movable blocker

### DIFF
--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -1866,15 +1866,18 @@ export class SyncService extends EventEmitter {
      * which downgrades the case to "unsatisfiable, reported" rather than
      * risking a stranded placeholder.
      *
-     * ## The property this actually has (Codex P1, second pass)
+     * ## The property this actually has (Codex P1, second pass; GH #1151)
      *
      * Not "it mirrors the loop exactly" — it does not, and claiming so is how
-     * the previous version drifted. The true, scoped claim is: FOR A ROW THAT
-     * IS LIVE ON `col` — the only rows `stageableOn` can ask about, since its
-     * filter is the index predicate — the only branch that rewrites the name
-     * is the both-active LWW one. The purge branch writes flags only;
-     * delete-propagation writes `_deletedAt` only; and both resurrect arms
-     * write on the DELETED side, which that same filter excludes.
+     * the previous version drifted. The true, scoped claim: for a row LIVE on
+     * `col`, the only branch that rewrites its name is the both-active LWW
+     * one (purge and delete-propagation write flags only); and for a row
+     * DELETED on `col`, the only name-writing branch is the resurrect — the
+     * live peer's body replacing the tombstoned one when the deletion
+     * strictly loses (the complement of the loop's GH #317 `>=` delete-wins
+     * rule). Both are modeled; everything else answers null. The deleted-side
+     * answer feeds `stageableOn`'s REQUESTER intents (`holdsName: false`),
+     * never its holders.
      *
      * The guards below therefore have to use the LOOP's classifications, not
      * lookalikes: `_purged === true` and `_deletedAt != null`, matching the
@@ -1891,7 +1894,10 @@ export class SyncService extends EventEmitter {
      * delete or purge frees the name in the same pass without renaming, so
      * treating that pair as a permanent holder stalls the collection once
      * (and cascade-skips its dependents) before converging cleanly. That is
-     * the trade this function was always making; it is not free.
+     * the trade this function was always making; it is not free. (The
+     * delete-PROPAGATION arm — a live holder about to be tombstoned,
+     * vacating its name without a rename — remains deliberately unmodeled:
+     * staging bets on a pending WRITE, and a tombstone has none.)
      */
     const desiredNameOn = (col: typeof localCol, syncId: string): string | null => {
       const localDoc = localBySyncId.get(syncId);
@@ -1900,7 +1906,26 @@ export class SyncService extends EventEmitter {
       // Purge first, mirroring the loop's branch order — its purge arm is
       // tested before either delete arm and writes no name at all.
       if (localDoc._purged === true || remoteDoc._purged === true) return null;
-      if (localDoc._deletedAt != null || remoteDoc._deletedAt != null) return null;
+      const localDeleted = localDoc._deletedAt != null;
+      const remoteDeleted = remoteDoc._deletedAt != null;
+      if (localDeleted && remoteDeleted) return null; // both trashed: no write
+      if (localDeleted !== remoteDeleted) {
+        // Resurrect arms (GH #1151). One side deleted: the loop either
+        // propagates the tombstone (deletion wins, GH #317 `>=` — a FLAG
+        // write, no name) or resurrects, replacing the DELETED side's body
+        // with the live side's — name included. So a name is written only on
+        // the deleted side's col, and only when the deletion strictly LOSES.
+        // NaN-safe `?? 0` mirrors the loop's own arithmetic (a raw
+        // `_deletedAt: ""` reads as time zero and loses to any real edit).
+        const deletedIsLocal = localDeleted;
+        if ((deletedIsLocal ? localCol : remoteCol) !== col) return null;
+        const deleted = deletedIsLocal ? localDoc : remoteDoc;
+        const live = deletedIsLocal ? remoteDoc : localDoc;
+        const deletedAt = SyncService.readTimestamp(deleted._deletedAt) ?? 0;
+        const liveTime = SyncService.readUpdatedAt(live) ?? 0;
+        if (deletedAt >= liveTime) return null; // delete wins: flags only
+        return typeof live.name === "string" ? live.name : null;
+      }
 
       const localTime = SyncService.readUpdatedAt(localDoc) ?? 0;
       const remoteTime = SyncService.readUpdatedAt(remoteDoc) ?? 0;
@@ -1930,38 +1955,51 @@ export class SyncService extends EventEmitter {
       if (cached) return cached;
       const docs = col === remoteCol ? remoteDocs : localDocs;
       const intents = docs
-        // INDEXED rows only (Codex P1, twice). The unique index is partial on
-        // `_deletedAt: null`, so a trashed row named "X" does NOT occupy that
-        // slot — GH #213 name reuse depends on it. Letting one into the graph
-        // made it the "holder" whenever it sorted first, and a trashed row
-        // never vacates, so the fixpoint declared the whole chain immovable
-        // and refused a swap that was perfectly resolvable — every cycle.
-        //
-        // The predicate is MongoDB's own, not JS truthiness. `{_deletedAt:
-        // null}` matches null AND missing and nothing else, so a raw
-        // `_deletedAt: ""` — which Mongoose casts to null on a Date path but
-        // the driver stores verbatim, the shape `trimEntityNames` documents at
-        // its own `== null` test — is OUTSIDE the index. `!d._deletedAt` let
-        // that row in as a holder, reintroducing the immovable-chain stall for
-        // a row that could never have blocked the write in the first place.
-        .filter((d) => d._deletedAt == null && typeof d.name === "string")
-        .map((d) => {
+        .filter((d) => typeof d.name === "string")
+        .flatMap((d) => {
           const syncId = typeof d.syncId === "string" ? d.syncId : null;
           const desired = syncId ? desiredNameOn(col, syncId) : null;
           // Round 23 (Codex P1): a QUARANTINED row's name-carrying write is
           // blocked at the row-loop gate this cycle, so the plan must not
-          // bet on it. willWrite: true here let an earlier pair stage the
-          // quarantined row aside and take its name — then the gate skipped
-          // the promised write and settlement could not restore (the name
-          // was occupied). It stays in the graph as a HOLDER (it really does
-          // occupy its index slot); it just cannot vacate.
+          // bet on it — for either role.
           const blocked = syncId !== null && quarantinedSyncIds.has(syncId);
-          return {
-            id: String(d._id),
-            currentName: d.name as string,
-            desiredName: desired ?? (d.name as string),
-            willWrite: desired !== null && !blocked,
-          };
+          // The HOLDER role is scoped to INDEXED rows only (Codex P1, twice).
+          // The unique index is partial on `_deletedAt: null`, so a trashed
+          // row named "X" does NOT occupy that slot — GH #213 name reuse
+          // depends on it. Letting one in as a holder made it win the
+          // first-holder slot and "never vacate", declaring resolvable
+          // chains immovable every cycle. The predicate is MongoDB's own,
+          // not JS truthiness: `{_deletedAt: null}` matches null AND missing
+          // only, so a raw `_deletedAt: ""` is OUTSIDE the index.
+          if (d._deletedAt == null) {
+            return [
+              {
+                id: String(d._id),
+                currentName: d.name as string,
+                desiredName: desired ?? (d.name as string),
+                willWrite: desired !== null && !blocked,
+              },
+            ];
+          }
+          // GH #1151 — the REQUESTER role for rows the holder filter
+          // excludes: a soft-deleted row this pass will resurrect writes the
+          // live peer's name onto this col, so the planner must see the
+          // request (or a movable holder of that name is never staged and
+          // the resurrect takes the nameConflicts exit, cascade-skipping
+          // dependents). `holdsName: false`: it occupies no index slot, can
+          // never block, can never be staged aside. Deleted rows with no
+          // predicted resurrect are omitted entirely — they neither hold
+          // nor request.
+          if (desired === null) return [];
+          return [
+            {
+              id: String(d._id),
+              currentName: d.name as string,
+              desiredName: desired,
+              willWrite: !blocked,
+              holdsName: false as const,
+            },
+          ];
         });
       const plan = planRenameStaging(intents, stagingNonce);
       const ids = new Set(plan.staged.map((st) => st.id));

--- a/src/lib/renameStaging.ts
+++ b/src/lib/renameStaging.ts
@@ -59,6 +59,14 @@ export interface RenameIntent {
   /** False for a row that is present but not being written this pass. It can
    *  still block a name, and it can never be staged out of the way. */
   willWrite: boolean;
+  /**
+   * False for a row OUTSIDE the partial unique index — a soft-deleted row
+   * this pass will RESURRECT (GH #1151). Such a row may REQUEST a name (its
+   * resurrect writes the peer's name onto it) but holds no index slot: it can
+   * never block another write and can never be staged aside. Default true —
+   * every pre-#1151 intent is a holder, byte-identical behavior.
+   */
+  holdsName?: boolean;
 }
 
 export interface StagedRename {
@@ -150,6 +158,12 @@ export function planRenameStaging(
   // the FIRST holder wins the slot — matching what the index would enforce.
   const holderByName = new Map<string, RenameIntent>();
   for (const row of rows) {
+    // A non-holder must never win the first-holder-wins slot (GH #1151): a
+    // deleted row named "X" would shadow the REAL active holder that
+    // legitimately shares the name under the partial index (GH #213 reuse),
+    // and a non-holder "never vacates", so the fixpoint would wrongly
+    // declare the chain immovable.
+    if (row.holdsName === false) continue;
     if (!holderByName.has(row.currentName)) holderByName.set(row.currentName, row);
   }
 
@@ -173,7 +187,12 @@ export function planRenameStaging(
    */
   const canVacate = new Set<string>();
   for (const row of rows) {
-    if (row.willWrite && row.desiredName !== row.currentName) canVacate.add(row.id);
+    // For a NON-holder, "vacate" is vacuous — the set means "its write can
+    // proceed" (GH #1151). A resurrect restoring its own stored name still
+    // needs the index slot, so the desired!==current test is holder-only.
+    if (row.willWrite && (row.holdsName === false || row.desiredName !== row.currentName)) {
+      canVacate.add(row.id);
+    }
   }
 
   // A CONTESTED destination poisons every row that desires it (Codex P1).
@@ -195,7 +214,11 @@ export function planRenameStaging(
   // cannot rely on it vacating, and is knocked out by the ordinary rule.
   const desireCount = new Map<string, number>();
   for (const row of rows) {
-    if (row.willWrite && row.desiredName !== row.currentName) {
+    // Same predicate as the canVacate seed (GH #1151): a resurrect
+    // contesting a destination with a rename must poison BOTH — the
+    // stranding-safety argument above applies identically, and there is
+    // still no principled winner.
+    if (row.willWrite && (row.holdsName === false || row.desiredName !== row.currentName)) {
       desireCount.set(row.desiredName, (desireCount.get(row.desiredName) ?? 0) + 1);
     }
   }
@@ -222,7 +245,10 @@ export function planRenameStaging(
   const stagedIds = new Set<string>();
   for (const row of rows) {
     if (!row.willWrite) continue;
-    if (row.desiredName === row.currentName) continue;
+    // desired === current is a no-op only for a HOLDER (it already owns the
+    // slot). A non-holder resurrecting under its own stored name (GH #1151,
+    // the common trash-restore shape) still needs the slot freed.
+    if (row.holdsName !== false && row.desiredName === row.currentName) continue;
 
     const holder = holderByName.get(row.desiredName);
     if (!holder || holder.id === row.id) continue;

--- a/tests/renameStaging.test.ts
+++ b/tests/renameStaging.test.ts
@@ -383,3 +383,76 @@ describe("isGeneratedPlaceholder", () => {
     expect(isGeneratedPlaceholder(null)).toBe(false);
   });
 });
+
+describe("planRenameStaging — requester/holder role split (GH #1151)", () => {
+  const N = "cafebabe";
+
+  it("stages a movable holder for a NON-holder requester, even under its own stored name", async () => {
+    // The common trash-restore shape: the deleted row resurrects under the
+    // very name it already stores — the old desired===current skip discarded
+    // exactly this request.
+    const plan = planRenameStaging(
+      [
+        { id: "dead", currentName: "X", desiredName: "X", willWrite: true, holdsName: false },
+        { id: "hold", currentName: "X", desiredName: "Y", willWrite: true },
+      ],
+      N,
+    );
+    expect(plan.staged.map((s) => s.id)).toEqual(["hold"]);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("refuses a NON-holder requester against an immovable holder", async () => {
+    const plan = planRenameStaging(
+      [
+        { id: "dead", currentName: "X", desiredName: "X", willWrite: true, holdsName: false },
+        { id: "hold", currentName: "X", desiredName: "X", willWrite: false },
+      ],
+      N,
+    );
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable).toEqual([{ id: "dead", desiredName: "X", heldBy: "hold" }]);
+  });
+
+  it("a non-holder never blocks: a rename into its currentName sees a free destination", async () => {
+    const plan = planRenameStaging(
+      [
+        { id: "dead", currentName: "Z", desiredName: "Q", willWrite: true, holdsName: false },
+        { id: "mover", currentName: "A", desiredName: "Z", willWrite: true },
+      ],
+      N,
+    );
+    // Nothing to stage and nothing unsatisfiable — "Z" is not held.
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable).toEqual([]);
+  });
+
+  it("a non-holder sorted FIRST cannot shadow the real holder of its name", async () => {
+    const plan = planRenameStaging(
+      [
+        // Deleted row named "X" first — must NOT win the first-holder slot.
+        { id: "dead", currentName: "X", desiredName: "X", willWrite: false, holdsName: false },
+        { id: "hold", currentName: "X", desiredName: "Y", willWrite: true },
+        { id: "mover", currentName: "B", desiredName: "X", willWrite: true },
+      ],
+      N,
+    );
+    // The REAL holder is movable, so the mover's request stages it.
+    expect(plan.staged.map((s) => s.id)).toEqual(["hold"]);
+  });
+
+  it("a resurrect contesting a destination with a rename refuses BOTH", async () => {
+    const plan = planRenameStaging(
+      [
+        { id: "dead", currentName: "X", desiredName: "X", willWrite: true, holdsName: false },
+        { id: "mover", currentName: "B", desiredName: "X", willWrite: true },
+        { id: "hold", currentName: "X", desiredName: "Y", willWrite: true },
+      ],
+      N,
+    );
+    // No principled winner between the resurrect and the rename: neither may
+    // stage the holder, both are reported.
+    expect(plan.staged).toEqual([]);
+    expect(plan.unsatisfiable.map((u) => u.id).sort()).toEqual(["dead", "mover"]);
+  });
+});

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1320,6 +1320,142 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
   });
 
+  describe("a resurrect can stage its movable blocker (GH #1151)", () => {
+    /**
+     * THE headline: restoring a filament from the trash on one peer, where
+     * its name was meanwhile taken by a row that is itself about to be
+     * renamed. Pre-#1151 the resurrect was invisible to the staging planner
+     * (the intent filter excluded deleted rows), so this reported "Rename
+     * one of them" and cascade-skipped dependents for a conflict the
+     * machinery could resolve — in ONE cycle, as pinned here.
+     */
+    it("resolves a resurrect whose name is held by a movable row, in one cycle", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date(Date.now() - 60_000);
+
+      // Pair rs-a: local trashed at `older`; remote live, edited at `newer`
+      // → the deletion loses, so the pass resurrects LOCAL rs-a as "X".
+      await localDb.collection("bedtypes").insertOne({
+        name: "X stale", material: "PEI", syncId: "rs-a",
+        _deletedAt: older, createdAt: older, updatedAt: older,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "X", material: "PEI", syncId: "rs-a", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+      // Pair rs-b: LOCAL holds "X" but its own LWW renames it to "Y"
+      // (remote newer) — a perfectly movable blocker.
+      await localDb.collection("bedtypes").insertOne({
+        name: "X", material: "PEI", syncId: "rs-b", _deletedAt: null,
+        createdAt: older, updatedAt: older,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "Y", material: "PEI", syncId: "rs-b", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+      const a = await localDb.collection("bedtypes").findOne({ syncId: "rs-a" });
+      expect(a?._deletedAt).toBeNull();
+      expect(a?.name).toBe("X");
+      expect((await localDb.collection("bedtypes").findOne({ syncId: "rs-b" }))?.name).toBe("Y");
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+      const queue = await localDb.collection("_migrations").findOne({ _id: "renameStagingRestores" as never });
+      expect(queue?.entries ?? []).toEqual([]);
+    });
+
+    it("resolves the mirror direction (resurrect on the REMOTE)", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date(Date.now() - 60_000);
+
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "M stale", material: "PEI", syncId: "rm-a",
+        _deletedAt: older, createdAt: older, updatedAt: older,
+      });
+      await localDb.collection("bedtypes").insertOne({
+        name: "M", material: "PEI", syncId: "rm-a", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "M", material: "PEI", syncId: "rm-b", _deletedAt: null,
+        createdAt: older, updatedAt: older,
+      });
+      await localDb.collection("bedtypes").insertOne({
+        name: "N", material: "PEI", syncId: "rm-b", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeUndefined();
+      const a = await remoteDb.collection("bedtypes").findOne({ syncId: "rm-a" });
+      expect(a?._deletedAt).toBeNull();
+      expect(a?.name).toBe("M");
+      expect((await remoteDb.collection("bedtypes").findOne({ syncId: "rm-b" }))?.name).toBe("N");
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+    });
+
+    it("still refuses a resurrect against a genuinely immovable holder", async () => {
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const older = new Date(Date.now() - 120_000);
+      const newer = new Date(Date.now() - 60_000);
+
+      await localDb.collection("bedtypes").insertOne({
+        name: "K stale", material: "PEI", syncId: "im-a",
+        _deletedAt: older, createdAt: older, updatedAt: older,
+      });
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "K", material: "PEI", syncId: "im-a", _deletedAt: null,
+        createdAt: older, updatedAt: newer,
+      });
+      // The holder's pair is at EQUAL timestamps — no write, immovable.
+      const same = new Date(Date.now() - 90_000);
+      await localDb.collection("bedtypes").insertOne({
+        name: "K", material: "PEI", syncId: "im-b", _deletedAt: null,
+        createdAt: older, updatedAt: same,
+      });
+      // Same timestamp = no write in either direction, so the holder is
+      // immovable no matter what the remote copy is named (it must differ
+      // here anyway: the remote's unique index already has im-a's "K").
+      await remoteDb.collection("bedtypes").insertOne({
+        name: "K remote", material: "PEI", syncId: "im-b", _deletedAt: null,
+        createdAt: older, updatedAt: same,
+      });
+
+      sync = makeSync();
+      const results = await sync.sync();
+
+      // Reported, not resolved — and nothing was staged or clobbered.
+      expect(results.find((r) => r.collection === "bedtypes")?.error).toBeDefined();
+      expect(
+        (await localDb.collection("bedtypes").findOne({ syncId: "im-a" }))?._deletedAt,
+      ).not.toBeNull();
+      expect((await localDb.collection("bedtypes").findOne({ syncId: "im-b" }))?.name).toBe("K");
+      for (const db of [localDb, remoteDb]) {
+        expect(
+          await db.collection("bedtypes").countDocuments({ name: { $regex: "^__sync-staging-" } }),
+        ).toBe(0);
+      }
+    });
+  });
+
   describe("unreadable tombstones are healed and never spread (GH #1152)", () => {
     /**
      * The raw-driver `_deletedAt: ""` shape sits between the engine's two


### PR DESCRIPTION
Fixes #1151 — a resurrect could never be staged for, so a movable name conflict still stalled the collection.

`stageableOn` built ONE intent array filtered to the partial index's predicate — correct for the HOLDER role, but it structurally excluded the resurrecting row (by definition the deleted one). `planRenameStaging` therefore never saw the request, the movable blocker was never staged, and a trash-restore whose name was meanwhile taken by a row itself about to be renamed reported "Rename one of them" and cascade-skipped dependents — for a conflict the machinery could resolve in one cycle.

**Planner** (`src/lib/renameStaging.ts`): `RenameIntent.holdsName` (default true — all 35 pre-existing planner tests pass byte-identically). Four mechanical changes, each with its rationale in place: non-holders never win the first-holder-wins slot (a deleted "X" must not shadow the real active holder — GH #213 name reuse); the `canVacate`/`desireCount` predicates treat a non-holder's entry as "its write can proceed" (a resurrect restoring its own stored name still needs the slot — the old `desired===current` skip discarded exactly the common trash-restore shape); and a resurrect contesting a destination with a rename refuses BOTH ("no principled winner", per the triage decision).

**Predictor** (`electron/sync-service.ts`): `desiredNameOn` models the resurrect arms — a name is written only on the DELETED side's col and only when the deletion strictly loses (the complement of the loop's GH #317 `>=` delete-wins rule, NaN-safe so a raw `_deletedAt: ""` reads as time zero). `stageableOn` emits requester intents (`holdsName: false`) for deleted rows with a predicted resurrect; the round-23 quarantine exclusion applies to both roles; both stale single-role docblocks rewritten. Deliberately NOT modeled (flagged in the docblock): the delete-propagation arm — staging bets on a pending write, and a tombstone has none.

**Safety asymmetry** that keeps this low-risk: requester-side over-claims are inert (staging still requires a real E11000 plus the fresh-source `pendingRenameCanFreeName` proof of the BLOCKER's pending rename); the dangerous holder-side claims are untouched. The `_deletedAt: ""` blocker and purge-zombie holder tests pass unchanged — the requester arm only ever targets the deleted side's own col.

**Tests**: five planner cases + three integration scenarios (headline one-cycle resolution, mirror direction, immovable holder still refused with nothing staged and nothing clobbered). Failing-before verified: with the requester arm removed, both headline tests reproduce the old stall while the immovable-holder pin stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)