### PR TITLE
feat(api): calibration lookup can be scoped to a printer (#1047 Phase 0)

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1290,6 +1290,15 @@
             "example": "Smooth PEI"
           },
           {
+            "name": "printer",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Printer NAME or ObjectId (same convention as bed_type). Selects the calibration tuned for that machine (GH #1047 Phase 0). Soft: an unknown printer falls back to the shareable printer-less defaults, then to any same-nozzle entry — never a new 404. With NO printer param the printer-less defaults are preferred (deterministic; previously the first matching entry won regardless of its printer)."
+          },
+          {
             "name": "format",
             "in": "query",
             "schema": {

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -113,7 +113,7 @@ export async function GET(
       nozzle?: { diameter?: number; name?: string; type?: string; highFlow?: boolean };
       // `_id` is an ObjectId at runtime (populated doc); typed loosely like
       // the bedType entry below so the lean() cast still overlaps.
-      printer?: { _id?: unknown; name?: string };
+      printer?: { _id?: unknown; name?: string; _deletedAt?: unknown };
       bedType?: { _id?: string; name?: string; material?: string } | null;
       extrusionMultiplier?: number;
       maxVolumetricSpeed?: number;
@@ -192,8 +192,15 @@ export async function GET(
       // above. Ids are compared case-folded because a populated `_id`
       // renders canonical lowercase.
       const looksLikeId = /^[0-9a-fA-F]{24}$/.test(raw);
+      // Only a LIVE printer is addressable (Codex P2 round 4). `populate()`
+      // does not filter tombstones, so a calibration still pointing at a
+      // soft-deleted printer would satisfy an id match and outrank an ACTIVE
+      // printer named with that id — the impostor problem inverted. Applied to
+      // every rung below, so "exists" means the same thing here as it does in
+      // the existence queries and in the rest of the printer API.
+      const addressable = scopedMatches.filter((cal) => cal.printer && !cal.printer._deletedAt);
       const idMatches = looksLikeId
-        ? scopedMatches.filter(
+        ? addressable.filter(
             (cal) => String(cal.printer?._id ?? "").trim().toLowerCase() === wanted,
           )
         : [];
@@ -211,15 +218,21 @@ export async function GET(
       const idIsRealPrinter =
         idMatches.length > 0 ||
         (looksLikeId && (await Printer.exists({ _id: raw, _deletedAt: null })) !== null);
-      // Then the EXACT trimmed name (Codex P2): the Printer name index is
-      // case-SENSITIVE, so "XL" and "xl" can both exist. When the caller
-      // supplies the stored spelling, array order must not decide which
-      // machine's values come back.
-      const exactName = scopedMatches.filter(
-        (cal) => (cal.printer?.name ?? "").trim() === raw,
-      );
-      // Finally fold case on the name.
-      const loose = scopedMatches.filter(
+      // Then the name, in three rungs from strictest to loosest. The Printer
+      // name index is case-SENSITIVE, so "XL" and "xl" can both exist; and
+      // hybrid sync writes through the raw driver, which bypasses the schema's
+      // trim setter, so "X" and "X " can both exist too. Array order must not
+      // decide between them when the caller spelled one of them exactly.
+      //
+      // 1. VERBATIM — the caller's spelling against the stored spelling, no
+      //    normalization on either side (Codex P2 round 4). This is the only
+      //    rung that can tell "X" from "X ".
+      const verbatimName = addressable.filter((cal) => (cal.printer?.name ?? "") === printerParam);
+      // 2. Trimmed exact — tolerates stray whitespace around the caller's
+      //    input, which is the ordinary case since stored names are trimmed.
+      const exactName = addressable.filter((cal) => (cal.printer?.name ?? "").trim() === raw);
+      // 3. Case-folded.
+      const loose = addressable.filter(
         (cal) => (cal.printer?.name ?? "").trim().toLowerCase() === wanted,
       );
       // The exact name gets the same existence question as the id, for the
@@ -228,11 +241,21 @@ export async function GET(
       // return "xl"'s calibration. An exact identity that exists suppresses
       // the case-folded fallback. Asked only when folding would actually
       // change the answer, so the ordinary lookup adds no query.
+      //
+      // Asked through the RAW driver, not the model: the schema's `trim`
+      // setter applies to query VALUES too, so `Printer.exists({name: "X "})`
+      // casts to `"X"` and answers about the wrong row — the same trap GH
+      // #1116 documents. The native query compares the spelling as given, and
+      // `_deletedAt: null` there also matches rows predating the field.
       const exactNameExists =
         !idIsRealPrinter &&
+        verbatimName.length === 0 &&
         exactName.length === 0 &&
         loose.length > 0 &&
-        (await Printer.exists({ name: raw, _deletedAt: null })) !== null;
+        (await Printer.collection.countDocuments(
+          { name: { $in: [printerParam, raw] }, _deletedAt: null },
+          { limit: 1 },
+        )) > 0;
 
       let printerMatches: typeof scopedMatches = [];
       if (idMatches.length > 0) printerMatches = idMatches;
@@ -241,6 +264,7 @@ export async function GET(
       // question — it answers a different one, so it stays off and the
       // shareable default below takes over.
       else if (idIsRealPrinter || exactNameExists) printerMatches = [];
+      else if (verbatimName.length > 0) printerMatches = verbatimName;
       else if (exactName.length > 0) printerMatches = exactName;
       else printerMatches = loose;
       if (printerMatches.length > 0) {

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -185,22 +185,31 @@ export async function GET(
     if (printerParam) {
       const raw = printerParam.trim();
       const wanted = raw.toLowerCase();
-      // EXACT trimmed name first (Codex P2): the Printer name index is
+      // A 24-hex input is an OBJECTID and wins outright (Codex P2), before
+      // any name matching: printer names are unrestricted, so one printer
+      // could be NAMED as another's id — and this endpoint documents
+      // ObjectId support, matching how the filament itself is resolved
+      // above. Ids are compared case-folded because a populated `_id`
+      // renders canonical lowercase.
+      const looksLikeId = /^[0-9a-fA-F]{24}$/.test(raw);
+      const idMatches = looksLikeId
+        ? scopedMatches.filter(
+            (cal) => String(cal.printer?._id ?? "").trim().toLowerCase() === wanted,
+          )
+        : [];
+      // Then the EXACT trimmed name (Codex P2): the Printer name index is
       // case-SENSITIVE, so "XL" and "xl" can both exist. When the caller
       // supplies the stored spelling, array order must not decide which
       // machine's values come back.
       const exactName = scopedMatches.filter(
         (cal) => (cal.printer?.name ?? "").trim() === raw,
       );
-      // Else fold case, and accept the ObjectId form (bed_type's
-      // convention). Both sides normalized — a populated id renders
-      // canonical lowercase, so an uppercase-hex id silently missed.
+      // Finally fold case on the name.
       const loose = scopedMatches.filter(
-        (cal) =>
-          (cal.printer?.name ?? "").trim().toLowerCase() === wanted ||
-          String(cal.printer?._id ?? "").trim().toLowerCase() === wanted,
+        (cal) => (cal.printer?.name ?? "").trim().toLowerCase() === wanted,
       );
-      const printerMatches = exactName.length > 0 ? exactName : loose;
+      const printerMatches =
+        idMatches.length > 0 ? idMatches : exactName.length > 0 ? exactName : loose;
       if (printerMatches.length > 0) {
         // Printer-scoped first, the shareable defaults retained behind them
         // (disjoint sets: a generic entry has no printer to match).

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -111,7 +111,9 @@ export async function GET(
     // Find calibration matching the nozzle diameter
     const calibrations = ((filament as NonNullable<typeof filament>).calibrations || []) as Array<{
       nozzle?: { diameter?: number; name?: string; type?: string; highFlow?: boolean };
-      printer?: { name?: string };
+      // `_id` is an ObjectId at runtime (populated doc); typed loosely like
+      // the bedType entry below so the lean() cast still overlaps.
+      printer?: { _id?: unknown; name?: string };
       bedType?: { _id?: string; name?: string; material?: string } | null;
       extrusionMultiplier?: number;
       maxVolumetricSpeed?: number;
@@ -134,6 +136,12 @@ export async function GET(
     const highFlowParam = searchParams.get("high_flow");
     const nozzleTypeParam = searchParams.get("nozzle_type");
     const bedTypeParam = searchParams.get("bed_type");
+    // GH #1047 Phase 0: the printer scope. `calibrations[].printer` has been
+    // populated since #107 but nothing could ASK for it, so a slicer on the
+    // XL got whichever same-nozzle entry happened to sort first — including
+    // one tuned for a different machine. Zero schema change; the full
+    // printer-scoped nozzle identity remains #1047's later phases.
+    const printerParam = searchParams.get("printer");
 
     const diameterMatches = calibrations.filter((cal) => {
       if (!cal.nozzle || Math.abs((cal.nozzle.diameter || 0) - nozzleDiameter) >= 0.01)
@@ -162,6 +170,36 @@ export async function GET(
         (cal) => (cal.nozzle?.type ?? "").trim().toLowerCase() === wanted,
       );
       if (typeMatches.length > 0) scopedMatches = typeMatches;
+    }
+
+    // GH #1047 Phase 0: narrow by PRINTER before the bed-type step, using the
+    // same name-or-ObjectId convention bed_type already uses. SOFT, matching
+    // the nozzle_type posture directly above — a printer match wins; else the
+    // shareable printer-null defaults; else the unscoped list, so a
+    // printer/data mismatch never turns a working lookup into a 404.
+    if (printerParam) {
+      const wanted = printerParam.trim().toLowerCase();
+      const printerMatches = scopedMatches.filter(
+        (cal) =>
+          (cal.printer?.name ?? "").trim().toLowerCase() === wanted ||
+          String(cal.printer?._id ?? "") === printerParam,
+      );
+      if (printerMatches.length > 0) {
+        scopedMatches = printerMatches;
+      } else {
+        // The shareable defaults (printer = null) are the right fallback for
+        // an unknown printer — they are what `prusaSlicerBundle` already
+        // prefers when baking a preset.
+        const defaults = scopedMatches.filter((cal) => !cal.printer);
+        if (defaults.length > 0) scopedMatches = defaults;
+      }
+    } else {
+      // No printer asked for: prefer the shareable defaults over a
+      // machine-specific entry. Deterministic where the old code took
+      // whatever sorted first — see the PR note; this is a small behavior
+      // change and the reason the param exists.
+      const defaults = scopedMatches.filter((cal) => !cal.printer);
+      if (defaults.length > 0) scopedMatches = defaults;
     }
 
     let match = scopedMatches[0];

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -172,39 +172,50 @@ export async function GET(
       if (typeMatches.length > 0) scopedMatches = typeMatches;
     }
 
-    // GH #1047 Phase 0: narrow by PRINTER before the bed-type step, using the
-    // same name-or-ObjectId convention bed_type already uses. SOFT, matching
-    // the nozzle_type posture directly above — a printer match wins; else the
-    // shareable printer-null defaults; else the unscoped list, so a
+    // GH #1047 Phase 0: PRIORITIZE by printer — deliberately reordering
+    // rather than filtering (Codex P2). Dropping the non-matching entries
+    // discarded the printer-less BEDLESS default that the bed_type step
+    // below falls back to, so `printer=P&bed_type=Smooth` with (P,Textured)
+    // + (null,null) returned the Textured entry, breaking the documented
+    // "a bed-type miss falls back to a calibration without a bed type".
+    // Ordering keeps that promise while `scopedMatches[0]` still prefers
+    // the printer match. Soft throughout, like nozzle_type beside it: a
     // printer/data mismatch never turns a working lookup into a 404.
+    const genericEntries = scopedMatches.filter((cal) => !cal.printer);
     if (printerParam) {
-      const wanted = printerParam.trim().toLowerCase();
-      // Both sides normalized through `wanted` (Codex P2): a populated
-      // ObjectId renders canonical lowercase, so an id typed/stored with
-      // uppercase hex — or with surrounding whitespace — missed the compare
-      // and silently fell through to the printer-less default, which looks
-      // like "no calibration for my machine" with no error to explain it.
-      const printerMatches = scopedMatches.filter(
+      const raw = printerParam.trim();
+      const wanted = raw.toLowerCase();
+      // EXACT trimmed name first (Codex P2): the Printer name index is
+      // case-SENSITIVE, so "XL" and "xl" can both exist. When the caller
+      // supplies the stored spelling, array order must not decide which
+      // machine's values come back.
+      const exactName = scopedMatches.filter(
+        (cal) => (cal.printer?.name ?? "").trim() === raw,
+      );
+      // Else fold case, and accept the ObjectId form (bed_type's
+      // convention). Both sides normalized — a populated id renders
+      // canonical lowercase, so an uppercase-hex id silently missed.
+      const loose = scopedMatches.filter(
         (cal) =>
           (cal.printer?.name ?? "").trim().toLowerCase() === wanted ||
           String(cal.printer?._id ?? "").trim().toLowerCase() === wanted,
       );
+      const printerMatches = exactName.length > 0 ? exactName : loose;
       if (printerMatches.length > 0) {
-        scopedMatches = printerMatches;
-      } else {
-        // The shareable defaults (printer = null) are the right fallback for
-        // an unknown printer — they are what `prusaSlicerBundle` already
-        // prefers when baking a preset.
-        const defaults = scopedMatches.filter((cal) => !cal.printer);
-        if (defaults.length > 0) scopedMatches = defaults;
+        // Printer-scoped first, the shareable defaults retained behind them
+        // (disjoint sets: a generic entry has no printer to match).
+        scopedMatches = [...printerMatches, ...genericEntries];
+      } else if (genericEntries.length > 0) {
+        // Unknown printer → the shareable defaults, which is what
+        // prusaSlicerBundle already prefers when baking a preset.
+        scopedMatches = genericEntries;
       }
-    } else {
-      // No printer asked for: prefer the shareable defaults over a
-      // machine-specific entry. Deterministic where the old code took
-      // whatever sorted first — see the PR note; this is a small behavior
-      // change and the reason the param exists.
-      const defaults = scopedMatches.filter((cal) => !cal.printer);
-      if (defaults.length > 0) scopedMatches = defaults;
+    } else if (genericEntries.length > 0) {
+      // No printer asked for: prefer the shareable defaults, keeping the
+      // machine-specific entries behind them so a filament with ONLY
+      // printer-scoped rows still answers. Deterministic where the old code
+      // took whatever sorted first — the small behavior change this adds.
+      scopedMatches = [...genericEntries, ...scopedMatches.filter((cal) => cal.printer)];
     }
 
     let match = scopedMatches[0];

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -235,37 +235,37 @@ export async function GET(
       const loose = addressable.filter(
         (cal) => (cal.printer?.name ?? "").trim().toLowerCase() === wanted,
       );
-      // The exact name gets the same existence question as the id, for the
-      // same reason (Codex P2 round 3): with "XL" and "xl" both active, a
-      // request for "XL" whose machine has no row here would fold case and
-      // return "xl"'s calibration. An exact identity that exists suppresses
-      // the case-folded fallback. Asked only when folding would actually
-      // change the answer, so the ordinary lookup adds no query.
+      // Every rung gets the same existence question as the id, and for the
+      // same reason (Codex P2 rounds 3–5): an identity that EXISTS and simply
+      // has no calibration here must not be answered by a weaker match. That
+      // has to be asked PER RUNG — a live "X " with no row here was still
+      // answered by "X"'s row, because the trimmed rung had matches and the
+      // single combined check never fired.
       //
       // Asked through the RAW driver, not the model: the schema's `trim`
       // setter applies to query VALUES too, so `Printer.exists({name: "X "})`
       // casts to `"X"` and answers about the wrong row — the same trap GH
       // #1116 documents. The native query compares the spelling as given, and
       // `_deletedAt: null` there also matches rows predating the field.
-      const exactNameExists =
-        !idIsRealPrinter &&
-        verbatimName.length === 0 &&
-        exactName.length === 0 &&
-        loose.length > 0 &&
+      const liveNamed = async (name: string) =>
         (await Printer.collection.countDocuments(
-          { name: { $in: [printerParam, raw] }, _deletedAt: null },
+          { name, _deletedAt: null },
           { limit: 1 },
         )) > 0;
 
+      // Strongest rung first; each `liveNamed` is reached — and therefore
+      // asked — only when the rung above found nothing and a weaker one would
+      // otherwise answer. The ordinary lookup (stored spelling, rows present)
+      // stops at `verbatimName` and issues no query at all.
       let printerMatches: typeof scopedMatches = [];
       if (idMatches.length > 0) printerMatches = idMatches;
-      // The caller addressed an identity that EXISTS and simply has no
-      // calibration here. A weaker match is not a second chance at the same
-      // question — it answers a different one, so it stays off and the
-      // shareable default below takes over.
-      else if (idIsRealPrinter || exactNameExists) printerMatches = [];
+      else if (idIsRealPrinter) printerMatches = [];
       else if (verbatimName.length > 0) printerMatches = verbatimName;
+      else if ((exactName.length > 0 || loose.length > 0) && (await liveNamed(printerParam)))
+        printerMatches = [];
       else if (exactName.length > 0) printerMatches = exactName;
+      else if (loose.length > 0 && raw !== printerParam && (await liveNamed(raw)))
+        printerMatches = [];
       else printerMatches = loose;
       if (printerMatches.length > 0) {
         // Printer-scoped first, the shareable defaults retained behind them

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -179,10 +179,15 @@ export async function GET(
     // printer/data mismatch never turns a working lookup into a 404.
     if (printerParam) {
       const wanted = printerParam.trim().toLowerCase();
+      // Both sides normalized through `wanted` (Codex P2): a populated
+      // ObjectId renders canonical lowercase, so an id typed/stored with
+      // uppercase hex — or with surrounding whitespace — missed the compare
+      // and silently fell through to the printer-less default, which looks
+      // like "no calibration for my machine" with no error to explain it.
       const printerMatches = scopedMatches.filter(
         (cal) =>
           (cal.printer?.name ?? "").trim().toLowerCase() === wanted ||
-          String(cal.printer?._id ?? "") === printerParam,
+          String(cal.printer?._id ?? "").trim().toLowerCase() === wanted,
       );
       if (printerMatches.length > 0) {
         scopedMatches = printerMatches;

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -6,7 +6,7 @@ import {
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
 import "@/models/Nozzle";
-import "@/models/Printer";
+import Printer from "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
 import { calibrationToOrcaSlicerKeys } from "@/lib/orcaSlicerBundle";
@@ -197,6 +197,16 @@ export async function GET(
             (cal) => String(cal.printer?._id ?? "").trim().toLowerCase() === wanted,
           )
         : [];
+      // Whether that id names a REAL printer is a question about the Printer
+      // COLLECTION, not about the rows we happen to have filtered (Codex P2
+      // round 2). Inferring existence from `idMatches` conflates "no such
+      // printer" with "that printer has no row for this nozzle" — and only the
+      // first may fall back to name matching. Get the second wrong and the
+      // impostor wins again by the back door. Queried only when the populated
+      // rows didn't already prove existence, so the hit path adds nothing.
+      const idIsRealPrinter =
+        idMatches.length > 0 ||
+        (looksLikeId && (await Printer.exists({ _id: raw })) !== null);
       // Then the EXACT trimmed name (Codex P2): the Printer name index is
       // case-SENSITIVE, so "XL" and "xl" can both exist. When the caller
       // supplies the stored spelling, array order must not decide which
@@ -209,7 +219,16 @@ export async function GET(
         (cal) => (cal.printer?.name ?? "").trim().toLowerCase() === wanted,
       );
       const printerMatches =
-        idMatches.length > 0 ? idMatches : exactName.length > 0 ? exactName : loose;
+        idMatches.length > 0
+          ? idMatches
+          : idIsRealPrinter
+            ? // The caller addressed a printer that EXISTS and simply has no
+              // calibration here. Name matching is not a second chance at the
+              // same question — it answers a different one, so it stays off.
+              []
+            : exactName.length > 0
+              ? exactName
+              : loose;
       if (printerMatches.length > 0) {
         // Printer-scoped first, the shareable defaults retained behind them
         // (disjoint sets: a generic entry has no printer to match).

--- a/src/app/api/filaments/[id]/calibration/route.ts
+++ b/src/app/api/filaments/[id]/calibration/route.ts
@@ -204,9 +204,13 @@ export async function GET(
       // first may fall back to name matching. Get the second wrong and the
       // impostor wins again by the back door. Queried only when the populated
       // rows didn't already prove existence, so the hit path adds nothing.
+      // `_deletedAt: null` because that is what the rest of the printer API
+      // means by "exists" (Codex P2 round 3). A soft-deleted row is not an
+      // identity a caller can address, so letting one suppress the name path
+      // would hide an ACTIVE printer that happens to be named with its id.
       const idIsRealPrinter =
         idMatches.length > 0 ||
-        (looksLikeId && (await Printer.exists({ _id: raw })) !== null);
+        (looksLikeId && (await Printer.exists({ _id: raw, _deletedAt: null })) !== null);
       // Then the EXACT trimmed name (Codex P2): the Printer name index is
       // case-SENSITIVE, so "XL" and "xl" can both exist. When the caller
       // supplies the stored spelling, array order must not decide which
@@ -218,17 +222,27 @@ export async function GET(
       const loose = scopedMatches.filter(
         (cal) => (cal.printer?.name ?? "").trim().toLowerCase() === wanted,
       );
-      const printerMatches =
-        idMatches.length > 0
-          ? idMatches
-          : idIsRealPrinter
-            ? // The caller addressed a printer that EXISTS and simply has no
-              // calibration here. Name matching is not a second chance at the
-              // same question — it answers a different one, so it stays off.
-              []
-            : exactName.length > 0
-              ? exactName
-              : loose;
+      // The exact name gets the same existence question as the id, for the
+      // same reason (Codex P2 round 3): with "XL" and "xl" both active, a
+      // request for "XL" whose machine has no row here would fold case and
+      // return "xl"'s calibration. An exact identity that exists suppresses
+      // the case-folded fallback. Asked only when folding would actually
+      // change the answer, so the ordinary lookup adds no query.
+      const exactNameExists =
+        !idIsRealPrinter &&
+        exactName.length === 0 &&
+        loose.length > 0 &&
+        (await Printer.exists({ name: raw, _deletedAt: null })) !== null;
+
+      let printerMatches: typeof scopedMatches = [];
+      if (idMatches.length > 0) printerMatches = idMatches;
+      // The caller addressed an identity that EXISTS and simply has no
+      // calibration here. A weaker match is not a second chance at the same
+      // question — it answers a different one, so it stays off and the
+      // shareable default below takes over.
+      else if (idIsRealPrinter || exactNameExists) printerMatches = [];
+      else if (exactName.length > 0) printerMatches = exactName;
+      else printerMatches = loose;
       if (printerMatches.length > 0) {
         // Printer-scoped first, the shareable defaults retained behind them
         // (disjoint sets: a generic entry has no printer to match).

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -226,6 +226,55 @@ describe("GET /api/filaments/[id]/calibration", () => {
       expect((await res.json()).calibration.pressureAdvance).toBe(0.42);
     });
 
+    it("an EXISTING exact name with no row here does not fold case to its twin", async () => {
+      // Same shape one rung down the ladder: "XL" and "xl" can both exist
+      // (the name index is case-sensitive). A request for "XL" whose machine
+      // has no row for this nozzle must not be answered by "xl" (Codex P2 r3).
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 T", diameter: 0.4, type: "Brass" });
+      const other = await Nozzle.create({ name: "0.6 T", diameter: 0.6, type: "Brass" });
+      const upper = await Printer.create({ name: "TW", manufacturer: "M", printerModel: "X" });
+      const lower = await Printer.create({ name: "tw", manufacturer: "M", printerModel: "X" });
+      const f = await Filament.create({
+        name: "PVA-D", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, printer: lower._id, pressureAdvance: 0.61 },
+          { nozzle: noz._id, pressureAdvance: 0.62 }, // the shareable default
+          { nozzle: other._id, printer: upper._id, pressureAdvance: 0.63 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=TW`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.62);
+    });
+
+    it("a SOFT-DELETED printer's id does not suppress an active printer named that", async () => {
+      // "Exists" means active everywhere else in the printer API, so a
+      // tombstoned row must not stand in the way of a live identity.
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 S", diameter: 0.4, type: "Brass" });
+      const gone = await Printer.create({
+        name: "Gone", manufacturer: "M", printerModel: "X", _deletedAt: new Date(),
+      });
+      const alive = await Printer.create({
+        name: String(gone._id), manufacturer: "M", printerModel: "X",
+      });
+      const f = await Filament.create({
+        name: "PVA-E", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, pressureAdvance: 0.71 },
+          { nozzle: noz._id, printer: alive._id, pressureAdvance: 0.72 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${gone._id}`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.72);
+    });
+
     it("a 24-hex string owned by NO printer is still matched as a name", async () => {
       // The other side of the same test: existence is what gates the name
       // path, so a hex-shaped name nobody owns as an id must still resolve.

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -199,6 +199,56 @@ describe("GET /api/filaments/[id]/calibration", () => {
       expect((await res.json()).calibration.pressureAdvance).toBe(0.32);
     });
 
+    it("an EXISTING printer id with no row here falls to the default, not a name twin", async () => {
+      // The impostor case one level deeper: the addressed printer is real but
+      // has no calibration for THIS nozzle, so the id can't be matched among
+      // the rows. Inferring "unknown id" from that and re-trying as a name
+      // handed the request to the twin (Codex P2 round 2).
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 R", diameter: 0.4, type: "Brass" });
+      const other = await Nozzle.create({ name: "0.6 R", diameter: 0.6, type: "Brass" });
+      const real = await Printer.create({ name: "RealB", manufacturer: "M", printerModel: "X" });
+      const impostor = await Printer.create({
+        name: String(real._id), manufacturer: "M", printerModel: "X",
+      });
+      const f = await Filament.create({
+        name: "PVA-B", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, printer: impostor._id, pressureAdvance: 0.41 },
+          { nozzle: noz._id, pressureAdvance: 0.42 }, // the shareable default
+          { nozzle: other._id, printer: real._id, pressureAdvance: 0.43 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${real._id}`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.42);
+    });
+
+    it("a 24-hex string owned by NO printer is still matched as a name", async () => {
+      // The other side of the same test: existence is what gates the name
+      // path, so a hex-shaped name nobody owns as an id must still resolve.
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 H", diameter: 0.4, type: "Brass" });
+      const orphanId = new mongoose.Types.ObjectId();
+      const named = await Printer.create({
+        name: String(orphanId), manufacturer: "M", printerModel: "X",
+      });
+      const f = await Filament.create({
+        name: "PVA-C", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, pressureAdvance: 0.51 },
+          { nozzle: noz._id, printer: named._id, pressureAdvance: 0.52 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${orphanId}`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.52);
+    });
+
     it("still answers when only printer-scoped entries exist", async () => {
       const Printer = mongoose.models.Printer;
       const noz = await Nozzle.create({ name: "0.6 Brass", diameter: 0.6, type: "Brass" });

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -96,6 +96,19 @@ describe("GET /api/filaments/[id]/calibration", () => {
       expect((await res.json()).calibration.pressureAdvance).toBe(0.05);
     });
 
+    it("matches an ObjectId case-insensitively and ignores stray whitespace", async () => {
+      const { f, xl } = await seedTwoPrinters();
+      const upper = String(xl._id).toUpperCase();
+      const res = await getCalibration(
+        getReq(
+          `http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${encodeURIComponent(` ${upper} `)}`,
+        ),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      // Pre-fix this silently returned the printer-less default (0.02).
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.05);
+    });
+
     it("falls back to the shareable default for an UNKNOWN printer — never a 404", async () => {
       const { f } = await seedTwoPrinters();
       const res = await getCalibration(

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -176,6 +176,29 @@ describe("GET /api/filaments/[id]/calibration", () => {
       expect((await res.json()).calibration.pressureAdvance).toBe(0.22);
     });
 
+    it("treats a 24-hex input as an ObjectId even if another printer is NAMED that (Codex P2)", async () => {
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 D", diameter: 0.4, type: "Brass" });
+      const real = await Printer.create({ name: "Real", manufacturer: "M", printerModel: "X" });
+      // A second printer literally NAMED as the first one's id.
+      const impostor = await Printer.create({
+        name: String(real._id), manufacturer: "M", printerModel: "X",
+      });
+      const f = await Filament.create({
+        name: "PVA", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, printer: impostor._id, pressureAdvance: 0.31 }, // sorts first
+          { nozzle: noz._id, printer: real._id, pressureAdvance: 0.32 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${real._id}`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      // The id must win over the name-collision impostor.
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.32);
+    });
+
     it("still answers when only printer-scoped entries exist", async () => {
       const Printer = mongoose.models.Printer;
       const noz = await Nozzle.create({ name: "0.6 Brass", diameter: 0.6, type: "Brass" });

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -275,6 +275,61 @@ describe("GET /api/filaments/[id]/calibration", () => {
       expect((await res.json()).calibration.pressureAdvance).toBe(0.72);
     });
 
+    it("the caller's VERBATIM spelling wins over a whitespace twin (r4)", async () => {
+      // Hybrid sync writes through the raw driver, which bypasses the schema's
+      // trim setter — so "VB" and "VB " can both be active. Trimming both
+      // sides of the exact compare let array order pick between them.
+      const noz = await Nozzle.create({ name: "0.4 V", diameter: 0.4, type: "Brass" });
+      const rawPrinters = mongoose.connection.collection("printers");
+      const now = new Date();
+      const tidy = new mongoose.Types.ObjectId();
+      const untidy = new mongoose.Types.ObjectId();
+      await rawPrinters.insertMany([
+        { _id: tidy, name: "VB", manufacturer: "M", printerModel: "X", _deletedAt: null, createdAt: now, updatedAt: now },
+        { _id: untidy, name: "VB ", manufacturer: "M", printerModel: "X", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+      const f = await Filament.create({
+        name: "PVA-F", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, printer: tidy, pressureAdvance: 0.81 }, // sorts first
+          { nozzle: noz._id, printer: untidy, pressureAdvance: 0.82 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(
+          `http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${encodeURIComponent("VB ")}`,
+        ),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.82);
+    });
+
+    it("a soft-deleted printer's own row does not outrank an active namesake (r4)", async () => {
+      // populate() doesn't filter tombstones, so a calibration still pointing
+      // at a deleted printer used to satisfy the id match — the impostor
+      // problem inverted, a dead identity beating a live one.
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 Z", diameter: 0.4, type: "Brass" });
+      const gone = await Printer.create({
+        name: "Gone2", manufacturer: "M", printerModel: "X", _deletedAt: new Date(),
+      });
+      const alive = await Printer.create({
+        name: String(gone._id), manufacturer: "M", printerModel: "X",
+      });
+      const f = await Filament.create({
+        name: "PVA-G", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, printer: gone._id, pressureAdvance: 0.91 }, // sorts first
+          { nozzle: noz._id, printer: alive._id, pressureAdvance: 0.92 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${gone._id}`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.92);
+    });
+
     it("a 24-hex string owned by NO printer is still matched as a name", async () => {
       // The other side of the same test: existence is what gates the name
       // path, so a hex-shaped name nobody owns as an id must still resolve.

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -132,6 +132,50 @@ describe("GET /api/filaments/[id]/calibration", () => {
       expect((await res.json()).calibration.pressureAdvance).toBe(0.02);
     });
 
+    it("keeps the bedless default reachable after printer narrowing (Codex P2)", async () => {
+      // (P, Textured) + (null, null): asking for P with bed_type=Smooth must
+      // fall back to the BEDLESS generic, per the documented bed-type rule —
+      // a filter-based narrowing hid it and returned the Textured entry.
+      const Printer = mongoose.models.Printer;
+      const BedType = mongoose.models.BedType;
+      const noz = await Nozzle.create({ name: "0.4 B", diameter: 0.4, type: "Brass" });
+      const p1 = await Printer.create({ name: "P1", manufacturer: "M", printerModel: "X" });
+      const textured = await BedType.create({ name: "Textured", material: "PEI" });
+      const f = await Filament.create({
+        name: "PC", vendor: "X", type: "PC",
+        calibrations: [
+          { nozzle: noz._id, printer: p1._id, bedType: textured._id, pressureAdvance: 0.11 },
+          { nozzle: noz._id, pressureAdvance: 0.01 }, // generic + bedless
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=P1&bed_type=Smooth`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.01);
+    });
+
+    it("prefers the EXACT printer name over a case-folded twin (Codex P2)", async () => {
+      // The Printer name index is case-sensitive, so XL and xl can coexist.
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 C", diameter: 0.4, type: "Brass" });
+      const lower = await Printer.create({ name: "xl", manufacturer: "M", printerModel: "X" });
+      const upper = await Printer.create({ name: "XL", manufacturer: "M", printerModel: "X" });
+      const f = await Filament.create({
+        name: "TPU", vendor: "X", type: "TPU",
+        calibrations: [
+          { nozzle: noz._id, printer: lower._id, pressureAdvance: 0.21 }, // sorts first
+          { nozzle: noz._id, printer: upper._id, pressureAdvance: 0.22 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=XL`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      // Array order would have handed back the lowercase machine's 0.21.
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.22);
+    });
+
     it("still answers when only printer-scoped entries exist", async () => {
       const Printer = mongoose.models.Printer;
       const noz = await Nozzle.create({ name: "0.6 Brass", diameter: 0.6, type: "Brass" });

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -57,6 +57,85 @@ describe("GET /api/filaments/[id]/calibration", () => {
     expect(json.calibration.extrusionMultiplier).toBe(0.98);
   });
 
+  describe("GH #1047 Phase 0 — printer scoping", () => {
+    async function seedTwoPrinters() {
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
+      const xl = await Printer.create({ name: "XL", manufacturer: "Prusa", printerModel: "XL" });
+      const core = await Printer.create({
+        name: "CoreOne", manufacturer: "Prusa", printerModel: "CoreOne",
+      });
+      const f = await Filament.create({
+        name: "PETG", vendor: "X", type: "PETG",
+        calibrations: [
+          // Printer-scoped entries first, so "whatever sorts first" would
+          // pick the XL one and never the shareable default.
+          { nozzle: noz._id, printer: xl._id, pressureAdvance: 0.05 },
+          { nozzle: noz._id, printer: core._id, pressureAdvance: 0.09 },
+          { nozzle: noz._id, pressureAdvance: 0.02 }, // shareable default
+        ],
+      });
+      return { f, xl, core };
+    }
+
+    it("selects the calibration for the named printer", async () => {
+      const { f } = await seedTwoPrinters();
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=CoreOne`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.09);
+    });
+
+    it("accepts an ObjectId as well as a name (the bed_type convention)", async () => {
+      const { f, xl } = await seedTwoPrinters();
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${xl._id}`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.05);
+    });
+
+    it("falls back to the shareable default for an UNKNOWN printer — never a 404", async () => {
+      const { f } = await seedTwoPrinters();
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=NoSuchPrinter`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.02);
+    });
+
+    it("with NO printer param prefers the shareable default (deterministic)", async () => {
+      // Behavior change, deliberate: the old code took whatever sorted first
+      // — here an XL-specific entry — for a caller that never named a
+      // printer. The printer-null default is what the bundle exporter
+      // already prefers when baking a preset.
+      const { f } = await seedTwoPrinters();
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.02);
+    });
+
+    it("still answers when only printer-scoped entries exist", async () => {
+      const Printer = mongoose.models.Printer;
+      const noz = await Nozzle.create({ name: "0.6 Brass", diameter: 0.6, type: "Brass" });
+      const xl = await Printer.create({ name: "XL2", manufacturer: "Prusa", printerModel: "XL" });
+      const f = await Filament.create({
+        name: "ASA", vendor: "X", type: "ASA",
+        calibrations: [{ nozzle: noz._id, printer: xl._id, pressureAdvance: 0.06 }],
+      });
+      const res = await getCalibration(
+        getReq(`http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.6`),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.06);
+    });
+  });
+
   it("#872 — nozzle_type disambiguates same-diameter nozzles with distinct PA", async () => {
     const brass = await Nozzle.create({ name: "0.4 Brass", diameter: 0.4, type: "Brass" });
     const diamond = await Nozzle.create({ name: "0.4 Diamondback", diameter: 0.4, type: "Diamondback" });

--- a/tests/calibration-route.test.ts
+++ b/tests/calibration-route.test.ts
@@ -304,6 +304,37 @@ describe("GET /api/filaments/[id]/calibration", () => {
       expect((await res.json()).calibration.pressureAdvance).toBe(0.82);
     });
 
+    it("an existing VERBATIM name with no row here does not fall to its trimmed twin (r5)", async () => {
+      // One rung below the r4 case: "VT " exists and is what the caller asked
+      // for, but has no row for this nozzle. The trimmed rung had matches, so
+      // a single combined existence check never fired and "VT"'s row answered.
+      const noz = await Nozzle.create({ name: "0.4 W", diameter: 0.4, type: "Brass" });
+      const other = await Nozzle.create({ name: "0.6 W", diameter: 0.6, type: "Brass" });
+      const rawPrinters = mongoose.connection.collection("printers");
+      const now = new Date();
+      const tidy = new mongoose.Types.ObjectId();
+      const untidy = new mongoose.Types.ObjectId();
+      await rawPrinters.insertMany([
+        { _id: tidy, name: "VT", manufacturer: "M", printerModel: "X", _deletedAt: null, createdAt: now, updatedAt: now },
+        { _id: untidy, name: "VT ", manufacturer: "M", printerModel: "X", _deletedAt: null, createdAt: now, updatedAt: now },
+      ]);
+      const f = await Filament.create({
+        name: "PVA-H", vendor: "X", type: "PVA",
+        calibrations: [
+          { nozzle: noz._id, printer: tidy, pressureAdvance: 0.11 },
+          { nozzle: noz._id, pressureAdvance: 0.12 }, // the shareable default
+          { nozzle: other._id, printer: untidy, pressureAdvance: 0.13 },
+        ],
+      });
+      const res = await getCalibration(
+        getReq(
+          `http://localhost/api/filaments/${f._id}/calibration?nozzle_diameter=0.4&printer=${encodeURIComponent("VT ")}`,
+        ),
+        { params: Promise.resolve({ id: String(f._id) }) },
+      );
+      expect((await res.json()).calibration.pressureAdvance).toBe(0.12);
+    });
+
     it("a soft-deleted printer's own row does not outrank an active namesake (r4)", async () => {
       // populate() doesn't filter tombstones, so a calibration still pointing
       // at a deleted printer used to satisfy the id match — the impostor


### PR DESCRIPTION
The zero-migration quick win from #1047. `calibrations[].printer` has been populated since #107, but the read route had no way to **ask** for it — so a slicer on the XL received whichever same-nozzle entry happened to sort first, possibly one tuned for a different machine. The compound nozzle identity, the canonical `Nozzle.printer` side and the dedupe migration stay in #1047's later phases; this changes no schema.

`?printer=<name|ObjectId>` follows the convention `bed_type` already uses, and is **soft** — matching the `nozzle_type` posture directly beside it: a printer match wins, else the shareable printer-less defaults, else the unscoped list. A printer/data mismatch never turns a working lookup into a 404.

**One deliberate behavior change**, documented in the OpenAPI description: with *no* printer param the printer-less defaults are now preferred instead of "whatever sorted first". That's deterministic, and it matches what `prusaSlicerBundle` already prefers when baking a preset. A filament whose only entries are printer-scoped still answers with one (test included), so nothing that used to resolve stops resolving.

Five route tests: named printer, ObjectId form, unknown-printer fallback, the no-param default preference, and printer-scoped-only. Failing-before verified by removing the block (three fail).

Note for the fork side: the sync-back WRITE path still has no printer context, so a printer-scoped row can shadow slicer edits — that's called out in the issue and needs a coordinated hyiger/PrusaSlicer change, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)