### PR TITLE
feat(skills): add the add-filament skill

### DIFF
--- a/.claude/skills/3d-printing-knowledge-base/SKILL.md
+++ b/.claude/skills/3d-printing-knowledge-base/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: 3d-printing-knowledge-base
+description: Answer questions about the user's 3D printing filament library, calibration values, polymer properties, and printing parameters using their local knowledge base and the Filament DB REST API. Use this skill whenever the user asks about a specific filament, a calibration value (extrusion multiplier, pressure advance, shrinkage, max volumetric speed), nozzle or bed temperatures, drying schedules, spool inventory, polymer chemistry, or anything about their own materials and printers — even if they do not mention Filament DB, the wiki, or an API by name. Also use it before answering any question where a wrong number would ruin a print, and whenever adding new reference material to the knowledge base.
+---
+
+# 3D printing knowledge base
+
+This project holds three kinds of material, and they are not equally
+trustworthy. Almost every way this skill can fail is a failure to keep them
+apart.
+
+## Layout
+
+```
+3d-printing-kb/
+├── filament-db.wiki/   "FDM Polymers: A Technical Reference" — a git clone of
+│                       the published volume. Materials science, not app
+│                       documentation. READ ONLY.
+├── authored/       →   a symlink to filament-db.wiki/. One directory under two
+│                       names; the paths cannot diverge. READ ONLY.
+└── external/           Third-party material. The ONLY writable directory.
+```
+
+Plus the live Filament DB REST API on `http://localhost:3456`.
+
+## Source precedence
+
+When two sources disagree, the higher one wins. Do not average them, reconcile
+them, or present both as equally valid.
+
+1. **Filament DB API** — authoritative for anything about a specific filament
+   record: calibration values, spool inventory, stored temperatures.
+2. **`authored/`** and **`filament-db.wiki/`** — the same document at two paths:
+   "FDM Polymers: A Technical Reference". Authoritative for polymer behaviour,
+   process guidance, and G-code semantics. It is accuracy-reviewed pass by pass,
+   carries its own source ledger, and states the basis of every figure it
+   publishes.
+3. **`external/`** — background only. Never authoritative for anything.
+
+These are two names for one directory — `authored/` is a symlink to
+`filament-db.wiki/` — so they cannot diverge, and finding the same figure down
+both paths is not corroboration. Reading through `authored/` also exposes the
+repository's tooling (`Makefile`, `claims.json`, the check scripts, `hooks/`,
+`tests/`): that machinery maintains the volume and is not reference content.
+
+If a lower tier contradicts a higher one, follow the higher one and say the
+conflict exists.
+
+## The rule that governs everything
+
+**Never state a value you did not just retrieve.**
+
+These numbers drive real prints. A wrong extrusion multiplier wastes a spool and
+an eight-hour print; a wrong nozzle temperature can clog a hotend. If a lookup
+fails, say it failed. Do not fall back on a plausible-sounding value, a value
+from earlier in the conversation, or a typical figure for the material. "I could
+not reach the API" is a useful answer. A confident wrong number is not.
+
+## Processing parameters have a restricted source list
+
+Any number that would go into a slicer or a printer — nozzle temperature, bed
+temperature, chamber temperature, drying temperature and time, extrusion
+multiplier, pressure advance, shrinkage compensation, max volumetric speed, fan
+speeds, retraction — may come **only** from the API or from the technical
+reference (either path).
+
+Never take one from `external/`, and never derive one from polymer chemistry.
+
+Nor from a family band. The reference publishes envelopes across a whole family
+*and* values for named grades, and they are different claims: a family band
+brackets what an unbranded grade is likely to need, while the printable number
+belongs to the spool in front of you. Quote the named grade where the volume
+has one, and where it only has a band, say it is a band and that the spool's own
+datasheet governs.
+
+This is the most likely way to give a damaging answer, because the two look
+similar and are not:
+
+| Property | Typical source value | Actual print value |
+|---|---|---|
+| PA6 melting point | ~220 °C | nozzle 260–280 °C |
+| PPS melting point | ~280 °C | PPS-CF nozzle 320–345 °C |
+| PC glass transition | ~147 °C | nozzle 260–290 °C |
+
+A melting point is not a nozzle temperature. A glass transition is not a bed
+temperature. If `external/` is the only place a number appears, report that no
+verified value exists rather than passing the chemistry figure along.
+
+## Adding material to `external/`
+
+New reference material goes in `external/` and nowhere else. Use the helper so
+provenance is recorded correctly:
+
+```bash
+scripts/new-external.sh <url> <slug>
+# e.g. scripts/new-external.sh https://en.wikipedia.org/wiki/Polyphenylene_sulfide pps
+```
+
+It creates `external/<slug>.md` with the required front matter already filled
+in. Write the body below it; leave the metadata block intact.
+
+Every file in `external/` must carry:
+
+```yaml
+---
+source:    <url or citation>
+retrieved: <YYYY-MM-DD>
+trust:     background
+scope:     <what this file may be used for>
+---
+```
+
+A file in `external/` without front matter is untrusted — flag it to the user
+rather than reading from it. `scripts/check-provenance.sh` audits the directory.
+
+**Licensing.** Much external material is copyleft (Wikipedia is CC BY-SA).
+Keeping it in `external/`, out of the published wiki, and attributed in front
+matter is what keeps that manageable. Never copy external content into
+`filament-db.wiki/` or `authored/`.
+
+## Write scope
+
+- `external/` — writable.
+- `authored/`, `filament-db.wiki/` — read only, and the same directory: writing
+  through either path writes to a live git clone of a published repo, dirtying
+  the working tree and risking publication of third-party content.
+- Never `git commit`, `git push`, or `git checkout` inside it, by either name.
+  Refreshing it is the user's job (`git pull`).
+
+If a request seems to need writing outside `external/`, describe the change and
+let the user confirm first.
+
+## Answering from files
+
+State which tier an answer came from. "From the technical reference, §8.3 (PCTG
+filament property envelope by brand)" and "from the Wikipedia article in
+`external/`" carry very different weight, and the user needs to know which they
+got. Cite the reference by its own section or table number rather than by which
+of its two paths you happened to read.
+
+Cite the specific file. Never blend an `authored/` figure and an `external/`
+figure into one sentence without marking which is which.
+
+---
+
+# Filament DB API
+
+## Preflight — do this first, every session
+
+```bash
+scripts/fdb.sh check
+```
+
+Expect `OK — API reachable`. If it errors:
+
+- **Connection refused** — the app is not running. Tell the user to open the
+  Filament DB Electron app, or run `npm run dev` in the repo. Stop; do not
+  answer from memory.
+- **HTTP 401/403** — this instance has `FILAMENTDB_API_KEY` set. That gate is
+  enforced in `src/proxy.ts` across `/api/:path*` with no same-origin exemption,
+  so it applies to every request including yours. Ask the user for the key and
+  `export FILAMENTDB_API_KEY=...` before retrying.
+
+## Inheritance — the thing that silently gives wrong answers
+
+A parent filament is a **template**. A variant that inherits a value stores
+`null` as the inherit sentinel, and the real value is resolved at read time from
+the parent by `resolveFilament`.
+
+So a raw collection read of a variant shows `null` for a field whose effective
+value sits on its parent. That does not look like an error. It looks like
+missing data.
+
+- Use the **single-record route** (`/api/filaments/{id}`, via `fdb.sh detail`)
+  for any calibration question. It goes through the app's resolution logic.
+- Treat `null` from the **list** endpoint as "unknown, look it up properly",
+  never as "not set".
+- If a field is genuinely absent after a single-record fetch, say so rather than
+  substituting a default.
+
+## Commands
+
+| Command | Use for |
+|---|---|
+| `fdb.sh check` | Preflight. Always first. |
+| `fdb.sh list` | Overview — name, material, brand, spool count. |
+| `fdb.sh find <text>` | Locate a filament by partial name. Returns ids. |
+| `fdb.sh detail <text>` | Full resolved record. **Use for calibration.** |
+| `fdb.sh schema` | Actual field names on a real record. |
+| `fdb.sh get <path>` | Any other endpoint. |
+
+Prefer these over hand-written curl and jq — the script already handles auth,
+connection failure, non-JSON responses, and the several shapes the list endpoint
+can return.
+
+**Do not guess field names.** The schema has evolved across many releases.
+Run `fdb.sh schema` once and work from what it reports. A guessed name yields
+`null`, and `null` here is indistinguishable from an inherit sentinel.
+
+**Do not guess endpoint paths.** A 404 means the route does not exist on this
+version. Ask the user rather than trying variations. Known routes include
+`/api/filaments`, `/api/filaments/{id}`, `/api/filaments/match`,
+`/api/spools/by-location`, `/api/spools/{spoolId}`, `/api/print-history`,
+`/api/analytics`, and per-slicer exports at
+`/api/filaments/{id}/{prusaslicer,orcaslicer,bambustudio}`.
+
+## Context discipline
+
+`GET /api/filaments` returns everything: spool subdocuments, `usageHistory`,
+`dryCycles`, and the `settings` passthrough bag, which carries every slicer key
+the app does not model. Potentially megabytes for a question about one number.
+
+Never pipe a raw collection response into your reasoning context. `fdb.sh list`
+and `fdb.sh find` already project down. When you need something they do not
+cover, project at the boundary:
+
+```bash
+scripts/fdb.sh get /api/filaments/ID | jq '{name, temperatures, shrinkageXY}'
+```
+
+## Read-only
+
+Do not `POST`, `PUT`, `PATCH`, or `DELETE` against the API, and do not run the
+slicer sync routes — those mutate stored records. Describe the change and let
+the user confirm.
+
+## Ambiguity
+
+If a name matches more than one filament, `fdb.sh detail` refuses and reports
+how many matched. That refusal is deliberate. Show the candidates from
+`fdb.sh find` and ask which was meant. Never pick one because it seems most
+likely — calibration values are per filament *and* per nozzle, and neighbouring
+records often differ only in nozzle size.
+
+## Answer format
+
+For a calibration lookup, report:
+
+1. The exact filament record name matched.
+2. The values retrieved, unchanged — do not round, reformat, or normalise units.
+3. Nozzle or printer context, when the record carries it.
+4. Any field that came back empty, stated as empty.
+
+Preserve significant figures exactly. An extrusion multiplier of `0.898` is not
+`0.9`.

--- a/.claude/skills/3d-printing-knowledge-base/SKILL.md
+++ b/.claude/skills/3d-printing-knowledge-base/SKILL.md
@@ -156,10 +156,13 @@ Expect `OK — API reachable`. If it errors:
 - **Connection refused** — the app is not running. Tell the user to open the
   Filament DB Electron app, or run `npm run dev` in the repo. Stop; do not
   answer from memory.
-- **HTTP 401/403** — this instance has `FILAMENTDB_API_KEY` set. That gate is
+- **HTTP 401** — this instance has `FILAMENTDB_API_KEY` set. That gate is
   enforced in `src/proxy.ts` across `/api/:path*` with no same-origin exemption,
   so it applies to every request including yours. Ask the user for the key and
   `export FILAMENTDB_API_KEY=...` before retrying.
+- **HTTP 403** — not this app. Its gate answers 401 and only 401, so a 403 came
+  from something in front of it (a proxy, a gateway, an allow-list) and an API
+  key cannot resolve it. Report the status; do not ask for a key.
 
 ## Inheritance — the thing that silently gives wrong answers
 

