### PR TITLE
fix(openprinttag): tokenized multi-field search in the OPT link dialog + browser

### DIFF
--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { safeHttpUrl } from "@/lib/safeRenderUrl";
 import { formatMinutesAsHm } from "@/lib/formatDuration";
+import { matchesTokenizedQuery } from "@/lib/materialSearch";
 
 // Row layout constants — the virtualized List needs known heights so it
 // can compute the absolute scroll position of every row without mounting
@@ -567,12 +568,9 @@ export default function OpenPrintTagBrowser() {
       materials = materials.filter((m) => m.completenessTier === tierFilter);
     }
     if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-      materials = materials.filter(
-        (m) =>
-          m.name.toLowerCase().includes(q) ||
-          m.brandName.toLowerCase().includes(q) ||
-          m.type.toLowerCase().includes(q),
+      // GH #1173: tokenized — same semantics as the OPT link dialog.
+      materials = materials.filter((m) =>
+        matchesTokenizedQuery([m.name, m.brandName, m.type], searchQuery),
       );
     }
 

--- a/src/app/openprinttag/page.tsx
+++ b/src/app/openprinttag/page.tsx
@@ -9,7 +9,11 @@ import { useTranslation } from "@/i18n/TranslationProvider";
 import { useNumberFormat } from "@/hooks/useNumberFormat";
 import { safeHttpUrl } from "@/lib/safeRenderUrl";
 import { formatMinutesAsHm } from "@/lib/formatDuration";
-import { matchesTokenizedQuery } from "@/lib/materialSearch";
+import {
+  matchesSearchTokens,
+  normalizeSearchFields,
+  tokenizeSearchQuery,
+} from "@/lib/materialSearch";
 
 // Row layout constants — the virtualized List needs known heights so it
 // can compute the absolute scroll position of every row without mounting
@@ -554,6 +558,19 @@ export default function OpenPrintTagBrowser() {
     return db.brands.filter((b) => b.name.toLowerCase().includes(q));
   }, [db, brandSearch]);
 
+  // Normalized once per loaded DB, not once per keystroke per row (Codex P2
+  // on PR #1181 — the search filter below runs over ~11.7k materials). Keyed
+  // by object identity: db.materials is stable for the life of the loaded db.
+  const searchFieldsByMaterial = useMemo(() => {
+    const map = new Map<OPTMaterial, string[]>();
+    if (db) {
+      for (const m of db.materials) {
+        map.set(m, normalizeSearchFields([m.name, m.brandName, m.type]));
+      }
+    }
+    return map;
+  }, [db]);
+
   const filteredMaterials = useMemo(() => {
     if (!db) return [];
     let materials = db.materials;
@@ -569,9 +586,12 @@ export default function OpenPrintTagBrowser() {
     }
     if (searchQuery) {
       // GH #1173: tokenized — same semantics as the OPT link dialog.
-      materials = materials.filter((m) =>
-        matchesTokenizedQuery([m.name, m.brandName, m.type], searchQuery),
-      );
+      const tokens = tokenizeSearchQuery(searchQuery);
+      if (tokens.length > 0) {
+        materials = materials.filter((m) =>
+          matchesSearchTokens(searchFieldsByMaterial.get(m) ?? [], tokens),
+        );
+      }
     }
 
     // Sort
@@ -592,7 +612,7 @@ export default function OpenPrintTagBrowser() {
     }
 
     return materials;
-  }, [db, brandFilter, typeFilter, tierFilter, searchQuery, sortKey]);
+  }, [db, brandFilter, typeFilter, tierFilter, searchQuery, sortKey, searchFieldsByMaterial]);
 
   // ── Handlers ───────────────────────────────────────────────────────
 

