### PR TITLE
feat(sync): surface hybrid-REMOTE name conflicts

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1189,6 +1189,9 @@ ipcMain.handle("get-sync-status", (event) => {
     lastSyncAt: null,
     error: null,
     progress: null,
+      // GH #1164: mode switches destroy the service, so the field resets
+      // with it — an absent list must not read as a stale one.
+      nameConflicts: [],
   };
 });
 

--- a/electron/nfc-service.ts
+++ b/electron/nfc-service.ts
@@ -31,7 +31,6 @@ import {
   resolveNtagEraseSize,
   NTAG_NAME_TO_NDEF_BYTES,
   NTAG_PHYSICAL_LAST_PAGE,
-  NTAG216_MAX_NDEF_BYTES,
   type NtagSizeName,
 } from "../src/lib/ntagVersion";
 import {

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -13,6 +13,7 @@ import {
   type TrimNameConflict,
   trimEntityNames,
   describeTrimResult,
+  TRIMMABLE_COLLECTIONS,
   type MinimalTrimDb,
 } from "../src/lib/trimEntityNames";
 import {
@@ -515,12 +516,22 @@ export class SyncService extends EventEmitter {
     // Declared outside the try so the catch below can publish them: a cycle
     // that dies after the trim passes still knows what those passes saw.
     const trimConflicts: SyncNameConflict[] = [];
-    // Only a scan that covered BOTH peers AND every collection is
-    // publishable. A partial one — thrown, aborted mid-loop, or silent about
-    // a collection the trim skipped — would drop rows it never looked at,
-    // which is worse than the stale list it would replace.
-    let trimScanCompleted = false;
-    let trimSkipped = false;
+    // Which `side:collection` pairs the trim actually LOOKED at (Codex P2
+    // round 6). Publishability is per pair, not global: the snapshot is
+    // authoritative about what it scanned and silent about the rest, so a
+    // single skip must not suppress a fresh conflict another collection just
+    // found — that hid it indefinitely whenever the skip and the failure both
+    // repeated. A pair the pass skipped, or a side it threw on, keeps
+    // whatever the previous status said.
+    const scannedPairs = new Set<string>();
+    const pairKey = (side: string, collection: string) => `${side}:${collection}`;
+    /** Fresh rows for scanned pairs; the previous status for everything else. */
+    const mergeWithPrevious = (fresh: SyncNameConflict[]): SyncNameConflict[] => [
+      ...fresh,
+      ...(this.status.nameConflicts ?? []).filter(
+        (c) => !scannedPairs.has(pairKey(c.side, c.collection)),
+      ),
+    ];
 
     try {
       await local.connect();
@@ -726,15 +737,18 @@ export class SyncService extends EventEmitter {
         // A collection the pass SKIPPED has un-normalized names by
         // definition, and it doesn't know WHICH — so that one really is
         // collection-wide.
-        for (const sk of trimResult.skipped) conflictedCollections.add(sk.collection);
         // A skip means the pass never looked at that collection's rows at all
         // — it gave up before querying any candidate (Codex P2 round 4). The
-        // snapshot is therefore silent about it, and publishing that silence
-        // would erase a previously-reported conflict there rather than
-        // refresh it. Same rule as the abort below, for the same reason.
-        if (trimResult.skipped.length > 0) trimSkipped = true;
+        // snapshot is therefore silent about it rather than clean, so record
+        // only what was really scanned; everything else keeps the previous
+        // status's rows. A side this loop THROWS on records nothing, since
+        // the throw discards whatever it had found so far.
+        const skippedHere = new Set(trimResult.skipped.map((sk) => sk.collection));
+        for (const sk of trimResult.skipped) conflictedCollections.add(sk.collection);
+        for (const collection of TRIMMABLE_COLLECTIONS) {
+          if (!skippedHere.has(collection)) scannedPairs.add(pairKey(side, collection));
+        }
       }
-      trimScanCompleted = !this.aborted && !trimSkipped;
       // (GH #1164 round 2: the conflict list is published AFTER the
       // collection copies — see the rescan near the end of the cycle. This
       // pre-copy point is too early: a conflict the user resolved locally
@@ -1291,9 +1305,7 @@ export class SyncService extends EventEmitter {
         // and that never self-corrects.
         ...(rescanned
           ? { nameConflicts }
-          : trimScanCompleted
-            ? { nameConflicts: trimConflicts }
-            : {}),
+          : { nameConflicts: mergeWithPrevious(trimConflicts) }),
       });
 
       if (erroredAll) this.emit("syncError", summary ?? "Sync failed");
@@ -1309,7 +1321,9 @@ export class SyncService extends EventEmitter {
         // read, any collection copy — and the end-of-cycle rescan never runs.
         // Publish what the trim saw rather than leaving the previous list,
         // which the health page cannot correct on its own for the remote side.
-        ...(trimScanCompleted ? { nameConflicts: trimConflicts } : {}),
+        // A cycle that died BEFORE the trim scanned anything merges to exactly
+        // the previous list, which is the old behaviour.
+        nameConflicts: mergeWithPrevious(trimConflicts),
       });
       this.emit("syncError", safe);
       return [];

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -515,10 +515,12 @@ export class SyncService extends EventEmitter {
     // Declared outside the try so the catch below can publish them: a cycle
     // that dies after the trim passes still knows what those passes saw.
     const trimConflicts: SyncNameConflict[] = [];
-    // Only a scan that covered BOTH peers is publishable. A partial one
-    // (thrown or aborted mid-loop) would drop the unscanned side's rows,
+    // Only a scan that covered BOTH peers AND every collection is
+    // publishable. A partial one — thrown, aborted mid-loop, or silent about
+    // a collection the trim skipped — would drop rows it never looked at,
     // which is worse than the stale list it would replace.
     let trimScanCompleted = false;
+    let trimSkipped = false;
 
     try {
       await local.connect();
@@ -725,8 +727,14 @@ export class SyncService extends EventEmitter {
         // definition, and it doesn't know WHICH — so that one really is
         // collection-wide.
         for (const sk of trimResult.skipped) conflictedCollections.add(sk.collection);
+        // A skip means the pass never looked at that collection's rows at all
+        // — it gave up before querying any candidate (Codex P2 round 4). The
+        // snapshot is therefore silent about it, and publishing that silence
+        // would erase a previously-reported conflict there rather than
+        // refresh it. Same rule as the abort below, for the same reason.
+        if (trimResult.skipped.length > 0) trimSkipped = true;
       }
-      trimScanCompleted = !this.aborted;
+      trimScanCompleted = !this.aborted && !trimSkipped;
       // (GH #1164 round 2: the conflict list is published AFTER the
       // collection copies — see the rescan near the end of the cycle. This
       // pre-copy point is too early: a conflict the user resolved locally

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -9,6 +9,7 @@ import {
   type MinimalDb,
 } from "../src/lib/legacyNozzleConditions";
 import {
+  scanTrimConflicts,
   type TrimNameConflict,
   trimEntityNames,
   describeTrimResult,
@@ -590,8 +591,6 @@ export class SyncService extends EventEmitter {
        * trimmed form, so that is what gets blocked.
        */
       const conflictedNames = new Map<string, Set<string>>();
-    // GH #1164: the cycle's ACTIVE conflicts, side-tagged, for SyncStatus.
-    const cycleNameConflicts: SyncNameConflict[] = [];
 
       // GH #1116 — normalize entity names on BOTH sides before any copy.
       //
@@ -698,11 +697,6 @@ export class SyncService extends EventEmitter {
         // logged; it just doesn't stop anything.
         for (const c of trimResult.conflicts) {
           if (!c.active) continue;
-          // GH #1164: carry the enriched conflict to the renderer, tagged
-          // with its side. Same ACTIVE-only rule as the gate below — an
-          // inactive conflict is unresolvable and invisible in the UI, so
-          // reporting it would be noise the user cannot act on.
-          cycleNameConflicts.push({ ...c, side });
           // Block the NAMES, not the collection (second adversarial audit).
           // Both spellings: the stored one and the trimmed one it would have
           // become — a pairing can be attempted under either.
@@ -716,11 +710,11 @@ export class SyncService extends EventEmitter {
         // collection-wide.
         for (const sk of trimResult.skipped) conflictedCollections.add(sk.collection);
       }
-      // Publish AFTER both sides so a cycle reports one complete set, and
-      // wholesale so a resolved conflict disappears rather than lingering.
-      // Only cycles that REACH the trim phase update it — a pre-trim connect
-      // failure leaves the previous (still accurate) list alone.
-      this.updateStatus({ nameConflicts: cycleNameConflicts });
+      // (GH #1164 round 2: the conflict list is published AFTER the
+      // collection copies — see the rescan near the end of the cycle. This
+      // pre-copy point is too early: a conflict the user resolved locally
+      // is propagated to the peer by THIS cycle's copy, so publishing here
+      // reported a row that no longer exists until the next cycle.)
 
       // GH #1021 (Codex P2 r23 / r25 / r26 / r27): drain the durable
       // transit-clear queues on BOTH databases (a failed local enqueue falls
@@ -1238,11 +1232,34 @@ export class SyncService extends EventEmitter {
           .join(" | ");
       }
 
+      // GH #1164 round 2 (Codex P2): rescan AFTER the collection copies.
+      // The trim pass runs at the top of the cycle, but the copies below it
+      // propagate a locally-resolved rename to the peer — so a pre-copy
+      // snapshot reported conflicts this very cycle had just fixed. The
+      // rescan is READ-ONLY (scanTrimConflicts, #1149: no index build, no
+      // writes) and classifies identically to the migration, so the list
+      // reflects post-sync reality. Best-effort: a rescan failure leaves
+      // the previous list rather than failing an otherwise-good cycle.
+      const nameConflicts: SyncNameConflict[] = [];
+      let rescanned = false;
+      try {
+        for (const [side, dbHandle] of [["local", localDb], ["remote", remoteDb]] as const) {
+          const found = await scanTrimConflicts(dbHandle as unknown as MinimalTrimDb);
+          // ACTIVE only — same rule as the gate: an inactive conflict is
+          // permanent and invisible in the UI, nothing a user can act on.
+          for (const c of found) if (c.active) nameConflicts.push({ ...c, side });
+        }
+        rescanned = true;
+      } catch (rescanErr) {
+        console.warn("[sync] could not rescan name conflicts after the cycle.", rescanErr);
+      }
+
       this.updateStatus({
         state: erroredAll ? "error" : erroredSome ? "partial" : "idle",
         lastSyncAt: new Date().toISOString(),
         error: summary,
         progress: null,
+        ...(rescanned ? { nameConflicts } : {}),
       });
 
       if (erroredAll) this.emit("syncError", summary ?? "Sync failed");

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -9,6 +9,7 @@ import {
   type MinimalDb,
 } from "../src/lib/legacyNozzleConditions";
 import {
+  type TrimNameConflict,
   trimEntityNames,
   describeTrimResult,
   type MinimalTrimDb,
@@ -262,6 +263,15 @@ export function wrapSyncErrorMessage(err: unknown, dbName: string): string {
   return full.replace(/mongodb(\+srv)?:\/\/[^\s]+/g, "mongodb://***");
 }
 
+/**
+ * GH #1164: a trim-collision conflict the SYNC pass found, tagged with the
+ * side it lives on. The enriched shape (#1149's id/trimsTo/collidesWith)
+ * already exists at the trim call below and was discarded there — the Data
+ * health page can only scan the database the SERVER talks to, so a
+ * remote-only conflict was previously invisible to every surface.
+ */
+export type SyncNameConflict = TrimNameConflict & { side: "local" | "remote" };
+
 export interface SyncStatus {
   /**
    * "partial" (GH #369) means some collections succeeded and at least one
@@ -275,6 +285,14 @@ export interface SyncStatus {
   lastSyncAt: string | null;
   error: string | null;
   progress: string | null;
+  /**
+   * GH #1164: ACTIVE trim-collision conflicts seen in the last cycle that
+   * reached the trim phase, tagged local/remote. Refreshed wholesale each
+   * such cycle (so a resolved conflict disappears) and naturally empty on a
+   * clean database. Additive: it never gates anything — the collection
+   * gating still runs off `conflictedNames`, untouched.
+   */
+  nameConflicts: SyncNameConflict[];
 }
 
 interface SyncResult {
@@ -339,6 +357,7 @@ export class SyncService extends EventEmitter {
     lastSyncAt: null,
     error: null,
     progress: null,
+    nameConflicts: [],
   };
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private syncing = false;
@@ -571,6 +590,8 @@ export class SyncService extends EventEmitter {
        * trimmed form, so that is what gets blocked.
        */
       const conflictedNames = new Map<string, Set<string>>();
+    // GH #1164: the cycle's ACTIVE conflicts, side-tagged, for SyncStatus.
+    const cycleNameConflicts: SyncNameConflict[] = [];
 
       // GH #1116 — normalize entity names on BOTH sides before any copy.
       //
@@ -677,6 +698,11 @@ export class SyncService extends EventEmitter {
         // logged; it just doesn't stop anything.
         for (const c of trimResult.conflicts) {
           if (!c.active) continue;
+          // GH #1164: carry the enriched conflict to the renderer, tagged
+          // with its side. Same ACTIVE-only rule as the gate below — an
+          // inactive conflict is unresolvable and invisible in the UI, so
+          // reporting it would be noise the user cannot act on.
+          cycleNameConflicts.push({ ...c, side });
           // Block the NAMES, not the collection (second adversarial audit).
           // Both spellings: the stored one and the trimmed one it would have
           // become — a pairing can be attempted under either.
@@ -690,6 +716,11 @@ export class SyncService extends EventEmitter {
         // collection-wide.
         for (const sk of trimResult.skipped) conflictedCollections.add(sk.collection);
       }
+      // Publish AFTER both sides so a cycle reports one complete set, and
+      // wholesale so a resolved conflict disappears rather than lingering.
+      // Only cycles that REACH the trim phase update it — a pre-trim connect
+      // failure leaves the previous (still accurate) list alone.
+      this.updateStatus({ nameConflicts: cycleNameConflicts });
 
       // GH #1021 (Codex P2 r23 / r25 / r26 / r27): drain the durable
       // transit-clear queues on BOTH databases (a failed local enqueue falls

--- a/electron/sync-service.ts
+++ b/electron/sync-service.ts
@@ -512,6 +512,14 @@ export class SyncService extends EventEmitter {
       }
     };
 
+    // Declared outside the try so the catch below can publish them: a cycle
+    // that dies after the trim passes still knows what those passes saw.
+    const trimConflicts: SyncNameConflict[] = [];
+    // Only a scan that covered BOTH peers is publishable. A partial one
+    // (thrown or aborted mid-loop) would drop the unscanned side's rows,
+    // which is worse than the stale list it would replace.
+    let trimScanCompleted = false;
+
     try {
       await local.connect();
       await remote.connect();
@@ -697,6 +705,14 @@ export class SyncService extends EventEmitter {
         // logged; it just doesn't stop anything.
         for (const c of trimResult.conflicts) {
           if (!c.active) continue;
+          // Keep a copy for the ERROR path (Codex P2 round 3). The published
+          // list normally comes from the post-copy rescan at the end of the
+          // cycle, but a cycle that throws between here and there never
+          // reaches it — and the outer catch would then leave the PREVIOUS
+          // list standing. That silently loses every remote-only conflict:
+          // the health page's own scan reads the local database, which by
+          // definition has no copy of one.
+          trimConflicts.push({ ...c, side });
           // Block the NAMES, not the collection (second adversarial audit).
           // Both spellings: the stored one and the trimmed one it would have
           // become — a pairing can be attempted under either.
@@ -710,6 +726,7 @@ export class SyncService extends EventEmitter {
         // collection-wide.
         for (const sk of trimResult.skipped) conflictedCollections.add(sk.collection);
       }
+      trimScanCompleted = !this.aborted;
       // (GH #1164 round 2: the conflict list is published AFTER the
       // collection copies — see the rescan near the end of the cycle. This
       // pre-copy point is too early: a conflict the user resolved locally
@@ -1259,7 +1276,16 @@ export class SyncService extends EventEmitter {
         lastSyncAt: new Date().toISOString(),
         error: summary,
         progress: null,
-        ...(rescanned ? { nameConflicts } : {}),
+        // Rescan first; the trim snapshot only as a fallback when it failed.
+        // That snapshot is PRE-copy, so it can name a conflict this cycle's
+        // copies just resolved on the peer — over-reporting for one cycle,
+        // which self-corrects. Leaving a stale list under-reports instead,
+        // and that never self-corrects.
+        ...(rescanned
+          ? { nameConflicts }
+          : trimScanCompleted
+            ? { nameConflicts: trimConflicts }
+            : {}),
       });
 
       if (erroredAll) this.emit("syncError", summary ?? "Sync failed");
@@ -1267,7 +1293,16 @@ export class SyncService extends EventEmitter {
       return results;
     } catch (err) {
       const safe = wrapSyncErrorMessage(err, getDbNameFromUri(this.atlasUri));
-      this.updateStatus({ state: "error", error: safe, progress: null });
+      this.updateStatus({
+        state: "error",
+        error: safe,
+        progress: null,
+        // A cycle can die anywhere after the trim passes — the remote nozzle
+        // read, any collection copy — and the end-of-cycle rescan never runs.
+        // Publish what the trim saw rather than leaving the previous list,
+        // which the health page cannot correct on its own for the remote side.
+        ...(trimScanCompleted ? { nameConflicts: trimConflicts } : {}),
+      });
       this.emit("syncError", safe);
       return [];
     } finally {

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -128,16 +128,26 @@ export default function DataHealthPage() {
     // whenever a cycle finishes. `lastSyncAt` changing is exactly that
     // signal; progress ticks during a cycle carry the same value and are
     // ignored, so this cannot loop.
+    // `seenInitial` is a SEPARATE flag, not `lastSeenSync === null`
+    // (Codex P2): null is a legitimate stamp — the app mounts mid-initial-
+    // sync, or after connection failures, with lastSyncAt still null — and
+    // conflating "unset" with "null" made the first REAL completion look
+    // like the mount snapshot, so its refetch was skipped.
+    let seenInitial = false;
     let lastSeenSync: string | null = null;
     const apply = (st: { nameConflicts?: typeof syncConflicts; lastSyncAt?: string | null }) => {
       if (cancelled) return;
       setSyncConflicts(st.nameConflicts ?? []);
       const stamp = st.lastSyncAt ?? null;
-      if (stamp && stamp !== lastSeenSync) {
-        const first = lastSeenSync === null;
+      if (!seenInitial) {
+        // The mount snapshot itself — record it, refetch nothing.
+        seenInitial = true;
         lastSeenSync = stamp;
-        // Skip the very first observation: that IS the mount snapshot.
-        if (!first) void load();
+        return;
+      }
+      if (stamp !== lastSeenSync) {
+        lastSeenSync = stamp;
+        void load();
       }
     };
     (async () => {

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useToast } from "@/components/Toast";
@@ -75,19 +75,29 @@ export default function DataHealthPage() {
   const [renameValue, setRenameValue] = useState("");
   const [busy, setBusy] = useState(false);
 
+  // Every scan of /api/name-conflicts takes a ticket, and only the newest
+  // ticket may write (Codex P2). The mount scan and a completion-triggered
+  // refetch are independent requests with no ordering: mounting while a sync
+  // finishes, the mount request can capture the PRE-copy database and resolve
+  // LAST, overwriting the post-copy list — the newly copied conflict then
+  // stays missing until another sync or a reload.
+  const scanSeq = useRef(0);
+
   // Refetch helper for the ACTION handlers (event handlers, not effects —
   // the react-hooks/set-state-in-effect rule does not apply there).
   const load = useCallback(async () => {
+    const seq = ++scanSeq.current;
     try {
       const res = await fetch("/api/name-conflicts");
       if (!res.ok) throw new Error();
       const body = (await res.json()) as { conflicts: Conflict[] };
+      if (seq !== scanSeq.current) return;
       setConflicts(body.conflicts);
       setError(false);
     } catch {
-      setError(true);
+      if (seq === scanSeq.current) setError(true);
     } finally {
-      setLoading(false);
+      if (seq === scanSeq.current) setLoading(false);
     }
   }, []);
 
@@ -97,18 +107,20 @@ export default function DataHealthPage() {
   // pattern OptResyncDialog established; the CI lint proved the difference).
   useEffect(() => {
     let cancelled = false;
+    const seq = ++scanSeq.current;
+    const current = () => !cancelled && seq === scanSeq.current;
     (async () => {
       try {
         const res = await fetch("/api/name-conflicts");
         if (!res.ok) throw new Error();
         const body = (await res.json()) as { conflicts: Conflict[] };
-        if (cancelled) return;
+        if (!current()) return;
         setConflicts(body.conflicts);
         setError(false);
       } catch {
-        if (!cancelled) setError(true);
+        if (current()) setError(true);
       } finally {
-        if (!cancelled) setLoading(false);
+        if (current()) setLoading(false);
       }
     })();
     return () => {

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -139,10 +139,15 @@ export default function DataHealthPage() {
       lastSyncAt?: string | null;
       state?: string;
     };
+    // The rendered list needs the same yield-to-live rule as the watcher's
+    // baseline (Codex P2): a live event can beat this promise, and installing
+    // the older snapshot's conflicts afterwards would drop a remote-only
+    // conflict from the page until some later status arrived.
+    let sawLiveStatus = false;
     (async () => {
       try {
         const st = await api.getSyncStatus();
-        if (cancelled) return;
+        if (cancelled || sawLiveStatus) return;
         setSyncConflicts((st as StatusSample).nameConflicts ?? []);
         watcher.seed(st);
       } catch {
@@ -151,6 +156,7 @@ export default function DataHealthPage() {
     })();
     const unsub = api.onSyncStatusChange?.((st) => {
       if (cancelled) return;
+      sawLiveStatus = true;
       setSyncConflicts((st as StatusSample).nameConflicts ?? []);
       if (watcher.observe(st)) void load();
     });

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -58,6 +58,18 @@ export default function DataHealthPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [conflicts, setConflicts] = useState<Conflict[]>([]);
+  // GH #1164: conflicts the desktop sync service saw, side-tagged. The scan
+  // above only covers the database THIS server talks to (the local one in
+  // hybrid mode), so a remote-only conflict has no other surface anywhere.
+  const [syncConflicts, setSyncConflicts] = useState<
+    Array<{
+      collection: string;
+      name: string;
+      trimsTo: string | null;
+      collidesWith: { id: string; name: string } | null;
+      side: "local" | "remote";
+    }>
+  >([]);
   const [renaming, setRenaming] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const [busy, setBusy] = useState(false);
@@ -100,6 +112,29 @@ export default function DataHealthPage() {
     })();
     return () => {
       cancelled = true;
+    };
+  }, []);
+
+  // GH #1164, desktop only: the sync service's view of BOTH databases.
+  // Same IIFE shape as above for the set-state-in-effect rule.
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.getSyncStatus) return;
+    let cancelled = false;
+    const apply = (st: { nameConflicts?: typeof syncConflicts }) => {
+      if (!cancelled) setSyncConflicts(st.nameConflicts ?? []);
+    };
+    (async () => {
+      try {
+        apply(await api.getSyncStatus());
+      } catch {
+        /* status unavailable — the local scan above still stands */
+      }
+    })();
+    const unsub = api.onSyncStatusChange?.(apply);
+    return () => {
+      cancelled = true;
+      unsub?.();
     };
   }, []);
 
@@ -300,6 +335,44 @@ export default function DataHealthPage() {
           );
         })}
       </div>
+
+      {/* GH #1164: REMOTE-side conflicts, read-only. Local ones already
+          appear above with dependent counts and actions; listing them twice
+          would read as two different problems. Resolution differs by shape:
+          a pair that also exists locally is fixed above and propagates on
+          the next sync; a remote-ONLY row has no local twin to act on. */}
+      {syncConflicts.some((c) => c.side === "remote") && (
+        <section className="mt-8">
+          <h2 className="text-lg font-semibold mb-1">{t("health.remote.title")}</h2>
+          <p className="text-sm text-gray-500 mb-3">{t("health.remote.subtitle")}</p>
+          <div className="space-y-2">
+            {syncConflicts
+              .filter((c) => c.side === "remote")
+              .map((c) => (
+                <div
+                  key={`${c.collection}-${c.name}`}
+                  className="rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-950/20 p-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] uppercase font-semibold tracking-wider px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                      {t(`health.col.${c.collection}`)}
+                    </span>
+                    <code className="text-sm font-mono">{JSON.stringify(c.name)}</code>
+                  </div>
+                  <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                    {c.collidesWith
+                      ? t("health.conflict.takenBy", {
+                          trimsTo: JSON.stringify(c.trimsTo ?? ""),
+                          twin: JSON.stringify(c.collidesWith.name),
+                        })
+                      : t("health.conflict.emptyName")}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-1">{t("health.remote.hint")}</p>
+                </div>
+              ))}
+          </div>
+        </section>
+      )}
     </main>
   );
 }

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -135,20 +135,33 @@ export default function DataHealthPage() {
     // like the mount snapshot, so its refetch was skipped.
     let seenInitial = false;
     let lastSeenSync: string | null = null;
-    const apply = (st: { nameConflicts?: typeof syncConflicts; lastSyncAt?: string | null }) => {
+    let wasSyncing = false;
+    const apply = (st: {
+      nameConflicts?: typeof syncConflicts;
+      lastSyncAt?: string | null;
+      state?: string;
+    }) => {
       if (cancelled) return;
       setSyncConflicts(st.nameConflicts ?? []);
       const stamp = st.lastSyncAt ?? null;
+      const syncing = st.state === "syncing";
       if (!seenInitial) {
         // The mount snapshot itself — record it, refetch nothing.
         seenInitial = true;
         lastSeenSync = stamp;
+        wasSyncing = syncing;
         return;
       }
-      if (stamp !== lastSeenSync) {
-        lastSeenSync = stamp;
-        void load();
-      }
+      // A cycle ENDED if the stamp advanced OR we left the syncing state.
+      // The second clause matters for a FAILED cycle (Codex P2): the
+      // terminal error status keeps the previous lastSyncAt, yet earlier
+      // collections in that cycle may already have copied a remote
+      // conflict into the local database — so a stamp-only rule left the
+      // actionable list stale until some later success.
+      const ended = stamp !== lastSeenSync || (wasSyncing && !syncing);
+      lastSeenSync = stamp;
+      wasSyncing = syncing;
+      if (ended) void load();
     };
     (async () => {
       try {

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useToast } from "@/components/Toast";
 import { useConfirm } from "@/components/ConfirmDialog";
+import { createSyncCycleWatcher } from "@/lib/syncCycleWatcher";
 
 /**
  * GH #1149 — Data health: the trim-collision resolution surface.
@@ -128,49 +129,31 @@ export default function DataHealthPage() {
     // whenever a cycle finishes. `lastSyncAt` changing is exactly that
     // signal; progress ticks during a cycle carry the same value and are
     // ignored, so this cannot loop.
-    // `seenInitial` is a SEPARATE flag, not `lastSeenSync === null`
-    // (Codex P2): null is a legitimate stamp — the app mounts mid-initial-
-    // sync, or after connection failures, with lastSyncAt still null — and
-    // conflating "unset" with "null" made the first REAL completion look
-    // like the mount snapshot, so its refetch was skipped.
-    let seenInitial = false;
-    let lastSeenSync: string | null = null;
-    let wasSyncing = false;
-    const apply = (st: {
+    // The "did a cycle end?" rule lives in a pure, unit-tested module
+    // (Codex P2): this page has no test harness, and that rule has been
+    // wrong three separate ways, each time leaving the actionable list
+    // silently stale.
+    const watcher = createSyncCycleWatcher();
+    type StatusSample = {
       nameConflicts?: typeof syncConflicts;
       lastSyncAt?: string | null;
       state?: string;
-    }) => {
-      if (cancelled) return;
-      setSyncConflicts(st.nameConflicts ?? []);
-      const stamp = st.lastSyncAt ?? null;
-      const syncing = st.state === "syncing";
-      if (!seenInitial) {
-        // The mount snapshot itself — record it, refetch nothing.
-        seenInitial = true;
-        lastSeenSync = stamp;
-        wasSyncing = syncing;
-        return;
-      }
-      // A cycle ENDED if the stamp advanced OR we left the syncing state.
-      // The second clause matters for a FAILED cycle (Codex P2): the
-      // terminal error status keeps the previous lastSyncAt, yet earlier
-      // collections in that cycle may already have copied a remote
-      // conflict into the local database — so a stamp-only rule left the
-      // actionable list stale until some later success.
-      const ended = stamp !== lastSeenSync || (wasSyncing && !syncing);
-      lastSeenSync = stamp;
-      wasSyncing = syncing;
-      if (ended) void load();
     };
     (async () => {
       try {
-        apply(await api.getSyncStatus());
+        const st = await api.getSyncStatus();
+        if (cancelled) return;
+        setSyncConflicts((st as StatusSample).nameConflicts ?? []);
+        watcher.seed(st);
       } catch {
         /* status unavailable — the local scan above still stands */
       }
     })();
-    const unsub = api.onSyncStatusChange?.(apply);
+    const unsub = api.onSyncStatusChange?.((st) => {
+      if (cancelled) return;
+      setSyncConflicts((st as StatusSample).nameConflicts ?? []);
+      if (watcher.observe(st)) void load();
+    });
     return () => {
       cancelled = true;
       unsub?.();

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -121,8 +121,24 @@ export default function DataHealthPage() {
     const api = window.electronAPI;
     if (!api?.getSyncStatus) return;
     let cancelled = false;
-    const apply = (st: { nameConflicts?: typeof syncConflicts }) => {
-      if (!cancelled) setSyncConflicts(st.nameConflicts ?? []);
+    // A COMPLETED cycle can copy a remote-only conflict INTO the local
+    // database (Codex P2) — after which the pair belongs in the actionable
+    // list above, not the read-only remote section whose copy says "resolve
+    // it above". The local scan is a mount-time snapshot, so refetch it
+    // whenever a cycle finishes. `lastSyncAt` changing is exactly that
+    // signal; progress ticks during a cycle carry the same value and are
+    // ignored, so this cannot loop.
+    let lastSeenSync: string | null = null;
+    const apply = (st: { nameConflicts?: typeof syncConflicts; lastSyncAt?: string | null }) => {
+      if (cancelled) return;
+      setSyncConflicts(st.nameConflicts ?? []);
+      const stamp = st.lastSyncAt ?? null;
+      if (stamp && stamp !== lastSeenSync) {
+        const first = lastSeenSync === null;
+        lastSeenSync = stamp;
+        // Skip the very first observation: that IS the mount snapshot.
+        if (!first) void load();
+      }
     };
     (async () => {
       try {
@@ -136,7 +152,7 @@ export default function DataHealthPage() {
       cancelled = true;
       unsub?.();
     };
-  }, []);
+  }, [load]);
 
   const handleDelete = useCallback(
     async (c: Conflict) => {

--- a/src/app/settings/health/page.tsx
+++ b/src/app/settings/health/page.tsx
@@ -201,6 +201,10 @@ export default function DataHealthPage() {
     [renameValue, t, toast, load],
   );
 
+  // GH #1164: derived ONCE — the all-clear banner and the remote section
+  // must agree about what "remote conflicts exist" means.
+  const remoteConflicts = syncConflicts.filter((c) => c.side === "remote");
+
   return (
     <main id="main-content" className="max-w-3xl mx-auto px-4 py-8">
       <Link href="/settings" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
@@ -216,7 +220,11 @@ export default function DataHealthPage() {
       {!loading && error && (
         <p className="text-sm text-red-500">{t("health.error")}</p>
       )}
-      {!loading && !error && conflicts.length === 0 && (
+      {/* GH #1164 (Codex P2): the all-clear must account for BOTH databases.
+          With a clean local scan and a remote-only conflict — the primary
+          case this PR adds — the page otherwise rendered "your data is
+          healthy" directly above an amber conflict list. */}
+      {!loading && !error && conflicts.length === 0 && remoteConflicts.length === 0 && (
         <div className="rounded-lg border border-green-300 dark:border-green-800 bg-green-50 dark:bg-green-950/30 p-5">
           <p className="text-sm text-green-700 dark:text-green-400">{t("health.empty")}</p>
         </div>
@@ -341,14 +349,12 @@ export default function DataHealthPage() {
           would read as two different problems. Resolution differs by shape:
           a pair that also exists locally is fixed above and propagates on
           the next sync; a remote-ONLY row has no local twin to act on. */}
-      {syncConflicts.some((c) => c.side === "remote") && (
+      {remoteConflicts.length > 0 && (
         <section className="mt-8">
           <h2 className="text-lg font-semibold mb-1">{t("health.remote.title")}</h2>
           <p className="text-sm text-gray-500 mb-3">{t("health.remote.subtitle")}</p>
           <div className="space-y-2">
-            {syncConflicts
-              .filter((c) => c.side === "remote")
-              .map((c) => (
+            {remoteConflicts.map((c) => (
                 <div
                   key={`${c.collection}-${c.name}`}
                   className="rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50/50 dark:bg-amber-950/20 p-3"

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
+import Link from "next/link";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useDateFormat } from "@/hooks/useDateFormat";
 
@@ -10,6 +11,15 @@ interface SyncStatus {
   lastSyncAt: string | null;
   error: string | null;
   progress: string | null;
+  /** GH #1164: trim-collision conflicts the sync pass saw, side-tagged.
+   *  Optional — an older main process simply omits it. */
+  nameConflicts?: Array<{
+    collection: string;
+    name: string;
+    trimsTo: string | null;
+    collidesWith: { id: string; name: string } | null;
+    side: "local" | "remote";
+  }>;
 }
 
 function formatRelativeTime(iso: string, t: (key: string, params?: Record<string, string | number>) => string): string {
@@ -303,6 +313,32 @@ export default function SyncStatusIndicator() {
           {status.error && (
             <div className="text-red-600 dark:text-red-400 mb-2 break-words">
               <strong>{t("sync.tooltip.error")}:</strong> {status.error}
+            </div>
+          )}
+          {/* GH #1164: name conflicts the sync pass found — the ONLY surface
+              for one that exists solely on the remote database (the Data
+              health page scans the local side). Deliberately NOT wired into
+              the pill's state machine: "partial" means a collection failed
+              to sync, which these are not. */}
+          {(status.nameConflicts?.length ?? 0) > 0 && (
+            <div className="text-amber-600 dark:text-amber-400 mb-2 break-words">
+              <strong>{t("sync.tooltip.nameConflicts")}:</strong>{" "}
+              {t("sync.tooltip.nameConflicts.count", {
+                count: status.nameConflicts!.length,
+              })}
+              <ul className="mt-1 space-y-0.5">
+                {status.nameConflicts!.slice(0, 3).map((c) => (
+                  <li key={`${c.side}-${c.collection}-${c.name}`} className="font-mono text-[11px]">
+                    {c.side} · {c.collection} · {JSON.stringify(c.name)}
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href="/settings/health"
+                className="underline hover:no-underline mt-1 inline-block"
+              >
+                {t("sync.tooltip.nameConflicts.link")}
+              </Link>
             </div>
           )}
           <button

--- a/src/components/SyncStatusIndicator.tsx
+++ b/src/components/SyncStatusIndicator.tsx
@@ -101,11 +101,20 @@ export default function SyncStatusIndicator() {
       }
     });
 
+    // A live event can beat this promise (Codex P2, GH #1164). Adopting the
+    // older snapshot then rolls the indicator back to a pre-completion state
+    // — and with it the conflict count and its Data health link, which may be
+    // the only notice a remote-only conflict ever gets — until some later
+    // status arrives. So the mount snapshot yields to anything already seen.
+    let sawLiveStatus = false;
     api.getSyncStatus().then((s) => {
-      if (active) setStatus(s);
+      if (active && !sawLiveStatus) setStatus(s);
     });
 
-    const unsub1 = api.onSyncStatusChange(setStatus);
+    const unsub1 = api.onSyncStatusChange((s) => {
+      sawLiveStatus = true;
+      setStatus(s);
+    });
     const unsub2 = api.onConnectionModeFallback(() => {
       setIsFallback(true);
     });

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1838,5 +1838,11 @@
   "settings.nfcNtagSizeAmbiguous": "Dieser Leser kann die Tag-Größe nicht ermitteln, und Lesezugriffe belegen, dass es kein vollständiger NTAG216 ist — er ist entweder ein kleinerer NTAG oder passwortgeschützt (hier nicht unterscheidbar). Es wurde nichts gelöscht. Verwenden Sie NFC schreiben (das die Größe explizit setzt) oder einen Leser mit GET_VERSION-Unterstützung.",
   "settings.nfcNtagWriteRefused": "Der Tag hat den Schreibzugriff auf Seite {page} verweigert — er ist möglicherweise passwort-schreibgeschützt. Das Löschen ist UNVOLLSTÄNDIG: Seiten vor {page} wurden geleert, Daten ab Seite {page} sind noch vorhanden.",
   "analytics.jobsApiHint": "über die REST-API erfasst",
-  "form.maxVolumetricSpeed": "Max. volumetrische Geschwindigkeit (mm³/s)"
+  "form.maxVolumetricSpeed": "Max. volumetrische Geschwindigkeit (mm³/s)",
+  "sync.tooltip.nameConflicts": "Namenskonflikte",
+  "sync.tooltip.nameConflicts.count": "{count} Zeile(n), deren Name sich von einer anderen nur durch Leerzeichen unterscheidet",
+  "sync.tooltip.nameConflicts.link": "Datenzustand öffnen",
+  "health.remote.title": "Auf der anderen Datenbank",
+  "health.remote.subtitle": "Konflikte, die der Sync-Dienst auf der Datenbank gefunden hat, mit der diese App synchronisiert. Sie werden nur zur Information angezeigt — die Aktionen oben gelten für die Datenbank, mit der diese App verbunden ist.",
+  "health.remote.hint": "Erscheint dasselbe Paar auch oben, lösen Sie es dort — die Korrektur wird synchronisiert. Andernfalls lösen Sie es auf dem Rechner, dem jene Datenbank gehört."
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1838,5 +1838,11 @@
   "settings.nfcNtagSizeAmbiguous": "This reader can't size the tag, and reads prove it is not a full NTAG216 — it is either a smaller NTAG or password-protected (indistinguishable here). Nothing was erased. Use Write NFC, which sizes the tag explicitly, or a reader that supports GET_VERSION.",
   "settings.nfcNtagWriteRefused": "The tag refused the write at page {page} — it may be password write-protected. The erase is INCOMPLETE: pages before {page} were cleared, data from page {page} on remains.",
   "analytics.jobsApiHint": "recorded via the REST API",
-  "form.maxVolumetricSpeed": "Max Volumetric Speed (mm³/s)"
+  "form.maxVolumetricSpeed": "Max Volumetric Speed (mm³/s)",
+  "sync.tooltip.nameConflicts": "Name conflicts",
+  "sync.tooltip.nameConflicts.count": "{count} row(s) whose name differs from another only by whitespace",
+  "sync.tooltip.nameConflicts.link": "Open Data health",
+  "health.remote.title": "On the other database",
+  "health.remote.subtitle": "Conflicts the sync service found on the database this app syncs WITH. They are listed read-only — the actions above apply to the database this app is connected to.",
+  "health.remote.hint": "If the same pair also appears above, resolve it there and the fix syncs across. Otherwise resolve it on the machine that owns that database."
 }

--- a/src/lib/syncCycleWatcher.ts
+++ b/src/lib/syncCycleWatcher.ts
@@ -1,0 +1,84 @@
+/**
+ * "Did a sync cycle just end?" — the rule the Data health page uses to decide
+ * when to refetch its own local scan (GH #1164).
+ *
+ * Why this is a module and not four `let`s inside the effect: the page has no
+ * test harness in this repo, and the rule has now been wrong three separate
+ * ways — each time in a direction that left the actionable conflict list
+ * silently stale, which is the one failure mode the page exists to prevent.
+ * Pure and coverage-gated here, the way `ntagPages.ts` and `ntagVersion.ts`
+ * carry the arithmetic that `electron/` cannot test.
+ *
+ * The page's local scan is a mount-time snapshot, and a COMPLETED cycle can
+ * copy a remote-only conflict INTO the local database — after which the pair
+ * belongs in the actionable list, not the read-only remote section whose copy
+ * says "resolve it above". So every ending has to trigger a refetch.
+ */
+export interface SyncCycleSample {
+  lastSyncAt?: string | null;
+  state?: string;
+}
+
+export interface SyncCycleWatcher {
+  /**
+   * The mount snapshot (the resolved `getSyncStatus()` promise). It only
+   * establishes the baseline, and only when no live event has already done so:
+   * the promise can resolve AFTER an event and carry older values, which would
+   * rewind the baseline and cause a redundant refetch on the next event.
+   */
+  seed(sample: SyncCycleSample): void;
+  /** A live status event. Returns true when a cycle just ended. */
+  observe(sample: SyncCycleSample): boolean;
+}
+
+export function createSyncCycleWatcher(): SyncCycleWatcher {
+  // A SEPARATE flag, not `lastSeenSync === null`: null is a legitimate stamp
+  // — the app mounts mid-initial-sync, or after connection failures, with
+  // `lastSyncAt` still null — and conflating "unset" with "null" made the
+  // first REAL completion look like the mount snapshot, so its refetch was
+  // skipped.
+  let seenInitial = false;
+  let lastSeenSync: string | null = null;
+  let wasSyncing = false;
+
+  const read = (sample: SyncCycleSample) => ({
+    stamp: sample.lastSyncAt ?? null,
+    syncing: sample.state === "syncing",
+  });
+
+  return {
+    seed(sample) {
+      if (seenInitial) return;
+      const { stamp, syncing } = read(sample);
+      seenInitial = true;
+      lastSeenSync = stamp;
+      wasSyncing = syncing;
+    },
+
+    observe(sample) {
+      const { stamp, syncing } = read(sample);
+      // A live event is by definition post-mount, even one that beats the
+      // snapshot promise. Letting such an event claim the baseline swallowed
+      // the very completion the refetch exists for: the page's own fetch had
+      // already returned, and the snapshot resolving afterwards carried the
+      // same terminal stamp, so nothing ever triggered a reload. With no
+      // baseline yet, any non-syncing event IS a cycle that ended.
+      //
+      // Otherwise: a cycle ended if the stamp advanced OR we left the syncing
+      // state. The second clause is what covers a FAILED cycle — the terminal
+      // error status keeps the previous `lastSyncAt`, yet earlier collections
+      // in that cycle may already have copied a remote conflict across, so a
+      // stamp-only rule stayed stale until some later success.
+      //
+      // Progress ticks during a cycle carry the same stamp and are still
+      // syncing, so they report false and this cannot loop.
+      const ended = seenInitial
+        ? stamp !== lastSeenSync || (wasSyncing && !syncing)
+        : !syncing;
+      seenInitial = true;
+      lastSeenSync = stamp;
+      wasSyncing = syncing;
+      return ended;
+    },
+  };
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,6 +12,20 @@ interface ElectronAPI {
     lastSyncAt: string | null;
     error: string | null;
     progress: string | null;
+    /** GH #1164: ACTIVE trim-collision conflicts from the last sync cycle,
+     *  tagged with the database side they live on. Optional so an older
+     *  main process (no field) still typechecks against a newer renderer.
+     *  Keep in lockstep with SyncStatus in electron/sync-service.ts. */
+    nameConflicts?: Array<{
+      collection: string;
+      name: string;
+      id: string;
+      trimsTo: string | null;
+      reason: "collision" | "empty-name";
+      collidesWith: { id: string; name: string } | null;
+      active: boolean;
+      side: "local" | "remote";
+    }>;
   }>;
   triggerSync: () => Promise<{ results?: unknown[]; error?: string }>;
   checkAtlasConnectivity: () => Promise<{ connected: boolean }>;
@@ -23,6 +37,20 @@ interface ElectronAPI {
     lastSyncAt: string | null;
     error: string | null;
     progress: string | null;
+    /** GH #1164: ACTIVE trim-collision conflicts from the last sync cycle,
+     *  tagged with the database side they live on. Optional so an older
+     *  main process (no field) still typechecks against a newer renderer.
+     *  Keep in lockstep with SyncStatus in electron/sync-service.ts. */
+    nameConflicts?: Array<{
+      collection: string;
+      name: string;
+      id: string;
+      trimsTo: string | null;
+      reason: "collision" | "empty-name";
+      collidesWith: { id: string; name: string } | null;
+      active: boolean;
+      side: "local" | "remote";
+    }>;
   }) => void) => () => void;
   onConnectionModeFallback: (cb: (info: { intended: string; actual: string }) => void) => () => void;
   /** Fires after a hybrid-mode sync cycle completes (success or no-op).

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1456,6 +1456,74 @@ describe("SyncService — v1.12 sync expansion", () => {
     });
   });
 
+  describe("sync reports trim-collision conflicts on SyncStatus (GH #1164)", () => {
+    /**
+     * The remote-only case is the whole point: the Data health page scans
+     * the database the SERVER talks to, so a conflict living only on the
+     * peer had no surface anywhere. The sync pass already computes the
+     * enriched conflict; it just discarded it.
+     */
+    it("carries a REMOTE-only conflict, side-tagged, with the enriched fields", async () => {
+      const remoteDb = remoteClient.db("filament-db");
+      const now = new Date();
+      // Raw driver: Mongoose's trim setter would normalize on insert.
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Shelf R", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Shelf R ", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+
+      const found = sync.getStatus().nameConflicts;
+      const remote = found.filter((c) => c.side === "remote");
+      expect(remote.length).toBe(1);
+      expect(remote[0].collection).toBe("bedtypes");
+      expect(remote[0].name).toBe("Shelf R ");
+      expect(remote[0].trimsTo).toBe("Shelf R");
+      expect(remote[0].reason).toBe("collision");
+      expect(remote[0].active).toBe(true);
+      expect(remote[0].collidesWith?.name).toBe("Shelf R");
+    });
+
+    it("is empty on a clean database and refreshes wholesale", async () => {
+      const localDb = localClient.db("filament-db");
+      const now = new Date();
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Shelf L", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Shelf L ", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+      expect(sync.getStatus().nameConflicts.some((c) => c.side === "local")).toBe(true);
+
+      // Resolve it by hand on BOTH sides — the first cycle propagated the
+      // pair to the peer, so a local-only delete leaves a real remote
+      // conflict (which the next cycle would rightly still report).
+      const remoteDb = remoteClient.db("filament-db");
+      await localDb.collection("bedtypes").deleteOne({ name: "Shelf L " });
+      await remoteDb.collection("bedtypes").deleteOne({ name: "Shelf L " });
+      sync.destroy();
+      sync = makeSync();
+      await sync.sync();
+      expect(sync.getStatus().nameConflicts).toEqual([]);
+    });
+
+    it("does not report an INACTIVE conflict — nothing a user could act on", async () => {
+      const localDb = localClient.db("filament-db");
+      const now = new Date();
+      // A tombstoned row with a whitespace-only name: permanent, invisible.
+      await localDb.collection("bedtypes").insertOne({
+        name: "   ", material: "PEI", _deletedAt: now, createdAt: now, updatedAt: now,
+      });
+
+      sync = makeSync();
+      await sync.sync();
+      expect(sync.getStatus().nameConflicts).toEqual([]);
+    });
+  });
+
   describe("unreadable tombstones are healed and never spread (GH #1152)", () => {
     /**
      * The raw-driver `_deletedAt: ""` shape sits between the engine's two

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1510,6 +1510,36 @@ describe("SyncService — v1.12 sync expansion", () => {
       expect(sync.getStatus().nameConflicts).toEqual([]);
     });
 
+    it("reflects POST-COPY reality — a conflict this cycle resolved is not reported (r2)", async () => {
+      // The trim pass runs at the top of the cycle; the collection copies
+      // below it propagate a locally-resolved rename to the peer. A
+      // pre-copy snapshot reported the peer's stale pair as a live
+      // conflict until the NEXT cycle.
+      const localDb = localClient.db("filament-db");
+      const remoteDb = remoteClient.db("filament-db");
+      const now = new Date();
+      // The remote carries the untrimmed twin; the local side is clean and
+      // NEWER, so this cycle's copy overwrites the remote row.
+      const syncId = "post-copy-a";
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Bench", material: "PEI", syncId: "post-copy-keep", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Bench ", material: "PEI", syncId, _deletedAt: null, createdAt: now, updatedAt: new Date(now.getTime() - 60_000) },
+      ]);
+      await localDb.collection("bedtypes").insertMany([
+        { name: "Bench", material: "PEI", syncId: "post-copy-keep", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Bench Two", material: "PEI", syncId, _deletedAt: null, createdAt: now, updatedAt: new Date(now.getTime() + 60_000) },
+      ]);
+
+      sync = makeSync();
+      await sync.sync();
+
+      // The copy renamed the remote row, so nothing is in conflict now.
+      expect(
+        await remoteDb.collection("bedtypes").countDocuments({ name: "Bench " }),
+      ).toBe(0);
+      expect(sync.getStatus().nameConflicts).toEqual([]);
+    });
+
     it("does not report an INACTIVE conflict — nothing a user could act on", async () => {
       const localDb = localClient.db("filament-db");
       const now = new Date();

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1602,6 +1602,36 @@ describe("SyncService — v1.12 sync expansion", () => {
       ).toBe(true);
     });
 
+    it("still publishes a SCANNED collection's fresh conflict when another was skipped (r6)", async () => {
+      // Publishability is per collection, not global. A skip elsewhere used to
+      // suppress the whole snapshot, hiding a conflict that was actually
+      // found — indefinitely, whenever the skip and the failure both repeat.
+      const remoteDb = remoteClient.db("filament-db");
+      const now = new Date();
+      // bedtypes: duplicate ACTIVE names, so its index build is refused and
+      // the collection is skipped before any row is read.
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Dup", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Dup", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+      // locations: a genuine trim conflict, in a collection that IS scanned.
+      await remoteDb.collection("locations").insertMany([
+        { name: "Loc X", kind: "shelf", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Loc X ", kind: "shelf", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+
+      sync = makeSync();
+      (sync as unknown as { reconcileNozzlesByName: () => Promise<void> })
+        .reconcileNozzlesByName = () => Promise.reject(new Error("boom"));
+      await sync.sync();
+
+      expect(sync.getStatus().state).toBe("error");
+      const found = sync.getStatus().nameConflicts;
+      expect(
+        found.some((c) => c.side === "remote" && c.collection === "locations" && c.name === "Loc X "),
+      ).toBe(true);
+    });
+
     it("does not report an INACTIVE conflict — nothing a user could act on", async () => {
       const localDb = localClient.db("filament-db");
       const now = new Date();

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1540,6 +1540,32 @@ describe("SyncService — v1.12 sync expansion", () => {
       expect(sync.getStatus().nameConflicts).toEqual([]);
     });
 
+    it("publishes the trim-phase conflicts when the cycle DIES before the rescan (r3)", async () => {
+      // A cycle that throws after the trim passes never reaches the
+      // end-of-cycle rescan, and the outer catch used to leave the previous
+      // list standing. For a REMOTE-only conflict that is total invisibility:
+      // the health page scans the local database, which has no copy of it.
+      const remoteDb = remoteClient.db("filament-db");
+      const now = new Date();
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Dead R", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Dead R ", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+
+      sync = makeSync();
+      // Fail the first uncaught step after the trim passes — the same shape
+      // as the remote nozzle-map read failing mid-cycle.
+      (sync as unknown as { reconcileNozzlesByName: () => Promise<void> })
+        .reconcileNozzlesByName = () => Promise.reject(new Error("boom"));
+      await sync.sync();
+
+      expect(sync.getStatus().state).toBe("error");
+      const remote = sync.getStatus().nameConflicts.filter((c) => c.side === "remote");
+      expect(remote.length).toBe(1);
+      expect(remote[0].name).toBe("Dead R ");
+      expect(remote[0].collection).toBe("bedtypes");
+    });
+
     it("does not report an INACTIVE conflict — nothing a user could act on", async () => {
       const localDb = localClient.db("filament-db");
       const now = new Date();

--- a/tests/sync-service-expansion.test.ts
+++ b/tests/sync-service-expansion.test.ts
@@ -1566,6 +1566,42 @@ describe("SyncService — v1.12 sync expansion", () => {
       expect(remote[0].collection).toBe("bedtypes");
     });
 
+    it("does not erase a conflict in a collection the trim SKIPPED (r4)", async () => {
+      // A skipped collection was never scanned, so the snapshot is SILENT
+      // about it — publishing that silence on the error path would delete a
+      // still-live conflict rather than refresh it.
+      const remoteDb = remoteClient.db("filament-db");
+      const now = new Date();
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Skip R", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Skip R ", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+
+      // Same instance across both cycles — the point is what SURVIVES.
+      sync = makeSync();
+      await sync.sync();
+      expect(
+        sync.getStatus().nameConflicts.some((c) => c.side === "remote" && c.name === "Skip R "),
+      ).toBe(true);
+
+      // Make the next trim SKIP remote bedtypes: drop the protective index and
+      // leave a duplicate ACTIVE name behind, so the rebuild is refused and the
+      // pass gives up before reading any candidate row.
+      await remoteDb.collection("bedtypes").dropIndex("name_1").catch(() => {});
+      await remoteDb.collection("bedtypes").insertMany([
+        { name: "Twin", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+        { name: "Twin", material: "PEI", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+      (sync as unknown as { reconcileNozzlesByName: () => Promise<void> })
+        .reconcileNozzlesByName = () => Promise.reject(new Error("boom"));
+      await sync.sync();
+
+      expect(sync.getStatus().state).toBe("error");
+      expect(
+        sync.getStatus().nameConflicts.some((c) => c.side === "remote" && c.name === "Skip R "),
+      ).toBe(true);
+    });
+
     it("does not report an INACTIVE conflict — nothing a user could act on", async () => {
       const localDb = localClient.db("filament-db");
       const now = new Date();

--- a/tests/syncCycleWatcher.test.ts
+++ b/tests/syncCycleWatcher.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { createSyncCycleWatcher } from "@/lib/syncCycleWatcher";
+
+/**
+ * GH #1164: the Data health page refetches its own local scan whenever a sync
+ * cycle ends, because a completed cycle can copy a remote-only conflict INTO
+ * the local database. Missing an ending leaves the actionable list stale with
+ * nothing to correct it, so each way of missing one is pinned here.
+ */
+describe("createSyncCycleWatcher", () => {
+  const idle = (at: string | null) => ({ lastSyncAt: at, state: "idle" });
+  const syncing = (at: string | null) => ({ lastSyncAt: at, state: "syncing" });
+
+  it("the mount snapshot alone never reports an ending", () => {
+    const w = createSyncCycleWatcher();
+    w.seed(idle("T1"));
+    expect(w.observe(idle("T1"))).toBe(false);
+  });
+
+  it("reports an ending when the stamp advances", () => {
+    const w = createSyncCycleWatcher();
+    w.seed(idle("T1"));
+    expect(w.observe(idle("T2"))).toBe(true);
+  });
+
+  it("ignores progress ticks inside a running cycle", () => {
+    const w = createSyncCycleWatcher();
+    w.seed(idle("T1"));
+    expect(w.observe(syncing("T1"))).toBe(false);
+    expect(w.observe(syncing("T1"))).toBe(false);
+  });
+
+  it("reports an ending for a FAILED cycle, which keeps the previous stamp", () => {
+    const w = createSyncCycleWatcher();
+    w.seed(idle("T1"));
+    expect(w.observe(syncing("T1"))).toBe(false);
+    expect(w.observe({ lastSyncAt: "T1", state: "error" })).toBe(true);
+  });
+
+  it("treats a terminal event that BEATS the snapshot as an ending", () => {
+    // The listener can deliver before `getSyncStatus()` resolves. Consuming
+    // that event as the baseline swallowed the completion: the page's own
+    // fetch had already returned, and the snapshot arriving afterwards
+    // carried the same stamp, so nothing ever triggered a reload.
+    const w = createSyncCycleWatcher();
+    expect(w.observe(idle("T2"))).toBe(true);
+  });
+
+  it("an early SYNCING event is not an ending, but its completion is", () => {
+    const w = createSyncCycleWatcher();
+    expect(w.observe(syncing(null))).toBe(false);
+    expect(w.observe(idle(null))).toBe(true);
+  });
+
+  it("a late snapshot does not rewind the baseline an event established", () => {
+    // The promise can resolve with values captured BEFORE the event it lost
+    // the race to; adopting them would re-report the same ending.
+    const w = createSyncCycleWatcher();
+    expect(w.observe(idle("T2"))).toBe(true);
+    w.seed(syncing("T1"));
+    expect(w.observe(idle("T2"))).toBe(false);
+  });
+
+  it("null is a real stamp, not 'unset' — the first completion still counts", () => {
+    // Mounting mid-initial-sync leaves lastSyncAt null; conflating that with
+    // "no baseline yet" made the first real completion look like the snapshot.
+    const w = createSyncCycleWatcher();
+    w.seed(syncing(null));
+    expect(w.observe(idle(null))).toBe(true);
+  });
+
+  it("treats a missing state/stamp as a completed cycle with a null stamp", () => {
+    const w = createSyncCycleWatcher();
+    w.seed({});
+    expect(w.observe({})).toBe(false);
+    expect(w.observe(idle("T1"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #1164 — the deferred half of #1149.

The Data health page scans the database the **server** talks to (the local one in hybrid mode), so a trim collision living only on the Atlas side was visible to nothing. The sync pass already computes the enriched conflict — #1149's `id`/`trimsTo`/`reason`/`collidesWith` — and then discarded it: a console line plus a name-set used only for gating.

**Additive reporting; the gating logic is untouched.** `SyncStatus` gains `nameConflicts` (the enriched shape plus a `local`/`remote` tag), collected in the per-side trim loop under the *same* active-only rule the gate uses (an inactive conflict is permanent and invisible in the UI — nothing a user could act on), and published once after both sides so each cycle reports a complete set and a resolved conflict disappears rather than lingering. Only cycles that reach the trim phase publish, so a pre-trim connect failure leaves the previous, still-accurate list alone.

**Surfaces**: the sync tooltip lists them (amber, first three, link to Data health) — deliberately *not* wired into the pill's state machine, since `partial` means a collection failed to sync, which these do not. Data health gains a read-only **remote** section whose copy splits the two resolutions: a pair that also exists locally is fixed above and syncs across; a remote-only row has no local twin and must be resolved where it lives. Local conflicts aren't duplicated there.

The IPC trio stays in lockstep (main's no-service default resets the field; both hand-mirrored `electron.d.ts` types carry it, optional so an older main still typechecks against a newer renderer).

**Tests**: three integration cases — a remote-only conflict surfaces side-tagged with its enriched fields; the list refreshes wholesale (resolved → empty, not accumulating); an inactive conflict is never reported. Failing-before verified by removing the publication line (two of the three fail).

Drive-by: removes an unused `NTAG216_MAX_NDEF_BYTES` import that #1172's final round left behind — a lint warning currently on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)