### PR TITLE
fix(form): number inputs accept imported decimals (step="any" sweep)

### DIFF
--- a/src/app/filaments/FilamentForm.tsx
+++ b/src/app/filaments/FilamentForm.tsx
@@ -1898,7 +1898,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           <input
             id="filament-cost"
             type="number"
-            step="0.01"
+            step="any"
             min="0"
             className={inputClass}
             value={form.cost}
@@ -1946,7 +1946,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-net-filament"
               type="number"
-              step="1"
+              step="any"
               min="0"
               className={inputClass}
               value={form.netFilamentWeight}
@@ -1960,7 +1960,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-spool-weight"
               type="number"
-              step="1"
+              step="any"
               min="0"
               className={inputClass}
               value={form.spoolWeight}
@@ -1983,7 +1983,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-initial-weight"
               type="number"
-              step="1"
+              step="any"
               min="0"
               className={inputClass}
               value={form.totalWeight}
@@ -2001,7 +2001,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-low-stock-threshold"
               type="number"
-              step="1"
+              step="any"
               min="0"
               className={inputClass}
               value={form.lowStockThreshold}
@@ -2072,7 +2072,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
         <div>
           <label htmlFor="filament-min-print-speed" className={labelClass}>{t("form.minPrintSpeed")}</label>
-          <input id="filament-min-print-speed" type="number" step="1" min="0" className={inputClass}
+          <input id="filament-min-print-speed" type="number" step="any" min="0" className={inputClass}
             value={form.minPrintSpeed}
             onChange={(e) => setForm({ ...form, minPrintSpeed: e.target.value })}
             placeholder={parentPh("minPrintSpeed")}
@@ -2080,7 +2080,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
         </div>
         <div>
           <label htmlFor="filament-max-print-speed" className={labelClass}>{t("form.maxPrintSpeed")}</label>
-          <input id="filament-max-print-speed" type="number" step="1" min="0" className={inputClass}
+          <input id="filament-max-print-speed" type="number" step="any" min="0" className={inputClass}
             value={form.maxPrintSpeed}
             onChange={(e) => setForm({ ...form, maxPrintSpeed: e.target.value })}
             placeholder={parentPh("maxPrintSpeed")}
@@ -2088,7 +2088,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
         </div>
         <div>
           <label htmlFor="filament-z-offset" className={labelClass}>{t("form.zOffset")}</label>
-          <input id="filament-z-offset" type="number" step="0.001" className={inputClass}
+          <input id="filament-z-offset" type="number" step="any" className={inputClass}
             value={form.zOffset}
             onChange={(e) => setForm({ ...form, zOffset: e.target.value })}
             placeholder={t("form.placeholder.zOffset")}
@@ -2123,6 +2123,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-temp-nozzle"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.nozzle}
@@ -2140,6 +2141,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-temp-nozzle-first-layer"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.nozzleFirstLayer}
@@ -2157,6 +2159,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-temp-bed"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.bed}
@@ -2174,6 +2177,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-temp-bed-first-layer"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.bedFirstLayer}
@@ -2191,6 +2195,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-temp-chamber"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.chamber}
@@ -2207,6 +2212,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-temp-standby"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.standby}
@@ -2224,6 +2230,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               id="filament-temp-nozzle-range-min"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.nozzleRangeMin}
@@ -2242,6 +2249,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
               ref={nozzleRangeMaxRef}
               id="filament-temp-nozzle-range-max"
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.temperatures.nozzleRangeMax}
@@ -2270,14 +2278,14 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                   }} placeholder={t("form.placeholder.bedType")} />
                 </div>
                 <div>