--- a/src/components/OptLinkDialog.tsx
+++ b/src/components/OptLinkDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useToast } from "@/components/Toast";
+import { matchesTokenizedQuery } from "@/lib/materialSearch";
 
 /**
  * Issue #753 (approach C) — "Link to OpenPrintTag" dialog.
@@ -100,15 +101,10 @@ export default function OptLinkDialog({ filamentId, onLinked, onClose, mode = "l
   }, [onClose]);
 
   const results = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (q === "") return [];
+    if (query.trim() === "") return [];
+    // GH #1173: tokenized — "arianeplast pl" hits brand + type across fields.
     return materials
-      .filter(
-        (m) =>
-          m.name.toLowerCase().includes(q) ||
-          m.brandName.toLowerCase().includes(q) ||
-          m.type.toLowerCase().includes(q),
-      )
+      .filter((m) => matchesTokenizedQuery([m.name, m.brandName, m.type], query))
       .slice(0, MAX_RESULTS);
   }, [materials, query]);
 

--- a/src/components/OptLinkDialog.tsx
+++ b/src/components/OptLinkDialog.tsx
@@ -3,7 +3,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "@/i18n/TranslationProvider";
 import { useToast } from "@/components/Toast";
-import { matchesTokenizedQuery } from "@/lib/materialSearch";
+import {
+  matchesSearchTokens,
+  normalizeSearchFields,
+  tokenizeSearchQuery,
+} from "@/lib/materialSearch";
 
 /**
  * Issue #753 (approach C) — "Link to OpenPrintTag" dialog.
@@ -100,13 +104,29 @@ export default function OptLinkDialog({ filamentId, onLinked, onClose, mode = "l
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  // Normalized once per loaded list, not once per keystroke per row
+  // (Codex P2 on PR #1181 — this filter runs over ~11.7k materials).
+  const searchable = useMemo(
+    () =>
+      materials.map((m) => ({
+        material: m,
+        fields: normalizeSearchFields([m.name, m.brandName, m.type]),
+      })),
+    [materials],
+  );
+
   const results = useMemo(() => {
     if (query.trim() === "") return [];
     // GH #1173: tokenized — "arianeplast pl" hits brand + type across fields.
-    return materials
-      .filter((m) => matchesTokenizedQuery([m.name, m.brandName, m.type], query))
-      .slice(0, MAX_RESULTS);
-  }, [materials, query]);
+    const tokens = tokenizeSearchQuery(query);
+    const out: OptMaterial[] = [];
+    for (const { material, fields } of searchable) {
+      if (!matchesSearchTokens(fields, tokens)) continue;
+      out.push(material);
+      if (out.length === MAX_RESULTS) break;
+    }
+    return out;
+  }, [searchable, query]);
 
   const handleLink = async () => {
     if (!selectedSlug) return;

--- a/src/lib/materialSearch.ts
+++ b/src/lib/materialSearch.ts
@@ -26,21 +26,47 @@ export function normalizeSearchText(value: string): string {
   return value.normalize("NFD").replace(COMBINING_MARKS_RE, "").toLowerCase();
 }
 
+/** Normalized whitespace-separated query tokens. Empty for a blank query. */
+export function tokenizeSearchQuery(query: string): string[] {
+  return normalizeSearchText(query).split(/\s+/).filter(Boolean);
+}
+
+/** Pre-normalize a row's searchable fields (drops null/undefined/empty). */
+export function normalizeSearchFields(
+  fields: ReadonlyArray<string | null | undefined>,
+): string[] {
+  return fields
+    .filter((f): f is string => typeof f === "string" && f !== "")
+    .map(normalizeSearchText);
+}
+
 /**
- * True when EVERY whitespace-separated token of `query` is a substring of AT
- * LEAST ONE of `fields` (AND across tokens, OR across fields), compared
- * accent- and case-insensitively. An empty / whitespace-only query matches
- * everything — callers that want "no query → no results" gate that case
- * themselves (the link dialog does).
+ * AND across tokens, OR across fields, over PRE-normalized inputs. Zero
+ * tokens match everything — callers that want "no query → no results" gate
+ * that case themselves (the link dialog does).
+ *
+ * Split from matchesTokenizedQuery so hot callers pay normalization once per
+ * SEARCH, not once per ROW: both UI callers filter the ~11.7k-material OPT
+ * list per keystroke inside useMemo, where re-tokenizing the query (and
+ * re-normalizing every row's fields) 11.7k times per keystroke measurably
+ * blocks input (Codex P2 on PR #1181). Tokenize the query once per search
+ * and cache normalizeSearchFields per row keyed on the loaded list.
+ */
+export function matchesSearchTokens(
+  normalizedFields: ReadonlyArray<string>,
+  tokens: ReadonlyArray<string>,
+): boolean {
+  return tokens.every((token) => normalizedFields.some((h) => h.includes(token)));
+}
+
+/**
+ * Convenience one-shot: true when EVERY whitespace-separated token of `query`
+ * is a substring of AT LEAST ONE of `fields` (accent- and case-insensitive).
+ * For per-keystroke filtering of large lists use the split form above.
  */
 export function matchesTokenizedQuery(
   fields: ReadonlyArray<string | null | undefined>,
   query: string,
 ): boolean {
-  const tokens = normalizeSearchText(query).split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) return true;
-  const haystacks = fields
-    .filter((f): f is string => typeof f === "string" && f !== "")
-    .map(normalizeSearchText);
-  return tokens.every((token) => haystacks.some((h) => h.includes(token)));
+  return matchesSearchTokens(normalizeSearchFields(fields), tokenizeSearchQuery(query));
 }

