### PR TITLE
fix(export): keep templates and printer-incompatible filaments out of slicer bundles

### DIFF
--- a/src/app/api/filaments/[id]/bambustudio/route.ts
+++ b/src/app/api/filaments/[id]/bambustudio/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import mongoose from "mongoose";
 import dbConnect from "@/lib/mongodb";
+import { TEMPLATE_NOT_EXPORTABLE } from "@/lib/templateExportFilter";
+import { hasVariants } from "@/lib/resolveFilament";
 import Filament from "@/models/Filament";
 import { generateOrcaSlicerProfiles } from "@/lib/orcaSlicerBundle";
 import {
@@ -47,6 +49,13 @@ export async function GET(
     const filament = await resolveFilamentForExport(id);
     if (!filament) {
       return errorResponse("Filament not found", 404);
+    }
+
+    // GH: a template is an abstract product line, not printable stock — there
+    // is no spool of it to load, so refuse rather than hand the slicer a
+    // preset the user can select but never actually have.
+    if (await hasVariants(Filament, String(filament._id))) {
+      return NextResponse.json(TEMPLATE_NOT_EXPORTABLE, { status: 400 });
     }
 
     // bakeCalibration: stock Bambu Studio has no dynamic calibration module,

--- a/src/app/api/filaments/[id]/orcaslicer/route.ts
+++ b/src/app/api/filaments/[id]/orcaslicer/route.ts
@@ -4,6 +4,8 @@ import {
   type MinimalNameCollection,
 } from "@/lib/trimmedNameLookup";
 import dbConnect from "@/lib/mongodb";
+import { TEMPLATE_NOT_EXPORTABLE } from "@/lib/templateExportFilter";
+import { hasVariants } from "@/lib/resolveFilament";
 import Filament from "@/models/Filament";
 import { generateOrcaSlicerProfiles } from "@/lib/orcaSlicerBundle";
 import { resolveSyncBackColor } from "@/lib/prusaSlicerBundle";
@@ -87,6 +89,13 @@ export async function GET(
     const filament = await resolveFilamentForExport(id);
     if (!filament) {
       return errorResponse("Filament not found", 404);
+    }
+
+    // GH: a template is an abstract product line, not printable stock — there
+    // is no spool of it to load, so refuse rather than hand the slicer a
+    // preset the user can select but never actually have.
+    if (await hasVariants(Filament, String(filament._id))) {
+      return NextResponse.json(TEMPLATE_NOT_EXPORTABLE, { status: 400 });
     }
 
     // Take the single profile object, not the [obj] wrapper, so the file

--- a/src/app/api/filaments/[id]/prusaslicer/route.ts
+++ b/src/app/api/filaments/[id]/prusaslicer/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
+import { TEMPLATE_NOT_EXPORTABLE } from "@/lib/templateExportFilter";
+import { hasVariants } from "@/lib/resolveFilament";
+import Filament from "@/models/Filament";
 import { generatePrusaSlicerBundle } from "@/lib/prusaSlicerBundle";
 import {
   resolveFilamentForExport,
@@ -29,6 +32,13 @@ export async function GET(
     const filament = await resolveFilamentForExport(id);
     if (!filament) {
       return errorResponse("Filament not found", 404);
+    }
+
+    // GH: a template is an abstract product line, not printable stock — there
+    // is no spool of it to load, so refuse rather than hand the slicer a
+    // preset the user can select but never actually have.
+    if (await hasVariants(Filament, String(filament._id))) {
+      return NextResponse.json(TEMPLATE_NOT_EXPORTABLE, { status: 400 });
     }
 
     const ini = generatePrusaSlicerBundle([filament]);

--- a/src/app/api/filaments/export/route.ts
+++ b/src/app/api/filaments/export/route.ts
@@ -1,57 +1,25 @@
-import { NextResponse } from "next/server";
-import dbConnect from "@/lib/mongodb";
-import Filament from "@/models/Filament";
-import "@/models/Nozzle";
-import "@/models/BedType";
-import { resolveFilament } from "@/lib/resolveFilament";
-import { generatePrusaSlicerBundle } from "@/lib/prusaSlicerBundle";
+import { NextRequest, NextResponse } from "next/server";
+import { GET as prusaSlicerExport } from "../prusaslicer/route";
 
-export async function GET() {
-  try {
-    await dbConnect();
-
-    const filaments = await Filament.find({ _deletedAt: null })
-      .sort({ name: 1 })
-      // GH #1005 F2: the slicer bundle mapping never reads spools; exclude the
-      // whole array (photoDataUrl blobs + usageHistory ledgers).
-      .select("-spools")
-      .populate("calibrations.nozzle")
-      .populate("calibrations.printer")
-      .populate("calibrations.bedType")
-      .populate("compatibleNozzles") // #872: diameters for compatible_printers_condition
-      .lean();
-
-    // Build a parent lookup for resolving variants
-    const parentMap = new Map<string, typeof filaments[number]>();
-    for (const f of filaments) {
-      if (!f.parentId) {
-        parentMap.set(f._id.toString(), f);
-      }
-    }
-
-    // Resolve inherited values for variants
-    const resolved = filaments.map((f) =>
-      f.parentId
-        ? resolveFilament(f, parentMap.get(f.parentId.toString()))
-        : f,
-    );
-
-    const iniContent = generatePrusaSlicerBundle(resolved);
-
-    // GH #341: legacy alias for /api/filaments/prusaslicer (same INI bundle
-    // output, kept for backward compatibility); charset aligned with that
-    // route so the two endpoints serving the same bytes agree.
-    return new NextResponse(iniContent, {
-      headers: {
-        "Content-Type": "text/plain; charset=utf-8",
-        "Content-Disposition": 'attachment; filename="filament_profiles.ini"',
-      },
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json(
-      { error: "Failed to export filaments", detail: message },
-      { status: 500 },
-    );
-  }
+/**
+ * GH #341: legacy alias for `/api/filaments/prusaslicer`, still the endpoint
+ * the two UI download buttons call.
+ *
+ * It used to be a hand-copied duplicate of that route, and duplicated export
+ * logic is exactly how a filter lands on one path and not the other — the
+ * template exclusion shipped to `/prusaslicer` while every bundle downloaded
+ * from the UI came through here unfiltered. Delegating removes the class:
+ * there is one implementation, and this endpoint differs only in the download
+ * filename it advertises.
+ */
+export async function GET(request: NextRequest) {
+  const res = await prusaSlicerExport(request);
+  // Errors pass through untouched — same status, same body.
+  if (!res.ok) return res;
+  return new NextResponse(await res.text(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="filament_profiles.ini"',
+    },
+  });
 }

--- a/src/app/api/filaments/orcaslicer/route.ts
+++ b/src/app/api/filaments/orcaslicer/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
+import Printer from "@/models/Printer";
 import "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
 import { liveTemplateIds, excludeTemplates } from "@/lib/templateExportFilter";
+import {
+  resolvePrinterScope,
+  isOfferableOnPrinter,
+  unknownPrinterBody,
+} from "@/lib/slicerExportScope";
 import { generateOrcaSlicerProfiles } from "@/lib/orcaSlicerBundle";
 import { errorResponse } from "@/lib/apiErrorHandler";
 
@@ -33,6 +39,14 @@ export async function GET(request: NextRequest) {
     const typeFilter = searchParams.get("type");
     const vendorFilter = searchParams.get("vendor");
     const idsFilter = searchParams.get("ids");
+
+    // Narrow the bundle to what this printer can actually run. Opt-in: no
+    // param leaves the response exactly as it was. Resolved BEFORE the heavy
+    // query so a typo costs a 400, not a silently empty bundle.
+    const scope = await resolvePrinterScope(Printer, searchParams.get("printer"));
+    if (scope.kind === "not-found") {
+      return NextResponse.json(unknownPrinterBody(scope.raw), { status: 400 });
+    }
 
     // Build query
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -99,11 +113,18 @@ export async function GET(request: NextRequest) {
     }
 
     // Resolve variants
-    const resolved = exportable.map((f) =>
+    const resolvedAll = exportable.map((f) =>
       f.parentId
         ? resolveFilament(f, parentMap.get(f.parentId.toString()))
         : f,
     );
+
+    // Filter on the RESOLVED docs: compatibleNozzles is whole-array fallback,
+    // so an inheriting variant's effective set only exists after resolution.
+    const resolved =
+      scope.kind === "scoped"
+        ? resolvedAll.filter((f) => isOfferableOnPrinter(f, scope.nozzleIds))
+        : resolvedAll;
 
     const profiles = generateOrcaSlicerProfiles(resolved);
 

--- a/src/app/api/filaments/orcaslicer/route.ts
+++ b/src/app/api/filaments/orcaslicer/route.ts
@@ -5,6 +5,7 @@ import "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
+import { liveTemplateIds, excludeTemplates } from "@/lib/templateExportFilter";
 import { generateOrcaSlicerProfiles } from "@/lib/orcaSlicerBundle";
 import { errorResponse } from "@/lib/apiErrorHandler";
 
@@ -67,10 +68,17 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // GH: a template is not printable stock, so it must not reach the slicer as
+    // a selectable preset. It still has to stay in `parentMap` above — its
+    // variants resolve through it — so the filter applies to what is EMITTED,
+    // not to what was loaded.
+    const templateIds = await liveTemplateIds(Filament);
+    const exportable = excludeTemplates(filaments, templateIds);
+
     // If a variant's parent isn't in the filtered results, batch-fetch missing parents
     const missingParentIds = [
       ...new Set(
-        filaments
+        exportable
           .filter((f) => f.parentId && !parentMap.has(f.parentId.toString()))
           .map((f) => f.parentId!.toString()),
       ),
@@ -91,7 +99,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Resolve variants
-    const resolved = filaments.map((f) =>
+    const resolved = exportable.map((f) =>
       f.parentId
         ? resolveFilament(f, parentMap.get(f.parentId.toString()))
         : f,

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -5,6 +5,7 @@ import "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
+import { liveTemplateIds, excludeTemplates } from "@/lib/templateExportFilter";
 import { generatePrusaSlicerBundle, collapsePerNozzleImportSections } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
 import { upsertIniFilament } from "@/lib/iniImportApply";
@@ -71,10 +72,17 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // GH: a template is not printable stock, so it must not reach the slicer as
+    // a selectable preset. It still has to stay in `parentMap` above — its
+    // variants resolve through it — so the filter applies to what is EMITTED,
+    // not to what was loaded.
+    const templateIds = await liveTemplateIds(Filament);
+    const exportable = excludeTemplates(filaments, templateIds);
+
     // If a variant's parent isn't in the filtered results, batch-fetch missing parents
     const missingParentIds = [
       ...new Set(
-        filaments
+        exportable
           .filter((f) => f.parentId && !parentMap.has(f.parentId.toString()))
           .map((f) => f.parentId!.toString()),
       ),
@@ -96,7 +104,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Resolve variants
-    const resolved = filaments.map((f) =>
+    const resolved = exportable.map((f) =>
       f.parentId
         ? resolveFilament(f, parentMap.get(f.parentId.toString()))
         : f,

--- a/src/app/api/filaments/prusaslicer/route.ts
+++ b/src/app/api/filaments/prusaslicer/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import dbConnect from "@/lib/mongodb";
 import Filament from "@/models/Filament";
+import Printer from "@/models/Printer";
 import "@/models/Nozzle";
 import "@/models/Printer";
 import "@/models/BedType";
 import { resolveFilament } from "@/lib/resolveFilament";
 import { liveTemplateIds, excludeTemplates } from "@/lib/templateExportFilter";
+import {
+  resolvePrinterScope,
+  isOfferableOnPrinter,
+  unknownPrinterBody,
+} from "@/lib/slicerExportScope";
 import { generatePrusaSlicerBundle, collapsePerNozzleImportSections } from "@/lib/prusaSlicerBundle";
 import { parseIniFilaments } from "@/lib/parseIni";
 import { upsertIniFilament } from "@/lib/iniImportApply";
@@ -36,6 +42,14 @@ export async function GET(request: NextRequest) {
     const typeFilter = searchParams.get("type");
     const vendorFilter = searchParams.get("vendor");
     const idsFilter = searchParams.get("ids");
+
+    // Narrow the bundle to what this printer can actually run. Opt-in: no
+    // param leaves the response exactly as it was. Resolved BEFORE the heavy
+    // query so a typo costs a 400, not a silently empty bundle.
+    const scope = await resolvePrinterScope(Printer, searchParams.get("printer"));
+    if (scope.kind === "not-found") {
+      return NextResponse.json(unknownPrinterBody(scope.raw), { status: 400 });
+    }
 
     // Build query
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -104,11 +118,18 @@ export async function GET(request: NextRequest) {
     }
 
     // Resolve variants
-    const resolved = exportable.map((f) =>
+    const resolvedAll = exportable.map((f) =>
       f.parentId
         ? resolveFilament(f, parentMap.get(f.parentId.toString()))
         : f,
     );
+
+    // Filter on the RESOLVED docs: compatibleNozzles is whole-array fallback,
+    // so an inheriting variant's effective set only exists after resolution.
+    const resolved =
+      scope.kind === "scoped"
+        ? resolvedAll.filter((f) => isOfferableOnPrinter(f, scope.nozzleIds))
+        : resolvedAll;
 
     const bundle = generatePrusaSlicerBundle(resolved);
 

--- a/src/lib/slicerExportScope.ts
+++ b/src/lib/slicerExportScope.ts
@@ -101,6 +101,14 @@ export type PrinterScope =
  * shadow it. Names then match verbatim, then trimmed, then case-folded, and
  * only a LIVE printer is addressable.
  *
+ * The VERBATIM rung compares the caller's parameter UNTRIMMED, and that is the
+ * whole point of it: hybrid sync writes through the raw driver and bypasses the
+ * `trim` setter, so live printers named `"X"` and `"X "` can both exist, and
+ * this is the only rung that can tell them apart. Trimming before it — the
+ * obvious tidy-up — silently redirects `?printer=X%20` to `X`, and the bundle
+ * is then filtered against the wrong printer's nozzles. Only the emptiness
+ * check, the ObjectId test and the looser rungs may see the trimmed value.
+ *
  * An unknown printer returns `not-found` rather than an empty scope. Treating
  * a typo as "this printer has no nozzles" would filter the bundle down to
  * nothing, which is the silent-emptiness failure this design exists to avoid;
@@ -111,7 +119,8 @@ export async function resolvePrinterScope(
   PrinterModel: any,
   rawParam: string | null,
 ): Promise<PrinterScope> {
-  const raw = (rawParam ?? "").trim();
+  const original = rawParam ?? "";
+  const raw = original.trim();
   if (!raw) return { kind: "none" };
 
   let printer: { _id: unknown; name?: string; installedNozzles?: NozzleRef[] } | null = null;
@@ -123,15 +132,15 @@ export async function resolvePrinterScope(
   }
 
   if (!printer) {
-    // Verbatim, then trimmed, then case-folded. The name index is
-    // case-SENSITIVE and hybrid sync writes through the raw driver bypassing
-    // the trim setter, so "X" and "X " can both exist — go strictest first
-    // rather than letting document order decide.
+    // Verbatim (UNTRIMMED — see the docblock), then trimmed, then case-folded.
+    // The name index is case-SENSITIVE and hybrid sync writes through the raw
+    // driver bypassing the trim setter, so "X" and "X " can both exist — go
+    // strictest first rather than letting document order decide.
     const live = await PrinterModel.find({ _deletedAt: null })
       .select("name installedNozzles")
       .lean();
     printer =
-      live.find((p: { name?: string }) => p.name === raw) ??
+      live.find((p: { name?: string }) => p.name === original) ??
       live.find((p: { name?: string }) => (p.name ?? "").trim() === raw) ??
       live.find(
         (p: { name?: string }) => (p.name ?? "").trim().toLowerCase() === raw.toLowerCase(),

--- a/src/lib/slicerExportScope.ts
+++ b/src/lib/slicerExportScope.ts
@@ -1,0 +1,165 @@
+/**
+ * Scoping a slicer bundle to one printer.
+ *
+ * The reported symptom: abrasive filaments — carbon- and glass-filled grades
+ * that erode a soft nozzle — appear as selectable presets when the active
+ * printer carries a nitrocarburized nozzle they must never touch.
+ *
+ * WHY THIS IS SERVER-SIDE AND NOT A `compatible_printers_condition`.
+ * PrusaSlicer's condition language exposes `nozzle_diameter`,
+ * `nozzle_high_flow`, `printer_model`, `printer_variant` and `printer_notes`.
+ * There is NO variable for nozzle material or hardness. Two nozzles can be
+ * identical on (diameter, high-flow) and differ only in that one is hardened,
+ * which is exactly the case that bites here — so no condition can separate
+ * them. Worse, when every hardened nozzle lives on a printer the slicer never
+ * sees, a truthful "hardened only" condition and a blanket hide are the same
+ * string. And deriving conditions from nozzle ticks is precisely what GH #1021
+ * removed, because it silently hid presets with no visible cause; the one-shot
+ * `legacyNozzleConditions` migration and the permanent ingestion strip exist to
+ * keep that from coming back.
+ *
+ * So the answer is to narrow the RESPONSE, on request, using the join the
+ * database already has: a printer owns nozzles, a filament lists the nozzles it
+ * may run on.
+ *
+ * FAIL OPEN, ALWAYS. Two rules keep this from becoming #1021 relocated to the
+ * server: it is opt-in (no `printer` param means the response is unchanged),
+ * and a filament that lists NO nozzles is INCLUDED rather than filtered out.
+ * Unknown compatibility is not the same as known incompatibility, and a
+ * silently missing preset is the failure mode this whole area is scarred by.
+ */
+
+/** A nozzle ref as it arrives — populated doc, raw ObjectId, or string. */
+type NozzleRef = { _id?: unknown } | string | null | undefined;
+
+/**
+ * Deliberately `unknown` at the boundary rather than a narrow interface.
+ *
+ * Callers pass either a lean Mongoose doc or a `resolveFilament` result, whose
+ * types differ and neither of which declares `compatibleNozzles` in a shape TS
+ * will match against an all-optional interface (weak-type detection rejects
+ * it). Reading defensively here is honest about that and costs nothing.
+ */
+
+function refId(ref: NozzleRef): string | null {
+  if (!ref) return null;
+  if (typeof ref === "string") return ref;
+  return ref._id == null ? null : String(ref._id);
+}
+
+/**
+ * The nozzle ids a filament may run on, as strings.
+ *
+ * Call this on a RESOLVED filament: `compatibleNozzles` is whole-array
+ * fallback, so a variant with an empty own array inherits the template's, and
+ * only the resolved doc carries the effective set. Filtering the stored value
+ * would drop every inheriting variant.
+ */
+export function nozzleIdsOf(filament: unknown): Set<string> {
+  const raw = (filament as { compatibleNozzles?: unknown } | null | undefined)?.compatibleNozzles;
+  const out = new Set<string>();
+  if (!Array.isArray(raw)) return out;
+  for (const ref of raw as NozzleRef[]) {
+    const id = refId(ref);
+    if (id) out.add(id);
+  }
+  return out;
+}
+
+/**
+ * Whether a resolved filament may be offered for a printer carrying
+ * `printerNozzleIds`.
+ *
+ * A filament with no nozzles listed is offered — see FAIL OPEN above. It is the
+ * difference between "we know this cannot go here" and "nobody has said yet".
+ */
+export function isOfferableOnPrinter(
+  filament: unknown,
+  printerNozzleIds: ReadonlySet<string>,
+): boolean {
+  const own = nozzleIdsOf(filament);
+  if (own.size === 0) return true;
+  for (const id of own) {
+    if (printerNozzleIds.has(id)) return true;
+  }
+  return false;
+}
+
+/** Outcome of reading the `printer` query parameter. */
+export type PrinterScope =
+  | { kind: "none" }
+  | { kind: "not-found"; raw: string }
+  | { kind: "scoped"; printerId: string; printerName: string; nozzleIds: Set<string> };
+
+/**
+ * Resolve `?printer=` to the set of nozzles that printer carries.
+ *
+ * Identity rules mirror the `?printer=` scope on
+ * `GET /api/filaments/{id}/calibration` (GH #1047), so the two behave the same:
+ * a 24-hex value is an ObjectId and is AUTHORITATIVE — printer names are
+ * unrestricted, so one printer could be NAMED as another's id and must not
+ * shadow it. Names then match verbatim, then trimmed, then case-folded, and
+ * only a LIVE printer is addressable.
+ *
+ * An unknown printer returns `not-found` rather than an empty scope. Treating
+ * a typo as "this printer has no nozzles" would filter the bundle down to
+ * nothing, which is the silent-emptiness failure this design exists to avoid;
+ * the caller turns it into a 400 that names the value.
+ */
+export async function resolvePrinterScope(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PrinterModel: any,
+  rawParam: string | null,
+): Promise<PrinterScope> {
+  const raw = (rawParam ?? "").trim();
+  if (!raw) return { kind: "none" };
+
+  let printer: { _id: unknown; name?: string; installedNozzles?: NozzleRef[] } | null = null;
+
+  if (/^[0-9a-fA-F]{24}$/.test(raw)) {
+    printer = await PrinterModel.findOne({ _id: raw, _deletedAt: null })
+      .select("name installedNozzles")
+      .lean();
+  }
+
+  if (!printer) {
+    // Verbatim, then trimmed, then case-folded. The name index is
+    // case-SENSITIVE and hybrid sync writes through the raw driver bypassing
+    // the trim setter, so "X" and "X " can both exist — go strictest first
+    // rather than letting document order decide.
+    const live = await PrinterModel.find({ _deletedAt: null })
+      .select("name installedNozzles")
+      .lean();
+    printer =
+      live.find((p: { name?: string }) => p.name === raw) ??
+      live.find((p: { name?: string }) => (p.name ?? "").trim() === raw) ??
+      live.find(
+        (p: { name?: string }) => (p.name ?? "").trim().toLowerCase() === raw.toLowerCase(),
+      ) ??
+      null;
+  }
+
+  if (!printer) return { kind: "not-found", raw };
+
+  const nozzleIds = new Set<string>();
+  for (const ref of printer.installedNozzles ?? []) {
+    const id = refId(ref);
+    if (id) nozzleIds.add(id);
+  }
+  return {
+    kind: "scoped",
+    printerId: String(printer._id),
+    printerName: printer.name ?? "",
+    nozzleIds,
+  };
+}
+
+/** The 400 body for an unresolvable `?printer=` value. */
+export function unknownPrinterBody(raw: string) {
+  return {
+    error: "printer_not_found",
+    message:
+      `No live printer matches "${raw}". Pass a printer id or its exact name, ` +
+      `or omit the parameter to export every filament.`,
+  };
+}

--- a/src/lib/templateExportFilter.ts
+++ b/src/lib/templateExportFilter.ts
@@ -1,0 +1,69 @@
+/**
+ * Templates are not printable stock, so they must not reach a slicer as
+ * selectable user presets.
+ *
+ * A filament with live variants is a TEMPLATE (GH #605): an abstract product
+ * line that deliberately carries no colour and no inventory. The slicer's
+ * filament dropdown is a list of things you can load and print, so a template
+ * appearing there is an entry the user can select but can never actually have
+ * on a spool — and picking it silently prints with the family's shared spec
+ * and no colour.
+ *
+ * The subtlety is that a template still has to be FETCHED, because its
+ * variants resolve their inherited values from it. So this is a filter on what
+ * is EMITTED, never on what is loaded: keep templates in the parent lookup,
+ * drop them from the section list.
+ */
+
+/** Minimal row shape the filter needs — deliberately not the Mongoose doc. */
+export interface ExportCandidate {
+  _id: unknown;
+  parentId?: unknown;
+}
+
+/**
+ * Ids of every filament that currently has at least one live variant.
+ *
+ * Mirrors `GET /api/filaments/parents`: one `distinct` over the non-deleted
+ * rows' `parentId`. Trashed variants deliberately do NOT count — a template
+ * whose only variants are in the trash has no live colours to sell, so it is a
+ * standalone again as far as the slicer is concerned, and it will re-acquire
+ * template-ness if one is restored.
+ */
+export async function liveTemplateIds(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  FilamentModel: any,
+): Promise<Set<string>> {
+  const ids: unknown[] = await FilamentModel.distinct("parentId", {
+    _deletedAt: null,
+    parentId: { $ne: null },
+  });
+  return new Set(ids.filter(Boolean).map((id) => String(id)));
+}
+
+/**
+ * Drop templates from a list bound for a slicer bundle.
+ *
+ * Pure and separately testable so the two bulk export routes cannot drift:
+ * they run the identical filter over their identical query results.
+ */
+export function excludeTemplates<T extends ExportCandidate>(
+  filaments: readonly T[],
+  templateIds: ReadonlySet<string>,
+): T[] {
+  return filaments.filter((f) => !templateIds.has(String(f._id)));
+}
+
+/**
+ * The 400 a single-filament export answers with when asked for a template.
+ *
+ * Exported as one object so all three per-slicer routes give byte-identical
+ * wording — a caller that special-cases the message must not have to match
+ * three variants of it.
+ */
+export const TEMPLATE_NOT_EXPORTABLE = {
+  error: "template_not_exportable",
+  message:
+    "This filament is a template — an abstract product line with no colour or inventory. " +
+    "Export one of its colour variants instead.",
+} as const;

--- a/tests/filaments-import-export-route.test.ts
+++ b/tests/filaments-import-export-route.test.ts
@@ -806,7 +806,7 @@ inherits = *PLA*
         { _id: parent._id },
         { $set: { cost: null, inherits: null }, $unset: { "temperatures.nozzle": "" } },
       );
-      const exportRes = await exportFilaments();
+      const exportRes = await exportFilaments(new NextRequest("http://localhost/api/filaments/export"));
       const bundle = await exportRes.text();
       const section = extractSection(bundle, "RT Base — Red");
       expect(section).not.toMatch(/^\s*inherits\s*=\s*\*PLA\*/m);
@@ -930,7 +930,7 @@ filament_shrinkage_compensation_xy = 0.3
         { _id: parent._id },
         { $set: { spoolWeight: null, shrinkageXY: null } },
       );
-      const exportRes = await exportFilaments();
+      const exportRes = await exportFilaments(new NextRequest("http://localhost/api/filaments/export"));
       const section = extractSection(await exportRes.text(), "SW Base — Red");
       expect(section).not.toMatch(/^\s*filament_spool_weight\s*=/m);
       expect(section).not.toMatch(/^\s*filament_shrinkage_compensation_xy\s*=/m);
@@ -1122,7 +1122,7 @@ filamentdb_nozzle = 0.6 Brass
   describe("GET /api/filaments/export (INI bundle)", () => {
     it("returns text/plain with an attachment Content-Disposition", async () => {
       await Filament.create({ name: "Export PLA", vendor: "T", type: "PLA" });
-      const res = await exportFilaments();
+      const res = await exportFilaments(new NextRequest("http://localhost/api/filaments/export"));
       expect(res.status).toBe(200);
       // GH #341 aligned this with /api/filaments/prusaslicer (charset=utf-8)
       expect(res.headers.get("Content-Type")).toMatch(/^text\/plain(;\s*charset=utf-8)?$/);
@@ -1139,7 +1139,7 @@ filamentdb_nozzle = 0.6 Brass
         type: "PLA",
         _deletedAt: new Date(),
       });
-      const res = await exportFilaments();
+      const res = await exportFilaments(new NextRequest("http://localhost/api/filaments/export"));
       const text = await res.text();
       expect(text).toMatch(/Live PLA/);
       expect(text).not.toMatch(/Trashed PLA/);

--- a/tests/printer-scoped-slicer-export.test.ts
+++ b/tests/printer-scoped-slicer-export.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as bundlePrusa } from "@/app/api/filaments/prusaslicer/route";
+import { GET as bundleOrca } from "@/app/api/filaments/orcaslicer/route";
+import { GET as legacyExport } from "@/app/api/filaments/export/route";
+
+/**
+ * The reported bug: abrasive filaments — assigned only hardened nozzles —
+ * appeared as selectable presets while the active printer carried the soft,
+ * nitrocarburized INDX nozzle that fibre fill would destroy.
+ *
+ * The fix narrows the RESPONSE on request rather than emitting a
+ * `compatible_printers_condition`, because PrusaSlicer has no variable for
+ * nozzle hardness and deriving conditions from nozzle ticks is what GH #1021
+ * removed for silently hiding presets.
+ *
+ * These tests pin both directions: the abrasive filament must disappear for
+ * the soft-nozzle printer, and NOTHING may disappear when no printer is named.
+ */
+describe("printer-scoped slicer export", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any, Nozzle: any, Printer: any;
+  let indxPrinterId: string, h2dPrinterId: string;
+
+  beforeEach(async () => {
+    const filMod = await import("@/models/Filament");
+    const nozMod = await import("@/models/Nozzle");
+    const prtMod = await import("@/models/Printer");
+    const bedMod = await import("@/models/BedType");
+    if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
+    if (!mongoose.models.Nozzle) mongoose.model("Nozzle", nozMod.default.schema);
+    if (!mongoose.models.Printer) mongoose.model("Printer", prtMod.default.schema);
+    if (!mongoose.models.BedType) mongoose.model("BedType", bedMod.default.schema);
+    Filament = mongoose.models.Filament;
+    Nozzle = mongoose.models.Nozzle;
+    Printer = mongoose.models.Printer;
+
+    // Two 0.4 high-flow nozzles differing ONLY in hardness — the case no
+    // slicer condition can express, which is why this is server-side.
+    const indx = await Nozzle.create({
+      name: "INDX", diameter: 0.4, type: "Other", highFlow: true, hardened: false,
+    });
+    const wc = await Nozzle.create({
+      name: "WC HF 0.4", diameter: 0.4, type: "Tungsten Carbide", highFlow: true, hardened: true,
+    });
+
+    const indxPrinter = await Printer.create({
+      name: "Prusa Core One INDX", manufacturer: "Prusa", printerModel: "Core One INDX",
+      installedNozzles: [indx._id],
+    });
+    const h2d = await Printer.create({
+      name: "Bambu Labs H2D", manufacturer: "Bambu Labs", printerModel: "H2D",
+      installedNozzles: [wc._id],
+    });
+    indxPrinterId = String(indxPrinter._id);
+    h2dPrinterId = String(h2d._id);
+
+    await Filament.create({
+      name: "Abrasive PA6-CF", vendor: "Acme", type: "PA-CF", color: "#000000",
+      compatibleNozzles: [wc._id], // hardened only
+    });
+    await Filament.create({
+      name: "Ordinary PLA", vendor: "Acme", type: "PLA", color: "#ff0000",
+      compatibleNozzles: [wc._id, indx._id],
+    });
+    await Filament.create({
+      name: "Unassigned PETG", vendor: "Acme", type: "PETG", color: "#00ff00",
+      // no compatibleNozzles at all — must still be offered (fail open)
+    });
+  });
+
+  const ini = async (qs = "") =>
+    (await bundlePrusa(new NextRequest(`http://localhost/api/filaments/prusaslicer${qs}`))).text();
+
+  it("withholds the abrasive filament from the soft-nozzle printer", async () => {
+    const out = await ini(`?printer=${indxPrinterId}`);
+    expect(out).not.toContain("[filament:Abrasive PA6-CF]");
+    expect(out).toContain("[filament:Ordinary PLA]");
+  });
+
+  it("offers the abrasive filament for the hardened-nozzle printer", async () => {
+    const out = await ini(`?printer=${h2dPrinterId}`);
+    expect(out).toContain("[filament:Abrasive PA6-CF]");
+    expect(out).toContain("[filament:Ordinary PLA]");
+  });
+
+  it("offers a filament with no nozzles assigned to either printer — fails open", async () => {
+    expect(await ini(`?printer=${indxPrinterId}`)).toContain("[filament:Unassigned PETG]");
+    expect(await ini(`?printer=${h2dPrinterId}`)).toContain("[filament:Unassigned PETG]");
+  });
+
+  it("changes nothing when no printer is named", async () => {
+    // The opt-in guarantee. If this ever fails, the change has become #1021
+    // relocated to the server.
+    const out = await ini();
+    expect(out).toContain("[filament:Abrasive PA6-CF]");
+    expect(out).toContain("[filament:Ordinary PLA]");
+    expect(out).toContain("[filament:Unassigned PETG]");
+  });
+
+  it("accepts a printer name as well as an id", async () => {
+    const out = await ini(`?printer=${encodeURIComponent("Prusa Core One INDX")}`);
+    expect(out).not.toContain("[filament:Abrasive PA6-CF]");
+  });
+
+  it("400s on an unknown printer instead of returning an empty bundle", async () => {
+    const res = await bundlePrusa(
+      new NextRequest("http://localhost/api/filaments/prusaslicer?printer=Nope"),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("printer_not_found");
+  });
+
+  it("scopes the OrcaSlicer bundle the same way", async () => {
+    const res = await bundleOrca(
+      new NextRequest(`http://localhost/api/filaments/orcaslicer?printer=${indxPrinterId}`),
+    );
+    const names = (await res.json()).map((p: Record<string, unknown>) => {
+      const v = p.filament_settings_id ?? p.name;
+      return Array.isArray(v) ? String(v[0]) : String(v);
+    });
+    expect(names).not.toContain("Abrasive PA6-CF");
+    expect(names).toContain("Ordinary PLA");
+  });
+
+  it("scopes the legacy /export alias too — the endpoint the UI actually calls", async () => {
+    // This alias was a hand-copied duplicate and missed the template filter
+    // entirely; it now delegates, so it can never drift again.
+    const res = await legacyExport(
+      new NextRequest(`http://localhost/api/filaments/export?printer=${indxPrinterId}`),
+    );
+    const out = await res.text();
+    expect(res.headers.get("Content-Disposition")).toContain("filament_profiles.ini");
+    expect(out).not.toContain("[filament:Abrasive PA6-CF]");
+    expect(out).toContain("[filament:Ordinary PLA]");
+  });
+
+  it("propagates the 400 through the legacy alias rather than masking it", async () => {
+    const res = await legacyExport(
+      new NextRequest("http://localhost/api/filaments/export?printer=Nope"),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/slicerExportScope.test.ts
+++ b/tests/slicerExportScope.test.ts
@@ -93,6 +93,26 @@ describe("resolvePrinterScope", () => {
     expect(s.kind === "scoped" && s.printerId).toBe(OID_B);
   });
 
+  it("distinguishes an untrimmed twin — the verbatim rung, untrimmed", async () => {
+    // Hybrid sync bypasses the trim setter, so "X" and "X " can both be live.
+    // Trimming the parameter before this rung would silently answer with "X"
+    // and filter the whole bundle against the wrong printer's nozzles.
+    const twins = [
+      { _id: OID_A, name: "Core One", installedNozzles: ["soft"] },
+      { _id: OID_B, name: "Core One ", installedNozzles: ["hard"] },
+    ];
+    const spaced = await resolvePrinterScope(printerModel(twins), "Core One ");
+    expect(spaced.kind === "scoped" && spaced.printerId).toBe(OID_B);
+    const bare = await resolvePrinterScope(printerModel(twins), "Core One");
+    expect(bare.kind === "scoped" && bare.printerId).toBe(OID_A);
+  });
+
+  it("still tolerates stray whitespace when there is no untrimmed twin", async () => {
+    // The forgiving rung has to survive the strict one being added above.
+    const s = await resolvePrinterScope(printerModel(rows), "  Prusa Core One INDX  ");
+    expect(s.kind === "scoped" && s.printerId).toBe(OID_B);
+  });
+
   it("prefers an exact name over a case-folded one", async () => {
     const dupes = [
       { _id: OID_A, name: "xl", installedNozzles: ["a"] },

--- a/tests/slicerExportScope.test.ts
+++ b/tests/slicerExportScope.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  nozzleIdsOf,
+  isOfferableOnPrinter,
+  resolvePrinterScope,
+  unknownPrinterBody,
+} from "@/lib/slicerExportScope";
+
+/** Stand-in Printer model — only findOne/find with .select().lean() are used. */
+function printerModel(rows: Array<Record<string, unknown>>) {
+  const chain = (value: unknown) => ({ select: () => ({ lean: async () => value }) });
+  return {
+    findOne: (q: Record<string, unknown>) =>
+      chain(rows.find((r) => String(r._id) === String(q._id) && r._deletedAt == null) ?? null),
+    find: () => chain(rows.filter((r) => r._deletedAt == null)),
+  };
+}
+
+const OID_A = "507f1f77bcf86cd799439011";
+const OID_B = "507f1f77bcf86cd799439012";
+
+describe("nozzleIdsOf", () => {
+  it("reads populated docs, raw ids and strings alike", () => {
+    expect(nozzleIdsOf({ compatibleNozzles: [{ _id: "n1" }, "n2", { _id: { toString: () => "n3" } }] }))
+      .toEqual(new Set(["n1", "n2", "n3"]));
+  });
+
+  it("is empty for a filament with no nozzles, and tolerates junk", () => {
+    expect(nozzleIdsOf({ compatibleNozzles: [] })).toEqual(new Set());
+    expect(nozzleIdsOf({})).toEqual(new Set());
+    expect(nozzleIdsOf(null)).toEqual(new Set());
+    expect(nozzleIdsOf({ compatibleNozzles: "not-an-array" })).toEqual(new Set());
+    expect(nozzleIdsOf({ compatibleNozzles: [null, undefined, { }] })).toEqual(new Set());
+  });
+});
+
+describe("isOfferableOnPrinter", () => {
+  const hardened = new Set(["dbk04", "wc04"]);
+
+  it("offers a filament that shares a nozzle with the printer", () => {
+    expect(isOfferableOnPrinter({ compatibleNozzles: ["dbk04"] }, hardened)).toBe(true);
+  });
+
+  it("withholds a filament with no nozzle in common — the reported bug", () => {
+    // An abrasive filament assigned only hardened nozzles must not be offered
+    // for a printer carrying the soft INDX.
+    expect(isOfferableOnPrinter({ compatibleNozzles: ["dbk04", "wc04"] }, new Set(["indx"])))
+      .toBe(false);
+  });
+
+  it("FAILS OPEN for a filament that lists no nozzles", () => {
+    // Unknown compatibility is not known incompatibility. Filtering these out
+    // would silently hide presets, which is the failure this design avoids.
+    expect(isOfferableOnPrinter({ compatibleNozzles: [] }, new Set(["indx"]))).toBe(true);
+    expect(isOfferableOnPrinter({}, new Set(["indx"]))).toBe(true);
+  });
+
+  it("withholds everything nozzle-bearing from a printer with no nozzles", () => {
+    // A printer with nothing installed can run nothing that names a nozzle —
+    // but the fail-open rule above still lets unassigned filaments through.
+    expect(isOfferableOnPrinter({ compatibleNozzles: ["dbk04"] }, new Set())).toBe(false);
+    expect(isOfferableOnPrinter({ compatibleNozzles: [] }, new Set())).toBe(true);
+  });
+});
+
+describe("resolvePrinterScope", () => {
+  const rows = [
+    { _id: OID_A, name: "Bambu Labs H2D", installedNozzles: ["dbk04", { _id: "wc04" }] },
+    { _id: OID_B, name: "Prusa Core One INDX", installedNozzles: ["indx"] },
+    { _id: "507f1f77bcf86cd799439013", name: "Retired", _deletedAt: new Date() },
+  ];
+
+  it("returns 'none' for an absent or blank param — the response is unchanged", async () => {
+    expect((await resolvePrinterScope(printerModel(rows), null)).kind).toBe("none");
+    expect((await resolvePrinterScope(printerModel(rows), "   ")).kind).toBe("none");
+  });
+
+  it("resolves by ObjectId and collects the installed nozzles", async () => {
+    const s = await resolvePrinterScope(printerModel(rows), OID_A);
+    expect(s.kind).toBe("scoped");
+    if (s.kind !== "scoped") return;
+    expect(s.nozzleIds).toEqual(new Set(["dbk04", "wc04"]));
+    expect(s.printerName).toBe("Bambu Labs H2D");
+  });
+
+  it("resolves by exact name", async () => {
+    const s = await resolvePrinterScope(printerModel(rows), "Prusa Core One INDX");
+    expect(s.kind === "scoped" && s.nozzleIds).toEqual(new Set(["indx"]));
+  });
+
+  it("falls back to a case-folded name match", async () => {
+    const s = await resolvePrinterScope(printerModel(rows), "prusa core one indx");
+    expect(s.kind === "scoped" && s.printerId).toBe(OID_B);
+  });
+
+  it("prefers an exact name over a case-folded one", async () => {
+    const dupes = [
+      { _id: OID_A, name: "xl", installedNozzles: ["a"] },
+      { _id: OID_B, name: "XL", installedNozzles: ["b"] },
+    ];
+    const s = await resolvePrinterScope(printerModel(dupes), "XL");
+    expect(s.kind === "scoped" && s.printerId).toBe(OID_B);
+  });
+
+  it("does not resolve a soft-deleted printer", async () => {
+    const s = await resolvePrinterScope(printerModel(rows), "Retired");
+    expect(s.kind).toBe("not-found");
+  });
+
+  it("reports not-found for an unknown value rather than an empty scope", async () => {
+    // An empty scope would filter the bundle to nothing — silent emptiness is
+    // exactly what this must never do, so the caller can 400 instead.
+    const s = await resolvePrinterScope(printerModel(rows), "No Such Printer");
+    expect(s).toEqual({ kind: "not-found", raw: "No Such Printer" });
+  });
+
+  it("reports not-found for a well-formed id that matches nothing", async () => {
+    const s = await resolvePrinterScope(printerModel(rows), "507f1f77bcf86cd7994390ff");
+    expect(s.kind).toBe("not-found");
+  });
+
+  it("treats a printer with no installedNozzles as scoped-but-empty, not not-found", async () => {
+    const s = await resolvePrinterScope(printerModel([{ _id: OID_A, name: "Bare" }]), "Bare");
+    expect(s.kind).toBe("scoped");
+    expect(s.kind === "scoped" && s.nozzleIds.size).toBe(0);
+  });
+});
+
+describe("unknownPrinterBody", () => {
+  it("names the offending value and says the param is optional", () => {
+    const b = unknownPrinterBody("Prsua");
+    expect(b.error).toBe("printer_not_found");
+    expect(b.message).toContain("Prsua");
+    expect(b.message).toMatch(/omit the parameter/i);
+  });
+});

--- a/tests/template-slicer-export-exclusion.test.ts
+++ b/tests/template-slicer-export-exclusion.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { NextRequest } from "next/server";
+import { GET as bundlePrusa } from "@/app/api/filaments/prusaslicer/route";
+import { GET as bundleOrca } from "@/app/api/filaments/orcaslicer/route";
+import { GET as onePrusa } from "@/app/api/filaments/[id]/prusaslicer/route";
+import { GET as oneOrca } from "@/app/api/filaments/[id]/orcaslicer/route";
+import { GET as oneBambu } from "@/app/api/filaments/[id]/bambustudio/route";
+
+/**
+ * A template is an abstract product line (GH #605): no colour, no inventory,
+ * nothing you can put on a spool. The slicer's filament dropdown lists things
+ * you load and print, so a template must never appear there as a selectable
+ * user preset — picking one prints with the family's shared spec and no colour.
+ *
+ * The load-bearing subtlety these tests pin: templates are still FETCHED,
+ * because variants resolve their inherited values through them. So excluding a
+ * template from the bundle must not strip its variants' inherited values.
+ */
+describe("templates are excluded from slicer exports", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Filament: any;
+  let templateId: string;
+  let variantId: string;
+  let standaloneId: string;
+
+  beforeEach(async () => {
+    const filMod = await import("@/models/Filament");
+    const nozMod = await import("@/models/Nozzle");
+    const prtMod = await import("@/models/Printer");
+    const bedMod = await import("@/models/BedType");
+    if (!mongoose.models.Filament) mongoose.model("Filament", filMod.default.schema);
+    if (!mongoose.models.Nozzle) mongoose.model("Nozzle", nozMod.default.schema);
+    if (!mongoose.models.Printer) mongoose.model("Printer", prtMod.default.schema);
+    if (!mongoose.models.BedType) mongoose.model("BedType", bedMod.default.schema);
+    Filament = mongoose.models.Filament;
+
+    const template = await Filament.create({
+      name: "Acme PETG",
+      vendor: "Acme",
+      type: "PETG",
+      color: null,
+      temperatures: { nozzle: 245, bed: 85 },
+      density: 1.27,
+    });
+    templateId = String(template._id);
+
+    const variant = await Filament.create({
+      name: "Acme PETG Cobalt",
+      vendor: "Acme",
+      type: "PETG",
+      color: "#0e21ae",
+      parentId: template._id,
+    });
+    variantId = String(variant._id);
+
+    const standalone = await Filament.create({
+      name: "Acme ASA Black",
+      vendor: "Acme",
+      type: "ASA",
+      color: "#000000",
+      temperatures: { nozzle: 260, bed: 100 },
+    });
+    standaloneId = String(standalone._id);
+  });
+
+  const bundleReq = () => new NextRequest("http://localhost/api/filaments/prusaslicer");
+  const oneReq = (id: string) =>
+    new NextRequest(`http://localhost/api/filaments/${id}/export`);
+
+  // ── bulk bundles ──────────────────────────────────────────────────
+
+  it("omits the template from the PrusaSlicer bundle but keeps its variant", async () => {
+    const ini = await (await bundlePrusa(bundleReq())).text();
+    expect(ini).not.toContain("[filament:Acme PETG]");
+    expect(ini).toContain("[filament:Acme PETG Cobalt]");
+    expect(ini).toContain("[filament:Acme ASA Black]");
+  });
+
+  it("still resolves the variant's inherited values from the omitted template", async () => {
+    // The whole risk of this change: dropping the template from the emitted
+    // set must not drop it from the parent lookup the variant resolves through.
+    const ini = await (await bundlePrusa(bundleReq())).text();
+    const section = ini.slice(ini.indexOf("[filament:Acme PETG Cobalt]"));
+    expect(section).toMatch(/^temperature = 245$/m);
+    expect(section).toMatch(/^bed_temperature = 85$/m);
+    expect(section).toMatch(/^filament_density = 1.27$/m);
+  });
+
+  it("omits the template from the OrcaSlicer bundle too", async () => {
+    const res = await bundleOrca(new NextRequest("http://localhost/api/filaments/orcaslicer"));
+    // Orca emits most values as single-element arrays, so flatten before
+    // comparing — matching on the raw field would make the negative
+    // assertion below pass vacuously.
+    const names = (await res.json()).map((p: Record<string, unknown>) => {
+      const v = p.filament_settings_id ?? p.name;
+      return Array.isArray(v) ? String(v[0]) : String(v);
+    });
+    expect(names).toContain("Acme PETG Cobalt");
+    expect(names).toContain("Acme ASA Black");
+    expect(names).not.toContain("Acme PETG");
+  });
+
+  it("exports a childless root — being a root is not being a template", async () => {
+    const ini = await (await bundlePrusa(bundleReq())).text();
+    expect(ini).toContain("[filament:Acme ASA Black]");
+  });
+
+  it("exports a former template again once its only variant is trashed", async () => {
+    await Filament.findByIdAndUpdate(variantId, { _deletedAt: new Date() });
+    const ini = await (await bundlePrusa(bundleReq())).text();
+    // No live colours left, so it is a standalone again and printable.
+    expect(ini).toContain("[filament:Acme PETG]");
+  });
+
+  // ── single-filament exports ───────────────────────────────────────
+
+  it.each([
+    ["PrusaSlicer", onePrusa],
+    ["OrcaSlicer", oneOrca],
+    ["Bambu Studio", oneBambu],
+  ])("refuses a single %s export of a template with 400", async (_label, handler) => {
+    const res = await handler(oneReq(templateId), {
+      params: Promise.resolve({ id: templateId }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("template_not_exportable");
+  });
+
+  it.each([
+    ["PrusaSlicer", onePrusa],
+    ["OrcaSlicer", oneOrca],
+    ["Bambu Studio", oneBambu],
+  ])("still exports a variant via the single %s route", async (_label, handler) => {
+    const res = await handler(oneReq(variantId), {
+      params: Promise.resolve({ id: variantId }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("still exports a standalone via the single route", async () => {
+    const res = await onePrusa(oneReq(standaloneId), {
+      params: Promise.resolve({ id: standaloneId }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("[filament:Acme ASA Black]");
+  });
+});

--- a/tests/templateExportFilter.test.ts
+++ b/tests/templateExportFilter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  excludeTemplates,
+  liveTemplateIds,
+  TEMPLATE_NOT_EXPORTABLE,
+} from "@/lib/templateExportFilter";
+
+/** Minimal stand-in for the Mongoose model — only `distinct` is used. */
+function modelReturning(ids: unknown[]) {
+  return {
+    distinct: async (field: string, filter: Record<string, unknown>) => {
+      expect(field).toBe("parentId");
+      // Trashed variants must not confer template-ness, and the null-parent
+      // rows (every root) must not come back as their own parents.
+      expect(filter).toEqual({ _deletedAt: null, parentId: { $ne: null } });
+      return ids;
+    },
+  };
+}
+
+describe("liveTemplateIds", () => {
+  it("returns the distinct parents of live variants as strings", async () => {
+    const ids = await liveTemplateIds(modelReturning(["aaa", "bbb", "aaa"]));
+    expect(ids).toEqual(new Set(["aaa", "bbb"]));
+  });
+
+  it("stringifies ObjectId-like values so Set lookups match route callers", async () => {
+    // The driver hands back ObjectIds, while callers test `String(f._id)`.
+    // Without the coercion every lookup would miss and nothing would filter.
+    const oid = { toString: () => "507f1f77bcf86cd799439011" };
+    const ids = await liveTemplateIds(modelReturning([oid]));
+    expect(ids.has("507f1f77bcf86cd799439011")).toBe(true);
+  });
+
+  it("drops null and undefined rather than admitting an empty-string id", async () => {
+    const ids = await liveTemplateIds(modelReturning([null, undefined, "ccc"]));
+    expect(ids).toEqual(new Set(["ccc"]));
+  });
+
+  it("is empty when no filament has variants", async () => {
+    expect(await liveTemplateIds(modelReturning([]))).toEqual(new Set());
+  });
+});
+
+describe("excludeTemplates", () => {
+  const rows = [
+    { _id: "t1", parentId: null }, // template
+    { _id: "v1", parentId: "t1" }, // its variant
+    { _id: "s1", parentId: null }, // standalone
+  ];
+
+  it("drops templates and keeps variants and standalones", () => {
+    expect(excludeTemplates(rows, new Set(["t1"])).map((r) => r._id)).toEqual(["v1", "s1"]);
+  });
+
+  it("keeps a childless root — a standalone is not a template", () => {
+    expect(excludeTemplates(rows, new Set()).map((r) => r._id)).toEqual(["t1", "v1", "s1"]);
+  });
+
+  it("matches on the stringified id, so ObjectId rows still filter", () => {
+    const withOid = [{ _id: { toString: () => "t1" }, parentId: null }];
+    expect(excludeTemplates(withOid, new Set(["t1"]))).toEqual([]);
+  });
+
+  it("never drops a variant whose own id is absent from the template set", () => {
+    // A variant can never itself be a template (no nested inheritance), so a
+    // parentId pointing at a template must not disqualify the child.
+    expect(excludeTemplates(rows, new Set(["t1"])).some((r) => r._id === "v1")).toBe(true);
+  });
+
+  it("does not mutate the input", () => {
+    const input = [...rows];
+    excludeTemplates(input, new Set(["t1"]));
+    expect(input).toHaveLength(3);
+  });
+});
+
+describe("TEMPLATE_NOT_EXPORTABLE", () => {
+  it("carries a stable machine-readable code the three routes share", () => {
+    expect(TEMPLATE_NOT_EXPORTABLE.error).toBe("template_not_exportable");
+    expect(TEMPLATE_NOT_EXPORTABLE.message).toMatch(/colour variant/i);
+  });
+});


### PR DESCRIPTION
All twelve templates appear in PrusaSlicer's filament dropdown as selectable user presets. Reported from the UI — the screenshot showed `Pro PCTG` sitting between `PRILINE PC-CF` and `Pro PCTG Cobalt Blue`.

## Why it's wrong

A filament with live variants is a **template** (#605): an abstract product line carrying the shared spec and deliberately holding no colour and no inventory. The slicer's filament dropdown is a list of things you load and print, so a template there is an entry you can select but can never actually have on a spool — and picking one slices with the family's shared spec and no colour at all.

Nothing in the export path filtered them. `GET /api/filaments/prusaslicer` does `Filament.find(query)` and emits a section per row; `prusaSlicerBundle.ts` has no mention of `hasVariants`, `parentId` or templates.

## The subtlety

A template still has to be **fetched**, because its variants resolve their inherited values through it. So this filters what is *emitted*, never what is *loaded*: templates stay in `parentMap`, and only the section list is narrowed.

There's a test pinning exactly that — the variant's `temperature`, `bed_temperature` and `filament_density` must still resolve from the template the bundle no longer contains. That's the way this change could plausibly break something, so it's asserted directly rather than implied.

## Shape

- `src/lib/templateExportFilter.ts` — `liveTemplateIds` (one `distinct`, mirroring `/api/filaments/parents`), `excludeTemplates` (pure), and `TEMPLATE_NOT_EXPORTABLE`.
- Both bulk routes share the filter rather than open-coding it twice. They're already structurally identical and have drifted before.
- The three single-filament exports answer **400 `template_not_exportable`** from one shared constant, so a caller special-casing the message doesn't have to match three spellings.

## Behaviour worth agreeing on

Template-ness follows **live** variants only, matching `hasVariants` and `/api/filaments/parents`. A template whose only variants are trashed has no live colours, so it becomes exportable again — and stops being so if one is restored. Tested.

## Tests

22 new (10 unit, 12 route). Full related suites re-run green: `single-filament-slicer-export`, `prusaSlicerBundle`, `orcaSlicerBundle`, `bambustudio-route`, `filaments-import-export-route`, `api-route-correctness` — 346 passing. `tsc --noEmit` and eslint clean.

## Not included

Users who already exported have the template presets sitting in their PrusaSlicer config; this stops them coming back but doesn't remove existing ones. Deleting user preset files from the server isn't something this should do — worth a note in the release notes instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)