-                  <input type="number" min="0" className={inputClass} value={bt.temperature} onChange={(e) => {
+                  <input type="number" step="any" min="0" className={inputClass} value={bt.temperature} onChange={(e) => {
                     const updated = [...form.bedTypeTemps];
                     updated[idx] = { ...bt, temperature: e.target.value };
                     setForm({ ...form, bedTypeTemps: updated });
                   }} placeholder={t("form.placeholder.temp")} />
                 </div>
                 <div>
-                  <input type="number" min="0" className={inputClass} value={bt.firstLayerTemperature} onChange={(e) => {
+                  <input type="number" step="any" min="0" className={inputClass} value={bt.firstLayerTemperature} onChange={(e) => {
                     const updated = [...form.bedTypeTemps];
                     updated[idx] = { ...bt, firstLayerTemperature: e.target.value };
                     setForm({ ...form, bedTypeTemps: updated });
@@ -2336,6 +2344,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <label className={labelClass}>{t("form.fanMinSpeed")}</label>
             <input
               type="number"
+              step="any"
               min="0"
               max="100"
               className={inputClass}
@@ -2347,6 +2356,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <label className={labelClass}>{t("form.fanMaxSpeed")}</label>
             <input
               type="number"
+              step="any"
               min="0"
               max="100"
               className={inputClass}
@@ -2358,6 +2368,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <label className={labelClass}>{t("form.fanBridgeSpeed")}</label>
             <input
               type="number"
+              step="any"
               min="0"
               max="100"
               className={inputClass}
@@ -2369,6 +2380,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <label className={labelClass}>{t("form.fanDisableFirstLayers")}</label>
             <input
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.fanDisableFirstLayers}
@@ -2377,21 +2389,21 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           </div>
           <div>
             <label className={labelClass}>{t("form.overhangFanSpeed")}</label>
-            <input type="number" min="0" max="100" className={inputClass}
+            <input type="number" step="any" min="0" max="100" className={inputClass}
               value={form.overhangFanSpeed}
               onChange={(e) => setForm({ ...form, overhangFanSpeed: e.target.value })}
             />
           </div>
           <div>
             <label className={labelClass}>{t("form.auxFanSpeed")}</label>
-            <input type="number" min="0" max="100" className={inputClass}
+            <input type="number" step="any" min="0" max="100" className={inputClass}
               value={form.auxFanSpeed}
               onChange={(e) => setForm({ ...form, auxFanSpeed: e.target.value })}
             />
           </div>
           <div>
             <label className={labelClass}>{t("form.fanBelowLayerTime")}</label>
-            <input type="number" min="0" className={inputClass}
+            <input type="number" step="any" min="0" className={inputClass}
               value={form.fanBelowLayerTime}
               onChange={(e) => setForm({ ...form, fanBelowLayerTime: e.target.value })}
               placeholder={t("form.placeholder.fanBelowLayerTime")}
@@ -2399,7 +2411,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           </div>
           <div>
             <label className={labelClass}>{t("form.slowDownMinSpeed")}</label>
-            <input type="number" min="0" className={inputClass}
+            <input type="number" step="any" min="0" className={inputClass}
               value={form.slowDownMinSpeed}
               onChange={(e) => setForm({ ...form, slowDownMinSpeed: e.target.value })}
               placeholder={t("form.placeholder.slowDownMinSpeed")}
@@ -2420,7 +2432,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               type="number"
               min="0"
-              step="0.1"
+              step="any"
               className={inputClass}
               value={form.retractLength}
               onChange={(e) => setForm({ ...form, retractLength: e.target.value })}
@@ -2430,6 +2442,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <label className={labelClass}>{t("form.retractSpeed")}</label>
             <input
               type="number"
+              step="any"
               min="0"
               className={inputClass}
               value={form.retractSpeed}
@@ -2441,7 +2454,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
             <input
               type="number"
               min="0"
-              step="0.01"
+              step="any"
               className={inputClass}
               value={form.retractLift}
               onChange={(e) => setForm({ ...form, retractLift: e.target.value })}
@@ -2449,7 +2462,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           </div>
           <div>
             <label className={labelClass}>{t("form.retractMinTravel")}</label>
-            <input type="number" min="0" step="0.1" className={inputClass}
+            <input type="number" min="0" step="any" className={inputClass}
               value={form.retractMinTravel}
               onChange={(e) => setForm({ ...form, retractMinTravel: e.target.value })}
               placeholder={t("form.placeholder.retractMinTravel")}
@@ -2467,28 +2480,28 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <div>
             <label className={labelClass}>{t("form.loadingSpeed")}</label>
-            <input type="number" min="0" step="0.1" className={inputClass}
+            <input type="number" min="0" step="any" className={inputClass}
               value={form.filamentLoadingSpeed}
               onChange={(e) => setForm({ ...form, filamentLoadingSpeed: e.target.value })}
             />
           </div>
           <div>
             <label className={labelClass}>{t("form.unloadingSpeed")}</label>
-            <input type="number" min="0" step="0.1" className={inputClass}
+            <input type="number" min="0" step="any" className={inputClass}
               value={form.filamentUnloadingSpeed}
               onChange={(e) => setForm({ ...form, filamentUnloadingSpeed: e.target.value })}
             />
           </div>
           <div>
             <label className={labelClass}>{t("form.loadTime")}</label>
-            <input type="number" min="0" step="0.1" className={inputClass}
+            <input type="number" min="0" step="any" className={inputClass}
               value={form.filamentLoadTime}
               onChange={(e) => setForm({ ...form, filamentLoadTime: e.target.value })}
             />
           </div>
           <div>
             <label className={labelClass}>{t("form.unloadTime")}</label>
-            <input type="number" min="0" step="0.1" className={inputClass}
+            <input type="number" min="0" step="any" className={inputClass}
               value={form.filamentUnloadTime}
               onChange={(e) => setForm({ ...form, filamentUnloadTime: e.target.value })}
             />
@@ -2511,7 +2524,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
         <div>
           <label className={labelClass}>{t("form.glassTempTransition")}</label>
-          <input type="number" step="1" min="0" className={inputClass}
+          <input type="number" step="any" min="0" className={inputClass}
             value={form.glassTempTransition}
             onChange={(e) => setForm({ ...form, glassTempTransition: e.target.value })}
             placeholder={parentPh("glassTempTransition") ?? t("form.placeholder.glassTempTransition")}
@@ -2519,7 +2532,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
         </div>
         <div>
           <label className={labelClass}>{t("form.heatDeflectionTemp")}</label>
-          <input type="number" step="1" min="0" className={inputClass}
+          <input type="number" step="any" min="0" className={inputClass}
             value={form.heatDeflectionTemp}
             onChange={(e) => setForm({ ...form, heatDeflectionTemp: e.target.value })}
             placeholder={parentPh("heatDeflectionTemp") ?? t("form.placeholder.heatDeflectionTemp")}
@@ -2542,7 +2555,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           <input
             className={inputClass}
             type="number"
-            step="1"
+            step="any"
             min="0"
             value={form.dryingTemperature}
             onChange={(e) => setForm({ ...form, dryingTemperature: e.target.value })}
@@ -2554,7 +2567,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           <input
             className={inputClass}
             type="number"
-            step="1"
+            step="any"
             min="0"
             value={form.dryingTime}
             onChange={(e) => setForm({ ...form, dryingTime: e.target.value })}
@@ -2580,7 +2593,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           <input
             className={inputClass}
             type="number"
-            step="1"
+            step="any"
             min="0"
             max="100"
             value={form.shoreHardnessA}
@@ -2593,7 +2606,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
           <input
             className={inputClass}
             type="number"
-            step="1"
+            step="any"
             min="0"
             max="100"
             value={form.shoreHardnessD}
@@ -2887,7 +2900,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <input
                         type="number"
                         min="0"
-                        step="0.01"
+                        step="any"
                         className={inputClass}
                         value={cal.extrusionMultiplier}
                         onChange={(e) =>
@@ -2901,7 +2914,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <input
                         type="number"
                         min="0"
-                        step="0.1"
+                        step="any"
                         className={inputClass}
                         value={cal.maxVolumetricSpeed}
                         onChange={(e) =>
@@ -2915,7 +2928,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <input
                         type="number"
                         min="0"
-                        step="0.001"
+                        step="any"
                         className={inputClass}
                         value={cal.pressureAdvance}
                         onChange={(e) =>
@@ -2929,7 +2942,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <input
                         type="number"
                         min="0"
-                        step="0.1"
+                        step="any"
                         className={inputClass}
                         value={cal.retractLength}
                         onChange={(e) =>
@@ -2942,6 +2955,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1" title={t("form.tooltip.retractSpeed")}>{t("form.cal.retractSpeed")}</label>
                       <input
                         type="number"
+                        step="any"
                         min="0"
                         className={inputClass}
                         value={cal.retractSpeed}
@@ -2956,7 +2970,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <input
                         type="number"
                         min="0"
-                        step="0.01"
+                        step="any"
                         className={inputClass}
                         value={cal.retractLift}
                         onChange={(e) =>
@@ -2974,6 +2988,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.nozzleTemp")}</label>
                       <input
                         type="number"
+                        step="any"
                         className={inputClass}
                         value={cal.nozzleTemp}
                         onChange={(e) => updateCalibration(key, "nozzleTemp", e.target.value)}
@@ -2984,6 +2999,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.nozzleTempFirstLayer")}</label>
                       <input
                         type="number"
+                        step="any"
                         className={inputClass}
                         value={cal.nozzleTempFirstLayer}
                         onChange={(e) => updateCalibration(key, "nozzleTempFirstLayer", e.target.value)}
@@ -2994,6 +3010,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.bedTemp")}</label>
                       <input
                         type="number"
+                        step="any"
                         className={inputClass}
                         value={cal.bedTemp}
                         onChange={(e) => updateCalibration(key, "bedTemp", e.target.value)}
@@ -3004,6 +3021,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.bedTempFirstLayer")}</label>
                       <input
                         type="number"
+                        step="any"
                         className={inputClass}
                         value={cal.bedTempFirstLayer}
                         onChange={(e) => updateCalibration(key, "bedTempFirstLayer", e.target.value)}
@@ -3014,6 +3032,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.chamberTemp")}</label>
                       <input
                         type="number"
+                        step="any"
                         className={inputClass}
                         value={cal.chamberTemp}
                         onChange={(e) => updateCalibration(key, "chamberTemp", e.target.value)}
@@ -3029,6 +3048,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.fanMin")}</label>
                       <input
                         type="number"
+                        step="any"
                         min="0"
                         max="100"
                         className={inputClass}
@@ -3041,6 +3061,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.fanMax")}</label>
                       <input
                         type="number"
+                        step="any"
                         min="0"
                         max="100"
                         className={inputClass}
@@ -3053,6 +3074,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                       <label className="block text-xs text-gray-500 mb-1">{t("form.cal.fanBridge")}</label>
                       <input
                         type="number"
+                        step="any"
                         min="0"
                         max="100"
                         className={inputClass}
@@ -3169,7 +3191,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                     <label className="block text-xs text-gray-500 mb-1" title={t("form.tooltip.em")}>{t("form.cal.em")}</label>
                     <input
                       type="number"
-                      step="0.01"
+                      step="any"
                       className={inputClass}
                       value={preset.extrusionMultiplier}
                       onChange={(e) => updatePreset(idx, "extrusionMultiplier", e.target.value)}
@@ -3180,6 +3202,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                     <label className="block text-xs text-gray-500 mb-1">{t("form.preset.nozzle")}</label>
                     <input
                       type="number"
+                      step="any"
                       className={inputClass}
                       value={preset.nozzle}
                       onChange={(e) => updatePreset(idx, "nozzle", e.target.value)}
@@ -3190,6 +3213,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                     <label className="block text-xs text-gray-500 mb-1">{t("form.preset.nozzleFirst")}</label>
                     <input
                       type="number"
+                      step="any"
                       className={inputClass}
                       value={preset.nozzleFirstLayer}
                       onChange={(e) => updatePreset(idx, "nozzleFirstLayer", e.target.value)}
@@ -3200,6 +3224,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                     <label className="block text-xs text-gray-500 mb-1">{t("form.preset.bed")}</label>
                     <input
                       type="number"
+                      step="any"
                       className={inputClass}
                       value={preset.bed}
                       onChange={(e) => updatePreset(idx, "bed", e.target.value)}
@@ -3210,6 +3235,7 @@ export default function FilamentForm({ initialData, onSubmit, onDirtyChange, isP
                     <label className="block text-xs text-gray-500 mb-1">{t("form.preset.bedFirst")}</label>
                     <input
                       type="number"
+                      step="any"
                       className={inputClass}
                       value={preset.bedFirstLayer}
                       onChange={(e) => updatePreset(idx, "bedFirstLayer", e.target.value)}

--- a/src/app/locations/LocationForm.tsx
+++ b/src/app/locations/LocationForm.tsx
@@ -143,7 +143,7 @@ export default function LocationForm({ initialData, onSubmit, onDirtyChange }: P
           type="number"
           min="0"
           max="100"
-          step="1"
+          step="any"
           className={inputClass}
           value={form.humidity}
           onChange={(e) => updateForm({ humidity: e.target.value })}

--- a/src/app/printers/PrinterForm.tsx
+++ b/src/app/printers/PrinterForm.tsx
@@ -636,7 +636,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
               id="printer-build-x"
               type="number"
               min="0"
-              step="1"
+              step="any"
               className={inputClass}
               value={form.buildVolume.x}
               onChange={(e) =>
@@ -650,7 +650,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
               id="printer-build-y"
               type="number"
               min="0"
-              step="1"
+              step="any"
               className={inputClass}
               value={form.buildVolume.y}
               onChange={(e) =>
@@ -664,7 +664,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
               id="printer-build-z"
               type="number"
               min="0"
-              step="1"
+              step="any"
               className={inputClass}
               value={form.buildVolume.z}
               onChange={(e) =>
@@ -680,7 +680,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
               id="printer-max-flow"
               type="number"
               min="0"
-              step="0.1"
+              step="any"
               className={inputClass}
               value={form.maxFlow}
               onChange={(e) => updateForm({ maxFlow: e.target.value })}
@@ -693,7 +693,7 @@ export default function PrinterForm({ initialData, onSubmit, onDirtyChange }: Pr
               id="printer-max-speed"
               type="number"
               min="0"
-              step="1"
+              step="any"
               className={inputClass}
               value={form.maxSpeed}
               onChange={(e) => updateForm({ maxSpeed: e.target.value })}

--- a/tests/form-step-attributes.test.ts
+++ b/tests/form-step-attributes.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * GH #1171 — source-level drift guard (same posture as the #1166 guard in
+ * api-route-correctness.test.ts).
+ *
+ * FilamentForm is a single <form> whose tab panels stay mounted-but-hidden so
+ * native constraint validation covers unopened tabs (#942). Consequently ANY
+ * number input whose `step` is coarser than what the import/sync pipeline
+ * stores (CSV parseNum, slicer parseFloat — arbitrary decimals) puts the form
+ * into a stepMismatch state that blocks saving the ENTIRE form for values the
+ * user never touched. #1166 hit this on max volumetric speed (step="0.1" vs a
+ * synced 12.34); #1171 is the class sweep.
+ *
+ * The subtle half of the class: an <input type="number"> with NO step
+ * attribute defaults to step=1, so a CSV-imported 217.5 °C temperature is just
+ * as save-blocking as an explicit step="1". That's why this guard requires an
+ * EXPLICIT step="any" on every number input rather than merely banning coarse
+ * values — absence is an offender too.
+ *
+ * Allowlist: density + diameter keep step="0.01" deliberately. Their stored
+ * values are the one place snapToStep normalizes at seed time (GH #570 — CBOR
+ * half-float dust like 1.2392578125), so the seeded value always sits on the
+ * 0.01 grid and can never stepMismatch. Loosening them without removing the
+ * snap would be dead relaxation; removing the snap resurfaces #570.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+// Every component that renders number inputs inside a real <form> (submit runs
+// native constraint validation). The detail-page / inventory weight inputs are
+// deliberately NOT here: they live outside any <form> with onClick saves, so
+// their step can never block anything.
+const FORM_FILES = [
+  "src/app/filaments/FilamentForm.tsx",
+  "src/app/printers/PrinterForm.tsx",
+  "src/app/locations/LocationForm.tsx",
+  "src/app/nozzles/NozzleForm.tsx",
+  "src/app/bed-types/BedTypeForm.tsx",
+];
+
+// file → identifying substrings of number inputs allowed to keep a finite step.
+const STEP_ALLOWLIST: Record<string, string[]> = {
+  "src/app/filaments/FilamentForm.tsx": [
+    'id="filament-density"', // GH #570 seed-snap keeps the value on the 0.01 grid
+    'id="filament-diameter"', // GH #570 seed-snap keeps the value on the 0.01 grid
+  ],
+};
+
+interface InputTag {
+  tag: string;
+  line: number;
+}
+
+// Extracts each <input …> JSX tag. A plain /<input[^>]*>/ regex truncates at
+// the `>` inside onChange={(e) => …}, so this walks characters tracking brace
+// depth: a `>` only terminates the tag at depth 0. Occurrences inside
+// comments (a line whose prefix is `//` or a block-comment `*`) are prose,
+// not controls — FilamentForm's getSettingVal docblock cites
+// `<input type="number">` verbatim and must not count as an offender.
+function extractInputTags(source: string): InputTag[] {
+  const tags: InputTag[] = [];
+  let searchFrom = 0;
+  for (;;) {
+    const start = source.indexOf("<input", searchFrom);
+    if (start === -1) break;
+    const lineStart = source.lastIndexOf("\n", start) + 1;
+    const linePrefix = source.slice(lineStart, start).trimStart();
+    if (linePrefix.startsWith("//") || linePrefix.startsWith("*") || linePrefix.startsWith("/*")) {
+      searchFrom = start + 1;
+      continue;
+    }
+    let depth = 0;
+    let end = -1;
+    for (let i = start; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+      else if (ch === ">" && depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    if (end === -1) break;
+    tags.push({
+      tag: source.slice(start, end + 1),
+      line: source.slice(0, start).split("\n").length,
+    });
+    searchFrom = end + 1;
+  }
+  return tags;
+}
+
+function numberInputs(source: string): InputTag[] {
+  return extractInputTags(source).filter((t) => t.tag.includes('type="number"'));
+}
+
+describe("form number inputs use step=\"any\" (GH #1171)", () => {
+  it("every number input in a real <form> carries step=\"any\" or is allowlisted", () => {
+    const offenders: string[] = [];
+    for (const file of FORM_FILES) {
+      const source = readFileSync(path.join(REPO_ROOT, file), "utf8");
+      const allowed = STEP_ALLOWLIST[file] ?? [];
+      for (const { tag, line } of numberInputs(source)) {
+        if (tag.includes('step="any"')) continue;
+        if (allowed.some((marker) => tag.includes(marker))) continue;
+        offenders.push(`${file}:${line}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("the allowlist stays live — each entry still names a finite-step number input", () => {
+    // If density/diameter are renamed or loosened, the allowlist must shrink
+    // rather than silently covering nothing.
+    for (const [file, markers] of Object.entries(STEP_ALLOWLIST)) {
+      const source = readFileSync(path.join(REPO_ROOT, file), "utf8");
+      const inputs = numberInputs(source);
+      for (const marker of markers) {
+        const matches = inputs.filter((t) => t.tag.includes(marker));
+        expect(matches, `${file} ${marker}`).toHaveLength(1);
+        expect(matches[0].tag, `${file} ${marker} should keep a finite step`).toMatch(
+          /step="0\.01"/,
+        );
+      }
+    }
+  });
+
+  it("the extractor ignores input tags cited inside comments", () => {
+    const jsx =
+      '// <input type="number"> is sanitized by browsers\n' +
+      "/* <input type=\"number\"> in a block comment\n" +
+      ' * <input type="number"> on a continuation line */\n' +
+      '<input type="number" step="any" />';
+    expect(extractInputTags(jsx)).toHaveLength(1);
+  });
+
+  it("the extractor sees through arrow functions in attributes", () => {
+    // Self-test: a regex-based extractor would truncate at the `=>` and lose
+    // the step attribute; this pins the brace-aware walk.
+    const jsx =
+      '<input\n  type="number"\n  onChange={(e) => setForm({ ...form, x: e.target.value })}\n  step="any"\n/>';
+    const tags = extractInputTags(jsx);
+    expect(tags).toHaveLength(1);
+    expect(tags[0].tag).toContain('step="any"');
+  });
+});


### PR DESCRIPTION
## Summary

Class sweep deferred from the #1166 Codex review. FilamentForm is one `<form>` whose tab panels stay mounted-but-hidden so native validation covers unopened tabs (#942) — so **any** number input whose `step` is coarser than what the import/sync pipeline stores blocks saving the whole form with an HTML stepMismatch, on values the user never touched. #1166 fixed the one reported input (base MVS); this fixes the class.

- **Explicit coarse steps → `step="any"`**: cost (`0.01`), spool weights / print speeds / glass / HDT / drying / shore (`1`), z-offset (`0.001`), retraction fields, MMU load/unload, and the per-nozzle calibration EM/MVS/PA/retract — including the calibration MVS input, the exact missed twin of the #1166 field. The pipeline stores arbitrary decimals for all of these (CSV `parseNum`, slicer `parseFloat`), so e.g. a CSV-imported `25.5` speed or a synced PA `0.0625` blocked every save.
- **Implicit steps too**: a number input with *no* step attribute defaults to `step=1`, so all 8 temperature inputs, bed-type temps, fan fields, and calibration temp overrides blocked a CSV-imported `217.5` just as hard. They now carry an explicit `step="any"`.
- **Same class in PrinterForm** (build volume, max flow/speed — printers arrive whole via hybrid sync / share / Atlas import) **and LocationForm** (humidity).
- **Untouched on purpose**: density + diameter keep `step="0.01"` — their seeded values are snapToStep-normalized onto that exact grid (GH #570), so they can never mismatch, and loosening them without the snap would resurface #570's half-float dust. Also untouched: the detail-page / inventory weight inputs — they live outside any `<form>` (onClick saves), so their step can never block anything.
- **Loosen, don't normalize**: snapping at seed would silently rewrite calibration-grade data (PA 0.0625 → 0.063 changes a print).

## Drift guard

`tests/form-step-attributes.test.ts` — the #1166 source-scan posture, made permanent: every `type="number"` input in the five form components must carry `step="any"` or be on the (density/diameter) allowlist. The extractor is brace-aware (a naive regex truncates at the `>` in `onChange={(e) => …}`), skips input tags cited inside comments, and a liveness check fails if an allowlist entry stops matching a real finite-step input.

Known trade-off (already accepted in #1166 for base MVS): spinner arrows step by 1 on the previously fine-grained fields.

## Test plan
- [x] `tests/form-step-attributes.test.ts` (new, 4 tests — fails before the sweep with 66 offenders, passes after)
- [x] Full suite: 4691 passed (215 files)
- [x] `npm run lint`, `tsc --noEmit` clean

Fixes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)