--- a/src/lib/materialSearch.ts
+++ b/src/lib/materialSearch.ts
@@ -1,0 +1,46 @@
+/**
+ * Tokenized multi-field search for the OpenPrintTag material lists (GH #1173).
+ *
+ * The OPT link dialog and the /openprinttag browser both used to require the
+ * WHOLE query as one contiguous substring inside a SINGLE field
+ * (name | brandName | type). The row title is the material name WITHOUT the
+ * brand (the brand renders as the subtitle), so the natural query
+ * "arianeplast pl" — brand + start of the material type — matched nothing:
+ * no single field contains that string. Tokenizing fixes it: every
+ * whitespace-separated token must match somewhere (AND across tokens), but
+ * each token may land in a different field (OR across fields).
+ *
+ * Accent folding uses NFD + the explicit combining range [̀-ͯ],
+ * NOT `\p{M}` — property escapes are ES2018 while the repo targets ES2017,
+ * and tsc validates regex FLAGS against the target but not regex BODIES, so
+ * `\p{M}` would typecheck and fail only at runtime (the tsplEncoder lesson).
+ * The OPT database is international (French "Améthyste", German umlauts), so
+ * folding matters in both directions: an unaccented query must match an
+ * accented name and vice versa.
+ */
+
+const COMBINING_MARKS_RE = /[̀-ͯ]/g;
+
+/** Lowercase + strip combining accents for comparison. */
+export function normalizeSearchText(value: string): string {
+  return value.normalize("NFD").replace(COMBINING_MARKS_RE, "").toLowerCase();
+}
+
+/**
+ * True when EVERY whitespace-separated token of `query` is a substring of AT
+ * LEAST ONE of `fields` (AND across tokens, OR across fields), compared
+ * accent- and case-insensitively. An empty / whitespace-only query matches
+ * everything — callers that want "no query → no results" gate that case
+ * themselves (the link dialog does).
+ */
+export function matchesTokenizedQuery(
+  fields: ReadonlyArray<string | null | undefined>,
+  query: string,
+): boolean {
+  const tokens = normalizeSearchText(query).split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return true;
+  const haystacks = fields
+    .filter((f): f is string => typeof f === "string" && f !== "")
+    .map(normalizeSearchText);
+  return tokens.every((token) => haystacks.some((h) => h.includes(token)));
+}

--- a/tests/materialSearch.test.ts
+++ b/tests/materialSearch.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { matchesTokenizedQuery, normalizeSearchText } from "@/lib/materialSearch";
+
+// GH #1173 — the reporter's exact rows: brand in one field, color-bearing
+// name in another, type in a third. The old single-substring filter could
+// never match a query spanning fields.
+const ARIANEPLAST_PLA_BLANC = ["PLA Blanc", "Arianeplast", "PLA"];
+
+describe("normalizeSearchText", () => {
+  it("lowercases", () => {
+    expect(normalizeSearchText("Arianeplast")).toBe("arianeplast");
+  });
+
+  it("strips combining accents via NFD", () => {
+    expect(normalizeSearchText("Améthyste")).toBe("amethyste");
+    expect(normalizeSearchText("Grün")).toBe("grun");
+  });
+
+  it("leaves plain ASCII untouched", () => {
+    expect(normalizeSearchText("pla blanc 1.75")).toBe("pla blanc 1.75");
+  });
+});
+
+describe("matchesTokenizedQuery", () => {
+  it("matches the reported flow: brand + first letter of the color", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "arianeplast b")).toBe(true);
+  });
+
+  it("matches the reported flow: brand + start of the material type", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "arianeplast pl")).toBe(true);
+  });
+
+  it("single-token queries behave like the old filter (substring of any field)", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "arian")).toBe(true);
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "blanc")).toBe(true);
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "xyz")).toBe(false);
+  });
+
+  it("AND across tokens: every token must land somewhere", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "arianeplast petg")).toBe(false);
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "prusa blanc")).toBe(false);
+  });
+
+  it("OR across fields: different tokens may hit different fields", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "blanc arianeplast pla")).toBe(true);
+  });
+
+  it("a contiguous multi-word phrase inside ONE field still matches (superset of old behavior)", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "pla blanc")).toBe(true);
+  });
+
+  it("is case-insensitive on both sides", () => {
+    expect(matchesTokenizedQuery(["PLA Blanc", "ARIANEPLAST", "PLA"], "ArIaNePlAsT bLaNc")).toBe(true);
+  });
+
+  it("accent-folds both directions", () => {
+    expect(matchesTokenizedQuery(["PLA Améthyste", "Francofil", "PLA"], "ameth")).toBe(true);
+    expect(matchesTokenizedQuery(["PLA Amethyste", "Francofil", "PLA"], "améth")).toBe(true);
+  });
+
+  it("empty and whitespace-only queries match everything (callers gate the empty case)", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "")).toBe(true);
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "   ")).toBe(true);
+  });
+
+  it("tolerates repeated whitespace between tokens", () => {
+    expect(matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, "  arianeplast   pla  ")).toBe(true);
+  });
+
+  it("tolerates null / undefined / empty fields", () => {
+    expect(matchesTokenizedQuery(["PLA Blanc", null, undefined, ""], "blanc")).toBe(true);
+    expect(matchesTokenizedQuery([null, undefined, ""], "blanc")).toBe(false);
+  });
+
+  it("no fields at all never matches a non-empty query", () => {
+    expect(matchesTokenizedQuery([], "pla")).toBe(false);
+    expect(matchesTokenizedQuery([], "")).toBe(true);
+  });
+});