--- a/.claude/skills/3d-printing-knowledge-base/scripts/check-provenance.sh
+++ b/.claude/skills/3d-printing-knowledge-base/scripts/check-provenance.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# check-provenance.sh — audit external/ for missing or malformed front matter,
+# and flag files that leaked out of scope.
+#
+# Usage: scripts/check-provenance.sh
+# Exit 0 = clean, 1 = problems found.
+
+set -uo pipefail
+
+root="$PWD"
+while [[ "$root" != "/" && ! -d "$root/external" ]]; do root="$(dirname "$root")"; done
+if [[ ! -d "$root/external" ]]; then
+  printf 'ERROR: no external/ directory found above %s\n' "$PWD" >&2; exit 1
+fi
+
+problems=0
+checked=0
+
+while IFS= read -r f; do
+  [[ -f "$f" ]] || continue
+  checked=$((checked+1))
+  rel="${f#"$root"/}"
+
+  if [[ "$(head -n1 "$f")" != "---" ]]; then
+    printf '%s\n    no front matter — untrusted, do not read from it\n' "$rel"
+    problems=$((problems+1))
+    continue
+  fi
+
+  fm="$(awk 'NR==1&&/^---$/{next} /^---$/{exit} {print}' "$f")"
+
+  missing=""
+  for key in source retrieved trust scope; do
+    grep -Eq "^${key}:[[:space:]]*[^[:space:]]" <<<"$fm" || missing="${missing}${missing:+ }${key}"
+  done
+  if [[ -n "$missing" ]]; then
+    printf '%s\n    missing/empty: %s\n' "$rel" "$missing"
+    problems=$((problems+1))
+    continue
+  fi
+
+  d="$(sed -n 's/^retrieved:[[:space:]]*//p' <<<"$fm" | head -1)"
+  [[ "$d" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || {
+    printf '%s\n    retrieved is not YYYY-MM-DD: %s\n' "$rel" "$d"
+    problems=$((problems+1)); continue; }
+
+  t="$(sed -n 's/^trust:[[:space:]]*//p' <<<"$fm" | head -1)"
+  [[ "$t" == "background" ]] || {
+    printf '%s\n    trust must be "background" in external/ (got: %s)\n' "$rel" "$t"
+    problems=$((problems+1)); continue; }
+done < <(find "$root/external" -type f -name '*.md' | sort)
+
+# Cheap smell test: process parameters that should never live in external/.
+# Only prose counts — front matter and HTML comments are stripped first, or the
+# template's own warning text trips the detector.
+PARAM_RE='nozzle temp|bed temp|chamber temp|extrusion multiplier|pressure advance|volumetric speed|dry(ing)? (temp|time)'
+leaks=0
+while IFS= read -r f; do
+  prose="$(awk 'NR==1&&/^---$/{fm=1;next} fm&&/^---$/{fm=0;next} !fm' "$f" \
+           | perl -0777 -pe 's/<!--.*?-->//gs' 2>/dev/null)"
+  [[ -z "$prose" ]] && continue
+  if grep -qiE "$PARAM_RE" <<<"$prose"; then
+    (( leaks == 0 )) && printf '\nPossible processing parameters in external/ (tier 4 must not carry these):\n'
+    printf '    %s\n' "${f#"$root"/}"
+    leaks=$((leaks+1))
+  fi
+done < <(find "$root/external" -type f -name '*.md' | sort)
+
+printf '\nChecked %d file(s) in external/.\n' "$checked"
+if (( problems == 0 && leaks == 0 )); then
+  printf 'Clean.\n'; exit 0
+fi
+printf '%d provenance problem(s), %d possible parameter leak(s).\n' "$problems" "$leaks"
+exit 1

--- a/.claude/skills/3d-printing-knowledge-base/scripts/check-provenance.sh
+++ b/.claude/skills/3d-printing-knowledge-base/scripts/check-provenance.sh
@@ -27,6 +27,20 @@ while IFS= read -r f; do
     continue
   fi
 
+  # The front matter must actually CLOSE. Without this, awk runs to EOF, the
+  # whole file becomes "front matter", the four keys are found somewhere in it
+  # and the file is reported Clean -- while the leak loop below sees no prose
+  # at all and skips its scan, so a body full of slicer values passes twice.
+  # Requiring the terminator BEFORE the first blank line is deliberate: a bare
+  # "does a second --- exist?" test is satisfied by an ordinary markdown
+  # horizontal rule further down the body, which is the same hole again. The
+  # schema is a contiguous four-key block, which is what new-external.sh emits.
+  if ! awk 'NR==1{next} /^---$/{ok=1;exit} /^[[:space:]]*$/{exit} END{exit ok?0:1}' "$f"; then
+    printf '%s\n    front matter never closed — no terminating "---" line\n' "$rel"
+    problems=$((problems+1))
+    continue
+  fi
+
   fm="$(awk 'NR==1&&/^---$/{next} /^---$/{exit} {print}' "$f")"
 
   missing=""
@@ -54,10 +68,21 @@ done < <(find "$root/external" -type f -name '*.md' | sort)
 # Only prose counts — front matter and HTML comments are stripped first, or the
 # template's own warning text trips the detector.
 PARAM_RE='nozzle temp|bed temp|chamber temp|extrusion multiplier|pressure advance|volumetric speed|dry(ing)? (temp|time)'
+# Without perl the comment strip used to fail into an empty $prose for every
+# file, skipping the entire scan while still printing "Clean." Refuse loudly.
+if ! command -v perl >/dev/null 2>&1; then
+  printf 'ERROR: perl is required for the parameter-leak scan (it strips HTML comments).\n' >&2
+  exit 1
+fi
 leaks=0
 while IFS= read -r f; do
-  prose="$(awk 'NR==1&&/^---$/{fm=1;next} fm&&/^---$/{fm=0;next} !fm' "$f" \
-           | perl -0777 -pe 's/<!--.*?-->//gs' 2>/dev/null)"
+  # Fail OPEN on unterminated front matter: if fm is still set at EOF the
+  # delimiter never closed, so treat the entire file as prose and scan it
+  # rather than emitting nothing. Skipping it is what let a body of prohibited
+  # values through -- and this loop does not share the `continue` above.
+  prose="$(awk 'NR==1&&/^---$/{fm=1;next} fm&&/^---$/{fm=0;next} !fm
+                END{if (fm) {while ((getline line < FILENAME) > 0) print line}}' "$f" \
+           | perl -0777 -pe 's/<!--.*?-->//gs')"
   [[ -z "$prose" ]] && continue
   if grep -qiE "$PARAM_RE" <<<"$prose"; then
     (( leaks == 0 )) && printf '\nPossible processing parameters in external/ (tier 4 must not carry these):\n'

--- a/.claude/skills/3d-printing-knowledge-base/scripts/fdb.sh
+++ b/.claude/skills/3d-printing-knowledge-base/scripts/fdb.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# fdb.sh — thin, safe wrapper around the Filament DB REST API.
+#
+# Handles base URL, optional bearer auth, and — most importantly — turns
+# failures into LOUD errors instead of empty output that an agent might
+# mistake for "no results".
+#
+# Usage:
+#   ./fdb.sh check                 Verify the API is reachable. Run this first.
+#   ./fdb.sh get <path>            Raw GET, e.g. get /api/filaments/abc123
+#   ./fdb.sh list                  All filaments, projected to a small summary
+#   ./fdb.sh find <substring>      Filaments whose name matches (case-insensitive)
+#   ./fdb.sh detail <substring>    Full record for the single best name match
+#   ./fdb.sh schema                Field names present on a sample record
+#
+# Env:
+#   FILAMENTDB_URL      default http://localhost:3456
+#   FILAMENTDB_API_KEY  sent as "Authorization: Bearer ..." when set
+
+set -euo pipefail
+
+BASE="${FILAMENTDB_URL:-http://localhost:3456}"
+
+TMPFILE=""
+cleanup() { [[ -n "${TMPFILE:-}" ]] && rm -f "$TMPFILE"; TMPFILE=""; }
+# Backstop for non-pipeline invocations. Note that req() runs inside a pipeline
+# in most subcommands, and a pipeline element is a subshell that does NOT
+# inherit this trap — so die() and the success path clean up explicitly too.
+trap cleanup EXIT INT TERM
+
+die() { cleanup; printf 'FDB ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || die "curl not found on PATH"
+command -v jq   >/dev/null 2>&1 || die "jq not found on PATH. Install with: brew install jq"
+
+# --- core request -----------------------------------------------------------
+# NOTE: deliberately avoids bash arrays. macOS ships bash 3.2, where expanding
+# an empty array under `set -u` raises "unbound variable".
+req() {
+  local path="$1" url tmp http rc
+  url="${BASE}${path}"
+  tmp="$(mktemp "${TMPDIR:-/tmp}/fdb.XXXXXX")" || die "cannot create temp file"
+  TMPFILE="$tmp"
+
+  if [[ -n "${FILAMENTDB_API_KEY:-}" ]]; then
+    http="$(curl -sS --max-time 30 -o "$tmp" -w '%{http_code}' \
+             -H "Authorization: Bearer ${FILAMENTDB_API_KEY}" "$url" 2>/dev/null)" || rc=$?
+  else
+    http="$(curl -sS --max-time 30 -o "$tmp" -w '%{http_code}' "$url" 2>/dev/null)" || rc=$?
+  fi
+  rc="${rc:-0}"
+
+  if [[ "$rc" -ne 0 ]]; then
+    case "$rc" in
+      7)  die "connection refused at ${BASE}
+  Filament DB is not running. Start the Electron app, or 'npm run dev' in the repo." ;;
+      6)  die "cannot resolve host in ${BASE}. Check FILAMENTDB_URL." ;;
+      28) die "timed out after 30s reaching ${url}. Is the app responding?" ;;
+      *)  die "curl exited ${rc} for ${url}" ;;
+    esac
+  fi
+
+  case "$http" in
+    200) ;;
+    401|403)
+      die "HTTP ${http} from ${path}
+  The FILAMENTDB_API_KEY bearer gate is active on this instance.
+  That gate is all-or-nothing across /api/:path* with no same-origin exemption.
+  Export the key in this shell and retry:  export FILAMENTDB_API_KEY=..." ;;
+    404) die "HTTP 404 from ${path} — endpoint does not exist on this version. Do NOT guess another path; ask the user." ;;
+    000) die "no HTTP response from ${url}. The server closed the connection." ;;
+    *)   die "HTTP ${http} from ${path}. Body: $(head -c 400 "$tmp")" ;;
+  esac
+
+  jq -e . "$tmp" >/dev/null 2>&1 \
+    || die "response from ${path} was not valid JSON. First 400 bytes: $(head -c 400 "$tmp")"
+
+  cat "$tmp"
+  cleanup
+}
+
+# Some deployments wrap collections as {data:[...]} or {filaments:[...]}.
+# Normalise to a bare array so downstream jq is stable.
+as_array() {
+  jq 'if type=="array" then .
+      elif has("data")      and (.data|type)=="array"      then .data
+      elif has("filaments") and (.filaments|type)=="array" then .filaments
+      elif has("items")     and (.items|type)=="array"     then .items
+      else error("unexpected list shape; run: fdb.sh get /api/filaments | jq \"keys\"") end'
+}
+
+cmd="${1:-}"; shift || true
+
+case "$cmd" in
+  check)
+    req /api/filaments | as_array \
+      | jq -r '"OK — API reachable at '"${BASE}"', \(length) filaments visible."'
+    ;;
+
+  get)
+    [[ $# -ge 1 ]] || die "usage: fdb.sh get <path>"
+    req "$1"
+    ;;
+
+  schema)
+    # Show what fields actually exist rather than assuming. Run once per session
+    # if you are unsure of a field name; do not guess names.
+    req /api/filaments | as_array | jq '
+      if length == 0 then error("no filaments returned") else
+        .[0] | to_entries
+        | map({key, type: (.value|type)})
+        | sort_by(.key)
+      end'
+    ;;
+
+  list)
+    req /api/filaments | as_array | jq '[.[] | {
+      id:       (._id // .id),
+      name,
+      material: (.material // .materialType // null),
+      brand:    (.brand // .manufacturer // null),
+      isParent: (.isTemplate // .isParent // null),
+      spools:   ((.spools // []) | length)
+    }] | sort_by(.name)'
+    ;;
+
+  find)
+    [[ $# -ge 1 ]] || die "usage: fdb.sh find <substring>"
+    req /api/filaments | as_array | jq --arg q "$1" '[.[]
+      | select((.name // "") | ascii_downcase | contains($q | ascii_downcase))
+      | { id: (._id // .id), name,
+          material: (.material // .materialType // null),
+          spools: ((.spools // []) | length) }]
+      | if length == 0 then error("no filament name contains \"" + $q + "\"") else . end'
+    ;;
+
+  detail)
+    [[ $# -ge 1 ]] || die "usage: fdb.sh detail <substring>"
+    ids="$(req /api/filaments | as_array | jq -r --arg q "$1" '[.[]
+      | select((.name // "") | ascii_downcase | contains($q | ascii_downcase))
+      | (._id // .id)] | .[]')"
+    count="$(printf '%s\n' "$ids" | grep -c . || true)"
+    [[ "$count" -eq 0 ]] && die "no filament name contains \"$1\""
+    [[ "$count" -gt 1 ]] && die "\"$1\" matched ${count} filaments. Narrow the search — do NOT pick one arbitrarily. Run: fdb.sh find \"$1\""
+    # Single-record route: this is the path that resolves parent/variant inheritance.
+    req "/api/filaments/${ids}"
+    ;;
+
+  ""|help|-h|--help)
+    sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+
+  *)
+    die "unknown command: ${cmd}. Run 'fdb.sh help'."
+    ;;
+esac

--- a/.claude/skills/3d-printing-knowledge-base/scripts/fdb.sh
+++ b/.claude/skills/3d-printing-knowledge-base/scripts/fdb.sh
@@ -62,11 +62,20 @@ req() {
 
   case "$http" in
     200) ;;
-    401|403)
-      die "HTTP ${http} from ${path}
+    401)
+      die "HTTP 401 from ${path}
   The FILAMENTDB_API_KEY bearer gate is active on this instance.
   That gate is all-or-nothing across /api/:path* with no same-origin exemption.
   Export the key in this shell and retry:  export FILAMENTDB_API_KEY=..." ;;
+    403)
+      # Filament DB's own gate answers 401 and only 401 (src/proxy.ts), so a
+      # 403 came from something in front of it — a reverse proxy, a corporate
+      # gateway, an allow-list. Prescribing an API key there sends the user
+      # after a fix that cannot work.
+      die "HTTP 403 from ${path}
+  Filament DB's own API-key gate answers 401, never 403, so this came from
+  something in front of it (a proxy or gateway). An API key will not help.
+  Check what is sitting between this shell and ${BASE}." ;;
     404) die "HTTP 404 from ${path} — endpoint does not exist on this version. Do NOT guess another path; ask the user." ;;
     000) die "no HTTP response from ${url}. The server closed the connection." ;;
     *)   die "HTTP ${http} from ${path}. Body: $(head -c 400 "$tmp")" ;;
@@ -105,21 +114,26 @@ case "$cmd" in
   schema)
     # Show what fields actually exist rather than assuming. Run once per session
     # if you are unsure of a field name; do not guess names.
-    req /api/filaments | as_array | jq '
-      if length == 0 then error("no filaments returned") else
-        .[0] | to_entries
-        | map({key, type: (.value|type)})
-        | sort_by(.key)
-      end'
+    #
+    # Reads a DETAIL record, not the list. The list route is a projection --
+    # it drops calibrations, drying, shrinkage and the settings bag among
+    # others -- so enumerating a list item reports a field as absent when it
+    # exists, which is precisely the wrong answer for a command whose whole
+    # job is "does this field name exist?".
+    sid="$(req /api/filaments | as_array | jq -r 'if length == 0 then error("no filaments returned") else .[0]._id // .[0].id end')"
+    req "/api/filaments/${sid}" | jq '
+      (.filament // .) | to_entries
+      | map({key, type: (.value|type)})
+      | sort_by(.key)'
     ;;
 
   list)
     req /api/filaments | as_array | jq '[.[] | {
       id:       (._id // .id),
       name,
-      material: (.material // .materialType // null),
-      brand:    (.brand // .manufacturer // null),
-      isParent: (.isTemplate // .isParent // null),
+      material: .type,
+      brand:    .vendor,
+      isParent: (.hasVariants // false),
       spools:   ((.spools // []) | length)
     }] | sort_by(.name)'
     ;;
@@ -129,7 +143,7 @@ case "$cmd" in
     req /api/filaments | as_array | jq --arg q "$1" '[.[]
       | select((.name // "") | ascii_downcase | contains($q | ascii_downcase))
       | { id: (._id // .id), name,
-          material: (.material // .materialType // null),
+          material: .type, brand: .vendor,
           spools: ((.spools // []) | length) }]
       | if length == 0 then error("no filament name contains \"" + $q + "\"") else . end'
     ;;

--- a/.claude/skills/3d-printing-knowledge-base/scripts/new-external.sh
+++ b/.claude/skills/3d-printing-knowledge-base/scripts/new-external.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# new-external.sh — create a provenance-stamped file in external/.
+#
+# Usage: scripts/new-external.sh <url-or-citation> <slug> [scope]
+#   scripts/new-external.sh https://en.wikipedia.org/wiki/Polyphenylene_sulfide pps
+#   scripts/new-external.sh "Vendor TDS, Fiberon PPS-CF, rev 3" fiberon-pps-cf "chemistry + supplier claims"
+#
+# Writes external/<slug>.md with front matter filled in, then prints the path.
+# Refuses to overwrite. Body is left for you to fill in below the metadata.
+
+set -euo pipefail
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ $# -ge 2 ]] || die "usage: new-external.sh <url-or-citation> <slug> [scope]"
+
+SRC="$1"
+SLUG="$2"
+SCOPE="${3:-chemistry and background only — no processing parameters}"
+
+# Locate the knowledge-base root: the dir containing external/.
+root="$PWD"
+while [[ "$root" != "/" && ! -d "$root/external" ]]; do root="$(dirname "$root")"; done
+[[ -d "$root/external" ]] || die "no external/ directory found above $PWD.
+  Create the knowledge-base layout first:  mkdir -p external authored"
+
+[[ "$SLUG" =~ ^[a-z0-9][a-z0-9._-]*$ ]] \
+  || die "slug must be lowercase alphanumeric with . _ - only (got: $SLUG)"
+
+case "$SRC" in
+  *[$'\n\r']*) die "source must be a single line" ;;
+esac
+
+out="$root/external/${SLUG}.md"
+[[ -e "$out" ]] && die "$out already exists. Pick another slug, or edit it directly."
+
+cat > "$out" <<EOF
+---
+source:    ${SRC}
+retrieved: $(date +%Y-%m-%d)
+trust:     background
+scope:     ${SCOPE}
+---
+
+# ${SLUG}
+
+<!--
+  Body goes here.
+
+  This file is TIER 4 (background only). Nothing in it is authoritative.
+  Do NOT record nozzle, bed, chamber, or drying temperatures here, or any
+  other value destined for a slicer — those belong in authored/ or the
+  Filament DB record, and only after verification.
+
+  Chemistry, structure, general material behaviour, and history are fine.
+-->
+EOF
+
+printf 'Created %s\n' "$out"

--- a/.claude/skills/3d-printing-knowledge-base/scripts/new-external.sh
+++ b/.claude/skills/3d-printing-knowledge-base/scripts/new-external.sh
@@ -31,15 +31,29 @@ case "$SRC" in
   *[$'\n\r']*) die "source must be a single line" ;;
 esac
 
+# Emit both free-text fields as YAML double-quoted scalars. The documented
+# citation form is prose, and prose routinely contains YAML-significant
+# characters: "Vendor TDS: revision 3" makes the line a nested mapping, and a
+# leading "#" makes the value an empty string plus a comment. Either way the
+# helper reports success while writing a file whose provenance is wrong or
+# gone -- and check-provenance.sh matches these lines with regexes, so it
+# would then certify the result as clean.
+yaml_quote() {
+  local v=$1
+  v=${v//\\/\\\\}   # backslashes first, or the next substitution doubles them
+  v=${v//\"/\\\"}
+  printf '"%s"' "$v"
+}
+
 out="$root/external/${SLUG}.md"
 [[ -e "$out" ]] && die "$out already exists. Pick another slug, or edit it directly."
 
 cat > "$out" <<EOF
 ---
-source:    ${SRC}
+source:    $(yaml_quote "$SRC")
 retrieved: $(date +%Y-%m-%d)
 trust:     background
-scope:     ${SCOPE}
+scope:     $(yaml_quote "$SCOPE")
 ---
 
 # ${SLUG}

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -71,6 +71,11 @@ variant, the parent becomes a colourless template) and repeat the identical requ
 `"promoteParent": true` added. Never send that flag without asking — it restructures a second
 record.
 
+Worth doing first: if that existing filament has a colour but no `colorName`, set one before
+triggering the gate. The promoted variant is auto-named `"<parent> — <colorName>"`, falling
+back to `"— Original"` when the field is blank, so one word turns a meaningless name into the
+right one.
+
 **Nothing exists** — create a standalone filament. Do not invent a template for a single
 colour; the model derives template-ness from having variants, so it happens on its own when
 the second colour arrives.
@@ -92,6 +97,19 @@ useful for colour, and it is the linkage that lets the record pull future update
 measurably wrong sometimes: in one audit of 27 linked filaments, four of the vendor-published
 colours disagreed with OPT and the user's existing values were the correct ones. If OPT and
 the vendor disagree, the vendor wins and it is worth telling the user.
+
+**When a vendor publishes a range, let the library pick the value.** A spec of "250–270 °C
+nozzle, 80–100 °C bed" still needs one number in each field. Before reaching for the midpoint,
+look for a same-material record with the same published range and see what the user actually
+runs — in one case an existing PC with an identical 250–270 window was set to 260/100, which
+is a far better answer than arithmetic because it reflects their hardware and habits. Store
+the range in `nozzleRangeMin`/`Max` as well, so the guardrails survive.
+
+**A record's own process values can expose a wrong vendor.** One filament filed under one
+manufacturer turned out to carry temperatures, max volumetric speed and shrinkage that exactly
+matched another maker's bench profile — the data identified the real product before anyone
+noticed the label was wrong. When a vendor lookup keeps coming up empty, or the numbers feel
+familiar, check them against the profiles you already have.
 
 **Ask third.** If neither source has a number, ask. A plausible-looking invented temperature
 is worse than a blank field, because a blank field is visibly missing.
@@ -148,6 +166,18 @@ first. Renaming later is disruptive because slicers key their presets on the fil
 Use the vendor spelling the rest of the library uses for that brand, so filters and grouping
 don't fragment across `3D Fuel` / `3D-Fuel`.
 
+**Keep nozzle references out of the name.** A filament is a material; a preset is a material
+*plus* a nozzle. `HF0.4` and `0.6` are meaningful on a slicer preset and wrong on a filament,
+which has no nozzle of its own — so `CHCKX PCTG HF0.4` is really `CHCKX PCTG`.
+
+**The `type` feeds a reference-chapter resolver, so it is not free text in practice.** Record
+the fill (`PC-CF`, not `PC`, for a carbon-filled polycarbonate) but drop the loading
+percentage (`PPS-CF`, not `PPS-CF10`) — the resolver strips a `-CF`/`-GF` suffix to find the
+base chemistry, and the rest of the library follows that convention. What it cannot do is
+invent: a tidier-looking `PLA-Wood` matches nothing and silently hides the reference panel,
+where the existing `Woodfill` resolves to the PLA chapter. Reuse a type the library already
+uses, and if a genuinely new one is needed, check it still resolves.
+
 ### 6. Weights, then the spool
 
 Adding a filament always means a physical roll arrived, so the record is not finished until it
@@ -199,6 +229,14 @@ want to know.
 `findOneAndUpdate`, so a nested `{"temperatures": {"nozzle": 250}}` **replaces the whole
 subdocument** and silently destroys `bed`, the range fields and the first-layer values. Send
 `{"temperatures.nozzle": 250}` instead. The same applies to `settings.<key>`.
+
+**Name uniqueness is case-sensitive here, and the filesystem may not be.** The unique index on
+`name` declares no collation, so it is a byte comparison — `SunLu PP` and `SUNLU PP` are two
+distinct filaments and neither create will complain. That becomes destructive the moment names
+reach a filesystem: on macOS, writing a preset for one lands on the file of the other, keeping
+the original filename and silently replacing its contents. So when adopting a vendor's
+capitalisation, compare names case-INsensitively against what already exists, and expect a
+file count that comes up one short to mean exactly this.
 
 **Templates reject colour and inventory silently.** Writing `color`, `colorName`,
 `totalWeight` or `lowStockThreshold` to a template strips those fields rather than erroring —

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -65,9 +65,19 @@ If the user scanned a tag, the decoded payload gives you most of this already.
 curl -s "$BASE/api/filaments" | jq -r '.[] | "\(._id)\t\(.name)\t\(.vendor)\t\(.type)\t\(.parentId // "root")\t\(.hasVariants)"'
 ```
 
-Keep the `_id` of whatever you match — it becomes `parentId` on the create, and `$TEMPLATE_ID`
-if the family needs its weights filling in. `parentId` is `root` for a template and a
-standalone alike, so it cannot identify the record for you.
+Assign the `_id` of whatever you match — every later step addresses the family through it:
+
+```bash
+TEMPLATE_ID=<the _id from the row you matched>
+```
+
+It becomes `parentId` on the create, and the target for filling in family weights, for the
+post-promotion cleanup in step 5a, and for the OpenPrintTag relink. Set it here rather than
+carrying the value in your head; a step that interpolates an unset variable builds a URL like
+`/api/filaments//spools`, which fails in a way that does not name the cause.
+
+`parentId` is `root` for a template and a standalone alike, so it cannot identify the record
+for you.
 
 Three cases, and they lead to different work:
 
@@ -255,14 +265,26 @@ over-specifies rather than loses:
 
 - **`transmissionDistance`** — an unconditional move. TD is per-colour optics; no two colours
   share one. `PUT` the value onto `$ORIG_ID`, then `null` on the template.
-- **`optTags`** — move only the tags that describe how that colour *looks*: `2` transparent,
-  `3` translucent, `16` matte, `17` silk, `22` sparkle, `23` phosphorescent, `24` glow, `25`
-  colour-changing, `27` gradient, `28` dual/`29` triple-colour. Everything else — `4` abrasive,
-  `0`/`31` fibre, `33` hygroscopic, `9` flexible, `5` food-safe — describes the product line
-  and stays. Moving the whole array takes `4` off the template and hides the entire family from
-  the abrasive/nozzle check in Settings → Data health, because that check reads the effective
-  value. **If a tag isn't clearly on the appearance list, leave it on the template**: a stranded
-  appearance tag is a visible rendering wart, a safety tag moved off the line is silent.
+- **`optTags`** — the array does not merge. `resolveFilament` uses whole-array fallback: a
+  variant with a non-empty array **replaces** the template's rather than adding to it. So this
+  is not a move, it is a split plus a copy.
+
+  Separate the template's tags into the ones describing how that colour *looks* — `2`
+  transparent, `3` translucent, `16` matte, `17` silk, `22` sparkle, `23` phosphorescent, `24`
+  glow, `25` colour-changing, `27` gradient, `28` dual/`29` triple-colour — and everything else,
+  which describes the product line: `4` abrasive, `0`/`31` fibre, `33` hygroscopic, `9`
+  flexible, `5` food-safe.
+
+  The template keeps **only the product-line tags**. The variant gets the appearance tags
+  **plus a copy of those same product-line tags**, because its own array is what it resolves to
+  and anything left out is simply gone for that colour. From `[2, 4]` that is template `[4]`,
+  variant `[2, 4]` — not variant `[2]`, which would strip the abrasive marker off the original
+  colour and hide it from the nozzle-safety check in Settings → Data health. New siblings, whose
+  array stays empty, inherit `[4]` correctly.
+
+  **If a tag isn't clearly on the appearance list, treat it as product-line**: it then stays on
+  the template *and* rides along on the variant, so an over-inclusive guess costs nothing while
+  a missed safety tag is silent.
 - **The OpenPrintTag link** — cannot be moved with a `PUT`; it is three fields, one of them
   server-owned. Follow the route sequence in `references/sources.md`, and keep its ordering:
   read the template's existing slug *before* the `DELETE`, because that slug belongs to the

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -81,7 +81,9 @@ colour turns it into a template. The server gates this: your create returns **40
 user what will happen (the existing filament's colour and spools move onto a new sibling
 variant, the parent becomes a colourless template) and repeat the identical request with
 `"promoteParent": true` added. Never send that flag without asking — it restructures a second
-record.
+record. When you take this path, **step 5a is not optional** — promotion strands the old
+colour's tags, TD and OpenPrintTag link on the new template, where your new colour inherits
+them.
 
 Worth doing first: if that existing filament has a colour but no `colorName`, set one before
 triggering the gate. The promoted variant is auto-named `"<parent> — <colorName>"`, falling
@@ -191,7 +193,8 @@ CODE=$(printf '%s' "$RESP" | tail -n1); BODY=$(printf '%s' "$RESP" | sed '$d')
 
 Check `$CODE` before going further. **201** — take the id with
 `ID=$(printf '%s' "$BODY" | jq -r '.filament._id // ._id')`. **409** — `$BODY` carries either
-the promotion gate (confirm, then retry with `promoteParent: true`) or a name collision.
+the promotion gate (confirm, then retry with `promoteParent: true`, then run step 5a) or a
+name collision.
 Anything else is a validation error naming its field. Extracting the id first instead turns a
 409 into the string `null` and every later call targets `/null`, silently, while the parent
 state you needed for the confirmation is gone.
@@ -222,6 +225,48 @@ base chemistry, and the rest of the library follows that convention. What it can
 invent: a tidier-looking `PLA-Wood` matches nothing and silently hides the reference panel,
 where the existing `Woodfill` resolves to the PLA chapter. Reuse a type the library already
 uses, and if a genuinely new one is needed, check it still resolves.
+
+### 5a. Only if you retried with `promoteParent: true`
+
+Promotion copies colour and inventory onto the generated original variant and **nothing else**.
+Anything colour-specific the old standalone was carrying stays behind on the new template,
+where the resolver hands it to every sibling that doesn't override it — including the one you
+just created. So the colour you added can silently inherit the *previous* colour's tags, its
+transmission distance, and its OpenPrintTag link.
+
+This is an inspection, not a ritual. Read the template back and act only on what is actually
+there; on a standalone that carried none of it, this step reads once and does nothing.
+
+```bash
+# the sibling promotion generated — the template's other child
+ORIG_ID=$(curl -s "$BASE/api/filaments/$TEMPLATE_ID" \
+  | jq -r --arg new "$ID" '._variants[]? | select(._id != $new) | ._id' | head -1)
+# what the template is actually holding (?raw=true — unresolved, so this is its OWN state)
+curl -s "$BASE/api/filaments/$TEMPLATE_ID?raw=true" \
+  | jq '{optTags, transmissionDistance, slug: .settings.openprinttag_slug}'
+```
+
+Use `?raw=true` for the template. A resolved read cannot answer this question, and `_variants`
+entries report *effective* values — before cleanup both children echo the template's tags,
+which is how you can tell the tags are stranded rather than genuinely shared.
+
+Then, for whatever that read showed, writing the variant first so an interrupted run
+over-specifies rather than loses:
+
+- **`transmissionDistance`** — an unconditional move. TD is per-colour optics; no two colours
+  share one. `PUT` the value onto `$ORIG_ID`, then `null` on the template.
+- **`optTags`** — move only the tags that describe how that colour *looks*: `2` transparent,
+  `3` translucent, `16` matte, `17` silk, `22` sparkle, `23` phosphorescent, `24` glow, `25`
+  colour-changing, `27` gradient, `28` dual/`29` triple-colour. Everything else — `4` abrasive,
+  `0`/`31` fibre, `33` hygroscopic, `9` flexible, `5` food-safe — describes the product line
+  and stays. Moving the whole array takes `4` off the template and hides the entire family from
+  the abrasive/nozzle check in Settings → Data health, because that check reads the effective
+  value. **If a tag isn't clearly on the appearance list, leave it on the template**: a stranded
+  appearance tag is a visible rendering wart, a safety tag moved off the line is silent.
+- **The OpenPrintTag link** — cannot be moved with a `PUT`; it is three fields, one of them
+  server-owned. Follow the route sequence in `references/sources.md`, and keep its ordering:
+  read the template's existing slug *before* the `DELETE`, because that slug belongs to the
+  original colour and the one you looked up in step 4 belongs to the new one.
 
 ### 6. Link the OpenPrintTag match
 

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -14,12 +14,18 @@ description: >
 
 # Adding a filament to Filament DB
 
-The API is at `http://localhost:3456` by default (override with `FILAMENTDB_URL`). If the
-instance sets `FILAMENTDB_API_KEY`, every request needs `Authorization: Bearer <key>` —
-the gate has no same-origin exemption.
+Set these up first — every command below uses them, and `$BASE` is empty until you do:
 
-Start with `curl -s -o /dev/null -w "%{http_code}" $BASE/api/filaments`. A connection error
-means the app is not running: say so and stop rather than guessing at the data.
+```bash
+BASE="${FILAMENTDB_URL:-http://localhost:3456}"
+AUTH=(); [ -n "${FILAMENTDB_API_KEY:-}" ] && AUTH=(-H "Authorization: Bearer $FILAMENTDB_API_KEY")
+curl -s "${AUTH[@]}" -o /dev/null -w '%{http_code}\n' "$BASE/api/filaments"
+```
+
+Expect `200`. A connection error means the app is not running: say so and stop rather than
+guessing at the data. A `401`/`403` means the instance sets `FILAMENTDB_API_KEY` — the gate has
+no same-origin exemption, so ask for the key and export it before retrying. Pass `"${AUTH[@]}"`
+on every later call; the examples below omit it only to stay readable.
 
 The companion `3d-printing-knowledge-base` skill is the **read** path and is deliberately
 read-only. This skill is the **write** path. Its sourcing discipline still applies here: a
@@ -118,47 +124,60 @@ Never carry a CSS colour name into the database as a placeholder. `#ff0000` for 
 `#FF00FF` for "magenta" are how the library fills up with values that look real and aren't.
 If you don't have the vendor's hex, leave the colour for the user to supply.
 
-### 4. Link to OpenPrintTag
+### 4. Find the OpenPrintTag match (but don't link yet)
 
-Search the catalogue and link if there is a genuine match:
+Search the catalogue now, so anything it offers can inform the create — but the link itself
+needs the new record's id, so it happens in step 6, after the create.
 
 ```bash
-curl -s "$BASE/api/openprinttag" | jq '[.materials[] | select(.brandSlug=="...")]'
-curl -s -X POST "$BASE/api/filaments/$ID/openprinttag/link" -H 'Content-Type: application/json' -d '{"slug":"..."}'
+curl -s "$BASE/api/openprinttag" -o /tmp/opt.json      # ~14k entries, several MB
+jq '[.materials[] | select(.brandSlug=="...")]' /tmp/opt.json
 ```
-
-Two rules that matter:
-
-**Link only colour-level records, never a template.** Every OPT entry is one colour, so
-linking a product line pins one colour's provenance onto the whole family.
-
-**The link route is safe; the import route is not.** `openprinttag/link` writes only the slug,
-uuid and provenance snapshot — never a field value — so it cannot damage anything. By
-contrast `POST /api/openprinttag/import` with a `parentId` *does* write values, and if the OPT
-entry is well-populated it will pin its temperatures onto the variant as local overrides,
-severing the inheritance you just set up. Import is only safe when the entry is a stub
-(`completenessTier: "stub"`, colour and nothing else) — check before using it, or use link
-plus your own values instead.
 
 Match on brand **and** colour, not name similarity. Name-similarity scoring reliably proposes
 `overture-petg-green` for "Overture PETG Grey" and matches product lines to whichever colour
 happens to sort first.
 
+**Link only colour-level records, never a template.** Every OPT entry is one colour, so
+linking a product line pins one colour's provenance onto the whole family — and a later
+check/sync can then write managed fields onto the template that every unoverridden variant
+inherits.
+
+**The link route is safe on a colour record; the import route is not.** `openprinttag/link`
+writes only the slug, uuid and provenance snapshot, never a field value. By contrast
+`POST /api/openprinttag/import` with a `parentId` *does* write values, and anything that
+differs from the parent survives pruning and becomes a local override, severing the
+inheritance you just set up.
+
+Do not use `completenessTier` as the safety check. "stub" covers every score from 0 to 3, so a
+stub can still carry density and print temperatures. **Inspect the mapped fields themselves** —
+if anything beyond colour is populated, prefer link plus your own values over import.
+
 ### 5. Create the record
 
+Capture the new `_id` — the link, the spool and the verification all need it.
+
 ```bash
-curl -s -X POST "$BASE/api/filaments" -H 'Content-Type: application/json' -d '{
+ID=$(curl -s -X POST "$BASE/api/filaments" -H 'Content-Type: application/json' -d '{
   "name": "Prusament PETG Prusa Orange",
   "vendor": "Prusament",
   "type": "PETG",
   "color": "#EB5403",
   "colorName": "Prusa Orange",
+  "transmissionDistance": 6.2,
+  "temperatures": { "nozzleRangeMin": 240, "nozzleRangeMax": 260 },
   "parentId": "<template id, omit for a standalone>"
-}'
+}' | jq -r '.filament._id // ._id')
 ```
 
 `name`, `vendor`, and `type` are required. For a variant, send nothing else unless this
 colour genuinely differs from the family.
+
+Two shapes that are easy to get wrong. **The nozzle range lives under `temperatures`** — a
+top-level `nozzleRangeMin` is silently dropped by the schema, and on a later `PUT` it needs the
+dotted `temperatures.nozzleRangeMin` form. And **if the vendor table gave you a TD, put it in
+`transmissionDistance` here**, or the value you went to the trouble of finding is discarded
+while the hex is kept.
 
 Match the family's existing naming convention rather than imposing one — look at the siblings
 first. Renaming later is disruptive because slicers key their presets on the filament name.
@@ -178,7 +197,22 @@ invent: a tidier-looking `PLA-Wood` matches nothing and silently hides the refer
 where the existing `Woodfill` resolves to the PLA chapter. Reuse a type the library already
 uses, and if a genuinely new one is needed, check it still resolves.
 
-### 6. Weights, then the spool
+### 6. Link the OpenPrintTag match
+
+Now that `$ID` exists, attach the slug chosen in step 4. Skip this entirely if the record is a
+template, or if nothing matched.
+
+```bash
+curl -s -X POST "$BASE/api/filaments/$ID/openprinttag/link" \
+  -H 'Content-Type: application/json' -d '{"slug":"3d-fuel-pro-pctg-natural"}'
+```
+
+A healthy link answers `{"linked": true, "found": true, "changes": []}` on
+`GET /api/filaments/$ID/openprinttag/check`. Any `changes` entry means the record and OPT
+disagree on a field — expected when you took a vendor value over OPT's, and worth saying so
+rather than silently adopting either.
+
+### 7. Weights, then the spool
 
 Adding a filament always means a physical roll arrived, so the record is not finished until it
 has a spool.
@@ -192,9 +226,16 @@ Three weights, and they are easy to confuse:
 | `totalWeight` | **spool** | gross weight of this roll right now, tare included |
 
 The first two are shared product spec and belong on the template. Take them from an existing
-variant or the template itself before asking — the family almost always already knows. Only
-if the family has neither, ask the user to weigh the roll, and be specific about wanting the
-gross weight with the spool on the scale.
+variant or the template itself before asking — the family almost always already knows.
+
+`totalWeight` is different and the family can never supply it: tare and nominal capacity
+describe the product, not how much filament is on *this* roll today. So ask for it separately,
+every time, and be specific about wanting the gross weight with the spool on the scale. The
+one shortcut is an unopened roll, where tare plus nominal net is a fair starting figure — say
+that you are assuming it rather than presenting it as measured.
+
+Skipping this is the most likely way to finish with a spool that tracks nothing: the record
+looks complete, the percentage bar is blank, and no error was ever raised.
 
 The remaining-percentage bar needs `netFilamentWeight` as its denominator, so a family missing
 it shows no bar at all. Worth filling in if you notice it absent.
@@ -209,7 +250,7 @@ NFC tags resolve against. Let it generate one. Only pass an explicit `instanceId
 a spool between records and preserving its printed identity, and note the uniqueness check
 ignores trashed rows, so a colliding id may need the old record trashing first.
 
-### 7. Verify against the resolved record
+### 8. Verify against the resolved record
 
 Read the record back **without** `?raw=true`. Raw shows stored values, where a variant's
 inherited fields are `null` and look alarming; the plain read shows what the app and the

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -60,8 +60,12 @@ If the user scanned a tag, the decoded payload gives you most of this already.
 ### 2. Find the family
 
 ```bash
-curl -s "$BASE/api/filaments" | jq -r '.[] | "\(.name)\t\(.vendor)\t\(.type)\t\(.parentId // "root")\t\(.hasVariants)"'
+curl -s "$BASE/api/filaments" | jq -r '.[] | "\(._id)\t\(.name)\t\(.vendor)\t\(.type)\t\(.parentId // "root")\t\(.hasVariants)"'
 ```
+
+Keep the `_id` of whatever you match — it becomes `parentId` on the create, and `$TEMPLATE_ID`
+if the family needs its weights filling in. `parentId` is `root` for a template and a
+standalone alike, so it cannot identify the record for you.
 
 Three cases, and they lead to different work:
 
@@ -158,7 +162,7 @@ if anything beyond colour is populated, prefer link plus your own values over im
 Capture the new `_id` — the link, the spool and the verification all need it.
 
 ```bash
-ID=$(curl -s -X POST "$BASE/api/filaments" -H 'Content-Type: application/json' -d '{
+RESP=$(curl -s -w '\n%{http_code}' -X POST "$BASE/api/filaments" -H 'Content-Type: application/json' -d '{
   "name": "Prusament PETG Prusa Orange",
   "vendor": "Prusament",
   "type": "PETG",
@@ -167,8 +171,16 @@ ID=$(curl -s -X POST "$BASE/api/filaments" -H 'Content-Type: application/json' -
   "transmissionDistance": 6.2,
   "temperatures": { "nozzleRangeMin": 240, "nozzleRangeMax": 260 },
   "parentId": "<template id, omit for a standalone>"
-}' | jq -r '.filament._id // ._id')
+}')
+CODE=$(printf '%s' "$RESP" | tail -n1); BODY=$(printf '%s' "$RESP" | sed '$d')
 ```
+
+Check `$CODE` before going further. **201** — take the id with
+`ID=$(printf '%s' "$BODY" | jq -r '.filament._id // ._id')`. **409** — `$BODY` carries either
+the promotion gate (confirm, then retry with `promoteParent: true`) or a name collision.
+Anything else is a validation error naming its field. Extracting the id first instead turns a
+409 into the string `null` and every later call targets `/null`, silently, while the parent
+state you needed for the confirmation is gone.
 
 `name`, `vendor`, and `type` are required. For a variant, send nothing else unless this
 colour genuinely differs from the family.
@@ -249,8 +261,10 @@ curl -s -X PUT "$BASE/api/filaments/$TEMPLATE_ID" -H 'Content-Type: application/
 ```
 
 The net is usually on the packaging or the listing; the tare almost never is, so expect to ask
-for a weighed empty spool. If only the net is available, write it anyway — the bar works and
-only the grams figure stays approximate.
+for a weighed empty spool — and do ask, because **net alone is not enough**. `computeRemaining`
+returns null the moment `spoolWeight` is null, before it reaches the percentage, so a roll with
+a net but no tare displays nothing at all. Store a known net anyway so it is not lost, but say
+plainly that the display stays blank until the tare arrives.
 
 ```bash
 curl -s -X POST "$BASE/api/filaments/$ID/spools?shape=spool" -H 'Content-Type: application/json' \

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -68,7 +68,7 @@ curl -s "$BASE/api/filaments" | jq -r '.[] | "\(._id)\t\(.name)\t\(.vendor)\t\(.
 Assign the `_id` of whatever you match — every later step addresses the family through it:
 
 ```bash
-TEMPLATE_ID=<the _id from the row you matched>
+TEMPLATE_ID=<the _id from the row you matched, or its parentId if that row is a variant>
 ```
 
 It becomes `parentId` on the create, and the target for filling in family weights, for the
@@ -88,6 +88,17 @@ If it exists, that record is `$ID` and you are done with steps 3 to 6: go straig
 register the spool. Creating anyway is not a harmless duplicate — the unique-name index returns
 a 409 and the roll never gets recorded, or, if your generated name differs by a word, you
 silently end up with two records for one colour and a promotion that should not have happened.
+
+```bash
+ID=<the _id of the matching colour>
+# If that row is a VARIANT, the family is its PARENT, not itself.
+TEMPLATE_ID=<its parentId, or its own _id when parentId is "root">
+```
+
+Getting that second line wrong is quiet and durable: step 7 fills in missing family weights on
+`$TEMPLATE_ID`, so pointing it at the variant pins overrides on one colour while the template
+and every other colour stay incomplete — and the bar those weights drive keeps reading empty
+everywhere else.
 
 Only when the colour is genuinely new do the three cases below apply:
 
@@ -295,9 +306,12 @@ over-specifies rather than loses:
   colour and hide it from the nozzle-safety check in Settings → Data health. On a matte line
   holding `[16, 4]`, both stay: template `[16, 4]`, variant `[16, 4]`.
 
-  **When you cannot tell, call it a line tag.** A line tag appears in both places, so an
-  over-inclusive guess costs nothing; a tag wrongly called colour-specific is removed from the
-  template and every later sibling loses it silently.
+  **When you cannot tell, ask.** There is no safe default here, which is why this is a question
+  and not a lookup: guess "line" and a `2` transparent stays on the template, so the next opaque
+  colour added renders see-through; guess "colour" and a shared `16` matte leaves the template,
+  so the next colour renders flat-less. Both are the same contamination in opposite directions,
+  and both are silent. One question to the user settles it — name the tag and the family and ask
+  whether every colour in the line shares it.
 - **The OpenPrintTag link** — cannot be moved with a `PUT`; it is three fields, one of them
   server-owned. Follow the route sequence in `references/sources.md`, and keep its ordering:
   read the template's existing slug *before* the `DELETE`, because that slug belongs to the

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -78,8 +78,14 @@ the second colour arrives.
 ### 3. Gather the values, in strict source order
 
 **Vendor first.** The manufacturer's own published figures beat everything else. Several
-vendors publish exact hex codes and full spec — see `references/sources.md` for the ones
-already known to work and how to extract them.
+vendors publish exact hex codes, and usually a HueForge TD value beside them worth taking for
+`transmissionDistance`. See `references/sources.md` for the ones already known to work and how
+to extract them.
+
+Do not conclude a vendor publishes nothing just because the product page is bare — the tables
+are often a blog post or a linked spreadsheet away, and a mention of HueForge anywhere on the
+site is a strong signal one exists. That search is worth the minute it costs: for one line it
+corrected nine of ten colours that had come from OpenPrintTag.
 
 **OpenPrintTag second**, and treat it as community data rather than truth. It is genuinely
 useful for colour, and it is the linkage that lets the record pull future updates. But it is

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -79,7 +79,17 @@ carrying the value in your head; a step that interpolates an unset variable buil
 `parentId` is `root` for a template and a standalone alike, so it cannot identify the record
 for you.
 
-Three cases, and they lead to different work:
+**First, check whether this exact colour is already there.** The headline rule of this skill is
+that a filament being added is always a new physical roll, and a roll of a colour already in the
+library needs no new record at all — only a spool. Match on vendor + name + colour, across
+variants as well as roots.
+
+If it exists, that record is `$ID` and you are done with steps 3 to 6: go straight to step 7 and
+register the spool. Creating anyway is not a harmless duplicate — the unique-name index returns
+a 409 and the roll never gets recorded, or, if your generated name differs by a word, you
+silently end up with two records for one colour and a promotion that should not have happened.
+
+Only when the colour is genuinely new do the three cases below apply:
 
 **A template already exists** (`hasVariants: true`, name matches the product line) — create a
 variant under it. This is the good case: the variant inherits everything and you only need
@@ -269,22 +279,25 @@ over-specifies rather than loses:
   variant with a non-empty array **replaces** the template's rather than adding to it. So this
   is not a move, it is a split plus a copy.
 
-  Separate the template's tags into the ones describing how that colour *looks* — `2`
-  transparent, `3` translucent, `16` matte, `17` silk, `22` sparkle, `23` phosphorescent, `24`
-  glow, `25` colour-changing, `27` gradient, `28` dual/`29` triple-colour — and everything else,
-  which describes the product line: `4` abrasive, `0`/`31` fibre, `33` hygroscopic, `9`
-  flexible, `5` food-safe.
+  Ask of each tag: *does it describe this colour, or the product line?* That is a question
+  about the family, not a fixed list of ids. `4` abrasive, `0`/`31` fibre, `33` hygroscopic,
+  `9` flexible and `5` food-safe are always the line. The appearance tags — `2` transparent,
+  `3` translucent, `16` matte, `17` silk, `22` sparkle, `23` phosphorescent, `24` glow, `25`
+  colour-changing, `27` gradient, `28` dual/`29` triple-colour — are usually the colour, but
+  not always: in a **Matte PLA** or **Silk PLA** line the finish is the product, shared by
+  every colour in it, and stripping it off the template makes each new sibling render wrong.
+  The family name and the sibling colours tell you which you are looking at.
 
-  The template keeps **only the product-line tags**. The variant gets the appearance tags
-  **plus a copy of those same product-line tags**, because its own array is what it resolves to
-  and anything left out is simply gone for that colour. From `[2, 4]` that is template `[4]`,
+  Then: the template keeps **every line tag**, and the variant gets **its colour-specific tags
+  plus a copy of every line tag**. Its own array is what it resolves to, so anything left out
+  is simply gone for that colour. From `[2, 4]` on a normal line that is template `[4]`,
   variant `[2, 4]` — not variant `[2]`, which would strip the abrasive marker off the original
-  colour and hide it from the nozzle-safety check in Settings → Data health. New siblings, whose
-  array stays empty, inherit `[4]` correctly.
+  colour and hide it from the nozzle-safety check in Settings → Data health. On a matte line
+  holding `[16, 4]`, both stay: template `[16, 4]`, variant `[16, 4]`.
 
-  **If a tag isn't clearly on the appearance list, treat it as product-line**: it then stays on
-  the template *and* rides along on the variant, so an over-inclusive guess costs nothing while
-  a missed safety tag is silent.
+  **When you cannot tell, call it a line tag.** A line tag appears in both places, so an
+  over-inclusive guess costs nothing; a tag wrongly called colour-specific is removed from the
+  template and every later sibling loses it silently.
 - **The OpenPrintTag link** — cannot be moved with a `PUT`; it is three fields, one of them
   server-owned. Follow the route sequence in `references/sources.md`, and keep its ordering:
   read the template's existing slug *before* the `DELETE`, because that slug belongs to the

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -291,8 +291,12 @@ over-specifies rather than loses:
   is not a move, it is a split plus a copy.
 
   Ask of each tag: *does it describe this colour, or the product line?* That is a question
-  about the family, not a fixed list of ids. `4` abrasive, `0`/`31` fibre, `33` hygroscopic,
-  `9` flexible and `5` food-safe are always the line. The appearance tags — `2` transparent,
+  about the family, not a fixed list of ids — and it applies to every tag, including the
+  material ones. `0`/`31` fibre, `33` hygroscopic, `9` flexible and `5` food-safe come from the
+  base polymer, so in practice they are always the line. `4` abrasive usually is too, but not
+  when the abrasive thing is the *pigment*: one glow colour in an otherwise ordinary line is
+  abrasive on its own account, and leaving `4` on the template marks every plain sibling
+  abrasive and restricts them all to hardened nozzles. The appearance tags — `2` transparent,
   `3` translucent, `16` matte, `17` silk, `22` sparkle, `23` phosphorescent, `24` glow, `25`
   colour-changing, `27` gradient, `28` dual/`29` triple-colour — are usually the colour, but
   not always: in a **Matte PLA** or **Silk PLA** line the finish is the product, shared by

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: add-filament
+description: >
+  Add a filament or spool to the user's Filament DB through its REST API — creating it as a
+  colour variant of an existing product line when one exists, enriching it from the vendor's
+  own published data and from OpenPrintTag, and always registering the physical spool. Use
+  this skill whenever the user wants to add, register, log, record, or enter a filament,
+  spool, or roll: "I bought some Prusament PETG", "new spool of Overture PLA in cobalt",
+  "add this filament", "just got a roll of PA6-CF", "put this on the shelf". Also use it when
+  they want a new colour variant of a filament they already have, when they have scanned an
+  NFC tag or QR code for something not yet in the database, and when they are entering
+  several new spools at once.
+---
+
+# Adding a filament to Filament DB
+
+The API is at `http://localhost:3456` by default (override with `FILAMENTDB_URL`). If the
+instance sets `FILAMENTDB_API_KEY`, every request needs `Authorization: Bearer <key>` —
+the gate has no same-origin exemption.
+
+Start with `curl -s -o /dev/null -w "%{http_code}" $BASE/api/filaments`. A connection error
+means the app is not running: say so and stop rather than guessing at the data.
+
+The companion `3d-printing-knowledge-base` skill is the **read** path and is deliberately
+read-only. This skill is the **write** path. Its sourcing discipline still applies here: a
+processing parameter you did not retrieve from a real source does not go in the database.
+
+## The one thing to understand before writing anything
+
+A filament with variants is a **template**. It is an abstract product line: it carries the
+shared spec (temperatures, drying, density, tare weight, net weight) and deliberately holds
+**no colour and no inventory**. Each colour is a variant that stores its own colour and its
+own spools, and leaves every shared field `null` so it resolves from the template at read
+time.
+
+That inheritance is live, not a copy. So the single most common way to damage this database
+is to fill a variant's fields in with values copied from its parent — it looks identical on
+screen, and then the template is edited a year later and the variant silently doesn't follow.
+
+**Leave inheritable fields null on the variant. That is the feature, not an omission.**
+
+What legitimately belongs on the variant: `name`, `color`, `colorName`, and its spools.
+Everything else belongs on the template unless this colour genuinely differs.
+
+## Workflow
+
+### 1. Identify what is being added
+
+You need vendor, product line, colour, and material type. Ask for whatever is missing rather
+than inferring — "Prusament PETG orange" is three facts, "some orange PETG" is one.
+
+If the user scanned a tag, the decoded payload gives you most of this already.
+
+### 2. Find the family
+
+```bash
+curl -s "$BASE/api/filaments" | jq -r '.[] | "\(.name)\t\(.vendor)\t\(.type)\t\(.parentId // "root")\t\(.hasVariants)"'
+```
+
+Three cases, and they lead to different work:
+
+**A template already exists** (`hasVariants: true`, name matches the product line) — create a
+variant under it. This is the good case: the variant inherits everything and you only need
+the colour.
+
+**A single filament exists for this product line but has no variants** — adding a second
+colour turns it into a template. The server gates this: your create returns **409
+`parent_promotion_required`**. That is not an error, it is a confirmation request. Show the
+user what will happen (the existing filament's colour and spools move onto a new sibling
+variant, the parent becomes a colourless template) and repeat the identical request with
+`"promoteParent": true` added. Never send that flag without asking — it restructures a second
+record.
+
+**Nothing exists** — create a standalone filament. Do not invent a template for a single
+colour; the model derives template-ness from having variants, so it happens on its own when
+the second colour arrives.
+
+### 3. Gather the values, in strict source order
+
+**Vendor first.** The manufacturer's own published figures beat everything else. Several
+vendors publish exact hex codes and full spec — see `references/sources.md` for the ones
+already known to work and how to extract them.
+
+**OpenPrintTag second**, and treat it as community data rather than truth. It is genuinely
+useful for colour, and it is the linkage that lets the record pull future updates. But it is
+measurably wrong sometimes: in one audit of 27 linked filaments, four of the vendor-published
+colours disagreed with OPT and the user's existing values were the correct ones. If OPT and
+the vendor disagree, the vendor wins and it is worth telling the user.
+
+**Ask third.** If neither source has a number, ask. A plausible-looking invented temperature
+is worse than a blank field, because a blank field is visibly missing.
+
+Never carry a CSS colour name into the database as a placeholder. `#ff0000` for "red" and
+`#FF00FF` for "magenta" are how the library fills up with values that look real and aren't.
+If you don't have the vendor's hex, leave the colour for the user to supply.
+
+### 4. Link to OpenPrintTag
+
+Search the catalogue and link if there is a genuine match:
+
+```bash
+curl -s "$BASE/api/openprinttag" | jq '[.materials[] | select(.brandSlug=="...")]'
+curl -s -X POST "$BASE/api/filaments/$ID/openprinttag/link" -H 'Content-Type: application/json' -d '{"slug":"..."}'
+```
+
+Two rules that matter:
+
+**Link only colour-level records, never a template.** Every OPT entry is one colour, so
+linking a product line pins one colour's provenance onto the whole family.
+
+**The link route is safe; the import route is not.** `openprinttag/link` writes only the slug,
+uuid and provenance snapshot — never a field value — so it cannot damage anything. By
+contrast `POST /api/openprinttag/import` with a `parentId` *does* write values, and if the OPT
+entry is well-populated it will pin its temperatures onto the variant as local overrides,
+severing the inheritance you just set up. Import is only safe when the entry is a stub
+(`completenessTier: "stub"`, colour and nothing else) — check before using it, or use link
+plus your own values instead.
+
+Match on brand **and** colour, not name similarity. Name-similarity scoring reliably proposes
+`overture-petg-green` for "Overture PETG Grey" and matches product lines to whichever colour
+happens to sort first.
+
+### 5. Create the record
+
+```bash
+curl -s -X POST "$BASE/api/filaments" -H 'Content-Type: application/json' -d '{
+  "name": "Prusament PETG Prusa Orange",
+  "vendor": "Prusament",
+  "type": "PETG",
+  "color": "#EB5403",
+  "colorName": "Prusa Orange",
+  "parentId": "<template id, omit for a standalone>"
+}'
+```
+
+`name`, `vendor`, and `type` are required. For a variant, send nothing else unless this
+colour genuinely differs from the family.
+
+Match the family's existing naming convention rather than imposing one — look at the siblings
+first. Renaming later is disruptive because slicers key their presets on the filament name.
+
+Use the vendor spelling the rest of the library uses for that brand, so filters and grouping
+don't fragment across `3D Fuel` / `3D-Fuel`.
+
+### 6. Weights, then the spool
+
+Adding a filament always means a physical roll arrived, so the record is not finished until it
+has a spool.
+
+Three weights, and they are easy to confuse:
+
+| Field | Lives on | Meaning |
+|---|---|---|
+| `spoolWeight` | template | tare — the empty spool |
+| `netFilamentWeight` | template | nominal filament content, e.g. 1000 g |
+| `totalWeight` | **spool** | gross weight of this roll right now, tare included |
+
+The first two are shared product spec and belong on the template. Take them from an existing
+variant or the template itself before asking — the family almost always already knows. Only
+if the family has neither, ask the user to weigh the roll, and be specific about wanting the
+gross weight with the spool on the scale.
+
+The remaining-percentage bar needs `netFilamentWeight` as its denominator, so a family missing
+it shows no bar at all. Worth filling in if you notice it absent.
+
+```bash
+curl -s -X POST "$BASE/api/filaments/$ID/spools?shape=spool" -H 'Content-Type: application/json' \
+  -d '{"totalWeight": 1186, "label": "", "purchaseDate": "2026-08-29"}'
+```
+
+The server mints an `instanceId` for the spool — a durable identity that printed QR labels and
+NFC tags resolve against. Let it generate one. Only pass an explicit `instanceId` when moving
+a spool between records and preserving its printed identity, and note the uniqueness check
+ignores trashed rows, so a colliding id may need the old record trashing first.
+
+### 7. Verify against the resolved record
+
+Read the record back **without** `?raw=true`. Raw shows stored values, where a variant's
+inherited fields are `null` and look alarming; the plain read shows what the app and the
+slicer actually see.
+
+```bash
+curl -s "$BASE/api/filaments/$ID" | jq '{name, color, temperatures, density, spools: [.spools[] | {instanceId, totalWeight}]}'
+```
+
+Confirm the temperatures resolved from the template, and that the spool exists. Then tell the
+user what was inherited versus stored — that distinction is the thing they can't see and will
+want to know.
+
+## Traps worth knowing before you hit them
+
+**Write temperatures as dotted paths.** `PUT /api/filaments/{id}` passes the body straight to
+`findOneAndUpdate`, so a nested `{"temperatures": {"nozzle": 250}}` **replaces the whole
+subdocument** and silently destroys `bed`, the range fields and the first-layer values. Send
+`{"temperatures.nozzle": 250}` instead. The same applies to `settings.<key>`.
+
+**Templates reject colour and inventory silently.** Writing `color`, `colorName`,
+`totalWeight` or `lowStockThreshold` to a template strips those fields rather than erroring —
+by design, so a slicer echoing stale values can't break the sync. If a colour you set doesn't
+appear, check whether you wrote it to the template.
+
+**`compatibleNozzles` and `calibrations` are whole-array fallback.** A variant with an empty
+array inherits the template's; a non-empty one overrides completely. Set nozzle compatibility
+on the template so every colour gets it.
+
+**Nozzle compatibility has physical consequences.** Abrasive filaments — anything CF, GF,
+metal-filled, glow, or flagged `filament_abrasive: "1"` — need hardened nozzles and will
+destroy a brass or nitrided one. Foaming grades and some flexibles are incompatible with
+high-flow nozzles. Follow whatever rule the user's existing records already express rather
+than assuming.
+
+**Dates are validated but Mongoose would roll them over.** `2026-02-30` becomes March 2nd if
+it reaches the driver. The routes guard this, so a 400 on a date is real.
+
+More detail on API shapes, error codes and vendor sources is in `references/`. Read
+`references/api-contracts.md` when a call returns something unexpected, and
+`references/sources.md` when you need a vendor's published figures.

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -23,8 +23,10 @@ curl -s "${AUTH[@]}" -o /dev/null -w '%{http_code}\n' "$BASE/api/filaments"
 ```
 
 Expect `200`. A connection error means the app is not running: say so and stop rather than
-guessing at the data. A `401`/`403` means the instance sets `FILAMENTDB_API_KEY` — the gate has
-no same-origin exemption, so ask for the key and export it before retrying. Pass `"${AUTH[@]}"`
+guessing at the data. A `401` means the instance sets `FILAMENTDB_API_KEY` — the gate has no
+same-origin exemption, so ask for the key and export it before retrying. A `403` is *not* that
+gate, which only ever answers 401: look to the same-origin request guard or a reverse proxy,
+and do not loop asking for a key that cannot help. Pass `"${AUTH[@]}"`
 on every later call; the examples below omit it only to stay readable.
 
 The companion `3d-printing-knowledge-base` skill is the **read** path and is deliberately
@@ -161,17 +163,29 @@ if anything beyond colour is populated, prefer link plus your own values over im
 
 Capture the new `_id` — the link, the spool and the verification all need it.
 
+A **variant** carries only what is its own. No temperatures — sending a range that merely
+equals the family's still pins it as an override that stops following later template edits,
+which is the central rule of this skill breaking in its own worked example:
+
 ```bash
-RESP=$(curl -s -w '\n%{http_code}' -X POST "$BASE/api/filaments" -H 'Content-Type: application/json' -d '{
-  "name": "Prusament PETG Prusa Orange",
-  "vendor": "Prusament",
-  "type": "PETG",
-  "color": "#EB5403",
-  "colorName": "Prusa Orange",
-  "transmissionDistance": 6.2,
-  "temperatures": { "nozzleRangeMin": 240, "nozzleRangeMax": 260 },
-  "parentId": "<template id, omit for a standalone>"
-}')
+PAYLOAD='{"name":"Prusament PETG Prusa Orange","vendor":"Prusament","type":"PETG",
+  "color":"#EB5403","colorName":"Prusa Orange","transmissionDistance":6.2,
+  "parentId":"'"$TEMPLATE_ID"'"}'
+```
+
+A **standalone** has no template to inherit from, so the shared spec goes here — nested on
+create, and note the weights, which nothing else will supply:
+
+```bash
+PAYLOAD='{"name":"PRILINE PC-CF","vendor":"PRILINE","type":"PC-CF",
+  "color":"#000000","colorName":"Black",
+  "temperatures":{"nozzle":260,"nozzleRangeMin":250,"nozzleRangeMax":270,"bed":100},
+  "spoolWeight":147,"netFilamentWeight":1000,"dryingTemperature":90,"dryingTime":480}'
+```
+
+```bash
+RESP=$(curl -s -w '\n%{http_code}' -X POST "$BASE/api/filaments" \
+  -H 'Content-Type: application/json' -d "$PAYLOAD")
 CODE=$(printf '%s' "$RESP" | tail -n1); BODY=$(printf '%s' "$RESP" | sed '$d')
 ```
 
@@ -249,8 +263,10 @@ that you are assuming it rather than presenting it as measured.
 Skipping this is the most likely way to finish with a spool that tracks nothing: the record
 looks complete, the percentage bar is blank, and no error was ever raised.
 
-**If the family has neither, gather them and write them before creating the spool** — noticing
-they are absent is not enough. The remaining-percentage bar divides by `netFilamentWeight`, and
+**If the family is missing either one, gather it and write it before creating the spool** —
+noticing it is absent is not enough, and one out of two is not enough either: without the tare
+there is no display at all, and without a positive net the percentage stays blank while only
+grams show. The remaining-percentage bar divides by `netFilamentWeight`, and
 remaining grams subtract `spoolWeight`, so a spool added to a family with both null tracks a
 gross number and nothing else. On a standalone, put them in the create payload. On an existing
 family, PUT them onto the template first, so every colour inherits them:
@@ -268,8 +284,12 @@ plainly that the display stays blank until the tare arrives.
 
 ```bash
 curl -s -X POST "$BASE/api/filaments/$ID/spools?shape=spool" -H 'Content-Type: application/json' \
-  -d '{"totalWeight": 1186, "label": "", "purchaseDate": "2026-08-29"}'
+  -d '{"totalWeight": 1186, "label": ""}'
 ```
+
+`purchaseDate` is optional and deliberately absent above: only send it when the user gives a
+date, or when they say the roll arrived today and you derive today's. A copied example date
+silently backdates every roll added afterwards.
 
 The server mints an `instanceId` for the spool — a durable identity that printed QR labels and
 NFC tags resolve against. Let it generate one. Only pass an explicit `instanceId` when moving

--- a/.claude/skills/add-filament/SKILL.md
+++ b/.claude/skills/add-filament/SKILL.md
@@ -237,8 +237,20 @@ that you are assuming it rather than presenting it as measured.
 Skipping this is the most likely way to finish with a spool that tracks nothing: the record
 looks complete, the percentage bar is blank, and no error was ever raised.
 
-The remaining-percentage bar needs `netFilamentWeight` as its denominator, so a family missing
-it shows no bar at all. Worth filling in if you notice it absent.
+**If the family has neither, gather them and write them before creating the spool** — noticing
+they are absent is not enough. The remaining-percentage bar divides by `netFilamentWeight`, and
+remaining grams subtract `spoolWeight`, so a spool added to a family with both null tracks a
+gross number and nothing else. On a standalone, put them in the create payload. On an existing
+family, PUT them onto the template first, so every colour inherits them:
+
+```bash
+curl -s -X PUT "$BASE/api/filaments/$TEMPLATE_ID" -H 'Content-Type: application/json' \
+  -d '{"spoolWeight": 147, "netFilamentWeight": 1000}'
+```
+
+The net is usually on the packaging or the listing; the tare almost never is, so expect to ask
+for a weighed empty spool. If only the net is available, write it anyway — the bar works and
+only the grams figure stays approximate.
 
 ```bash
 curl -s -X POST "$BASE/api/filaments/$ID/spools?shape=spool" -H 'Content-Type: application/json' \

--- a/.claude/skills/add-filament/references/api-contracts.md
+++ b/.claude/skills/add-filament/references/api-contracts.md
@@ -11,7 +11,7 @@ else is wrong.
 
 | Call | Purpose |
 |---|---|
-| `GET /api/filaments` | List. Carries `hasVariants`, `parentId`, `hasCalibrations`. Temperatures are already resolved. |
+| `GET /api/filaments` | List. Carries `hasVariants`, `parentId`, `hasCalibrations`. Temperatures are resolved but **projected to `nozzle` and `bed` only** — range, first-layer and standby are absent, so compare ranges via the detail read, not here. |
 | `GET /api/filaments/{id}` | **Resolved** record — what the app and slicer see. Use this to verify. |
 | `GET /api/filaments/{id}?raw=true` | **Stored** record. Inherited fields read `null`. Use to check what a record actually owns; carries `_parent` and `_variants`. |
 | `GET /api/filaments/colors` | Distinct `{name, hex}` pairs already in use — good for matching an existing colour convention. |

--- a/.claude/skills/add-filament/references/api-contracts.md
+++ b/.claude/skills/add-filament/references/api-contracts.md
@@ -92,9 +92,11 @@ matching the snapshot classify as `adopt`; fields the user has changed classify 
 and are not auto-applied. A clean result (`changes: []`) means the link is healthy.
 
 `POST /api/openprinttag/import` with `{"slugs":["..."], "parentId":"..."}` **does write field
-values**. It prunes values equal to the parent's effective value, so it is safe against a stub
-entry (colour only) and dangerous against a well-populated one, which will pin temperatures as
-variant overrides. Check `completenessTier` first. Single slug only in variant mode; a name
+values**. It prunes values equal to the parent's effective value, so anything that
+differs survives and becomes a local override, severing inheritance. **Do not gate this on
+`completenessTier`** — "stub" spans scores 0 to 3, so a stub can still carry density and print
+temperatures. Inspect the mapped fields themselves and prefer link-plus-your-own-values
+whenever anything beyond colour is populated. Single slug only in variant mode; a name
 collision returns 409 without mutating anything.
 
 ## Deleting

--- a/.claude/skills/add-filament/references/api-contracts.md
+++ b/.claude/skills/add-filament/references/api-contracts.md
@@ -50,8 +50,15 @@ Responses:
 natural one. An empty body is refused so a stray call can't mint a phantom 0 g spool.
 
 ```json
-{ "totalWeight": 1186, "label": "", "purchaseDate": "2026-08-29", "locationId": null }
+{ "totalWeight": 1186, "label": "", "locationId": null }
 ```
+
+`purchaseDate` and `openedDate` are absent on purpose. Both are optional, and a date copied
+out of a reference is a date the user never gave — it looks right, so nobody catches it. Send
+either only when the user states or implies one. A placeholder would not help: leaving the key
+in the body still says "this field belongs here", and the agent then fills it in. Both accept
+`YYYY-MM-DD`, a full ISO 8601 string, or `null`; an ISO-shaped but impossible date such as
+`2026-02-30` is rejected rather than rolled over, so a 400 naming one of these is real.
 
 `totalWeight` is **gross** — filament plus spool. Append `?shape=spool` to get just the created
 spool back instead of the whole filament document with every sibling's photo blob.

--- a/.claude/skills/add-filament/references/api-contracts.md
+++ b/.claude/skills/add-filament/references/api-contracts.md
@@ -13,14 +13,15 @@ else is wrong.
 |---|---|
 | `GET /api/filaments` | List. Carries `hasVariants`, `parentId`, `hasCalibrations`. Temperatures are already resolved. |
 | `GET /api/filaments/{id}` | **Resolved** record — what the app and slicer see. Use this to verify. |
-| `GET /api/filaments/{id}?raw=true` | **Stored** record. Inherited fields read `null`. Use to check what a record actually owns, plus `_variants`, `_parent`, `_inherited`. |
+| `GET /api/filaments/{id}?raw=true` | **Stored** record. Inherited fields read `null`. Use to check what a record actually owns; carries `_parent` and `_variants`. |
 | `GET /api/filaments/colors` | Distinct `{name, hex}` pairs already in use — good for matching an existing colour convention. |
 | `GET /api/openprinttag` | Whole OPT catalogue (~14k entries, several MB, cached an hour). Fetch to a file and filter locally rather than into context. |
 | `GET /api/nozzles`, `/api/printers`, `/api/bed-types` | Reference data for compatibility. |
 | `GET /api/spools/next-label` | `{next, max}` — suggested next numeric roll label. Suggestion only; reserves nothing. |
 
-`_inherited` on the resolved read is the quickest way to confirm a variant is inheriting
-rather than storing its own copies.
+`_inherited` appears **only on the resolved read** — `?raw=true` skips `resolveFilament`, so
+it never produces that field. It is the quickest way to confirm a variant is inheriting rather
+than storing its own copies, but you have to ask for the resolved shape to get it.
 
 ## Creating a filament
 
@@ -80,8 +81,11 @@ pass through, which is how a legacy template gets cleaned up.
 ## OpenPrintTag
 
 `POST /api/filaments/{id}/openprinttag/link` with `{"slug": "..."}` — writes only
-`settings.openprinttag_slug`, `openprinttag_uuid`, and the `openprinttagSnapshot`. Never a
-field value, so it is safe on any record. `DELETE` on the same route removes the linkage.
+`settings.openprinttag_slug`, `openprinttag_uuid`, and the `openprinttagSnapshot`, never a
+field value. Safe on a **standalone or a variant**; not on a template. An OPT entry is one
+colour, so linking a product line attaches that colour's provenance to the whole family, and a
+later check/sync can then write managed fields such as `transmissionDistance` and `optTags`
+onto the template, which every unoverridden variant inherits. `DELETE` on the same route removes the linkage.
 
 `GET /api/filaments/{id}/openprinttag/check` — diffs the record against upstream. Fields
 matching the snapshot classify as `adopt`; fields the user has changed classify as `conflict`

--- a/.claude/skills/add-filament/references/api-contracts.md
+++ b/.claude/skills/add-filament/references/api-contracts.md
@@ -1,0 +1,114 @@
+# Filament DB API contracts for the add path
+
+Base `http://localhost:3456` unless `FILAMENTDB_URL` says otherwise. Add
+`Authorization: Bearer $FILAMENTDB_API_KEY` when that variable is set.
+
+Mutating routes carry a same-origin guard that rejects browser cross-origin requests. `curl`
+sends neither `Origin` nor `Sec-Fetch-Site`, so it passes — a 403 from `curl` means something
+else is wrong.
+
+## Reads used while adding
+
+| Call | Purpose |
+|---|---|
+| `GET /api/filaments` | List. Carries `hasVariants`, `parentId`, `hasCalibrations`. Temperatures are already resolved. |
+| `GET /api/filaments/{id}` | **Resolved** record — what the app and slicer see. Use this to verify. |
+| `GET /api/filaments/{id}?raw=true` | **Stored** record. Inherited fields read `null`. Use to check what a record actually owns, plus `_variants`, `_parent`, `_inherited`. |
+| `GET /api/filaments/colors` | Distinct `{name, hex}` pairs already in use — good for matching an existing colour convention. |
+| `GET /api/openprinttag` | Whole OPT catalogue (~14k entries, several MB, cached an hour). Fetch to a file and filter locally rather than into context. |
+| `GET /api/nozzles`, `/api/printers`, `/api/bed-types` | Reference data for compatibility. |
+| `GET /api/spools/next-label` | `{next, max}` — suggested next numeric roll label. Suggestion only; reserves nothing. |
+
+`_inherited` on the resolved read is the quickest way to confirm a variant is inheriting
+rather than storing its own copies.
+
+## Creating a filament
+
+`POST /api/filaments` — required `name`, `vendor`, `type`.
+
+```json
+{ "name": "Overture PETG Cobalt", "vendor": "Overture", "type": "PETG",
+  "color": "#0e21ae", "colorName": "Cobalt", "parentId": "<template id>" }
+```
+
+Responses:
+
+- **201** created.
+- **400** validation. The message names the field.
+- **409 duplicate name.** Names are unique among non-deleted rows, so a trashed record can
+  hold the name you want; check the trash before renaming around it.
+- **409 `parent_promotion_required`.** This create would produce the first variant of a parent
+  that still holds a colour or inventory. Body carries the parent's state. Confirm with the
+  user, then repeat the identical request plus `"promoteParent": true`. The server then moves
+  the parent's colour, colourName, weight and spools onto a new sibling variant and clears the
+  parent. Declining writes nothing.
+
+## Creating a spool
+
+`POST /api/filaments/{id}/spools` — needs at least one meaningful field; `totalWeight` is the
+natural one. An empty body is refused so a stray call can't mint a phantom 0 g spool.
+
+```json
+{ "totalWeight": 1186, "label": "", "purchaseDate": "2026-08-29", "locationId": null }
+```
+
+`totalWeight` is **gross** — filament plus spool. Append `?shape=spool` to get just the created
+spool back instead of the whole filament document with every sibling's photo blob.
+
+**409 "That spool ID is already used"** when passing an explicit `instanceId`. Uniqueness is
+checked against other spools' ids and other filaments' top-level ids, filtered to
+non-deleted rows — so trashing the holder frees the id.
+
+A template refuses spools with **400 `template_no_spools`**: inventory belongs on variants.
+
+## Updating
+
+`PUT /api/filaments/{id}`. The body goes to `findOneAndUpdate` essentially verbatim, which
+drives two rules:
+
+**Dotted paths for anything nested.** `{"temperatures.nozzle": 250}`, not
+`{"temperatures": {...}}` — the nested form replaces the entire subdocument and wipes the
+siblings. Same for `settings.<key>`. Settings are a flat bag; nested paths are rejected.
+
+**Explicit `null` clears a field.** That is how you make a variant inherit again — clear its
+own value rather than trying to match the parent's.
+
+Writing `color`, `colorName`, `totalWeight` or `lowStockThreshold` to a **template** strips
+them silently and reports `_strippedTemplateFields` in the response. An explicit `null` does
+pass through, which is how a legacy template gets cleaned up.
+
+## OpenPrintTag
+
+`POST /api/filaments/{id}/openprinttag/link` with `{"slug": "..."}` — writes only
+`settings.openprinttag_slug`, `openprinttag_uuid`, and the `openprinttagSnapshot`. Never a
+field value, so it is safe on any record. `DELETE` on the same route removes the linkage.
+
+`GET /api/filaments/{id}/openprinttag/check` — diffs the record against upstream. Fields
+matching the snapshot classify as `adopt`; fields the user has changed classify as `conflict`
+and are not auto-applied. A clean result (`changes: []`) means the link is healthy.
+
+`POST /api/openprinttag/import` with `{"slugs":["..."], "parentId":"..."}` **does write field
+values**. It prunes values equal to the parent's effective value, so it is safe against a stub
+entry (colour only) and dangerous against a well-populated one, which will pin temperatures as
+variant overrides. Check `completenessTier` first. Single slug only in variant mode; a name
+collision returns 409 without mutating anything.
+
+## Deleting
+
+`DELETE /api/filaments/{id}` soft-deletes to the trash. `?permanent=true` purges, and requires
+the record to already be in the trash. Purges leave a `_purged` tombstone that propagates as
+permanently-deleted to sync peers.
+
+Referential guards refuse deletes rather than leaving dangling refs: a nozzle referenced by any
+filament's ticks **or calibrations** cannot be deleted, and the check counts trashed filaments
+(only `_purged` ones are ignored). The error names the count.
+
+## Error shapes worth recognising
+
+| Status / code | Meaning |
+|---|---|
+| 409 `parent_promotion_required` | Confirm, then retry with `promoteParent: true`. |
+| 409 `parent_must_be_template_first` | A trash restore would create a first variant. Not retryable — the user converts the parent via `POST /api/filaments/{id}/promote`. |
+| 409 `name_taken` / duplicate key | Name collision among live rows. |
+| 400 `template_no_spools` | Inventory attempted on a template. |
+| 400 invalid shape | `?shape=` given something other than `spool`. |

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -126,6 +126,11 @@ phosphorescent, `24` glow, `25` colour-changing, `27` gradient, `28` dual-colour
 triple-colour — alongside what the material *is*: `4` abrasive, `0`/`31` glass and carbon fibre,
 `33` hygroscopic, `9` flexible, `5` food-safe.
 
+Those groupings are the usual case, not a partition you can apply blind. A finish is
+colour-specific in a line that has one silk colour among many, and is the *product* in a
+"Matte PLA" line where every colour shares it — same tag id, opposite answer. Read the family
+name and the siblings before deciding.
+
 Both halves of that matter, and the obvious remedies each break one. Sweeping the whole array
 onto the variant takes `4` off the product line, so every later sibling inherits no abrasive
 marker. But moving *only* the appearance tags fails too, and less obviously: `resolveFilament`
@@ -133,14 +138,14 @@ gives `optTags` whole-array fallback, so a variant holding `[2]` **replaces** th
 `[4]` instead of adding to it — the original colour loses its abrasive marker and drops out of
 the nozzle-safety check in Settings → Data health, which reads the resolved value.
 
-So the template keeps only the product-line tags, and the variant gets the appearance tags plus
+So the template keeps every product-line tag, and the variant gets its colour-specific tags plus
 a **copy** of those product-line tags. `[2, 4]` becomes template `[4]`, variant `[2, 4]`. New
-siblings leave their array empty and inherit `[4]`.
+siblings leave their array empty and inherit `[4]`. On a matte line holding `[16, 4]`, the
+finish is shared, so nothing splits at all: template `[16, 4]`, variant `[16, 4]`.
 
-**When a tag is not clearly one of the appearance tags listed above, treat it as
-product-line.** It then stays on the template and rides along on the variant, so an
-over-inclusive guess costs nothing, while a safety tag left out of the variant's array is
-silent.
+**When you cannot tell which a tag is, call it product-line.** It then stays on the template and
+rides along on the variant, so an over-inclusive guess costs nothing — while a tag wrongly
+called colour-specific is removed from the template and every later sibling loses it silently.
 
 The link is the one that cannot be hand-moved. It is three fields — `openprinttag_slug`,
 `openprinttag_uuid` and the server-owned `openprinttagSnapshot` — and a generic `PUT` strips

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -116,9 +116,21 @@ post-create move:
 
 | Stranded | Consequence for later siblings | How to move it |
 |---|---|---|
-| `optTags` | an opaque colour renders transparent | `PUT` the array onto the variant, `[]` on the template |
+| `optTags` | an opaque colour renders transparent | move **only the appearance tags** — see below — and leave the rest on the template |
 | `transmissionDistance` | inherits the original colour's TD as their own | `PUT` the value onto the variant, `null` on the template |
 | the OpenPrintTag link | template-level linkage, which the main skill forbids; a later sync can push one colour's managed values family-wide | **not a PUT** — `DELETE …/openprinttag/link` on the template, then `POST` the slug to the variant |
+
+**`optTags` is a mixed namespace, so moving the whole array is wrong.** It carries how a colour
+*looks* alongside what the material *is*: `2` transparent, `3` translucent, `16` matte, `17`
+silk, `22` sparkle, `23` phosphorescent, `24` glow, `25` colour-changing, `27` gradient, `28`
+dual-colour and `29` triple-colour describe this colour and belong on the variant. `4` abrasive,
+`0`/`31` glass and carbon fibre, `33` hygroscopic, `9` flexible, `5` food-safe and the rest
+describe the product line and must stay on the template, where every sibling inherits them.
+Sweeping the array across takes `4` off the line, which — because the resolver reads the
+effective value — hides the whole family from the abrasive/nozzle check in Settings → Data
+health. **When a tag is not clearly one of the appearance tags listed above, leave it on the
+template**: an appearance tag stranded there is a visible rendering wart, a safety tag moved
+off it is silent.
 
 The link is the one that cannot be hand-moved. It is three fields — `openprinttag_slug`,
 `openprinttag_uuid` and the server-owned `openprinttagSnapshot` — and a generic `PUT` strips

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -105,8 +105,11 @@ that declares none inherits it, and an opaque colour added later renders transpa
 standalone outright ("a standalone becomes a template when its first variant is created"), and
 the gated create performs the promotion and the new sibling in one step, so there is no moment
 in between. Do it immediately after that create — the generated original variant is the
-parent's other child, the one whose id is not the one the create just returned — moving
-`optTags` onto it and clearing them from the template.
+parent's other child, the one whose id is not the one the create just returned.
+
+What to do with `optTags` there is not a straight move — the split rule below governs it, and
+a shared finish stays on the template as well as the variant. Clearing the template
+unconditionally is what causes the mirror-image bug on a Matte or Silk product line.
 
 **Generalise this, because the tag is not the only thing that strands.** Promotion copies
 colour and inventory and nothing else, so *anything colour-specific held on a standalone stays
@@ -143,9 +146,11 @@ a **copy** of those product-line tags. `[2, 4]` becomes template `[4]`, variant 
 siblings leave their array empty and inherit `[4]`. On a matte line holding `[16, 4]`, the
 finish is shared, so nothing splits at all: template `[16, 4]`, variant `[16, 4]`.
 
-**When you cannot tell which a tag is, call it product-line.** It then stays on the template and
-rides along on the variant, so an over-inclusive guess costs nothing — while a tag wrongly
-called colour-specific is removed from the template and every later sibling loses it silently.
+**When you cannot tell which a tag is, ask the user.** Neither default is safe. Guessing
+product-line leaves a `2` transparent on the template, so the next opaque colour renders
+see-through; guessing colour-specific takes a shared `16` matte off it, so the next colour loses
+the finish. Same contamination, opposite directions, both silent. Ask whether every colour in
+that line shares the property.
 
 The link is the one that cannot be hand-moved. It is three fields — `openprinttag_slug`,
 `openprinttag_uuid` and the server-owned `openprinttagSnapshot` — and a generic `PUT` strips

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -49,10 +49,54 @@ headers are indented product names. Take care attributing values: plain `PLA` an
 PROFESSIONAL` both appear as blocks beginning "PLA", and they carry different values for the
 same colour name.
 
+### 3D-Fuel — and the reason to keep digging
+
+Hex **and** TD for every colour, per material line:
+
+<https://docs.google.com/spreadsheets/d/15hLIEGU3xl0QXJnoWtb-UiYsOSPAiOtg83_sv3qbKpc/>
+
+Any Google Sheet exports as CSV, and the tab you want is rarely the first one:
+
+```bash
+# list the tabs
+curl -sL "https://docs.google.com/spreadsheets/d/<ID>/htmlview" | grep -o 'gid=[0-9]*' | sort -u
+# then fetch one
+curl -sL "https://docs.google.com/spreadsheets/d/<ID>/export?format=csv&gid=<GID>"
+```
+
+This one is worth generalising from, because the data was three hops from where it should
+have been. The product page carried no specification at all. A search turned up a **blog
+post** announcing hex codes and a HueForge colour library, and that post linked the sheet,
+which had a separate tab per material line — `gid=0` was Standard PLA+, not the PCTG line
+being looked for.
+
+So: a product page with no figures does not mean the vendor publishes none. Search their blog
+and support pages too, and treat **any mention of HueForge as a strong signal** that a hex and
+TD table exists somewhere, because supplying one is the whole point of a HueForge library.
+
+Finding it mattered. The values in that sheet corrected nine of ten colours that had been
+taken from OpenPrintTag, several of them badly — OPT rendered two blacks as `#000000` where
+the vendor publishes `#383737` and `#434443`. It also settled a product's identity: a colour
+that looked like a rebadged spool from another brand turned out to be in the maker's own
+catalogue all along.
+
 ### Vendors confirmed to publish nothing
 
-SUNLU and Kexcelled have no public hex list. Fall back to OpenPrintTag for those and say
-that's what you did — the sourcing is weaker and the user should know which values rest on it.
+SUNLU and Kexcelled have no public hex list, and CHCKX appears in neither a vendor table nor
+OpenPrintTag. Fall back to OpenPrintTag where it has the product, say that's what you did, and
+where nothing exists at all leave the colour for the user rather than inventing one.
+
+## Transmission distance is usually free alongside the hex
+
+The Prusa, Polymaker and 3D-Fuel tables all carry a HueForge **TD** value next to each hex,
+and it populates `transmissionDistance` directly. It is worth taking whenever you are already
+reading the table — it is almost never populated otherwise, and HueForge work is unusable
+without it.
+
+TD runs 0 (opaque) to 100 (completely clear), which also makes it good evidence about a
+colour's nature: 3D-Fuel's Pro PCTG Natural reads 100, confirming a genuinely clear filament
+rather than a tinted one. A high TD is a reason to set the transparent or translucent finish
+tag (`optTags` 2 and 3) so the swatch renders see-through.
 
 ## When the vendor lists no hex at all
 

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -98,6 +98,13 @@ colour's nature: 3D-Fuel's Pro PCTG Natural reads 100, confirming a genuinely cl
 rather than a tinted one. A high TD is a reason to set the transparent or translucent finish
 tag (`optTags` 2 and 3) so the swatch renders see-through.
 
+**A finish tag on a standalone becomes a family-wide default if that filament is ever
+promoted.** Promotion moves colour and inventory to the generated original variant but leaves
+`optTags` behind on the new template, and `optTags` is whole-array fallback — so every sibling
+that declares none inherits it, and an opaque colour added later renders transparent. If you
+set a transparent tag on a standalone, move it to the original variant and clear it from the
+template as part of the promotion, before adding the second colour.
+
 ## When the vendor lists no hex at all
 
 Some products genuinely have no colour. Overture's PETG Transparent is listed in their own PDF

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -101,9 +101,12 @@ tag (`optTags` 2 and 3) so the swatch renders see-through.
 **A finish tag on a standalone becomes a family-wide default if that filament is ever
 promoted.** Promotion moves colour and inventory to the generated original variant but leaves
 `optTags` behind on the new template, and `optTags` is whole-array fallback — so every sibling
-that declares none inherits it, and an opaque colour added later renders transparent. If you
-set a transparent tag on a standalone, move it to the original variant and clear it from the
-template as part of the promotion, before adding the second colour.
+that declares none inherits it, and an opaque colour added later renders transparent. Note the cleanup can only run *after* the fact: `/promote` rejects a
+standalone outright ("a standalone becomes a template when its first variant is created"), and
+the gated create performs the promotion and the new sibling in one step, so there is no moment
+in between. Do it immediately after that create — the generated original variant is the
+parent's other child, the one whose id is not the one the create just returned — moving
+`optTags` onto it and clearing them from the template.
 
 ## When the vendor lists no hex at all
 

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -123,7 +123,20 @@ post-create move:
 The link is the one that cannot be hand-moved. It is three fields — `openprinttag_slug`,
 `openprinttag_uuid` and the server-owned `openprinttagSnapshot` — and a generic `PUT` strips
 the snapshot, leaving a linkage that looks present and classifies wrongly on the next check.
-Let the routes rebuild it: delete on the template, link on the variant. Before promoting anything, look at what else the standalone carries that describes
+Let the routes rebuild it, and mind the order, because **two different slugs are in play**:
+the one on the template belongs to the ORIGINAL colour, while the one you looked up in step 4
+belongs to the NEW colour you are adding. Deleting first destroys the value you need.
+
+```bash
+# 1. save the ORIGINAL colour's slug off the template before touching anything
+ORIG_SLUG=$(curl -s "$BASE/api/filaments/$TEMPLATE_ID?raw=true" \
+  | jq -r '.filament.settings.openprinttag_slug // .settings.openprinttag_slug')
+# 2. now the template can be unlinked
+curl -s -X DELETE "$BASE/api/filaments/$TEMPLATE_ID/openprinttag/link"
+# 3. relink the GENERATED ORIGINAL variant with its own slug, not the new colour's
+curl -s -X POST "$BASE/api/filaments/$ORIGINAL_VARIANT_ID/openprinttag/link" \
+  -H 'Content-Type: application/json' -d "{\"slug\":\"$ORIG_SLUG\"}"
+``` Before promoting anything, look at what else the standalone carries that describes
 its colour rather than its product line — the list above is what has been hit so far, not a
 guarantee it is complete.
 

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -129,10 +129,13 @@ phosphorescent, `24` glow, `25` colour-changing, `27` gradient, `28` dual-colour
 triple-colour — alongside what the material *is*: `4` abrasive, `0`/`31` glass and carbon fibre,
 `33` hygroscopic, `9` flexible, `5` food-safe.
 
-Those groupings are the usual case, not a partition you can apply blind. A finish is
-colour-specific in a line that has one silk colour among many, and is the *product* in a
-"Matte PLA" line where every colour shares it — same tag id, opposite answer. Read the family
-name and the siblings before deciding.
+Those groupings are the usual case, not a partition you can apply blind, and that cuts both
+ways. A finish is colour-specific in a line with one silk colour among many, and is the
+*product* in a "Matte PLA" line where every colour shares it — same tag id, opposite answer.
+`4` abrasive runs the other direction: it is a property of the base polymer in a CF line, but a
+property of the *pigment* in a line carrying one glow colour, where leaving it on the template
+marks every plain sibling abrasive and restricts them all to hardened nozzles. Read the family
+name and the siblings before deciding, for every tag.
 
 Both halves of that matter, and the obvious remedies each break one. Sweeping the whole array
 onto the variant takes `4` off the product line, so every later sibling inherits no abrasive

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -114,14 +114,16 @@ behind on the new template* — and every field the resolver treats as inheritab
 adopted by each sibling that doesn't override it. Three known cases, all needing the same
 post-create move:
 
-| Stranded | Consequence for later siblings |
-|---|---|
-| `optTags` | an opaque colour renders transparent |
-| `transmissionDistance` | inherits the original colour's TD as their own |
-| `settings.openprinttag_slug` + `openprinttagSnapshot` | template-level OPT linkage, which the main skill forbids; a later sync can push one colour's managed values family-wide |
+| Stranded | Consequence for later siblings | How to move it |
+|---|---|---|
+| `optTags` | an opaque colour renders transparent | `PUT` the array onto the variant, `[]` on the template |
+| `transmissionDistance` | inherits the original colour's TD as their own | `PUT` the value onto the variant, `null` on the template |
+| the OpenPrintTag link | template-level linkage, which the main skill forbids; a later sync can push one colour's managed values family-wide | **not a PUT** — `DELETE …/openprinttag/link` on the template, then `POST` the slug to the variant |
 
-So the cleanup pass is: move those onto the generated original variant, clear them from the
-template. Before promoting anything, look at what else the standalone carries that describes
+The link is the one that cannot be hand-moved. It is three fields — `openprinttag_slug`,
+`openprinttag_uuid` and the server-owned `openprinttagSnapshot` — and a generic `PUT` strips
+the snapshot, leaving a linkage that looks present and classifies wrongly on the next check.
+Let the routes rebuild it: delete on the template, link on the variant. Before promoting anything, look at what else the standalone carries that describes
 its colour rather than its product line — the list above is what has been hit so far, not a
 guarantee it is complete.
 

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -108,11 +108,22 @@ in between. Do it immediately after that create — the generated original varia
 parent's other child, the one whose id is not the one the create just returned — moving
 `optTags` onto it and clearing them from the template.
 
-The **OpenPrintTag link strands the same way**, and for the same reason: the promotion copy
-carries no `settings`, so a standalone's `openprinttag_slug` and snapshot stay on what is now a
-template — precisely the template-level linkage the main skill forbids, and a later sync can
-push that one colour's managed values across the family. Unlink the template and relink the
-generated original variant in the same cleanup pass.
+**Generalise this, because the tag is not the only thing that strands.** Promotion copies
+colour and inventory and nothing else, so *anything colour-specific held on a standalone stays
+behind on the new template* — and every field the resolver treats as inheritable is then
+adopted by each sibling that doesn't override it. Three known cases, all needing the same
+post-create move:
+
+| Stranded | Consequence for later siblings |
+|---|---|
+| `optTags` | an opaque colour renders transparent |
+| `transmissionDistance` | inherits the original colour's TD as their own |
+| `settings.openprinttag_slug` + `openprinttagSnapshot` | template-level OPT linkage, which the main skill forbids; a later sync can push one colour's managed values family-wide |
+
+So the cleanup pass is: move those onto the generated original variant, clear them from the
+template. Before promoting anything, look at what else the standalone carries that describes
+its colour rather than its product line — the list above is what has been hit so far, not a
+guarantee it is complete.
 
 ## When the vendor lists no hex at all
 

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -116,21 +116,31 @@ post-create move:
 
 | Stranded | Consequence for later siblings | How to move it |
 |---|---|---|
-| `optTags` | an opaque colour renders transparent | move **only the appearance tags** — see below — and leave the rest on the template |
+| `optTags` | an opaque colour renders transparent | **split, then copy** — see below; the array replaces rather than merges, so a plain move loses tags |
 | `transmissionDistance` | inherits the original colour's TD as their own | `PUT` the value onto the variant, `null` on the template |
 | the OpenPrintTag link | template-level linkage, which the main skill forbids; a later sync can push one colour's managed values family-wide | **not a PUT** — `DELETE …/openprinttag/link` on the template, then `POST` the slug to the variant |
 
-**`optTags` is a mixed namespace, so moving the whole array is wrong.** It carries how a colour
-*looks* alongside what the material *is*: `2` transparent, `3` translucent, `16` matte, `17`
-silk, `22` sparkle, `23` phosphorescent, `24` glow, `25` colour-changing, `27` gradient, `28`
-dual-colour and `29` triple-colour describe this colour and belong on the variant. `4` abrasive,
-`0`/`31` glass and carbon fibre, `33` hygroscopic, `9` flexible, `5` food-safe and the rest
-describe the product line and must stay on the template, where every sibling inherits them.
-Sweeping the array across takes `4` off the line, which — because the resolver reads the
-effective value — hides the whole family from the abrasive/nozzle check in Settings → Data
-health. **When a tag is not clearly one of the appearance tags listed above, leave it on the
-template**: an appearance tag stranded there is a visible rendering wart, a safety tag moved
-off it is silent.
+**`optTags` is a mixed namespace, and the array does not merge.** It carries how a colour
+*looks* — `2` transparent, `3` translucent, `16` matte, `17` silk, `22` sparkle, `23`
+phosphorescent, `24` glow, `25` colour-changing, `27` gradient, `28` dual-colour, `29`
+triple-colour — alongside what the material *is*: `4` abrasive, `0`/`31` glass and carbon fibre,
+`33` hygroscopic, `9` flexible, `5` food-safe.
+
+Both halves of that matter, and the obvious remedies each break one. Sweeping the whole array
+onto the variant takes `4` off the product line, so every later sibling inherits no abrasive
+marker. But moving *only* the appearance tags fails too, and less obviously: `resolveFilament`
+gives `optTags` whole-array fallback, so a variant holding `[2]` **replaces** the template's
+`[4]` instead of adding to it — the original colour loses its abrasive marker and drops out of
+the nozzle-safety check in Settings → Data health, which reads the resolved value.
+
+So the template keeps only the product-line tags, and the variant gets the appearance tags plus
+a **copy** of those product-line tags. `[2, 4]` becomes template `[4]`, variant `[2, 4]`. New
+siblings leave their array empty and inherit `[4]`.
+
+**When a tag is not clearly one of the appearance tags listed above, treat it as
+product-line.** It then stays on the template and rides along on the variant, so an
+over-inclusive guess costs nothing, while a safety tag left out of the variant's array is
+silent.
 
 The link is the one that cannot be hand-moved. It is three fields — `openprinttag_slug`,
 `openprinttag_uuid` and the server-owned `openprinttagSnapshot` — and a generic `PUT` strips
@@ -146,7 +156,7 @@ ORIG_SLUG=$(curl -s "$BASE/api/filaments/$TEMPLATE_ID?raw=true" \
 # 2. now the template can be unlinked
 curl -s -X DELETE "$BASE/api/filaments/$TEMPLATE_ID/openprinttag/link"
 # 3. relink the GENERATED ORIGINAL variant with its own slug, not the new colour's
-curl -s -X POST "$BASE/api/filaments/$ORIGINAL_VARIANT_ID/openprinttag/link" \
+curl -s -X POST "$BASE/api/filaments/$ORIG_ID/openprinttag/link" \
   -H 'Content-Type: application/json' -d "{\"slug\":\"$ORIG_SLUG\"}"
 ``` Before promoting anything, look at what else the standalone carries that describes
 its colour rather than its product line — the list above is what has been hit so far, not a

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -1,0 +1,83 @@
+# Vendor sources for filament spec
+
+Vendor-published figures take precedence over OpenPrintTag and over anything inferred. These
+are the sources already confirmed to carry real data, with the quirks of getting at them.
+
+## Vendors that publish exact hex codes
+
+### Prusa / Prusament — the best of the bunch
+
+<https://help.prusa3d.com/article/hueforge-filament-transparency-values-and-hexcodes_762314>
+
+A measured HexCode **and** HueForge TD value for every Prusament material and colour. Fetching
+the page and asking for specific products works well. The TD figure is also directly useful —
+it populates `transmissionDistance`.
+
+Worth knowing: OPT's values for Prusament are frequently off by one in the last digit
+(`ea5e1a` against Prusa's `EA5E19`), which suggests OPT samples swatch images rather than
+copying this table. Occasionally the gap is real — Prusa publishes `#494546` for PETG Prusa
+Galaxy Black against OPT's `#3d3e3d`.
+
+### Polymaker
+
+<https://wiki.polymaker.com/polymaker-products/more-about-our-products/hex-codes-and-transmission-distances>
+
+Hex codes and transmission distances by SKU. Search by product name; the table distinguishes
+sub-lines properly (PolyMax PC Grey is not PolyMax PLA Grey).
+
+Note Polymaker retired **PolyTerra** and sells that line as **Panchroma** now, with many
+sub-lines (Basic, Matte, Silk, Satin, Galaxy, Marble, Celestial, Dual, Neon, CoPE). A record
+still named PolyTerra needs the sub-line identifying before it can be matched. **Fiberon** is
+Polymaker's engineering line, so those products carry Polymaker as the vendor.
+
+### Overture
+
+<https://cdn.shopify.com/s/files/1/0207/3624/5824/files/Overture_Hex_Code_List.pdf>
+
+Complete hex list across PLA, Silk PLA, Matte PLA, Rock PLA, Air PLA, PLA Professional, Super
+PLA+, Easy PLA, PETG, TPU, ABS, ASA, Easy Nylon and PC Professional.
+
+Both the PDF and the equivalent wiki page resist direct fetching — the text does not render.
+Download and extract locally instead:
+
+```bash
+pdftotext -layout Overture_Hex_Code_List.pdf out.txt
+```
+
+The layout is two columns, colour names on one line and hex values on the line below. Section
+headers are indented product names. Take care attributing values: plain `PLA` and `PLA
+PROFESSIONAL` both appear as blocks beginning "PLA", and they carry different values for the
+same colour name.
+
+### Vendors confirmed to publish nothing
+
+SUNLU and Kexcelled have no public hex list. Fall back to OpenPrintTag for those and say
+that's what you did — the sourcing is weaker and the user should know which values rest on it.
+
+## When the vendor lists no hex at all
+
+Some products genuinely have no colour. Overture's PETG Transparent is listed in their own PDF
+with the word "Transparent" where a hex would be. The right representation is `color: null`
+plus the transparent finish tag (`optTags` 2 = transparent, 3 = translucent), which renders as
+a see-through swatch. Do not substitute the white of the same line — OPT does exactly that,
+and it is wrong.
+
+## Reading a TDS for process parameters
+
+A datasheet gives nozzle and bed ranges, drying schedule, density, and sometimes max
+volumetric flow. Two cautions:
+
+**A melting point is not a nozzle temperature, and a glass transition is not a bed
+temperature.** PA6 melts around 220 °C and prints at 260–280 °C. Never derive a process
+setting from a polymer property.
+
+**Extrusion multiplier and pressure advance are per-spool measurements**, not datasheet
+values. A vendor never publishes them. If the family has a calibration on the same nozzle it
+is a reasonable starting point, but record it as inherited from the template rather than
+asserting it as this roll's measured value.
+
+## Recording where a value came from
+
+When several sources are in play, say per-field which won — "temperatures from the Prusa
+knowledge base, colour from OPT since the vendor publishes none". The user can then judge
+which figures to trust, and the weakly-sourced ones are the ones worth re-checking later.

--- a/.claude/skills/add-filament/references/sources.md
+++ b/.claude/skills/add-filament/references/sources.md
@@ -108,6 +108,12 @@ in between. Do it immediately after that create — the generated original varia
 parent's other child, the one whose id is not the one the create just returned — moving
 `optTags` onto it and clearing them from the template.
 
+The **OpenPrintTag link strands the same way**, and for the same reason: the promotion copy
+carries no `settings`, so a standalone's `openprinttag_slug` and snapshot stay on what is now a
+template — precisely the template-level linkage the main skill forbids, and a later sync can
+push that one colour's managed values across the family. Unlink the template and relink the
+generated original variant in the same cleanup pass.
+
 ## When the vendor lists no hex at all
 
 Some products genuinely have no colour. Overture's PETG Transparent is listed in their own PDF


### PR DESCRIPTION
Adds a skill capturing the workflow for adding a filament or spool through the REST API, so a fresh session doesn't have to rediscover the data model by trial and error.

## Why

Adding a filament touches several contracts that are easy to get wrong and whose failure modes are silent rather than loud. This encodes them once, with the reasoning, rather than leaving each session to rederive them.

The core is the **template/variant contract**: a filament with variants is an abstract product line carrying the shared spec and no colour or inventory, and its variants leave inheritable fields `null` so they resolve at read time. That inheritance is live rather than copied — so filling a variant's fields with values copied from its parent looks correct on screen and silently stops tracking the template later.

## Traps it encodes

- `temperatures` and `settings` must be written as **dotted paths**; a nested object reaches `findOneAndUpdate` and replaces the whole subdocument, wiping its siblings
- `openprinttag/link` writes only provenance and is safe anywhere; `openprinttag/import` writes values and pins variant overrides unless the upstream entry is a colour-only stub
- an OPT entry is a single colour, so a template must never be linked to one
- `409 parent_promotion_required` is a confirmation request, not a failure — `promoteParent` restructures a second record and is never sent unasked
- verification reads the **resolved** record; `?raw=true` shows inherited fields as `null` and reads as missing data
- abrasive grades need hardened nozzles; foaming grades reject high-flow

## Sourcing

Vendor-published figures take precedence over OpenPrintTag. In an audit of 27 OPT-linked filaments, four vendor colours disagreed with OPT and the stored values were the correct ones — so the precedence rule ships with its evidence.

`references/sources.md` records the vendors confirmed to publish exact hex codes (Prusa's HueForge table, Polymaker's wiki, Overture's PDF) along with the extraction quirks — Overture's PDF needs `pdftotext -layout`, and has two blocks both labelled "PLA" carrying different values for the same colour name.

## Layout

```
.claude/skills/add-filament/
├── SKILL.md                    217 lines
└── references/
    ├── api-contracts.md        114 lines  endpoints, error codes, promotion handshake
    └── sources.md               83 lines  vendor hex sources
```

## Note on installation

`~/.claude/skills/add-filament` is symlinked to this directory so the skill is available in every session from a single versioned source. That means it only resolves while a branch containing it is checked out — merging this is what makes it permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)