### PR TITLE
Bump version to 1.77.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filament-db",
-  "version": "1.76.0",
+  "version": "1.77.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filament-db",
-      "version": "1.76.0",
+      "version": "1.77.0",
       "license": "(AGPL-3.0-or-later AND CC-BY-NC-ND-4.0)",
       "dependencies": {
         "@pokusew/pcsclite": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filament-db",
-  "version": "1.76.0",
+  "version": "1.77.0",
   "description": "Desktop and web app for managing 3D printing filament profiles",
   "author": {
     "name": "hyiger",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Filament DB API",
     "description": "REST API for managing 3D printing filament profiles, spools, nozzles, printers, bed types, locations, print history, sharing, slicer integrations, and OpenPrintTag imports.",
-    "version": "1.76.0",
+    "version": "1.77.0",
     "license": {
       "name": "AGPL-3.0-or-later",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
Version bump across the three canonical spots (package.json, package-lock.json ×2, public/openapi.json) for the v1.77.0 release — the manual equivalent of release-bump.yml (403 with this token), auto-merged on CI green per the documented bump flow.

Shipping since v1.76.0: the Data health page (#1149), OPT unlink/change-link (#1150), URL-shareable filter state (#1141), and the hybrid-sync hardening batch (#1142/#1143/#1151–#1155 across PRs #1145–#1163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)