--- a/tests/materialSearch.test.ts
+++ b/tests/materialSearch.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { matchesTokenizedQuery, normalizeSearchText } from "@/lib/materialSearch";
+import {
+  matchesSearchTokens,
+  matchesTokenizedQuery,
+  normalizeSearchFields,
+  normalizeSearchText,
+  tokenizeSearchQuery,
+} from "@/lib/materialSearch";
 
 // GH #1173 — the reporter's exact rows: brand in one field, color-bearing
 // name in another, type in a third. The old single-substring filter could
@@ -18,6 +24,30 @@ describe("normalizeSearchText", () => {
 
   it("leaves plain ASCII untouched", () => {
     expect(normalizeSearchText("pla blanc 1.75")).toBe("pla blanc 1.75");
+  });
+});
+
+describe("the compile-once split form (Codex P2 on PR #1181)", () => {
+  it("tokenizeSearchQuery normalizes, splits on whitespace runs, and drops empties", () => {
+    expect(tokenizeSearchQuery("  Arianeplast   PLá ")).toEqual(["arianeplast", "pla"]);
+    expect(tokenizeSearchQuery("")).toEqual([]);
+    expect(tokenizeSearchQuery("   ")).toEqual([]);
+  });
+
+  it("normalizeSearchFields normalizes and drops null/undefined/empty entries", () => {
+    expect(normalizeSearchFields(["PLA Blanc", null, undefined, "", "Améthyste"])).toEqual([
+      "pla blanc",
+      "amethyste",
+    ]);
+  });
+
+  it("matchesSearchTokens is the equivalence-preserving core of matchesTokenizedQuery", () => {
+    const fields = normalizeSearchFields(ARIANEPLAST_PLA_BLANC);
+    for (const q of ["arianeplast b", "arianeplast petg", "", "pla blanc"]) {
+      expect(matchesSearchTokens(fields, tokenizeSearchQuery(q))).toBe(
+        matchesTokenizedQuery(ARIANEPLAST_PLA_BLANC, q),
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The "Link to OpenPrintTag" dialog (`OptLinkDialog.tsx`) and the `/openprinttag` browser had byte-identical filters requiring the **whole query as one contiguous substring inside a single field** (`name | brandName | type`). The row title is the material name *without* the brand (brand is the subtitle), so the reporter's natural queries — "arianeplast b" (brand + color initial), "arianeplast pl" (brand + type prefix) — matched nothing: no single field contains those strings.

- New pure helper [src/lib/materialSearch.ts](src/lib/materialSearch.ts): `matchesTokenizedQuery(fields, query)` — split on whitespace; **every token must substring-match at least one field** (AND across tokens, OR across fields), case- and accent-insensitively. Accent folding is NFD + the explicit combining range, **not** `\p{M}` (ES2018 property escapes; the repo targets ES2017 and `tsc` validates regex flags but not bodies — the tsplEncoder lesson). Matters for this international dataset ("Améthyste" ↔ "amethyste").
- Both surfaces swap to the shared helper so they can't drift. Empty-query gates and the dialog's 50-result cap unchanged.
- **Strict superset for single-word queries** (identical results), and a contiguous phrase inside one field ("pla blanc") still matches under token-AND — no regressions.
- Deliberately out of scope: true fuzzy/typo-tolerant matching (needs a scoring dep + reordering — can be a follow-up if wanted), and the FilamentPicker / inventory searches (different surfaces the issue didn't name).

## Test plan
- [x] `tests/materialSearch.test.ts` — the two reported flows verbatim, AND/OR semantics, accent folding both directions, case-insensitivity, whitespace/empty queries, null fields; 100% line/branch coverage on the new lib (coverage-gated dir)
- [x] `npm run lint`, `tsc --noEmit` clean

Fixes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)